### PR TITLE
The corporate actions and events ontology needs basic clean-up

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -106,7 +106,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->	 
 
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"/>	 
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>	 
 	 
 	<!-- 
     ///////////////////////////////////////////////////////////////////////////////////////

--- a/CAE/CorporateEvents/CorporateActionsEvents.rdf
+++ b/CAE/CorporateEvents/CorporateActionsEvents.rdf
@@ -101,18 +101,34 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AssimilationPariPassu">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">assimilation pari passu</rdfs:label>
-		<skos:definition xml:lang="en">Assimilation. Occurs when securities with different characteristics, eg, shares with different entitlements to dividend or voting rights, become identical in all respects, ie, pari-passu. SWIFT = PARI</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">attachment action</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;DetachmentAction"/>
 		<skos:definition xml:lang="en">The combination of different security types to create a unit. Units are usually comprised of warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention. Further NOtes: is there some common term for these (see Detachment event)?; Are there separate scenarios for attachment of different kinds of security. Definition says &quot;usually&quot; Warrant. Probably applies to any fungible securities, whether or not warrants. For example two fungible tranches of a debt issues, that are funged later on in their life. Are these ever notified differently or have different details for warrants, fungible debt etc.? No. the message can relate to any, and the event defined here can be defined in terms of &quot;any&quot; securities.</skos:definition>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;BIDS">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">BIDS</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;RepurchaseOffer"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;RepurchaseOffer"/>
+		<lcc-lr:hasTag>BIDS</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;BONU">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">BONU</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
+		<lcc-lr:hasTag>BONU</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;BPUT">
 		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
@@ -135,26 +151,16 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bond default event</rdfs:label>
-		<skos:definition xml:lang="en">bond-specific obligation default as a consequence of non-payment of interest or debt principal when due</skos:definition>
+		<skos:definition xml:lang="en">corporate action which indicates a failure by the issuer to perform obligations defined as default events under the bond agreement and that have not been remedied</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isIssueOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">bonus issue</rdfs:label>
-		<skos:definition xml:lang="en">Event in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding. These may be from current profits or may be from accumulated reserves of the company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are different taxation rules for the Bonus Issue compared to the Dividend. There could also be a difference in the ranking of the shares that are given, to what the holder already holds. Always announce the event on the ones that they hold, and based on the holding they are given additional shares. They may be of a different ranking. Bonus Issues increase the capital base but not the capital value of the company, since all they are doing is diluting the share capital. Difference from Dividend: Increases holding of shareholder. Other similar terms: Awards; Also see difference between Dividend and Bonus. Dividend is from current profits and bonus may be from accumulated reserves of the company. Separate this into 2 terms. We have: Capitalisation Issue Bonus rights Issue Original SWIFT definition - strippoed out synonyms for the formal definition above: &quot;Attribution Gratuite (FR); Scrip Issue (GB); Capitalisation Issue. Security holders are awarded additional assets free of payment from the issuer in priportion to their holding.&quot; More 25 May A scrip issue is the issue of new shares at no charge pro rata to the holder of existing shares. This means the term Scrip Issue is as modeled here &quot;no charge&quot;. But Capitalization becomes close to this in definition. More detail May 25: No change to the par value of the share so why would there be a change inthe capitaliation? Because from an accountingf point of view they change the value of overall capital of the company - they don&apos;t change the market value of the conpany but the accountants will record an increase in the issued capital of the company. This is the disctinction between nominal capital and the market capital. Nominal - there is more nominal share value.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">corporate action in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are different taxation rules for the bonus issue compared to the dividend. There could also be a difference in the ranking of the shares that are given to what the holder already holds. Dividends are paid from current profits and bonus may be from accumulated reserves of the company. A scrip issue is the issue of new shares at no charge pro rata to the holder of existing shares.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">capitalisation issue</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">scrip issue</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusRightsIssue">
@@ -216,12 +222,6 @@
 		<rdfs:label xml:lang="en">capital gains distribution</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that distributes profits resulting from the sale of company assets to shareholders</skos:definition>
 		<skos:example xml:lang="en">Shareholders of Mutual Funds, Unit Trusts, or SICAVs are recipients of capital gains distributions which are often reinvested in additional shares of the fund</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalizationIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">capitalization issue</rdfs:label>
-		<skos:definition xml:lang="en">A general kind of issue which increases the capital base of the company. Other kinds of issue: Like a Bonus Issue except that it would increase the capital. There could be several events which could be considered as Capitalization Issues. 25 May Later research: Scrip or Bonus issue is seen to be synonymous with this but more accurate. However, we question this - if you have the chance to purchase shares at a particular price (which is a right) would extend the definition of .. 20 July: this could have a broader meaning than Capital reserves Distribution It would include distribution of capital and trying to raise capital by additional capital injection Example: If the company issues bonds, that also changes the capital base. Now to change the capital base, there are two directions, up or down. Bonus issue falls into the above because you are increasing the capital base. A rights issue also increateses the capital base. Distributions of capital has the opposite effect. Paying out cash to reduce those items that are in your reserves. the reserves are greater than you need so you pay out cash on those. Labeling: capitalization implies the creation of capital so only suggests an increase the capital base</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CashDividendAction">
@@ -452,6 +452,17 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DFLT">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">DFLT</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that indicate a failure by the issuer to perform obligations defined as default events under the bond agreement and that have not been remedied</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;BondDefaultAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;BondDefaultAction"/>
+		<lcc-lr:hasTag>DFLT</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DRIP">
 		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">DRIP</rdfs:label>
@@ -611,7 +622,7 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-cae-ce-cae;ExchangeOffer">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;ShareBuybackOffer">
+					<rdf:Description rdf:about="&fibo-cae-ce-cae;RepurchaseOffer">
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-cae-ce-cae;TenderOffer">
 					</rdf:Description>
@@ -753,6 +764,17 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<skos:definition xml:lang="en">The issuing company changes it&apos;s name. Event shows the change from old name to new name and may involve surrendering physical shares with the old name to the registrar. SWIFT = NAME</skos:definition>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;PARI">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">PARI</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that occur when securities with different characteristics become identical in all respects</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PariPassuAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PariPassuAction"/>
+		<lcc-lr:hasTag>PARI</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;PCAL">
 		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">PCAL</rdfs:label>
@@ -785,6 +807,15 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<lcc-lr:hasTag>PRIO</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-cae-ce-cae;PariPassuAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">pari-passu action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that occurs when securities with different characteristics become identical in all respects</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A pari-passu event includes cases, for example, when shares with different entitlements to dividend or voting rights become equivalent through assimilation or pari-passu. Such an event may be scheduled in advance, for example, when shares resulting from a bonus may become fungible after a pre-set period of time, or may result from outside events, for example, merger, reorganisation, issue of supplementary tranches, etc.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The term, pari-passu, means &apos;at the same rate or on an equal footing&apos;, and in finance is used to describe situations where two or more assets, securities, creditors, or obligations are equally managed without preference. An example of pari-passu occurs during bankruptcy proceedings: When the court reaches a verdict, the court regards all creditors equally, and the trustee will repay them the same fractional amount as other creditors and at the same time.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">assimilation</fibo-fnd-utl-av:synonym>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialDefeasanceAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
@@ -885,6 +916,15 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, the nominal/par value of security in a national currency is restated in another currency.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-cae-ce-cae;RepurchaseOffer">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+		<rdfs:label xml:lang="en">repurchase offer</rdfs:label>
+		<skos:definition xml:lang="en">corporate action in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The objective of the offer is to reduce the number of outstanding equities.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">issuer bid</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">reverse rights</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ReverseStockSplit">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:subClassOf>
@@ -928,7 +968,7 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isDistributionOf"/>
@@ -982,18 +1022,6 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<lcc-lr:hasTag>SPLR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareBuybackOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">share buyback offer</rdfs:label>
-		<skos:definition xml:lang="en">Issuer bid; Reduction of circulation shares; Reverse Rights. Offer by Issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.</skos:definition>
-	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;SharesPremiumDividendAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>

--- a/CAE/CorporateEvents/CorporateActionsEvents.rdf
+++ b/CAE/CorporateEvents/CorporateActionsEvents.rdf
@@ -101,13 +101,6 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">attachment action</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;DetachmentAction"/>
-		<skos:definition xml:lang="en">The combination of different security types to create a unit. Units are usually comprised of warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention. Further NOtes: is there some common term for these (see Detachment event)?; Are there separate scenarios for attachment of different kinds of security. Definition says &quot;usually&quot; Warrant. Probably applies to any fungible securities, whether or not warrants. For example two fungible tranches of a debt issues, that are funged later on in their life. Are these ever notified differently or have different details for warrants, fungible debt etc.? No. the message can relate to any, and the event defined here can be defined in terms of &quot;any&quot; securities.</skos:definition>
-	</owl:Class>
-	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;BIDS">
 		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">BIDS</rdfs:label>
@@ -247,6 +240,13 @@
 		<lcc-lr:hasTag>CONV</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-cae-ce-cae;CallOnIntermediateSecurities">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">call on intermediate securities</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This code is used for the second event, when an intermediate securities&apos; issue (rights/coupons) is composed of two events, the first event being the distribution of intermediate securities.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CancellationOfShares">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
@@ -561,29 +561,11 @@
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtDrawingNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">debt drawing notification</rdfs:label>
-		<skos:definition xml:lang="en">Redemption in part before the scheduled final maturity date of a security. SWIFT = DRAW</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtInstrumentBuybackNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">debt instrument buyback notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an event where det securities are bought back by the issuer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See also puts and calls (these are usually pre-arranged). Here the company goes out to the market and buys back their own debt. This does not really need to be a corporate event, they just do it. REVIEW: This term may not be needed. Not a corporate action.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;DecreaseInValueAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">decrease in value action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action resulting in a reduction of face value of a share or the value of fund assets</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The number of circulating shares/units remains unchanged. This event may include a cash pay out to holders.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DetachmentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">detachment action</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;DisclosureAction">
@@ -629,6 +611,17 @@
 		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ExchangeAction"/>
 		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ExchangeAction"/>
 		<lcc-lr:hasTag>EXOF</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXRI">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">EXRI</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CallOnIntermediateSecurities"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CallOnIntermediateSecurities"/>
+		<lcc-lr:hasTag>EXRI</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	

--- a/CAE/CorporateEvents/CorporateActionsEvents.rdf
+++ b/CAE/CorporateEvents/CorporateActionsEvents.rdf
@@ -1,19 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-cae-ce-cae "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/">
 	<!ENTITY fibo-der-drc-raw "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
+	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
+	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-md-temx-trs "https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
+	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -23,19 +32,28 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-cae-ce-cae="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"
 	xmlns:fibo-der-drc-raw="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
+	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
+	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-md-temx-trs="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
+	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -45,129 +63,79 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/">
 		<rdfs:label xml:lang="en">CorporateActionsEvents</rdfs:label>
-		<dct:abstract>All corporate events and actions, along with definitions of kinds of message in which those events are communicated.</dct:abstract>
+		<dct:abstract>This ontology covers income and corporate action events as specified in SWIFT ISO 15022, including extensions as of 3 September 2020. Scope has been limited to events and actions only, and excludes notification and meetings related events and message definitions associated with ISO 15022 as well as related messages covered by ISO 20022.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-cae-ce-cae</sm:fileAbbreviation>
+		<sm:filename>CorporateActionsEvents.rdf</sm:filename>
 		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AbstentionResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">abstention response</rdfs:label>
-		<skos:definition xml:lang="en">Vote expressed as abstain. In this case, the issuing company will add the number of shares to the quorum of the meeting.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the voting right is not executed, it will not be added to the quorum. In this case the response should be &quot;No Action&quot;. . SWIFT definition Vote expressed as abstain. In this case, the issuing company will add the number of shares to the quorum of the meeting. If the voting right is not executed, it will not be added to the quorum. In this case, code NOAC should be used. SWIFT Code: ABST</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AbstentionResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">abstention response message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AdviceOfAPossibleAction">
-		<rdfs:label xml:lang="en">advice of a possible action</rdfs:label>
-		<skos:definition xml:lang="en">Advice - action voluntary This includes a number of things, it&apos;s not always clear why these things are here.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AllOrNoneChoiceCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
-		<rdfs:label xml:lang="en">all or none choice corporate action</rdfs:label>
-		<skos:definition xml:lang="en">A Mandator Corporate Action with some choice for the Holder, where the Holder&apos;s options are limited to all of the stated choices or none of them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AnnouncementMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">announcement message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AnnualGeneralMeeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
-		<rdfs:label xml:lang="en">annual general meeting</rdfs:label>
-		<skos:definition xml:lang="en">Annual General Meeting. SWIFT = MEET</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;AssimilationPariPassu">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">assimilation pari passu</rdfs:label>
 		<skos:definition xml:lang="en">Assimilation. Occurs when securities with different characteristics, eg, shares with different entitlements to dividend or voting rights, become identical in all respects, ie, pari-passu. SWIFT = PARI</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">attachment action</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;DetachmentAction"/>
 		<skos:definition xml:lang="en">The combination of different security types to create a unit. Units are usually comprised of warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention. Further NOtes: is there some common term for these (see Detachment event)?; Are there separate scenarios for attachment of different kinds of security. Definition says &quot;usually&quot; Warrant. Probably applies to any fungible securities, whether or not warrants. For example two fungible tranches of a debt issues, that are funged later on in their life. Are these ever notified differently or have different details for warrants, fungible debt etc.? No. the message can relate to any, and the event defined here can be defined in terms of &quot;any&quot; securities.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AttachmentOrDetachmentNotificationMessage"/>
-		<rdfs:label xml:lang="en">attachment notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of the combination of different security types to create a unit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Units usually comprise warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention. Examples of automatic ones: If you have a unit with warrants and the warrants expore, they would be detached immediately. Is there a Notification? They would have to break up the unit as the unit no longer exists. Have to deliver off the unit and put the bond back into the client&apos;s account or into you position as an operation. depositories would change the CUSIP from the Unit CUSIP to the Bond CUSIP. Who initiates? The issuer has to do this based on the terms. Attavhment and Detachment also applicable to TRahcnes in CDOs. At some point a tranch might attach at 6 and detach at 10% for example. This might be a corporate action as it is declared when the issue is created - the attachment and deta chment points are specified inthe prospectus for the deal and would not be seen as a corporate action. SWIFT full text: &quot;The combination of different security types to create a unit. Units are usually comprised of warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;BPUT">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">BPUT</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PutRedemptionAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PutRedemptionAction"/>
+		<lcc-lr:hasTag>BPUT</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentOrDetachmentNotificationMessage">
-		<rdfs:label xml:lang="en">attachment or detachment notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an action in which the issuer attaches or detaches securities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
-		<rdfs:label xml:lang="en">bond action</rdfs:label>
-		<skos:definition xml:lang="en">Some action in relation to a bond, by the Issuer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondDefaultEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;DefaultEvent"/>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;BondDefaultAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationDefault"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.2"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bond default event</rdfs:label>
-		<skos:definition xml:lang="en">Non payment of interest or non payment of debt principal when due.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondDefaultNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExPostNotification"/>
-		<rdfs:label xml:lang="en">bond default notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of non payment of interest or non payment of debt principal when due.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an Ex Post notification.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondPutRedemption">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;BondAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PutAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.3"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond put redemption</rdfs:label>
-		<skos:definition xml:lang="en">Early redemption of a bond at the election of the bondholder subject to the terms and condition of the issue.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notification in advance of this happening.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondPutRedemptionInstruction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
-		<rdfs:label xml:lang="en">bond put redemption instruction</rdfs:label>
-		<skos:definition xml:lang="en">Early redemption of a bond at the election of the bondholder subject to the terms and condition of the issue.</skos:definition>
+		<skos:definition xml:lang="en">bond-specific obligation default as a consequence of non-payment of interest or debt principal when due</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusIssue">
@@ -180,20 +148,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.4"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bonus issue</rdfs:label>
 		<skos:definition xml:lang="en">Event in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding. These may be from current profits or may be from accumulated reserves of the company.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are different taxation rules for the Bonus Issue compared to the Dividend. There could also be a difference in the ranking of the shares that are given, to what the holder already holds. Always announce the event on the ones that they hold, and based on the holding they are given additional shares. They may be of a different ranking. Bonus Issues increase the capital base but not the capital value of the company, since all they are doing is diluting the share capital. Difference from Dividend: Increases holding of shareholder. Other similar terms: Awards; Also see difference between Dividend and Bonus. Dividend is from current profits and bonus may be from accumulated reserves of the company. Separate this into 2 terms. We have: Capitalisation Issue Bonus rights Issue Original SWIFT definition - strippoed out synonyms for the formal definition above: &quot;Attribution Gratuite (FR); Scrip Issue (GB); Capitalisation Issue. Security holders are awarded additional assets free of payment from the issuer in priportion to their holding.&quot; More 25 May A scrip issue is the issue of new shares at no charge pro rata to the holder of existing shares. This means the term Scrip Issue is as modeled here &quot;no charge&quot;. But Capitalization becomes close to this in definition. More detail May 25: No change to the par value of the share so why would there be a change inthe capitaliation? Because from an accountingf point of view they change the value of overall capital of the company - they don&apos;t change the market value of the conpany but the accountants will record an increase in the issued capital of the company. This is the disctinction between nominal capital and the market capital. Nominal - there is more nominal share value.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusIssueNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssueNotification"/>
-		<rdfs:label xml:lang="en">bonus issue notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of event in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These may be from current profits or may be from accumulated reserves of the company. SWIFT definition text: &quot;Attribution Gratuite (FR); Scrip Issue (GB); Capitalisation Issue. Security holders are awarded additional assets free of payment from the issuer in priportion to their holding.&quot;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusRightsIssue">
@@ -203,124 +164,79 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Rights = right to buy shares at a specified price. May be given the right for nothing (Bonus Rights Issue) or you may be offered to purchase that right at a subscription price (which you take up or don&apos;t). Bonus Rights Issue: given the option for free. May exercise at the Exercise Price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusRightsIssueNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssueNotification"/>
-		<rdfs:label xml:lang="en">bonus rights issue notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a Bonus Rights Issue, that is a Rights Issue in which the rights are given to the holders of the referenced shares for free.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusSharePlanDistribution">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
 		<rdfs:label xml:lang="en">bonus share plan distribution</rdfs:label>
 		<skos:definition xml:lang="en">Event in which shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications. SWIFT Definition (adapted above) &quot;Typically found in Australia, shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications.&quot; To be researches further. There are certainly Share Plans in Australia, where you can take a dividend as shares. Thewse would be in the nature of Bonus Shares. They are a tradeoff from cash dividends. Other terms to model: A &quot;Scheme of Arrangment&quot; - does this change the capital reserves or is it just another word for restructure. An arrangement with the company&apos;s debtors, and coule potentially change the capital base by converting the debt to shares (see other diagram note with these in).</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusSharePlanDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistributionNotification"/>
-		<rdfs:label xml:lang="en">bonus share plan distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of issue of shares from the Share Premium Reserve of the company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are are considered as a capital distribution rather than a disbursement of income, with different tax implications. Typically found in Australia. SWIFT full text: &quot;Typically found in Australia, shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications.&quot;</fibo-fnd-utl-av:explanatoryNote>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;BusinessStrategyOrientedAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
+		<rdfs:label xml:lang="en">business strategy oriented action</rdfs:label>
+		<skos:definition xml:lang="en">classifier of corporate actions that involves improving liquidity or changing the overall structure of the organization through diversification, combining and closing parts of the business, etc, to increase long-term profitability</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CallAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">call action</rdfs:label>
-		<skos:definition xml:lang="en">Note this is an Issuer action.</skos:definition>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CAPD">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">CAPD</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
+		<lcc-lr:hasTag>CAPD</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CallMeeting">
-		<rdfs:label xml:lang="en">call meeting</rdfs:label>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CAPG">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">CAPG</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that distribute profits resulting from the sale of company assets to shareholders</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CapitalGainsDistribution"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CapitalGainsDistribution"/>
+		<lcc-lr:hasTag>CAPG</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CancellationOfShares">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">cancellation of shares</rdfs:label>
 		<skos:definition xml:lang="en">The cancellation of shares. Further Notes Only possible with shares not publicly issued i.e. treasury shares</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryDistribution"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">capital distribution</rdfs:label>
-		<skos:definition xml:lang="en">An action in which capital of the issuing company is distributed. Trem Orign:SME Reviews</skos:definition>
+		<skos:definition xml:lang="en">corporate action that pays shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This action does not result in a reduction of the face value of a share or in a change to the number of shares in circulation.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">capital distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an action in which capital of the issuing company is distributed.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalReservesDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
-		<rdfs:label xml:lang="en">capital reserves distribution</rdfs:label>
-		<skos:definition xml:lang="en">Distribution of capital reserves of the issuing company. Further Notes Distribution comes from earnings and reduces the capital base. REVIEW: How does this differ from CAPG? That is, does this scenario exist outside of funds capital gains distribution?</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalReservesDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistributionNotification"/>
-		<rdfs:label xml:lang="en">capital reserves distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of distribution of capital reserves of the issuing company.</skos:definition>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalGainsDistribution">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+		<rdfs:label xml:lang="en">capital gains distribution</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that distributes profits resulting from the sale of company assets to shareholders</skos:definition>
+		<skos:example xml:lang="en">Shareholders of Mutual Funds, Unit Trusts, or SICAVs are recipients of capital gains distributions which are often reinvested in additional shares of the fund</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalizationIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">capitalization issue</rdfs:label>
 		<skos:definition xml:lang="en">A general kind of issue which increases the capital base of the company. Other kinds of issue: Like a Bonus Issue except that it would increase the capital. There could be several events which could be considered as Capitalization Issues. 25 May Later research: Scrip or Bonus issue is seen to be synonymous with this but more accurate. However, we question this - if you have the chance to purchase shares at a particular price (which is a right) would extend the definition of .. 20 July: this could have a broader meaning than Capital reserves Distribution It would include distribution of capital and trying to raise capital by additional capital injection Example: If the company issues bonds, that also changes the capital base. Now to change the capital base, there are two directions, up or down. Bonus issue falls into the above because you are increasing the capital base. A rights issue also increateses the capital base. Distributions of capital has the opposite effect. Paying out cash to reduce those items that are in your reserves. the reserves are greater than you need so you pay out cash on those. Labeling: capitalization implies the creation of capital so only suggests an increase the capital base</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalizationIssueNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">capitalization issue notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an issue which increases the capital base of the company.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashAndSecuritiesResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-		<rdfs:label xml:lang="en">cash and securities response</rdfs:label>
-		<skos:definition xml:lang="en">Response is to take a distribution of both securities and cash as offered.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Term:&quot;Cash and Securities&quot; Definition:&quot;Election choice includes a distribution of both cash and securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashDisbursementResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
-		<rdfs:label xml:lang="en">cash disbursement response message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of response opting to take cash.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Term: &quot;Cash&quot; Definition: &quot;Distribution of cash to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashDividendEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">cash dividend event</rdfs:label>
-		<skos:definition xml:lang="en">Distribution of cash to shareholders, in proportion to their equity holding. Ordinary dividends are recurring and regular. Shareholder must take cash and is not offered a choice in the form of distribution.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">cash dividend notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-		<rdfs:label xml:lang="en">cash response</rdfs:label>
-		<skos:definition xml:lang="en">Response is to take cash.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: &quot;Distribution of cash to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;CashDividendAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">cash dividend action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that distributes cash to shareholders in proportion to their equity holding</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Ordinary dividends are typically recurring and regular.  The shareholder must take cash, and may be offered a choice of currency.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeInDetailsNotification">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.5"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-le-cb;StockCorporation">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">change in details notification</rdfs:label>
@@ -331,7 +247,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.6"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -341,237 +257,147 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeOfStateEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
 		<rdfs:label xml:lang="en">change of state event</rdfs:label>
 		<skos:definition xml:lang="en">Some event relating to some change of state.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeToSmallestNegotiableUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">change to smallest negotiable unit</rdfs:label>
 		<skos:definition xml:lang="en">Modification of the smallest negotiable unit of shares in order to obtain a new negotiable unit. SWIFT:SMAL</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChoiceExists">
-		<rdfs:label xml:lang="en">choice exists</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChoiceOffer">
-		<rdfs:label xml:lang="en">choice offer</rdfs:label>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ClassActionProposedSettlementEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ManagementAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">class action proposed settlement event</rdfs:label>
 		<skos:definition xml:lang="en">Proposed settlement to a class action filing. Situation where interested parties seek restitution for financial loss.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction. 
 Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed settlement. Situation where interested parties seek restitution for financial loss. Security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction.&quot; Description clarifies that the event is not the class action or the initiation of the class action, but the initiation of a proposed settlement, in which holders are encouraged to participate. Note that this is an action with some optional action on the part of the Holder.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CombinedCashAndSecuritiesResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
-		<rdfs:label xml:lang="en">combined cash and securities response message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of response opting to take a distribution of both securities and cash as offered.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Term:&quot;Cash and Securities&quot; Definition:&quot;Election choice includes a distribution of both cash and securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CompanyOptionEvent">
-		<rdfs:label xml:lang="en">company option event</rdfs:label>
-		<skos:definition xml:lang="en">A company option may be granted by the company, allowing the holder to take up shares at some future date(s) at a pre arranged price in the company.</skos:definition>
-		<skos:editorialNote xml:lang="en">Is this an Event? Or is notification of the option the event?</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentDenied">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">consent denied</rdfs:label>
-		<skos:definition xml:lang="en">Vote not to approve the event or proposal. SWIFT: CONN</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentDeniedMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">consent denied message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentGranted.1">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">consent granted</rdfs:label>
-		<skos:definition xml:lang="en">Vote to approve the event or proposal. SWIFT: CONY</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentGrantedMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">consent granted message</rdfs:label>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitation">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;AbstentionResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;ConsentDenied"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;ConsentGranted.1"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;VotingNoAction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.7"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">consent solicitation</rdfs:label>
 		<skos:definition xml:lang="en">Solicitation of shareholders consent. Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationCommunication">
-		<rdfs:label xml:lang="en">consent solicitation communication</rdfs:label>
-		<skos:definition xml:lang="en">Activity in which the issuer of a security, wanting consent, communicates this to the holders, from whom consent would need to be granted.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationEnd">
-		<rdfs:label xml:lang="en">consent solicitation end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationRequest">
-		<rdfs:label xml:lang="en">consent solicitation request</rdfs:label>
-		<skos:definition xml:lang="en">Solicitation of shareholders consent.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting. SWIFT Full TExt: &quot;Solicitation of shareholders consent. Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationResponse">
-		<rdfs:label xml:lang="en">consent solicitation response</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationStart">
-		<rdfs:label xml:lang="en">consent solicitation start</rdfs:label>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;ConversionResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conversionActionAvailableResponseTakeNoActionResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;TakeNoActionResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isConversionFrom"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isConversionTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">conversion action</rdfs:label>
 		<skos:definition xml:lang="en">Conversion or optional exchange of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">conversion notification</rdfs:label>
-		<skos:definition xml:lang="en">Conversion or optional exchange of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">conversion response</rdfs:label>
-		<skos:definition xml:lang="en">Response of the holder is to convert. SWIFT: Convert (CONV)</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionSuspensionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">conversion suspension action</rdfs:label>
 		<skos:definition xml:lang="en">Suspensiion of conversion of securities generally a couple of weeks before a meeting takes place. SWIFT = SCOP</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionSuspensionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">conversion suspension notification</rdfs:label>
-		<skos:definition xml:lang="en">Suspensiion of conversion of securities generally a couple of weeks before a meeting takes place. SWIFT = SCOP</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-fi-fi;Security">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.8"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.8"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">corporate action</rdfs:label>
-		<skos:definition xml:lang="en">An event which has some effect on the details or terms of an issued Financial Security or on market perception of the value of that security.</skos:definition>
-		<skos:scopeNote xml:lang="en">Removed from scope of this term and moved to Issuer Corporate Action: &quot;This is an action which is compulsory on the issuer of the security.&quot; - REVIEW AND CLEAN OUT OF HERE Earlier review notes (pre refinement of this scope). REVIEW AND CLEAN OUT: Broader definition would also include things which might change the market price (for debt or equity), there asre things fo which you have to notify the market. these do not necessarily include changes to the details of the security. Most CAE will change the market perception. Not all actions which change the market perception are Corporate Events. Suggestion A corporate action is a generic class not actually homogenous, one of whcih si the Corporate Action of providin information to the market. There are legal requirements in most jurisdicitons saying that companies must advise their shareholders or bondhoders, about things whic might change the price. A separate kind of event notifies holders of securities (shares or bonds) of events which require an aciton on the part of the older (mandatory or bvoluntart) of the holder of the share. Then there are a set of events that don&apos;t get classified as CAE but have been included by SWIFT which are the actions by the holder, which would impact the issuer. These include calls on rights. Conclusion: There is one &quot;Corporate Event&quot; superclass of which everything is defined. earlier Event: Event has Terms and Conditions asspciated with it. Ts and Cs include mandatory and voluntary responses.</skos:scopeNote>
+		<skos:definition xml:lang="en">event carried out by a legal entity that affects the securities it issues and may have a material impact on its stakeholders, such as shareholders and creditors</skos:definition>
+		<skos:example xml:lang="en">Examples of corporate actions include stock splits, dividends, mergers and acquisitions, rights issues, and spin-offs.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Corporate actions are typically approved by a company&apos;s board of directors and authorized by the shareholders.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionAnnouncer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;FinancialSecuritiesActor"/>
-		<rdfs:label xml:lang="en">corporate action announcer</rdfs:label>
-		<skos:definition xml:lang="en">The party which makes the CA announcement. Best label for this? unclear. note that they may be issuers of other stock but they do not have to be. You can initiate a corporate action but you are not the issuer of that security, but the action is still about a particular security. Not all actions are bound to specific to a security/. A n action may impact one or more securities, The actions may require different communications. So we should probably distinguish actions versus communications about events. ADD: Communication. Example: Bell breakout. Sample use case for CAE.</skos:definition>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionClassificationScheme">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;ClassificationScheme"/>
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeSet"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasMember"/>
+				<owl:allValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;defines"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>corporate action classification scheme</rdfs:label>
+		<skos:definition>scheme for classifying corporate actions</skos:definition>
+		<fibo-fnd-utl-av:usageNote>The set of corporate actions and income events included herein are a subset of those specified in ISO 15022 Securities - Scheme for Messages (Data Field Dictionary). Other schemes that are specific to a custodian, depository, or regulatory agency may also be important, and should take a similar approach with respect to classification.</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionConfirmation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">corporate action confirmation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionHolderResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">corporate action holder response</rdfs:label>
-		<skos:definition xml:lang="en">Response by the Holder of a security, to a previous Offer made by the Issuer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Some CAE types fall under this heading. The action will specify what choices are available to the Holder by way of a response (for example cash, securities, no action and so on). See list ... Embedded as a scheme in a ISO 15022 field.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionNarrative">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">corporate action narrative</rdfs:label>
-		<skos:definition xml:lang="en">A message containing further narrative about some corporate action. This does not relate to any specific kind of action but is an additional stand-alone message.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Can extend information with user defined language and fields.</fibo-fnd-utl-av:explanatoryNote>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionClassifier">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDefinedIn"/>
+				<owl:onClass rdf:resource="&fibo-cae-ce-cae;CorporateActionClassificationScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-cae-ce-cae;CorporateActionClassificationScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">corporate action classifier</rdfs:label>
+		<skos:definition xml:lang="en">classifier that distinguishes income-oriented events from other corporate actions</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">ISO 15022 classifies events as impacting income vs. others.  Other classification schemes distinguish between actions that return profits to shareholders, actions that are designed to influence the share price, and actions involving a change in structure to the issuer organization.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionObligation">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;Duty"/>
 		<rdfs:label xml:lang="en">corporate action obligation</rdfs:label>
 		<skos:definition xml:lang="en">An obligation related to the holding of a Security.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Delivery of a security. Not defining direction at this level of the model - one party may have an obligation to deliver security or to pay; other party may have an obligation to deliver or to pay. Or there may be just one.</fibo-fnd-utl-av:explanatoryNote>
@@ -588,43 +414,26 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<skos:definition xml:lang="en">Some obligation to deliver some security in the thr context of corporate actions. All cash proceeds and security proceeds can be represented a s acontractual obligation. Where does that obligation arise? Usually in the Contract itself - but there may be other answers to this. Defines what has to be delivered. or paid. Entitlement meanwhile is a calculation based on the Contract.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionStatusMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">corporate action status message</rdfs:label>
-		<skos:definition xml:lang="en">A message which relates to the status of a corporate action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Example would be if there is a Tender Offer, and the offer has been accepted, then a processing instruction would be sent. Not to be confused with a message about the status of a security or company.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ChangeOfStateEvent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">corporate change of status event</rdfs:label>
 		<skos:definition xml:lang="en">Some change to the status of some security.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is generally described by a corporate event message. For example, change in trading status, listing status.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateEvent">
-		<rdfs:label xml:lang="en">corporate event</rdfs:label>
-		<skos:definition xml:lang="en">Events v Actions Notifiable versus non notifiable. Whether notfiable could be required by statute or by listing rules. Notifiable: Does this apply only to those events compulsory on the issuer? See Tender Offer. In takeover scenarios, the issuer will have actions incumbent o nthem to inform the market (e..g Aus Part B response). Offerer initiates Part A (Takeover Offer) with the details. Akin to a information memorandum or prospectus on the takeover. All interest parties (and non shareholders) have a potential interest, as it has a potential effect on the shares.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateEventProcess">
-		<rdfs:label xml:lang="en">corporate event process</rdfs:label>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateModificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">corporate modification event</rdfs:label>
 		<skos:definition xml:lang="en">Some change in details of some company, which needs to be described for publicly issued securities issued by that company.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Usually described in a corporate event message. Note that the change relates to the company, but notification about this, for publicly issued securities (shares, bonds) is notificed to the holders of each such security, as corporate event messages.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CouponStrip">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;BondAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.9"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -632,23 +441,71 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<skos:definition xml:lang="en">Coupon stripping is the process whereby interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CouponStripNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtIssuerCorporateActionNotification"/>
-		<rdfs:label xml:lang="en">coupon strip notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification that the debt security is to be stripped, that is that interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">THis will result in two securities where previously there was one. REVIEW: precise details for the relation between the stripped instrument and the traded interest and principal components (does one of the remain the same security, or are two new securities created and one retired?); also account for recombination. SWIFT full text: &quot;Coupon stripping is the process whereby interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DECR">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">DECR</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that reduce the face value of a share or the value of fund assets</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DecreaseInValueAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DecreaseInValueAction"/>
+		<lcc-lr:hasTag>DECR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CourtDecisionSubsequentMeeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
-		<rdfs:label xml:lang="en">court decision subsequent meeting</rdfs:label>
-		<skos:definition xml:lang="en">Meeting following a court decision.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Named according to the description. Original SWIFT name is &quot;Court Meeting&quot;, which is not what it is.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DRIP">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">DRIP</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DividendReinvestmentAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DividendReinvestmentAction"/>
+		<lcc-lr:hasTag>DRIP</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;Custodian">
-		<rdfs:label xml:lang="en">custodian</rdfs:label>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DSCL">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">DSCL</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DisclosureAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DisclosureAction"/>
+		<lcc-lr:hasTag>DSCL</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DVCA">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">DVCA</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that distribute cash to shareholders in proportion to their equity holding</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CashDividendAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CashDividendAction"/>
+		<lcc-lr:hasTag>DVCA</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DVOP">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">DVOP</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DividendOptionAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DividendOptionAction"/>
+		<lcc-lr:hasTag>DVOP</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DVSE">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">DVSE</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders in the form of equities of the issuing corporation</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;StockDividendAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;StockDividendAction"/>
+		<lcc-lr:hasTag>DVSE</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtDrawingNotification">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
@@ -657,223 +514,95 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtInstrumentBuybackNotification">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
 		<rdfs:label xml:lang="en">debt instrument buyback notification</rdfs:label>
 		<skos:definition xml:lang="en">Notification of an event where det securities are bought back by the issuer.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See also puts and calls (these are usually pre-arranged). Here the company goes out to the market and buys back their own debt. This does not really need to be a corporate event, they just do it. REVIEW: This term may not be needed. Not a corporate action.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtIssuerCorporateActionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">debt issuer corporate action notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtRedenomination">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.10"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt redenomination</rdfs:label>
-		<skos:definition xml:lang="en">Event by which the unit (currency and/or nominal) of a debt is restated, eg, a debt in a national currency unit is restated in euro.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Would be notified in advance.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtSecurityAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:label xml:lang="en">debt security action</rdfs:label>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;DecreaseInValueAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">decrease in value action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action resulting in a reduction of face value of a share or the value of fund assets</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The number of circulating shares/units remains unchanged. This event may include a cash pay out to holders.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;DetachmentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">detachment action</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DetachmentNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AttachmentOrDetachmentNotificationMessage"/>
-		<rdfs:label xml:lang="en">detachment notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of separation of components that comprise a security - usually units comprised of warrants and bond or warrants and equity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Units may be broken up at the request of the security holder or based on market convention. Scope: See Attachment. SWIFT Full text: &quot;Separation of components that comprise a security - usually units comprised of warrants and bond or warrants and equity. Units may be broken up at the request of the security holder or based on market convention.&quot;</fibo-fnd-utl-av:explanatoryNote>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;DisclosureAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+		<rdfs:label xml:lang="en">disclosure action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action involving a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This event only occurs with the characteristic VOLU, otherwise it is part of the SRD II.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DeterminationEvent">
-		<rdfs:label xml:lang="en">determination event</rdfs:label>
-		<skos:definition xml:lang="en">An Event in which some amount or other parameter is determined, independently of any other event in which that which was determined is put into use. For example, the event by which interest is determined, as distinct from the event by which interest is paid on a different date or time.</skos:definition>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendOptionAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
+		<rdfs:label xml:lang="en">dividend option action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Shareholders may choose to receive shares or cash. A dividend option action is distinguished from reinvestment (DRIP) as, like a cash dividend, the company creates new share capital in exchange for the dividend rather than investing the dividend in the market.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DisbursementResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">disbursement response</rdfs:label>
-		<skos:definition xml:lang="en">Response by a holder to some choice of disbursement method, as offered by the issuer in some corporate action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a generalization of a range of possible responses to offers by an issuer, which may be made in a number of Corporate Actions. Not all responses are available in all instances, and the Corporate Action notitificaiton will generally define which actions are held out to the Holder for a specific action; also some action types by their nature will be constrained to a sub set of these kinds of response. Note that this action (of choosing) is communicated to the Issuer by some message; the SWIFT terms for the messages are replicated here as kinds of Action which correspond to those. Hence the Action types and Message types are the same, and have the same origin in the SWIFT messages.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DisbursementResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">disbursement response message</rdfs:label>
-		<skos:definition xml:lang="en">Message conveying the response by a holder to some choice of disbursement method, as offered by the issuer in some corporate action.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DisclosureMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">disclosure message</rdfs:label>
-		<skos:definition xml:lang="en">Disclosure of some fact or facts, by the holder of some security, as a result of some formal requirement imposed upon holders or beneficial owners under some applicable regulation.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The message modeled here is the message in which the disclosure is made. Individual types of disclosure are not modeled and may vary across jurisdictions. A fact about the disclosure is the regulation under which it was required to be made. Another fact is the disclosing party, that is the holder or beneficial owner. Note that in the Business Entities ontology, beneficial ownership is modeled separately from control ownership. This type of message may result from formal requirements placed upon either. SWIFT Full text: &quot;Requirement under some regulations for holders or beneficial owners to disclose&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryDistribution"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dividend distribution</rdfs:label>
-		<skos:definition xml:lang="en">Any event relating to a dividend payment.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">dividend distribution notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendOption">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">dividend option</rdfs:label>
-		<skos:definition xml:lang="en">Distribution of a dividend to shareholder with the choice of payment method. Shareholder must choose the form of payment - stock, cash, or both.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendOptionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">dividend option notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendReinvestment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">dividend reinvestment</rdfs:label>
-		<skos:definition xml:lang="en">Dividend payment where cash dividend is rolled over into additional shares in the issuing company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Announcement would by that either get stock or cash. May have an announcement that pays a stock dividend only - hence this would be a bonus Issue. Dividend reinvestment is a choice on the part of the Holder but is not part of the announcement.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendReinvestmentNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">dividend reinvestment notification</rdfs:label>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendReinvestmentAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
+		<rdfs:label xml:lang="en">dividend reinvestment action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Dividend reinvestment is distinguished from a cash dividend in that the issuer invests the dividend in the market rather than creating new share capital in exchange for the dividend.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;Drawing">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">drawing</rdfs:label>
 		<skos:definition xml:lang="en">Redemption in part before the scheduled final maturity date of a security.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notification in advance of this happening.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;DutchAuction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">dutch auction</rdfs:label>
 		<skos:definition xml:lang="en">Similar to a tender offer, a Dutch auction is an action by a party wishing to acquire a particular security. Current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings. UPDATE THIS DEFINITION: Similar to a tender offer, a Dutch auction is the result of an action by a third party wishing to acquire a particular security. Current holders of the targeted security are invited (and given a message by the issuer) to make an offer in which they would be willling to sell their holdings. OR It might also represent a separate scenario where third parties do this, as per the original SWIFT defition. You can only go to the Registrar which would the other scenario impossible. Agents and Registrars: The issue issuer os the company which issued the shares (as modeled); Most companies don&apos;t interact directly with the market to find out who they need to disseminate the info to. They can, but more likely the employ &quot;Issuers Agent&quot;. That provides one point of contact from the organization. That agent handles all coms with the Registrars, and to the news wires etc., to disseminate the corporate action. Context: CAE only, or in the context of the Issue? When you issue the security you nominate an Agent, in the prospectus, there is specified an Issuing Agent. This is the one that does these things. Usually a merchant bank etc. in the old days. This is who will have directly facilitated that direct market engagement. Next question: This is part of going public, so these agents are appointed as part of going public.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The party to which the offer is made need not be the holder. Details: Question on &quot;Who is the actor?&quot; Dutch auction would have multiple parties? What is the scenario? Usually happens when a company is about to go into administration. Looking at the scneario descried in the SWIFT definition - not clear if this is the only such scenario. Possibly the issuer has to notif ythe shareholders that the offer is being made. The offer is made by the third party but the notice is sent by the issuer (via their agent) and via the registrar who holds the details of who holds all the shares. Example: Lloyds banking group - most shares would be owned by the market, and a small percentage might be held by private investors. So in this scenario everyone has to be given the opportunity to sell at the given price. so the CAE message is still issued by the Issuer. SWIFT detailed names (synonym?) &quot;Dutch Auction, Bid Tender&quot;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DutchAuctionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyFormalOfferNotification"/>
-		<rdfs:label xml:lang="en">dutch auction notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a Dutch auction, that is an action by a party wishing to acquire a particular security. Under the terms of this offer, current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See notes for the event itself - there is some unclarity as to whether this notification supports one message flow or several i.e. whether it is from third party, from Issuer&apos;s Agent to holders, from third party to Issuers Agent, or all three. REVIEW SWIFT full text: &quot;Similar to a tender offer, a Dutch auction is an action by a party wishing to acquire a particular security. Current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXTM">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">EXTM</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve prolonging the maturity date of a bond</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;MaturityExtension"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;MaturityExtension"/>
+		<lcc-lr:hasTag>EXTM</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;EventAnnouncement.1">
-		<rdfs:label xml:lang="en">event announcement</rdfs:label>
-		<skos:definition xml:lang="en">An Event whereby some parties announces its intention to carry out some act at some present or future time. An Announcement is defined relative to the Event that is announced, for example the announcement of the issue of a financial security is defined in relation to the issue of a security (an Issuance Event).</skos:definition>
-		<skos:definition xml:lang="en">The announcement</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;EventNotification">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;communicatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">event notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExPostNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">ex post notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an event that is expected or unexpected and has happened.</skos:definition>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXWA">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">EXWA</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that offer holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;WarrantExerciseAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;WarrantExerciseAction"/>
+		<lcc-lr:hasTag>EXWA</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ExchangeOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOffer"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.12"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">exchange offer</rdfs:label>
 		<skos:definition xml:lang="en">Exchange offer; Capital reorganisation. Offer to shareholders to exchange their holdings for other securities and/or cash. Exchange offers are usually voluntary. Example: Where the &quot;usually voluntary&quot; comes in is that Announcement Payout Option 1: Cash 2. Stocks 3. Cash and Stock Holder picks option 1, 2 or 3 (= 1 &amp; 2). the voluntary aspect is where it&apos;s an Exchange Offer. It&apos;s mandatory to pick one of 1 - 3. Otherwise defaults to cash on payment date. Option Payout Componnet is the terms for the choice. Exchange Offer may be voluntary, not always Mandator With Choice. for example, there are legal qualifications on what is possible. Preceded by Tender Offer. Consequences dependent on scenarios. Once the firm making the offer gets to a given (legally defined) threshold e.g. 90% then they have the right to acquire all of the outstanding shares. An Exchange Offer is therefore a specialization of a Tender Offer. It&apos;s the specialization where the above mentioned requirements have been met. Further detail: Happens in a wider range of circumsntaces. Is soecifically associated with the issuer. this could be voluntary or not. EXOF could be any of the three (mand, vol, man w choice). tendre is always voluntary.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExchangeOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOfferNotification"/>
-		<rdfs:label xml:lang="en">exchange offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an offer to shareholders to exchange their holdings for other securities and/or cash.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Exchange offers are usually voluntary. Full SWIFT Definition text: &quot;Exchange offer; Capital reorganisation. Offer to shareholders to exchange their holdings for other securities and/or cash. Exchange offers are usually voluntary.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExerciseAction">
-		<rdfs:label xml:lang="en">exercise action</rdfs:label>
-		<skos:definition xml:lang="en">Some action in which spome party decides to exercise some option or some optionality concept.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These include puts and calls - I can put it to you or I can call it from you. can also be full or partial. Hence full call, partial call. Note that in Bonds, only the Issuer can call it, and only the Holder can Put it. However with this exception / narrowing of scope, the meaning of Put and Call are the same as for any other context, it&apos;s just that the implied other two cominations are not realizable in the world of Bonds.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExerciseExChangeOptionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
-		<rdfs:label xml:lang="en">exercise ex change option notification</rdfs:label>
-		<skos:definition xml:lang="en">Exchange options are mentioned in the terms and conditions of a security and are valid during the whole lifetime of a security. SWIFT: &quot;Option for shareholders to exchange their holdings for other secuities and/or cash. Exchange options are mentioned in the terms and conditions of a security and are valid during the whole lifetime of a security.&quot;</skos:definition>
-		<skos:definition xml:lang="en">Notification of exercise by Holder of an exsting option for shareholders to exchange their holdings for other securities and/or cash.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExerciseExchangeOption">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableChoices"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exercise exchange option</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExtraordinaryGeneralMeeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
-		<rdfs:label xml:lang="en">extraordinary general meeting</rdfs:label>
-		<skos:definition xml:lang="en">Extraordinary General Meeting</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FinancialSecuritiesActor">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;hasSomeRoleIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial securities actor</rdfs:label>
-		<skos:definition xml:lang="en">Some actor which has some agency in securities issuance or trading, or is some third party in such.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Is generally also a Party to some security, but need not be (e.g. hostile take-over bid actor).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;FormalOffer">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">formal offer</rdfs:label>
 		<owl:equivalentClass>
 			<owl:Class>
@@ -892,148 +621,42 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<skos:definition xml:lang="en">Event which is an offer to the holder or potential holder or other intersted party, to enter into a trade which is or would be legally binding on the part of the party making the offer (the offeror).</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FullCall">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CallAction"/>
-		<rdfs:label xml:lang="en">full call</rdfs:label>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;FullCallEarlyRedemptionAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">full call early redemption action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
+		<skos:example xml:lang="en">Examples securities that may be subject to a full call/early redemption include bonds, preferred equity, funds, that may be redeemed by the issuer or its agent before final maturity.</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FullExerciseAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
-		<rdfs:label xml:lang="en">full exercise action</rdfs:label>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;INTR">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">INTR</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve distribution of a regular interest payment to holders of an interest-bearing asset</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
+		<lcc-lr:hasTag>INTR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FundCapitalGainsDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryDistribution"/>
-		<rdfs:label xml:lang="en">fund capital gains distribution</rdfs:label>
-		<skos:definition xml:lang="en">Distribution of profits resulting from the sale of securities. Shareholders of Mutual Funds, Unit Trusts, or Sicavs are recipients of capital gains distributions which are often reinvested in additional shares of the fund.</skos:definition>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;CorporateActionClassificationScheme"/>
+		<rdfs:label>ISO 15022 corporate action classification scheme</rdfs:label>
+		<skos:definition>scheme for classifying corporate actions according to ISO 15022 Securities - Scheme for Messages (Data Field Dictionary)</skos:definition>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FundCapitalGainsDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistributionNotification"/>
-		<rdfs:label xml:lang="en">fund capital gains distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of distribution to shareholders of funds, of profits resulting from the sale of securities.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Shareholders of Mutual Funds, Unit Trusts, or Sicavs are recipients of capital gains distributions which are often reinvested in additional shares of the fund. SWIFT full text: &quot;Distribution of profits resulting from the sale of securities. Shareholders of Mutual Funds, Unit Trusts, or Sicavs are recipients of capital gains distributions which are often reinvested in additional shares of the fund.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderDisclosure">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-		<rdfs:label xml:lang="en">holder disclosure</rdfs:label>
-		<skos:definition xml:lang="en">An action by a holder to voluntarily disclose some information. Examples: ENRON Disclosure rules. This is an action by the Holder on discovery of their legal requirement. Is there an Issuer action If so there may be an Issuer action asking for such disclosure. Or this may not exist since at the time of the action the Issuer should know all this. Conclusion: From a CA viewpoint specifically, the Disclosure would be from the holder.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderDisclosureMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
-		<rdfs:label xml:lang="en">holder disclosure message</rdfs:label>
-		<skos:definition xml:lang="en">An action by a holder to voluntarily disclose some information.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT:&quot;Requirement under some regulations for holders or beneficial owners to disclose&quot; This comes from examples such as ENRON, and is a message in which the holdler of the security volunteers some information without prompting.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">holder event</rdfs:label>
-		<skos:definition xml:lang="en">A CAE event relating to actions on the part of the holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Change of ownership has a message. Someone has to communicate the exercise.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitatedActionStart">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;flow"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;HolderInitiatedActionInitiation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">holder initated action start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">holder initiated action</rdfs:label>
-		<skos:definition xml:lang="en">Any action initiated by a Holder of a Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedActionEnd">
-		<rdfs:label xml:lang="en">holder initiated action end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedActionInitiation">
-		<rdfs:label xml:lang="en">holder initiated action initiation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedInstruction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InstructionMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">holder initiated instruction</rdfs:label>
-		<skos:definition xml:lang="en">A message being an instruction by the holder of some security, made not in response to come choice offered by the issuer, but made on the holder&apos;s own initiative.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a general category of message. Note that there is one kind of message of this type in the original SWIFT-derived list of event message types, however it is assumed there must be others.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderMeetingResponse">
-		<rdfs:label xml:lang="en">holder meeting response</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InstructionMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">holder response message</rdfs:label>
-		<skos:definition xml:lang="en">A message conveying the Holder&apos;s choice in some Corporate Action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The message identifies the Corporate Action that they are a response to. In the event that they are not, this is highlighted in the message instructions - these are identified as such as in the ISO 15022 descriptions. See worksheet: some responses can be responses to more than one kind of message. Based on the type of notificaiton, there are various applicable response types. Based on the message sent out as a notification there are some or all of these responses, as being the possible responses to the message itself. That is down to the notifying party. Specified in the Notification what available responses there are.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderResponseToChoice">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;givesRiseTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">holder response to choice</rdfs:label>
-		<skos:definition xml:lang="en">Instructions consequent upon notifications. Instruction messages - some of these are responses to notifications. May be MT 565 related - has consent Yes, consent No, no action, accept shares, accept cash and securities etc. There are also ones that can be initiated by holders (not in this process step) such as puts. These can be presented without a notification previously having been sense. These are the ones we deided not to classify as &quot;Corporate Actions&quot; as these can be initiated by the holder. As such these are an instruction rather than a notification.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InformationAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">information action</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These will have an Effective date. Similar to name change - actions where there is nothign the Holder can do about it, but there is an action at a certain date.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InformationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
-		<rdfs:label xml:lang="en">information event</rdfs:label>
-		<skos:definition xml:lang="en">A corporate event which is simply a notification about something. People may wish to respond</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InstalmentCall">
-		<rdfs:label xml:lang="en">instalment call</rdfs:label>
-		<skos:definition xml:lang="en">Increase of share capital through additional payment on face value of partly-paid shares, with part payments in several instalments. SWIFT = PPMT</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InstructionMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">instruction message</rdfs:label>
-		<skos:definition xml:lang="en">A message which embodies some instruction.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review whether we need this.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PaymentOrInterestPaymentAction"/>
-		<rdfs:label xml:lang="en">interest payment</rdfs:label>
-		<skos:definition xml:lang="en">Payment of Interest to the Holder. Further notes: Are there options on the Holder? Yes, you can opt to be paid in a certain currency. It is not always defined in the security terms. So if the Terms in the Security terms sheet gives you an option, there is a choice for the Holder at this point. Such choices would include: - Currency - Pay in Kind (&quot;Spinoff&quot; or PiK - see PiK corporate Action) Could be mandatory. If there were an option then the letter announcing it would require a response. This is usually stated in the message. Is there a message even if there is no option? Yes. Usually have to generate the events artificially as the Servicing organization. you can&apos;t rely on a feed or message coming in but because it is part of the security contract the above has to generate at the expected time, and arrange the payments. Q: That is the point at there was a choice you would expect to see a message, or end up still having to generate it but with the choices. A: The ones with Choices come as announcements and don&apos;t ave to be generated by the Service. Older definitin (re-scoped now: An Event in which a payment occurs. Anything can have a payment event. If a thing hits a pay date, whether it&apos;s voluntary or mandatory, that&apos;s a payment event. Divide into: Securities Cash Combination Payment or Distribution? Are these exclusive? Take an event that&apos;s always a combination of options, and an option is a combination of payouts. Generates transactions - determine what txns happen when a customer chooses that option. Distribution / delivery: generic concept Payment - implis cash distribution. So payment is specialization of distribution.</skos:definition>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;IncomeOrientedAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
+		<rdfs:label xml:lang="en">income-oriented action</rdfs:label>
+		<skos:definition xml:lang="en">classifier of corporate actions that impacts income to shareholders</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Cash dividends are a classic example where a public company declares a dividend to be paid on each outstanding share. Bonus is another case where the shareholder is rewarded. In a stricter sense, the bonus issue should not impact the share price but in reality, in rare cases, it does and results in an overall increase in value.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InterestPayment"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">interest payment action</rdfs:label>
-		<skos:definition xml:lang="en">Regular interest payment, only in cash, distributed to holders of an interest bearing asset. According to the terms of the issue, a bondholder may be able to elect the currency interest is paid in.</skos:definition>
+		<skos:definition xml:lang="en">corporate action that involves distribution of a regular interest payment to holders of an interest-bearing asset</skos:definition>
+		<skos:editorialNote xml:lang="en">Further notes: Are there options on the Holder? Yes, you can opt to be paid in a certain currency. It is not always defined in the security terms. So if the Terms in the Security terms sheet gives you an option, there is a choice for the Holder at this point. Such choices would include: - Currency - Pay in Kind (&quot;Spinoff&quot; or PiK - see PiK corporate Action) Could be mandatory. If there were an option then the letter announcing it would require a response. This is usually stated in the message. Is there a message even if there is no option? Yes. Usually have to generate the events artificially as the Servicing organization. you can&apos;t rely on a feed or message coming in but because it is part of the security contract the above has to generate at the expected time, and arrange the payments. Q: That is the point at there was a choice you would expect to see a message, or end up still having to generate it but with the choices. A: The ones with Choices come as announcements and don&apos;t ave to be generated by the Service. Older definitin (re-scoped now: An Event in which a payment occurs. Anything can have a payment event. If a thing hits a pay date, whether it&apos;s voluntary or mandatory, that&apos;s a payment event. Divide into: Securities Cash Combination Payment or Distribution? Are these exclusive? Take an event that&apos;s always a combination of options, and an option is a combination of payouts. Generates transactions - determine what txns happen when a customer chooses that option. Distribution / delivery: generic concept Payment - implis cash distribution. So payment is specialization of distribution.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentInKind">
@@ -1049,10 +672,10 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestRateAdjustment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.13"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;VariableCouponBond"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1061,60 +684,9 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The SWIFT definition as given defines the notification of the interest rate change, not the adjustment. Adjusted to describe the event. REVIEW: Is this really an action? Usually consider that it&apos;s expected. Given definition was for the announcement. SWIFT full definition &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestRateAdjustmentNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExPostNotification"/>
-		<rdfs:label xml:lang="en">interest rate adjustment notification</rdfs:label>
-		<skos:definition xml:lang="en">Announcement of the current coupon rate for a floating or adjustable rate security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Definition as given refers to this notification (message) rather than the event itself. This is done for completeness, and sent out as a Notification by the Issuer or the Issuer&apos;s Agent. SWIFT Full definition: &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;announcedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionAnnouncer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuer corporate action</rdfs:label>
-		<skos:definition xml:lang="en">Some corporate action initiated by the issuer of the Security. This is an action which is compulsory on the issuer of the security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is most of the kinds of action generally thought of as &quot;Corporate Actions&quot;. These may be mandaytory, voluntary, or mandatory with one or more choices fo rthe holder to make. This is the term for which it is mandatory on the issuer to notify this event to the marketplace and / or to holders of the security.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerCorporateActionAnnouncer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionAnnouncer"/>
-		<rdfs:label xml:lang="en">issuer corporate action announcer</rdfs:label>
-		<skos:definition xml:lang="en">The announcer of an event which is also the issuer of the security that the event is about.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arr-doc;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuer corporate action notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an action by the issuer of the security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerFormalOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">issuer formal offer</rdfs:label>
-		<skos:definition xml:lang="en">An action in which the issuer of the security makes a formal offer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Encompasses Exchange Offer and Repurchase Offer. Note that there are also offers made by third parties. These do not come under this term.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerFormalOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">issuer formal offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of some formal offer by the issuer of the security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;LiquidationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationEvent"/>
-		<rdfs:label xml:lang="en">liquidation event</rdfs:label>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;LiquidationAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">liquidation action</rdfs:label>
 		<skos:definition xml:lang="en">Liquidating dividend/Liquidation consist of a distribution of cash, assets, or both. Debt may be paid in order of priority based on preferred claims to assets specified by the security. SWIFT = LIQU</skos:definition>
 	</owl:Class>
 	
@@ -1124,210 +696,125 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<skos:definition xml:lang="en">Security is no longer able to comply with the listing requirements of a stock exchange and is removed from official board quotation.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ManagementAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">management action</rdfs:label>
-		<skos:definition xml:lang="en">An event relating to the management of a company or other concern.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCashDividendEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendEvent"/>
-		<rdfs:label xml:lang="en">mandatory cash dividend event</rdfs:label>
-		<skos:definition xml:lang="en">Cash dividend with no option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCashDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendNotification"/>
-		<rdfs:label xml:lang="en">mandatory cash dividend notification</rdfs:label>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;MCAL">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">MCAL</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;FullCallEarlyRedemptionAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;FullCallEarlyRedemptionAction"/>
+		<lcc-lr:hasTag>MCAL</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">mandatory corporate action</rdfs:label>
-		<skos:definition xml:lang="en">An event where there are no choice on the part of the Holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">for the purposes of clarity: Mandatory here means mandatory on the holder. Corporate Events as a whole are defined in terms of being mandatory on the part of the Issuer. In other words, Mandatory actions versus mandatory reactions. See Barron&apos;s: Dictionary of banking terms - no definition of Corporate Action.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCorporateEventProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventProcess"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;hasStart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;MandatoryEventStart"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mandatory corporate event process</rdfs:label>
-		<skos:definition xml:lang="en">Mandatory corporate event: Action requires an action by the shareholder Corporate action event initiated by the corporation. Participation by shareholders is mandatory (for those relating to shares).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryEventEnd">
-		<rdfs:label xml:lang="en">mandatory event end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryEventStart">
-		<rdfs:label xml:lang="en">mandatory event start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryPutEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PutAction"/>
-		<rdfs:label xml:lang="en">mandatory put event</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;OptionalPut"/>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is a Put Bond, which is a kind of option in the sense that in return for getting less yield it allows you to put it back to the issuer. This means Put is a voluntary event. Therefore Mandatory Put is nonsensical? discussion: Or is it? If you are the issuer (therefore the granter of the option) then the event is to the holder). Partly paid shre for example gives the issuer the right to call funds but also has the right to put. So put is not by definition ... someone can have the right to put something. Conclusion: these do not appear to make sense as terms. A put bond allows the holder to redeem the issue. So this is by definition a voluntary event. Conclusion: go back to Pershing and find out what this term meant. Also we don&apos;t even know what kind of security this event was intended to refer to. We assume it refers to Put bond. This is on the assumption that Options can&apos;t be defined as having corporate action.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">event initiated by the board of directors of the corporation that affects all shareholders</skos:definition>
+		<skos:example xml:lang="en">Examples of mandatory corporate actions include cash dividends, stock splits, mergers, pre-refunding, return of capital, bonus issue, asset ID change, and spin-offs.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Mandatory means mandatory participation by all shareholders, however the shareholder is not required to do anything.  Shareholders are passive beneficiaries of mandatory actions.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">mandatory with choice corporate action</rdfs:label>
-		<skos:definition xml:lang="en">An event which is going to happen but there are choices to be made by the Holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is usually some default, e.g. if you don&apos;t choose by the payment date there is some default e.g. the issue currency. Voluntary differ from this in that the Holder chooses whether to do anything or not.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">mandatory corporate action where shareholders are given an opportunity to choose among several options</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In case a shareholder does not submit the election, the default option will be applied.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;MaturityExtension">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;BondAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">maturity extension</rdfs:label>
-		<skos:definition xml:lang="en">As stipulated in a bond&apos;s Terms and Conditions, the issuer or the bondholder may prolong the maturity date of a bond. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This would ne notified in advance. Fits into the normal &quot;Action&quot; workflow. SWIFT = EXTM</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MaturityExtensionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">maturity extension notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an extension to the maturity date of a bond by the issuer, in line with existing terms and conditions.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As stipulated in a bond&apos;s Terms and Conditions, the issuer or the bondholder may prolong the maturity date of a bond. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval. Note that the definition given for this in SWIFT is really narrative. New definition drafted in its place. SWIFT Full Text &quot;As stipulated in a bond&apos;s Terms and Conditions, the issuer or the bondholder may prolong the maturity date of a bond. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;Meeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ManagementAction"/>
-		<rdfs:label xml:lang="en">meeting</rdfs:label>
-		<skos:definition xml:lang="en">A Management Event in which stakeholders meet one another either face to face or through some electronic or voice medium, in order to process some management activity (the Agenda).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MeetingProcessEnd">
-		<rdfs:label xml:lang="en">meeting process end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MeetingProcessStart">
-		<rdfs:label xml:lang="en">meeting process start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;NonIssuerCorporateActionAnnouncer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionAnnouncer"/>
-		<rdfs:label xml:lang="en">non issuer corporate action announcer</rdfs:label>
-		<skos:definition xml:lang="en">The announcer of an event which is not the issuer of the security that the event is about.</skos:definition>
+		<skos:definition xml:lang="en">corporate action that, as stipulated in a bond&apos;s terms and conditions, the issuer or the bondholder may prolong the maturity date of a bond</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval. May be mandatory or voluntary, depending on who initiates it and the surrounding circumstances.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;NotificationEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">notification event</rdfs:label>
 		<skos:definition xml:lang="en">A notification to the shareholders that therre is a corporate action out there. This is distinct from the CA itself. not the same as Event Announcement. There are steps between when the announcement happens and the rest Announcement: at the level of sub custodians. then you gether the people who are affected by the event that&apos;s to come. Then you send the announcement - a notification to the holder, informing them of the options that are available to them. If it&apos;s mandatory these distinctions still happen, but there is no choice. So still announcement is made, then when it effects people you send out notificaiton and collect responses. &quot;EVENT&quot;: two aspects: The event itself Events within the Corporat eAction, e.g. notification, deadline when a responses is due by, payment dates, Define as: lifecycle of the Corporate Action. Sometimes have to re-notify, there may be changes in the life oc the &quot;Corporate Event&quot;. So the Corporate Event is a sequence of events.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;OddLotSale"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">odd lot offer</rdfs:label>
 		<skos:definition xml:lang="en">Offer by issuer to allow holders of an odd lot of a security to order a commission-free transaction at market price, to sell the odd lot, or to buy an amount of shares which will bring the position to a round lot (board lot). SWIFT = ODLT</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotOfferMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">odd lot offer message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotSale">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">odd lot sale</rdfs:label>
-		<skos:definition xml:lang="en">Sale of odd-lot back to the issuing company.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotSaleInstruction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;OddLotSale"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">odd lot sale instruction</rdfs:label>
-		<skos:definition xml:lang="en">Notification of holder choice to sell odd-lot back to the issuing company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is in response to the Issuer-initiated Corporate Action in which they make an Odd Lot Offer. SWIFT: Term:&quot;Odd Lot Sale&quot; Definition:&quot;Sale of odd-lot back to the issuing company.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OptionalCashDividendEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendEvent"/>
-		<rdfs:label xml:lang="en">optional cash dividend event</rdfs:label>
-		<skos:definition xml:lang="en">Cash dividend with currency options. This is a dividend payment where payment is mandatorily in the form of Cash. The choice is what currency the cash is to be received in.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OptionalCashDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendNotification"/>
-		<rdfs:label xml:lang="en">optional cash dividend notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OptionalPut">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PutAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
-		<rdfs:label xml:lang="en">optional put</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OrdinaryGeneralMeeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
-		<rdfs:label xml:lang="en">ordinary general meeting</rdfs:label>
-		<skos:definition xml:lang="en">Ordinary General Meeting SWIFT = OMET</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OrganizationModificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
-		<rdfs:label xml:lang="en">organization modification event</rdfs:label>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;OrganizationNameChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;OrganizationModificationEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
 		<rdfs:label xml:lang="en">organization name change</rdfs:label>
 		<skos:definition xml:lang="en">The issuing company changes it&apos;s name. Event shows the change from old name to new name and may involve surrendering physical shares with the old name to the registrar. SWIFT = NAME</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialCall">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CallAction"/>
-		<rdfs:label xml:lang="en">partial call action</rdfs:label>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;PCAL">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">PCAL</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PartialRedemptionWithReductionOfNominalValueAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PartialRedemptionWithReductionOfNominalValueAction"/>
+		<lcc-lr:hasTag>PCAL</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;PRED">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">PRED</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PartialRedemptionWithoutReductionOfNominalValueAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PartialRedemptionWithoutReductionOfNominalValueAction"/>
+		<lcc-lr:hasTag>PRED</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;PRIO">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">PRIO</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a public offer where priority is given to existing shareholders</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PriorityIssue"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PriorityIssue"/>
+		<lcc-lr:hasTag>PRIO</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialDefeasanceAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">partial defeasance action</rdfs:label>
 		<skos:definition xml:lang="en">The setting aside by a borrower of cash or bonds sufficient to service the borrower&apos;s debt.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From Free dictionary: Both the borrower&apos;s debt and the offsetting cash or bonds are removed from the balance sheet. In securities trading, where a clearing house becomes counterparty to each side of a trade, after the trade has been agreed. This is necessary to facilitate netting, and reduce counterparty risk exposure. The term has become popular recently, because of the growth of central counterparty clearing services in European cash equities markets. Origin: http://financial-dictionary.thefreedictionary.com/defeasance SWIFT: Term:PDEF; &quot;Partial Defeasance/Prefunding&quot; Definition:&quot;Issuer has money set aside to redeem a portion of an issue and the indenture states that the securities could be called earlier than the stated maturity.&quot;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialExerciseEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
-		<rdfs:label xml:lang="en">partial exercise event</rdfs:label>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialRedemptionWithReductionOfNominalValueAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+		<rdfs:label xml:lang="en">partial redemption with reduction of nominal value action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The outstanding amount of securities will be reduced proportionally.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PaymentOrInterestPaymentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">payment or interest payment action</rdfs:label>
-		<skos:definition xml:lang="en">The payment of some mandatory payment as defined in the contractual terms of the security, such as interst payment of amortization. this is income generated to the HOlder because of the security contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is distinct from any other kind of distribution based on the Issuer deciding to do something;l in this case the OIssuer has no choice (these are payments defined in contractual terms) and if they do not do it,. this is a Default</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PayoutOptionTerms">
-		<rdfs:label xml:lang="en">payout option terms</rdfs:label>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialRedemptionWithoutReductionOfNominalValueAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+		<rdfs:label xml:lang="en">partial redemption without reduction of nominal value action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is commonly done by pool factor reduction.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;PlaceOfIncorporationChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;OrganizationModificationEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
 		<rdfs:label xml:lang="en">place of incorporation change</rdfs:label>
 		<skos:definition xml:lang="en">Changes in the state of incorporation for US companies and changes in the place of incorporation for foreign companies. Where shares need to be registered following the incorporation change, the holder(s) may have to elect the registrar. SWIFT = PLAC</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;PostMergerSecuritiesExchange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;definesAdditional"/>
@@ -1337,13 +824,13 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;exchangesFrom"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;exchangesInto"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">post merger securities exchange</rdfs:label>
@@ -1351,42 +838,66 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an action as a result of the Merger, not the merger itself.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PostMergerSecuritiesExchangeNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">post merger securities exchange notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of mandatory or voluntary exchange of outstanding securities as the result of two or more companies combining assets.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Cash payments may accompany share exchange. Note that the event to which this applies was labeled &quot;Merger&quot; in source material but refers to the exchange of securities following a merger, not the merger itself. SWIFT full definition &quot;Mandatory or voluntary exchange of an outstanding securities as the result of two or more companies combining assets. Cash payments may accompany share exchange.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;PriorityIssue">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">priority issue</rdfs:label>
-		<skos:definition xml:lang="en">Form of open or public offer where priority is given to existing shareholders due to limited amount of securities available in the offer. Shareholders can buy a type of security during a short period of time.</skos:definition>
+		<skos:definition xml:lang="en">corporate action that is a public offer where, due to a limited amount of securities available, priority is given to existing shareholders</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PutAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-		<rdfs:label xml:lang="en">put action</rdfs:label>
-		<skos:definition xml:lang="en">The putting of some debt security back to its issuer by the holder</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note this is a holder action. There may be terms in the security giving the holder the ability to redeem early. If so, this is the event where that happens. Could apply to MTN as well as Bonds. We have defined MTN as a kind of Bond in this model. Review discussion: scope fo this: You could in theory put a share but no-one has come across this. Issuer may buy back shares at a given price but that&apos;s a different context - there&apos;s message for that. Makes an offer to repurchase shares. So therefore it is not possible in principle to have a call fo ra non debt instrument. In other circumstances e.g. compulsory acquisition in a takeover, is equivalent to this but it&apos;s a different term.</fibo-fnd-utl-av:explanatoryNote>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;PutRedemptionAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+		<rdfs:label xml:lang="en">put redemption action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action involving early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;Redemption">
-		<rdfs:label xml:lang="en">redemption</rdfs:label>
-		<skos:definition xml:lang="en">Repayment in full of a debt security, investment trust or a preferred stock issue, at stated maturity. SWIFT = REDM</skos:definition>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;REDM">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">REDM</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities at final maturity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;RedemptionAtMaturityAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;RedemptionAtMaturityAction"/>
+		<lcc-lr:hasTag>REDM</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;REDO">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">REDO</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions by which the unit (currency and/or nominal) of a security is restated</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;RedenominationAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;RedenominationAction"/>
+		<lcc-lr:hasTag>REDO</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-cae-ce-cae;RedemptionAtMaturityAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">redemption at maturity action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves redemption of an entire issue outstanding of securities at final maturity</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-cae-ce-cae;RedenominationAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">redenomination action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action by which the unit (currency and/or nominal) of a security is restated</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, the nominal/par value of security in a national currency is restated in another currency.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ReverseStockSplit">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AdviceOfAPossibleAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.15"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">reverse stock split</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
+		<skos:definition xml:lang="en">corporate action involving a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equity price and nominal value are increased accordingly.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">change in nominal value</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsDistribution">
@@ -1400,7 +911,7 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.16"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1409,14 +920,8 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Does the Rights Distribution have to be proportion to the Shareholding? Sometimes this is offered at market prices, so all you are doing is offering shareholders the right to purchase. Conclusion: Not &quot;in proportion&quot; at all. REVISE: May also have Bonus Rights Issue, where you don&apos; have a subscriptiojn price. This works like a rights issue but without a price attached to it. The rate of how many you can buy is definitely in proportion to your holding. The rate of distribution of the right is proportional to the holdings. Another difference: A Rights thing you have to pay for the additional shares if you choose to purchase them (exercise the right) whereas a Bonus Issue you do not pay, you get them outright for free. TWO PARTS: 1. Distribution of the rights in proportion to their holding 2. Exercise of the Rights. Hence RHDI v EXRI where EXRI is the exercising of the right to purchase the shares. The Rights that are distributed is a formal &quot;Rights&quot; instrument. This may have the sort of features we see in other rights instruments, such as restriction in when you can exercise it.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssueNotification"/>
-		<rdfs:label xml:lang="en">rights distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of the distribution of rights to shareholders, in proportion to their equity holding.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsExerciseEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">rights exercise event</rdfs:label>
 		<skos:definition xml:lang="en">Exercising the right to purchase the shares. Furhter Notes: This is an action on the part of the holder. SWIFT: Call/exercise on nil-paid securities/rights resulting from a rights distribution (RHDI) (To be used for the second event in case rights issue is dealt with in 2 events, first event being the RHDI).</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is a rights trading period overlaps with rights subscriptiuon period (you can trade the rights) Rights exercise period - expiry date. Some time after the expiry the new shares are distributed. This is the distribution.</fibo-fnd-utl-av:explanatoryNote>
@@ -1434,284 +939,108 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 		<skos:definition xml:lang="en">Some issue of rights to holders.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsIssueNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssueNotification"/>
-		<rdfs:label xml:lang="en">rights issue notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of some issue of rights to holders.</skos:definition>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;SHPR">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">SHPR</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the shares premium reserve</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;SharesPremiumDividendAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;SharesPremiumDividendAction"/>
+		<lcc-lr:hasTag>SHPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ScripDividend">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">scrip dividend</rdfs:label>
-		<skos:definition xml:lang="en">Dividend paid in the form of scrip (temporary certificate) which represents the company&apos;s promise to pay a cash dividend. Occurs when earnings are sufficient but issuer wishes to conserve cash holdings. Shareholders are not offered a choice.</skos:definition>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;SOFF">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">SOFF</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;SpinOff"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;SpinOff"/>
+		<lcc-lr:hasTag>SOFF</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ScripDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">scrip dividend notification</rdfs:label>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;SPLF">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">SPLF</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve an increase in a corporation&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
+		<lcc-lr:hasTag>SPLF</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo"/>
-				<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities combination or detachment</rdfs:label>
-		<skos:definition xml:lang="en">An event in which a security is split into separate securities or separate seucrities are combined into one security. Includes splits, detachments, attachments and so on.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecuritiesDisbursementResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
-		<rdfs:label xml:lang="en">securities disbursement response message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of response opting to take the securities offered.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Term:&quot;Securities Option&quot; Definition:&quot;Distribution of securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecurityAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">security action</rdfs:label>
-		<skos:definition xml:lang="en">Some action taken with respect to some Security, by the Issuer of that security. THIS IS REDUNDANT</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecurityDeliveryResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-		<rdfs:label xml:lang="en">security delivery response</rdfs:label>
-		<skos:definition xml:lang="en">Response is to take the securities</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: &quot;Distribution of securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecurityModificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
-		<rdfs:label xml:lang="en">security modification event</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:label xml:lang="en">share action</rdfs:label>
-		<skos:definition xml:lang="en">Some action relating to equity shares. Add: relationship to Share</skos:definition>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;SPLR">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">SPLR</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ReverseStockSplit"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ReverseStockSplit"/>
+		<lcc-lr:hasTag>SPLR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareBuybackOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOffer"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">share buyback offer</rdfs:label>
 		<skos:definition xml:lang="en">Issuer bid; Reduction of circulation shares; Reverse Rights. Offer by Issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareBuybackOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOfferNotification"/>
-		<rdfs:label xml:lang="en">share buyback offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an offer by the issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT extra text, presumably synonyms: &quot;Issuer bid; Reduction of circulation shares; Reverse Rights.&quot; Scope: Shares only? The definition implies Shares but can this apply to Debt security. Issuer of debt securities could repurchase. In the case of Debt repurchase you would purchase the debt and then cancel the debt. Also RePo market - would this Notification be used and this action apply? No. SWIFT definition full text: &quot;Issuer bid; Reduction of circulation shares; Reverse Rights. Offer by Issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueChangeAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">share value change action</rdfs:label>
-		<skos:definition xml:lang="en">Event in which there is some change to the value of Shares.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Added to accommodate events like decrease in value. Definition there refers explicitly to Shares. Identify whether applicable to other types of instrument (I can&apos;t think of any).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueChangeNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">share value change notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a change in the face value of a share.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are styled as a kind of Action not simply an Event, since this is something that the issuer carries out.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueDecreaseAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeAction"/>
-		<rdfs:label xml:lang="en">share value decrease action</rdfs:label>
-		<skos:definition xml:lang="en">Reduction of the share capital and face value of a single share. The number of the circulating shares remains unchanged. May include a capital pay-out to shareholder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a type of Action. Not the same as the resulting change of value from a stock split or similar. Here we have the change of the par value.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueDecreaseNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeNotification"/>
-		<rdfs:label xml:lang="en">share value decrease notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a reduction of the share capital and face value of a single share.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The number of the circulating shares remains unchanged. May include a capital pay-out to shareholder. SWIFT full text: &quot;Reduction of the share capital and face value of a single share. The number of the circulating shares remains unchanged. May include a capital pay-out to shareholder.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueIncreaseAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeAction"/>
-		<rdfs:label xml:lang="en">share value increase action</rdfs:label>
-		<skos:definition xml:lang="en">Increase of the share capital. The face value of the single share is changed without modification of the number of shares in circulation. May include a capital payout to shareholder.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueIncreaseNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeNotification"/>
-		<rdfs:label xml:lang="en">share value increase notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an increase of the share capital. The face value of the single share is changed without modification of the number of shares in circulation.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">May include a capital payout to shareholder. 
-Further Notes:SWIFT Full Text: &quot;Increase of the share capital. The face value of the single share is changed without modification of the number of shares in circulation. May include a capital payout to shareholder.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SharesDistributionEvent">
-		<rdfs:label xml:lang="en">shares distribution event</rdfs:label>
-		<skos:definition xml:lang="en">The distribution of shares in response to the exercise of some rights.</skos:definition>
-		<skos:editorialNote xml:lang="en">not in CAE lists. This would not involve any further announcements.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SharesPremiumDividendPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">shares premium dividend payment</rdfs:label>
-		<skos:definition xml:lang="en">This corporate event pays shareholders an amount in cash issued from the shares premium reserve. It is similar to a dividend but with different tax implications. SWIFT = SHPR</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SharesPremiumDividendPaymentNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">shares premium dividend payment notification</rdfs:label>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;SharesPremiumDividendAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
+		<rdfs:label xml:lang="en">shares premium dividend action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that pays shareholders an amount in cash issued from the shares premium reserve</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It is similar to a dividend but with different tax implications.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;SpinOff">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">spin off</rdfs:label>
-		<skos:definition xml:lang="en">Demerger; Distribution; Unbundling. A distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares. Spin-off represents a form of divestiture resulting in an independent company.</skos:definition>
+		<skos:definition xml:lang="en">corporate action involving the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Spin-off represents a form of divestiture usually resulting in an independent company or in an existing company. For example, demerger, distribution, unbundling.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;StockDividend">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">stock dividend</rdfs:label>
-		<skos:definition xml:lang="en">Dividend paid to shareholders in the form of shares of stock in the issuing company or in another company. Shareholder must take stock and is not offered a choice in the form of distribution.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;StockDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">stock dividend notification</rdfs:label>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;StockDividendAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">stock dividend action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves distribution of a dividend to shareholders in the form of equities of the issuing corporation</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;StockSplit">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AdviceOfAPossibleAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.17"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">stock split</rdfs:label>
-		<skos:definition xml:lang="en">The increase in a company&apos;s number of outstanding shares of stock without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Change in nominal value; Subdivision.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TakeNoActionNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;TakeNoActionResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">take no action notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a Take No Action response. SWIFT: Term: NOAC Definition: &quot;Take no action&quot;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TakeNoActionResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">take no action response</rdfs:label>
-		<skos:definition xml:lang="en">Take No Action. SWIFT: Term: NOAC Definition: &quot;Take no action&quot;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TaxReclaimActivity">
-		<rdfs:label xml:lang="en">tax reclaim activity</rdfs:label>
-		<skos:definition xml:lang="en">We dont&apos; have detailed information on what kinds of activities there are, but there may be a broad range of these. For instance, may be giving the issuer&apos;s location, or the rules for tax reclaims. Different rules exist. May set the rules on each action. For instance, It versus Fr, different rules. The CA notificaiton may be setting out the rules on each tax reclaim. Example: Aus: Issuer may make declaration to tax department, that securities are widely issued, this has some effect on withholding etc. Countries may have standing rules fo rreclaims, but may be special rules at an issue action level for large issue action. this would go out as a message (notification) using this message code. Similar to VAT in Canada - as an individual you pay VAT and reclaim it when you leave the country. Fill out a form etc. Then they send the VAT back. Conclusions: A general activity of Tax Reclaim - not formally modeled, just iterated here; notification which is the SWIFT message notoification type.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TaxReclaimActivityMessage">
-		<rdfs:label xml:lang="en">tax reclaim activity message</rdfs:label>
-		<skos:definition xml:lang="en">Message about some Tax Reclaim activity. SWIFT:&quot;Event related to tax reclaim activities.&quot;</skos:definition>
+		<skos:definition xml:lang="en">corporate action involving an increase in a corporation&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equity price and nominal value are reduced accordingly.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">change in nominal value</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">subdivision</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;TenderOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.18"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">tender offer</rdfs:label>
 		<skos:definition xml:lang="en">Offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices. Generally, the objective of a tender is to take control of the target company.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The announcer is not the issuer of the shares. The party to which the offer is made need not be the holder. Assumption: someone else trying to take over ythe company.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TenderOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyFormalOfferNotification"/>
-		<rdfs:label xml:lang="en">tender offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Generally, the objective of a tender is to take control of the target company. SWIFT whole text: &quot;Offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices. Generally, the objective of a tender is to take control of the target company.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionAnnouncement">
-		<rdfs:label xml:lang="en">third party action announcement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionChoiceExists">
-		<rdfs:label xml:lang="en">third party action choice exists</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionChoiceOffer">
-		<rdfs:label xml:lang="en">third party action choice offer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionHolderResponseToChoice">
-		<rdfs:label xml:lang="en">third party action holder response to choice</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionNotification">
-		<rdfs:label xml:lang="en">third party action notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;announcedBy.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;NonIssuerCorporateActionAnnouncer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">third party corporate action</rdfs:label>
-		<skos:definition xml:lang="en">Some action initiated by some third party to the security, i.e. not the issuer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example an offer made in the context of a takeover bid. Quesytion: if a third party makes such an action, doe sthe issuer also have to send out the notification? If the company is listed ,then the issuer is also obligated to notify holders that this thing is taking place. If both companies are listed, both have to send out a notificaiton to the market that they are doing this action. So the target company has to notify the market. sothere is a separate message which is the target company notifying its holders that a Tender Offer etc. is taking place. Is this in the ISO 15022 list? Are they both done with the same message? Example: Company B makes a bid in private to Company A. Discussion may go on in private. At some point you have to legally make it clear. So then Company A says &quot;we are being approached by company B&quot; and Company B has to put out a message saying &quot;We are going to try and take over Company B&quot;. Are they the same message? The &quot;Tender Offer&quot; message type is rich enough that both things can be conveyed. So when we try to semantically distinguish the message from the action? The party making the bid completes different fields in the message, to those filled in by the target company. This then marks out the semantics of &quot;This is a bid offer and I am the 3rd party&quot; or &quot;I am reporting a bid offer&quot;. Semantically: There is an event and there is a message describing the event. TElling the market about something happening to a company can be something your company is doing, or something causing a change in circumstances. Either way, the issuer of the affected securities has to identify and notify that there is something which might be affecting the price of their securities. May be internal or external things, and either way the issuer has to notify the market.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionEnd">
-		<rdfs:label xml:lang="en">third party corporate action end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionIssuerMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">third party corporate action issuer message</rdfs:label>
-		<skos:definition xml:lang="en">Message from security issuer, notifying holders of a third party action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These actions are initiated by some party other than the issuer. The issuer would also send out a message to holders, in order that they are formally notified of the action. Note also that the CAE message types may be the same in both cases.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:label xml:lang="en">third party corporate action notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a third party corporate action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There will be two lots of notification message for third party action.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionOriginatorMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">third party corporate action originator message</rdfs:label>
-		<skos:definition xml:lang="en">Message from a third party, notifying holders of a third party action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These actions are initiated by some party other than the issuer. As well as this message, the issuer would also send out a message to holders, in order that they are formally notified of the action. Note also that the CAE message types may be the same in both cases.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionStart">
-		<rdfs:label xml:lang="en">third party corporate action start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyFormalOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">third party formal offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of some third party offer, to the shareholders.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This message may be circulated by the third party or by the issuer REVIEW: to be confirmed.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusActiveMessage">
@@ -1731,7 +1060,7 @@ Further Notes:SWIFT Full Text: &quot;Increase of the share capital. The face val
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">trading status message</rdfs:label>
@@ -1746,124 +1075,38 @@ Further Notes:SWIFT Full Text: &quot;Increase of the share capital. The face val
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">voluntary corporate action</rdfs:label>
-		<skos:definition xml:lang="en">An event with some choice on the part of the Holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Voluntary on the part of the Holder. This refers to voluntary types of actions (not necessarily for dividends). Rights take-up is an example.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<skos:definition xml:lang="en">event in which the shareholders elect to participate and must respond in order for the issuer to process the action</skos:definition>
+		<skos:example xml:lang="en">An example of a voluntary corporate action is a tender offer, in which the issuer may request shareholders to tender their shares at a predetermined price.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Shareholders send responses to the issuer&apos;s agents, and the issuer will send the proceeds of the action to those shareholders who elect to participate.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryCorporateEventProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventProcess"/>
-		<rdfs:label xml:lang="en">voluntary corporate event process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:label xml:lang="en">voluntary distribution</rdfs:label>
-		<skos:definition xml:lang="en">An action in which funds are distributed voluntarily by the issuer of a security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is distinct from expected and contractually obligation distributions such as payments of interest or repayments of debt capital. 29 June notes: Have Income Services these then divide into: Interest income Dividend income If income includes both interest and dividend, this may be artificial and not useful - not how the business uses the term. If we include Capital Gains Distribiution? Older notes Pay date: examples - splits and so on. Also Calls. (Options calls; Debt calls have different meaning) Applies to either. Call is &quot;to you&quot; where distributing is &quot;from you&quot;.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoteAgainstManagement">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">vote against management</rdfs:label>
-		<skos:definition xml:lang="en">Vote against management.</skos:definition>
-		<skos:editorialNote xml:lang="en">It is not clear how this is distinct from Consent Denied. It is not a response to a Consent message, but it is a voting response of some sort. Possibly a specialization of Consent Denied? Keep it distinct for now. Consent Denied is not necessarily a vote against management, since management may have one or another view about the proposal that is on the table, that is defined in the Consent message. SWIFT: AMGT</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoteAgainstManagementMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">vote against management message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VotingNoAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">voting no action</rdfs:label>
-		<skos:definition xml:lang="en">Option for the account owner not to take part in the event. SWIFT: NOAC</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VotingNoActionMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">voting no action message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VotingResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">voting response</rdfs:label>
-		<skos:definition xml:lang="en">Some response to a voting activity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VotingResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:label xml:lang="en">voting response message</rdfs:label>
-	</owl:Class>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;WRTH">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+		<rdfs:label xml:lang="en">WRTH</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve booking out of valueless securities</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;WorthlessSecurityAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;WorthlessSecurityAction"/>
+		<lcc-lr:hasTag>WRTH</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;WarrantExerciseAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">warrant exercise action</rdfs:label>
-		<skos:definition xml:lang="en">Option offered to holders to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time (which usually corresponds to the life of the issue). Fiurther Notes: Note this is the issuer offering the holders the opportunity to do this exercise, it is not the exercise itself - misnamed in SWIFT. SWIFT = EXWA</skos:definition>
+		<skos:definition xml:lang="en">corporate action that offers holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time (which usually corresponds to the life of the issue)</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that participation by the warrant holder may be mandatory or voluntary and may involve a choice in the mandatory case.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;WorthlessSecurityBookingOut">
-		<rdfs:label xml:lang="en">worthless security booking out</rdfs:label>
-		<skos:definition xml:lang="en">Booking out of some worthless security by the Issuer. SWIFT:&quot;Booking out of valueless securities.&quot;</skos:definition>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;WorthlessSecurityAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">worthless security action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves booking out of valueless securities</skos:definition>
 	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;announcedBy">
-		<rdfs:label xml:lang="en">announced by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionAnnouncer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;announcedBy.1">
-		<rdfs:label xml:lang="en">announced by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;NonIssuerCorporateActionAnnouncer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;availableChoices">
-		<rdfs:subPropertyOf rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-		<rdfs:label xml:lang="en">available choices</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ExerciseExchangeOption"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;availableResponse">
-		<rdfs:label xml:lang="en">available response</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;communicatedBy">
-		<rdfs:label xml:lang="en">communicated by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;EventNotification"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conversionActionAvailableResponseTakeNoActionResponse">
-		<rdfs:subPropertyOf rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-		<rdfs:label xml:lang="en">conversion action available response take no action response</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;TakeNoActionResponse"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conveys">
-		<rdfs:label xml:lang="en">conveys</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conveys.1">
-		<rdfs:label xml:lang="en">conveys</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conveys.2">
-		<rdfs:label xml:lang="en">conveys</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;definesAdditional">
 		<rdfs:label xml:lang="en">defines additional</rdfs:label>
@@ -1871,64 +1114,28 @@ Further Notes:SWIFT Full Text: &quot;Increase of the share capital. The face val
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;effectiveDate">
-		<rdfs:label xml:lang="en">effective date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;InformationAction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;exchangesFrom">
 		<rdfs:label xml:lang="en">exchanges from</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;exchangesInto">
 		<rdfs:label xml:lang="en">exchanges into</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
 	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;flow">
-		<rdfs:label xml:lang="en">flow</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderInitatedActionStart"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;HolderInitiatedActionInitiation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;givesRiseTo">
-		<rdfs:label xml:lang="en">gives rise to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderResponseToChoice"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;hasSomeRoleIn">
-		<rdfs:label xml:lang="en">has some role in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;FinancialSecuritiesActor"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;hasStart">
-		<rdfs:label xml:lang="en">has start</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateEventProcess"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;MandatoryEventStart"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-cae-ce-cae;holderHasChoices">
-		<rdfs:label xml:lang="en">holder has choices</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isConversionFrom">
 		<rdfs:label xml:lang="en">is conversion from</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isConversionTo">
 		<rdfs:label xml:lang="en">is conversion to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isDistributionOf">
@@ -1943,171 +1150,11 @@ Further Notes:SWIFT Full Text: &quot;Increase of the share capital. The face val
 		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-cae-ce-cae;mandatory">
-		<rdfs:label xml:lang="en">mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BonusRightsIssue"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-cae-ce-cae;mandatory.1">
-		<rdfs:label xml:lang="en">mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether the action is mandatory on the Holder.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-cae-ce-cae;mandatory.2">
-		<rdfs:label xml:lang="en">mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;MandatoryCashDividendEvent"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether the action is mandatory on the Holder. This is &quot;yes&quot; i.e. it is a mandatory event.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-cae-ce-cae;mandatory.3">
-		<rdfs:label xml:lang="en">mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;OptionalCashDividendEvent"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether the action is mandatory on the Holder. This is &quot;no&quot; i.e. it is a voluntary event.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;oversubscriptionAmount">
 		<rdfs:label xml:lang="en">oversubscription amount</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">The amount of additional rights that may be purchased by the holder over and above the initial allocation. Further notes: In addition to a Subscription Price (see the Price term in the Subscription rights term), there is an additional privilege extended to the holders, to subscribe to additional shares. This also is in a certain proportion. This is to catch if not enough rights were subscribed, you may be left with some left over. These can then be given to the over-subscribers. Additional terms: if this exists there is a ratio for this as well. Notes Some people may pass up the right, and another person may pick this up through over-subscription. Therefore there is no oversubscription on a Bonus issue because people are getting it for free.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.10">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;DebtRedenomination"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.11">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;EventAnnouncement.1"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.12">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ExchangeOffer"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.13">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;InterestRateAdjustment"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bnd;VariableCouponBond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.15">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ReverseStockSplit"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.16">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<skos:definition xml:lang="en">The Rights Distribution relates to Share.</skos:definition>
-		<skos:editorialNote xml:lang="en">REVIEW: Share or Publicly Traded Share?</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.17">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.18">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;TenderOffer"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.2">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BondDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.3">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BondPutRedemption"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.4">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.5">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ChangeInDetailsNotification"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-be-le-cb;StockCorporation">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.6">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ChangeOfSecurityTradingStatusEvent"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.7">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConsentSolicitation"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.8">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<skos:definition xml:lang="en">The business entity to which the corporate event relates. It is from this that the securities affected are determined.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.9">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CouponStrip"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-cae-ce-cae;requiresResponse">
-		<rdfs:label xml:lang="en">requires response</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether the notification refers to an event which requires a response from the holder of the security .</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-cae-ce-cae;requiresResponse.1">
-		<rdfs:label xml:lang="en">requires response</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ShareValueChangeNotification"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;subscriptionPrice">
-		<rdfs:label xml:lang="en">subscription price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The price at which the Subscription Rights instrument itself may be purchased.</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/CAE/CorporateEvents/CorporateActionsEvents.rdf
+++ b/CAE/CorporateEvents/CorporateActionsEvents.rdf
@@ -204,6 +204,50 @@
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CHAN">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">CHAN</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that disseminate information regarding a change further described in the corporate action details</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ChangeAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ChangeAction"/>
+		<lcc-lr:hasTag>CHAN</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CLSA">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">CLSA</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving a situation where interested parties seek restitution for financial loss</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ClassAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ClassAction"/>
+		<lcc-lr:hasTag>CLSA</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CONS">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">CONS</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve procedures aiming to obtain consent of holder to a proposal by the issuer or a third party without convening a meeting</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ConsentSolicitation"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ConsentSolicitation"/>
+		<lcc-lr:hasTag>CONS</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CONV">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">CONV</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve conversion of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price/ratio</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
+		<lcc-lr:hasTag>CONV</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CancellationOfShares">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">cancellation of shares</rdfs:label>
@@ -231,16 +275,11 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Ordinary dividends are typically recurring and regular.  The shareholder must take cash, and may be offered a choice of currency.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeInDetailsNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">change in details notification</rdfs:label>
-		<skos:definition xml:lang="en">Information regarding a generic change, eg, change in the terms of an issue, change in the identification of a security, change of board lot, change from global to definitive.</skos:definition>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">change action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action to disseminate information regarding a change further described in the corporate action details</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Generic changes may include a change in the terms of an issue, change in the identification of a security, change of board lot, change from global to definitive, etc.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeOfSecurityTradingStatusEvent">
@@ -253,13 +292,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">change of security trading status event</rdfs:label>
 		<skos:definition xml:lang="en">An event in which the trading status of a tradable security changes.</skos:definition>
-		<skos:editorialNote xml:lang="en">Link this to the State Transition diagram (not yet done).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeOfStateEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
-		<rdfs:label xml:lang="en">change of state event</rdfs:label>
-		<skos:definition xml:lang="en">Some event relating to some change of state.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeToSmallestNegotiableUnit">
@@ -268,22 +300,23 @@
 		<skos:definition xml:lang="en">Modification of the smallest negotiable unit of shares in order to obtain a new negotiable unit. SWIFT:SMAL</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ClassActionProposedSettlementEvent">
+	<owl:Class rdf:about="&fibo-cae-ce-cae;ClassAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
-		<rdfs:label xml:lang="en">class action proposed settlement event</rdfs:label>
-		<skos:definition xml:lang="en">Proposed settlement to a class action filing. Situation where interested parties seek restitution for financial loss.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction. 
-Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed settlement. Situation where interested parties seek restitution for financial loss. Security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction.&quot; Description clarifies that the event is not the class action or the initiation of the class action, but the initiation of a proposed settlement, in which holders are encouraged to participate. Note that this is an action with some optional action on the part of the Holder.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label xml:lang="en">class action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action involving a situation where interested parties seek restitution for financial loss</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">proposed settlement</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitation">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">consent solicitation</rdfs:label>
-		<skos:definition xml:lang="en">Solicitation of shareholders consent. Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting.</skos:definition>
+		<skos:definition xml:lang="en">corporate action that is a procedure that aims to obtain consent of holder to a proposal by the issuer or a third party without convening a meeting</skos:definition>
+		<skos:example xml:lang="en">For example, consent to change the terms of a bond.</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isConversionFrom"/>
@@ -297,7 +330,7 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">conversion action</rdfs:label>
-		<skos:definition xml:lang="en">Conversion or optional exchange of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price.</skos:definition>
+		<skos:definition xml:lang="en">corporate action involving conversion of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price/ratio</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionSuspensionAction">
@@ -415,7 +448,6 @@ Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed set
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ChangeOfStateEvent"/>
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">corporate change of status event</rdfs:label>
 		<skos:definition xml:lang="en">Some change to the status of some security.</skos:definition>

--- a/CAE/CorporateEvents/CorporateActionsEvents.rdf
+++ b/CAE/CorporateEvents/CorporateActionsEvents.rdf
@@ -3,7 +3,6 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-cae-ce-cae "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/">
-	<!ENTITY fibo-der-drc-raw "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -34,7 +33,6 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-cae-ce-cae="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"
-	xmlns:fibo-der-drc-raw="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -76,7 +74,6 @@
 		<sm:filename>CorporateActionsEvents.rdf</sm:filename>
 		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -157,7 +154,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusRightsIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IntermediateSecuritiesDistribution"/>
 		<rdfs:label xml:lang="en">bonus rights issue</rdfs:label>
 		<skos:definition xml:lang="en">A Rights Issue in which the rights are given to the holders of the referenced shares for free.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Rights = right to buy shares at a specified price. May be given the right for nothing (Bonus Rights Issue) or you may be offered to purchase that right at a subscription price (which you take up or don&apos;t). Bonus Rights Issue: given the option for free. May exercise at the Exercise Price.</fibo-fnd-utl-av:explanatoryNote>
@@ -242,7 +239,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CallOnIntermediateSecurities">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">call on intermediate securities</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This code is used for the second event, when an intermediate securities&apos; issue (rights/coupons) is composed of two events, the first event being the distribution of intermediate securities.</fibo-fnd-utl-av:explanatoryNote>
@@ -319,13 +316,13 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isConversionFrom"/>
+				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;convertsFrom"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isConversionTo"/>
+				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;convertsTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -449,16 +446,16 @@
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleEvent"/>
 		<rdfs:label xml:lang="en">corporate change of status event</rdfs:label>
 		<skos:definition xml:lang="en">Some change to the status of some security.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is generally described by a corporate event message. For example, change in trading status, listing status.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateModificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">corporate modification event</rdfs:label>
-		<skos:definition xml:lang="en">Some change in details of some company, which needs to be described for publicly issued securities issued by that company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Usually described in a corporate event message. Note that the change relates to the company, but notification about this, for publicly issued securities (shares, bonds) is notificed to the holders of each such security, as corporate event messages.</fibo-fnd-utl-av:explanatoryNote>
+	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateInformationAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">corporate information action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;CouponStrip">
@@ -637,6 +634,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXWA">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
 		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">EXWA</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that offer holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time</skos:definition>
@@ -671,7 +669,7 @@
 				</owl:unionOf>
 			</owl:Class>
 		</owl:equivalentClass>
-		<skos:definition xml:lang="en">Event which is an offer to the holder or potential holder or other intersted party, to enter into a trade which is or would be legally binding on the part of the party making the offer (the offeror).</skos:definition>
+		<skos:definition xml:lang="en">corporat action involving an offer to a holder, potential holder, or other intersted party, to enter into a trade which is or would be legally binding on the part of the party making the offer (the offeror).</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;FullCallEarlyRedemptionAction">
@@ -680,6 +678,17 @@
 		<skos:definition xml:lang="en">corporate action that involves redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
 		<skos:example xml:lang="en">Examples securities that may be subject to a full call/early redemption include bonds, preferred equity, funds, that may be redeemed by the issuer or its agent before final maturity.</skos:example>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;INFO">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">INFO</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CorporateInformationAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CorporateInformationAction"/>
+		<lcc-lr:hasTag>INFO</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;INTR">
 		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
@@ -737,10 +746,31 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The SWIFT definition as given defines the notification of the interest rate change, not the adjustment. Adjusted to describe the event. REVIEW: Is this really an action? Usually consider that it&apos;s expected. Given definition was for the announcement. SWIFT full definition &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-cae-ce-cae;IntermediateSecuritiesDistribution">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">intermediate securities distribution</rdfs:label>
+		<skos:definition xml:lang="en">corporate action involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
+		<fibo-fnd-utl-av:synonym xml:lang="en">rights distribution</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;LIQU">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">LIQU</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;LiquidationAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;LiquidationAction"/>
+		<lcc-lr:hasTag>LIQU</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;LiquidationAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">liquidation action</rdfs:label>
-		<skos:definition xml:lang="en">Liquidating dividend/Liquidation consist of a distribution of cash, assets, or both. Debt may be paid in order of priority based on preferred claims to assets specified by the security. SWIFT = LIQU</skos:definition>
+		<skos:definition xml:lang="en">corporate action consisting of distribution of cash, assets, or both</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by the security.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">liquidation dividend</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">liquidation payment</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;ListingStatusDelistingMessage">
@@ -757,6 +787,17 @@
 		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;FullCallEarlyRedemptionAction"/>
 		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;FullCallEarlyRedemptionAction"/>
 		<lcc-lr:hasTag>MCAL</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;MRGR">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">MRGR</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve the exchange of outstanding securities, initiated by the issuer which may include options, as the result of two or more companies combining assets, that is, an external, third party company</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
+		<lcc-lr:hasTag>MRGR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -801,7 +842,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;OrganizationNameChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateInformationAction"/>
 		<rdfs:label xml:lang="en">organization name change</rdfs:label>
 		<skos:definition xml:lang="en">The issuing company changes it&apos;s name. Event shows the change from old name to new name and may involve surrendering physical shares with the old name to the registrar. SWIFT = NAME</skos:definition>
 	</owl:Class>
@@ -867,21 +908,21 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialRedemptionWithReductionOfNominalValueAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">partial redemption with reduction of nominal value action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The outstanding amount of securities will be reduced proportionally.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The outstanding amount of securities will be reduced proportionally. May be mandatory or voluntary.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialRedemptionWithoutReductionOfNominalValueAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">partial redemption without reduction of nominal value action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is commonly done by pool factor reduction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is commonly done by pool factor reduction. May be mandatory or voluntary.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;PlaceOfIncorporationChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateInformationAction"/>
 		<rdfs:label xml:lang="en">place of incorporation change</rdfs:label>
 		<skos:definition xml:lang="en">Changes in the state of incorporation for US companies and changes in the place of incorporation for foreign companies. Where shares need to be registered following the incorporation change, the holder(s) may have to elect the registrar. SWIFT = PLAC</skos:definition>
 	</owl:Class>
@@ -890,25 +931,26 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;definesAdditional"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;exchangesFrom"/>
+				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;convertsFrom"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;exchangesInto"/>
+				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;convertsTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">post merger securities exchange</rdfs:label>
-		<skos:definition xml:lang="en">Mandatory or voluntary exchange of an outstanding securities as the result of two or more companies combining assets. Cash payments may accompany share exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an action as a result of the Merger, not the merger itself.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label xml:lang="en">post-merger securities exchange</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that involves the exchange of outstanding securities, initiated by the issuer which may include options, as the result of two or more companies combining assets, that is, an external, third party company</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an action as a result of the merger, not the merger itself, and may be mandatory or voluntary. Cash payments may accompany share exchange.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;PriorityIssue">
@@ -942,6 +984,17 @@
 		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;RedenominationAction"/>
 		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;RedenominationAction"/>
 		<lcc-lr:hasTag>REDO</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;RHDI">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">RHDI</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;IntermediateSecuritiesDistribution"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;IntermediateSecuritiesDistribution"/>
+		<lcc-lr:hasTag>RHDI</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -982,43 +1035,11 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">change in nominal value</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;oversubscriptionAmount"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">rights distribution</rdfs:label>
-		<skos:definition xml:lang="en">The distribution of rights to shareholders, in proportion to their equity holding.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Does the Rights Distribution have to be proportion to the Shareholding? Sometimes this is offered at market prices, so all you are doing is offering shareholders the right to purchase. Conclusion: Not &quot;in proportion&quot; at all. REVISE: May also have Bonus Rights Issue, where you don&apos; have a subscriptiojn price. This works like a rights issue but without a price attached to it. The rate of how many you can buy is definitely in proportion to your holding. The rate of distribution of the right is proportional to the holdings. Another difference: A Rights thing you have to pay for the additional shares if you choose to purchase them (exercise the right) whereas a Bonus Issue you do not pay, you get them outright for free. TWO PARTS: 1. Distribution of the rights in proportion to their holding 2. Exercise of the Rights. Hence RHDI v EXRI where EXRI is the exercising of the right to purchase the shares. The Rights that are distributed is a formal &quot;Rights&quot; instrument. This may have the sort of features we see in other rights instruments, such as restriction in when you can exercise it.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsExerciseEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:label xml:lang="en">rights exercise event</rdfs:label>
 		<skos:definition xml:lang="en">Exercising the right to purchase the shares. Furhter Notes: This is an action on the part of the holder. SWIFT: Call/exercise on nil-paid securities/rights resulting from a rights distribution (RHDI) (To be used for the second event in case rights issue is dealt with in 2 events, first event being the RHDI).</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is a rights trading period overlaps with rights subscriptiuon period (you can trade the rights) Rights exercise period - expiry date. Some time after the expiry the new shares are distributed. This is the distribution.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isDistributionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-raw;SubscriptionRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">rights issue</rdfs:label>
-		<skos:definition xml:lang="en">Some issue of rights to holders.</skos:definition>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;SHPR">
@@ -1100,6 +1121,17 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">subdivision</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;TEND">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">TEND</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;TenderOffer"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;TenderOffer"/>
+		<lcc-lr:hasTag>TEND</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;TenderOffer">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:subClassOf>
@@ -1109,8 +1141,11 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">tender offer</rdfs:label>
-		<skos:definition xml:lang="en">Offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices. Generally, the objective of a tender is to take control of the target company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The announcer is not the issuer of the shares. The party to which the offer is made need not be the holder. Assumption: someone else trying to take over ythe company.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">corporate action involving an offer made to shareholders, normally by a third party, requesting them to sell (tender) or exchange their equities</skos:definition>
+		<fibo-fnd-utl-av:synonym xml:lang="en">acquisition</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">buyback</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">purchase offer</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">takeover</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusActiveMessage">
@@ -1178,53 +1213,16 @@
 		<skos:definition xml:lang="en">corporate action that involves booking out of valueless securities</skos:definition>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;definesAdditional">
-		<rdfs:label xml:lang="en">defines additional</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;exchangesFrom">
-		<rdfs:label xml:lang="en">exchanges from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
+	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;convertsFrom">
+		<rdfs:label xml:lang="en">converts from</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;exchangesInto">
-		<rdfs:label xml:lang="en">exchanges into</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
+	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;convertsTo">
+		<rdfs:label xml:lang="en">converts to</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
 		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isConversionFrom">
-		<rdfs:label xml:lang="en">is conversion from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
-		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isConversionTo">
-		<rdfs:label xml:lang="en">is conversion to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
-		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isDistributionOf">
-		<rdfs:label xml:lang="en">is distribution of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsIssue"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-raw;SubscriptionRight"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isIssueOf">
-		<rdfs:label xml:lang="en">is issue of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;oversubscriptionAmount">
-		<rdfs:label xml:lang="en">oversubscription amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount of additional rights that may be purchased by the holder over and above the initial allocation. Further notes: In addition to a Subscription Price (see the Price term in the Subscription rights term), there is an additional privilege extended to the holders, to subscribe to additional shares. This also is in a certain proportion. This is to catch if not enough rights were subscribed, you may be left with some left over. These can then be given to the over-subscribers. Additional terms: if this exists there is a ratio for this as well. Notes Some people may pass up the right, and another person may pick this up through over-subscription. Therefore there is no oversubscription on a Bonus issue because people are getting it for free.</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/CAE/CorporateEvents/CorporateActionsEvents.rdf
+++ b/CAE/CorporateEvents/CorporateActionsEvents.rdf
@@ -517,6 +517,17 @@
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DTCH">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">DTCH</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving parties wishing to acquire a security</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DutchAuction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DutchAuction"/>
+		<lcc-lr:hasTag>DTCH</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DVCA">
 		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">DVCA</rdfs:label>
@@ -606,9 +617,20 @@
 	<owl:Class rdf:about="&fibo-cae-ce-cae;DutchAuction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">dutch auction</rdfs:label>
-		<skos:definition xml:lang="en">Similar to a tender offer, a Dutch auction is an action by a party wishing to acquire a particular security. Current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings. UPDATE THIS DEFINITION: Similar to a tender offer, a Dutch auction is the result of an action by a third party wishing to acquire a particular security. Current holders of the targeted security are invited (and given a message by the issuer) to make an offer in which they would be willling to sell their holdings. OR It might also represent a separate scenario where third parties do this, as per the original SWIFT defition. You can only go to the Registrar which would the other scenario impossible. Agents and Registrars: The issue issuer os the company which issued the shares (as modeled); Most companies don&apos;t interact directly with the market to find out who they need to disseminate the info to. They can, but more likely the employ &quot;Issuers Agent&quot;. That provides one point of contact from the organization. That agent handles all coms with the Registrars, and to the news wires etc., to disseminate the corporate action. Context: CAE only, or in the context of the Issue? When you issue the security you nominate an Agent, in the prospectus, there is specified an Issuing Agent. This is the one that does these things. Usually a merchant bank etc. in the old days. This is who will have directly facilitated that direct market engagement. Next question: This is part of going public, so these agents are appointed as part of going public.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The party to which the offer is made need not be the holder. Details: Question on &quot;Who is the actor?&quot; Dutch auction would have multiple parties? What is the scenario? Usually happens when a company is about to go into administration. Looking at the scneario descried in the SWIFT definition - not clear if this is the only such scenario. Possibly the issuer has to notif ythe shareholders that the offer is being made. The offer is made by the third party but the notice is sent by the issuer (via their agent) and via the registrar who holds the details of who holds all the shares. Example: Lloyds banking group - most shares would be owned by the market, and a small percentage might be held by private investors. So in this scenario everyone has to be given the opportunity to sell at the given price. so the CAE message is still issued by the Issuer. SWIFT detailed names (synonym?) &quot;Dutch Auction, Bid Tender&quot;</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">corporate action by a party wishing to acquire a security</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Holders of the security are invited to make an offer to sell, within a specific price range. The acquiring party will buy from the holder with lowest offer.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXOF">
+		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+		<rdfs:label xml:lang="en">EXOF</rdfs:label>
+		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that reflect an exchange of holdings for other securities and/or cash</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ExchangeAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ExchangeAction"/>
+		<lcc-lr:hasTag>EXOF</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXTM">
 		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
@@ -632,16 +654,11 @@
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExchangeOffer">
+	<owl:Class rdf:about="&fibo-cae-ce-cae;ExchangeAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exchange offer</rdfs:label>
-		<skos:definition xml:lang="en">Exchange offer; Capital reorganisation. Offer to shareholders to exchange their holdings for other securities and/or cash. Exchange offers are usually voluntary. Example: Where the &quot;usually voluntary&quot; comes in is that Announcement Payout Option 1: Cash 2. Stocks 3. Cash and Stock Holder picks option 1, 2 or 3 (= 1 &amp; 2). the voluntary aspect is where it&apos;s an Exchange Offer. It&apos;s mandatory to pick one of 1 - 3. Otherwise defaults to cash on payment date. Option Payout Componnet is the terms for the choice. Exchange Offer may be voluntary, not always Mandator With Choice. for example, there are legal qualifications on what is possible. Preceded by Tender Offer. Consequences dependent on scenarios. Once the firm making the offer gets to a given (legally defined) threshold e.g. 90% then they have the right to acquire all of the outstanding shares. An Exchange Offer is therefore a specialization of a Tender Offer. It&apos;s the specialization where the above mentioned requirements have been met. Further detail: Happens in a wider range of circumsntaces. Is soecifically associated with the issuer. this could be voluntary or not. EXOF could be any of the three (mand, vol, man w choice). tendre is always voluntary.</skos:definition>
+		<rdfs:label xml:lang="en">exchange action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action that reflects an exchange of holdings for other securities and/or cash</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The exchange can be either mandatory or voluntary involving the exchange of outstanding securities for different securities and/or cash. For example, &apos;exchange offer&apos;, &apos;capital reorganisation&apos; or &apos;funds separation&apos;.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-cae;FormalOffer">
@@ -652,7 +669,7 @@
 				<owl:unionOf rdf:parseType="Collection">
 					<rdf:Description rdf:about="&fibo-cae-ce-cae;DutchAuction">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;ExchangeOffer">
+					<rdf:Description rdf:about="&fibo-cae-ce-cae;ExchangeAction">
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-cae-ce-cae;RepurchaseOffer">
 					</rdf:Description>

--- a/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
+++ b/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
@@ -21,24 +21,30 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/">
 		<rdfs:label>Metadata for the EDMC-FIBO Corporate Actions and Events (CAE) Corporate Events Module</rdfs:label>
-		<dct:abstract>This module contains ontologies of general corporate events and action-related concepts including events, messages, activities and, where applicable, responses required from security holders.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
+		<dct:abstract>This module contains ontologies of general corporate events and securities-related actions.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-cae-ce-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataCAECorporateEvents.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20200401/CorporateEvents/MetadataCAECorporateEvents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20201001/CorporateEvents/MetadataCAECorporateEvents/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-mod;CorporateEventsModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Corporate Events Module</rdfs:label>
-		<dct:abstract>This module contains ontologies of general corporate events and action-related concepts including events, messages, activities and, where applicable, responses required from security holders.</dct:abstract>
-		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"/>
+		<dct:abstract>This module contains ontologies of general corporate events and securities-related actions.</dct:abstract>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:moduleAbbreviation>fibo-cae-ce</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>

--- a/CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf
+++ b/CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf
@@ -2,7 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-cae-ce-cae "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/">
+	<!ENTITY fibo-cae-ce-srca "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -29,10 +29,10 @@
 	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-cae-ce-cae="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"
+	xmlns:fibo-cae-ce-srca="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -59,9 +59,9 @@
 	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/">
-		<rdfs:label xml:lang="en">CorporateActionsEvents</rdfs:label>
-		<dct:abstract>This ontology covers income and corporate action events as specified in SWIFT ISO 15022, including extensions as of 3 September 2020. Scope has been limited to events and actions only, and excludes notification and meetings related events and message definitions associated with ISO 15022 as well as related messages covered by ISO 20022.</dct:abstract>
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/">
+		<rdfs:label xml:lang="en">Security-related Corporate Actions Ontology</rdfs:label>
+		<dct:abstract>This ontology covers income and corporate action events as specified in SWIFT ISO 15022, including extensions as of 3 September 2020. Scope has been limited to security-related events and actions only, and excludes notification and meetings related events and message definitions associated with ISO 15022 as well as related messages covered by ISO 20022.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
 		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
@@ -70,8 +70,8 @@
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-cae-ce-cae</sm:fileAbbreviation>
-		<sm:filename>CorporateActionsEvents.rdf</sm:filename>
+		<sm:fileAbbreviation>fibo-cae-ce-srca</sm:fileAbbreviation>
+		<sm:filename>SecurityRelatedCorporateActions.rdf</sm:filename>
 		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
@@ -94,45 +94,45 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;BIDS">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;BIDS">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">BIDS</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;RepurchaseOffer"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;RepurchaseOffer"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RepurchaseOffer"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;RepurchaseOffer"/>
 		<lcc-lr:hasTag>BIDS</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;BONU">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;BONU">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">BONU</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;BonusIssue"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;BonusIssue"/>
 		<lcc-lr:hasTag>BONU</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;BPUT">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;BPUT">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">BPUT</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PutRedemptionAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PutRedemptionAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PutRedemptionAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PutRedemptionAction"/>
 		<lcc-lr:hasTag>BPUT</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondDefaultAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;BondDefaultAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationDefault"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -144,8 +144,8 @@
 		<skos:definition xml:lang="en">corporate action which indicates a failure by the issuer to perform obligations defined as default events under the bond agreement and that have not been remedied</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;BonusIssue">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">bonus issue</rdfs:label>
 		<skos:definition xml:lang="en">corporate action in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are different taxation rules for the bonus issue compared to the dividend. There could also be a difference in the ranking of the shares that are given to what the holder already holds. Dividends are paid from current profits and bonus may be from accumulated reserves of the company. A scrip issue is the issue of new shares at no charge pro rata to the holder of existing shares.</fibo-fnd-utl-av:explanatoryNote>
@@ -153,134 +153,134 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">scrip issue</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusRightsIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IntermediateSecuritiesDistribution"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;BonusRightsIssue">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution"/>
 		<rdfs:label xml:lang="en">bonus rights issue</rdfs:label>
 		<skos:definition xml:lang="en">A Rights Issue in which the rights are given to the holders of the referenced shares for free.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Rights = right to buy shares at a specified price. May be given the right for nothing (Bonus Rights Issue) or you may be offered to purchase that right at a subscription price (which you take up or don&apos;t). Bonus Rights Issue: given the option for free. May exercise at the Exercise Price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusSharePlanDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;BonusSharePlanDistribution">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CapitalDistribution"/>
 		<rdfs:label xml:lang="en">bonus share plan distribution</rdfs:label>
 		<skos:definition xml:lang="en">Event in which shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications. SWIFT Definition (adapted above) &quot;Typically found in Australia, shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications.&quot; To be researches further. There are certainly Share Plans in Australia, where you can take a dividend as shares. Thewse would be in the nature of Bonus Shares. They are a tradeoff from cash dividends. Other terms to model: A &quot;Scheme of Arrangment&quot; - does this change the capital reserves or is it just another word for restructure. An arrangement with the company&apos;s debtors, and coule potentially change the capital base by converting the debt to shares (see other diagram note with these in).</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BusinessStrategyOrientedAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;BusinessStrategyOrientedAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateActionClassifier"/>
 		<rdfs:label xml:lang="en">business strategy oriented action</rdfs:label>
 		<skos:definition xml:lang="en">classifier of corporate actions that involves improving liquidity or changing the overall structure of the organization through diversification, combining and closing parts of the business, etc, to increase long-term profitability</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CAPD">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CAPD">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">CAPD</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CapitalDistribution"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;CapitalDistribution"/>
 		<lcc-lr:hasTag>CAPD</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CAPG">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CAPG">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">CAPG</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that distribute profits resulting from the sale of company assets to shareholders</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CapitalGainsDistribution"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CapitalGainsDistribution"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CapitalGainsDistribution"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;CapitalGainsDistribution"/>
 		<lcc-lr:hasTag>CAPG</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CHAN">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CHAN">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">CHAN</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that disseminate information regarding a change further described in the corporate action details</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ChangeAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ChangeAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ChangeAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;ChangeAction"/>
 		<lcc-lr:hasTag>CHAN</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CLSA">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CLSA">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">CLSA</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving a situation where interested parties seek restitution for financial loss</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ClassAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ClassAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ClassAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;ClassAction"/>
 		<lcc-lr:hasTag>CLSA</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CONS">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CONS">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">CONS</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve procedures aiming to obtain consent of holder to a proposal by the issuer or a third party without convening a meeting</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ConsentSolicitation"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ConsentSolicitation"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ConsentSolicitation"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;ConsentSolicitation"/>
 		<lcc-lr:hasTag>CONS</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;CONV">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CONV">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">CONV</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve conversion of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price/ratio</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ConversionAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;ConversionAction"/>
 		<lcc-lr:hasTag>CONV</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CallOnIntermediateSecurities">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CallOnIntermediateSecurities">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">call on intermediate securities</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This code is used for the second event, when an intermediate securities&apos; issue (rights/coupons) is composed of two events, the first event being the distribution of intermediate securities.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CancellationOfShares">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CancellationOfShares">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">cancellation of shares</rdfs:label>
 		<skos:definition xml:lang="en">The cancellation of shares. Further Notes Only possible with shares not publicly issued i.e. treasury shares</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CapitalDistribution">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">capital distribution</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that pays shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This action does not result in a reduction of the face value of a share or in a change to the number of shares in circulation.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalGainsDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CapitalGainsDistribution">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">capital gains distribution</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that distributes profits resulting from the sale of company assets to shareholders</skos:definition>
 		<skos:example xml:lang="en">Shareholders of Mutual Funds, Unit Trusts, or SICAVs are recipients of capital gains distributions which are often reinvested in additional shares of the fund</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashDividendAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CashDividendAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">cash dividend action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that distributes cash to shareholders in proportion to their equity holding</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Ordinary dividends are typically recurring and regular.  The shareholder must take cash, and may be offered a choice of currency.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ChangeAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">change action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action to disseminate information regarding a change further described in the corporate action details</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Generic changes may include a change in the terms of an issue, change in the identification of a security, change of board lot, change from global to definitive, etc.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeOfSecurityTradingStatusEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ChangeOfSecurityTradingStatusEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateChangeOfStatusEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
@@ -291,38 +291,38 @@
 		<skos:definition xml:lang="en">An event in which the trading status of a tradable security changes.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeToSmallestNegotiableUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ChangeToSmallestNegotiableUnit">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">change to smallest negotiable unit</rdfs:label>
 		<skos:definition xml:lang="en">Modification of the smallest negotiable unit of shares in order to obtain a new negotiable unit. SWIFT:SMAL</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ClassAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ClassAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">class action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving a situation where interested parties seek restitution for financial loss</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en">proposed settlement</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitation">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ConsentSolicitation">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">consent solicitation</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that is a procedure that aims to obtain consent of holder to a proposal by the issuer or a third party without convening a meeting</skos:definition>
 		<skos:example xml:lang="en">For example, consent to change the terms of a bond.</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ConversionAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;convertsFrom"/>
+				<owl:onProperty rdf:resource="&fibo-cae-ce-srca;convertsFrom"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;convertsTo"/>
+				<owl:onProperty rdf:resource="&fibo-cae-ce-srca;convertsTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -330,13 +330,13 @@
 		<skos:definition xml:lang="en">corporate action involving conversion of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price/ratio</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionSuspensionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ConversionSuspensionAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">conversion suspension action</rdfs:label>
 		<skos:definition xml:lang="en">Suspensiion of conversion of securities generally a couple of weeks before a meeting takes place. SWIFT = SCOP</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateAction">
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CorporateAction">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -356,7 +356,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-srca;CorporateActionClassifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">corporate action</rdfs:label>
@@ -365,19 +365,19 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Corporate actions are typically approved by a company&apos;s board of directors and authorized by the shareholders.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionClassificationScheme">
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CorporateActionClassificationScheme">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;ClassificationScheme"/>
 		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeSet"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;hasMember"/>
-				<owl:allValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
+				<owl:allValuesFrom rdf:resource="&fibo-cae-ce-srca;CorporateActionClassifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;defines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-srca;CorporateActionClassifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>corporate action classification scheme</rdfs:label>
@@ -385,33 +385,33 @@
 		<fibo-fnd-utl-av:usageNote>The set of corporate actions and income events included herein are a subset of those specified in ISO 15022 Securities - Scheme for Messages (Data Field Dictionary). Other schemes that are specific to a custodian, depository, or regulatory agency may also be important, and should take a similar approach with respect to classification.</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionClassifier">
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CorporateActionClassifier">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
 		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDefinedIn"/>
-				<owl:onClass rdf:resource="&fibo-cae-ce-cae;CorporateActionClassificationScheme"/>
+				<owl:onClass rdf:resource="&fibo-cae-ce-srca;CorporateActionClassificationScheme"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
-				<owl:onClass rdf:resource="&fibo-cae-ce-cae;CorporateActionClassificationScheme"/>
+				<owl:onClass rdf:resource="&fibo-cae-ce-srca;CorporateActionClassificationScheme"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -425,41 +425,41 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">ISO 15022 classifies events as impacting income vs. others.  Other classification schemes distinguish between actions that return profits to shareholders, actions that are designed to influence the share price, and actions involving a change in structure to the issuer organization.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CorporateActionObligation">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;Duty"/>
 		<rdfs:label xml:lang="en">corporate action obligation</rdfs:label>
 		<skos:definition xml:lang="en">An obligation related to the holding of a Security.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Delivery of a security. Not defining direction at this level of the model - one party may have an obligation to deliver security or to pay; other party may have an obligation to deliver or to pay. Or there may be just one.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionPaymentObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionObligation"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CorporateActionPaymentObligation">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateActionObligation"/>
 		<rdfs:label xml:lang="en">corporate action payment obligation</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionSecuritiesDeliveryObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionObligation"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CorporateActionSecuritiesDeliveryObligation">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateActionObligation"/>
 		<rdfs:label xml:lang="en">corporate action securities delivery obligation</rdfs:label>
 		<skos:definition xml:lang="en">Some obligation to deliver some security in the thr context of corporate actions. All cash proceeds and security proceeds can be represented a s acontractual obligation. Where does that obligation arise? Usually in the Contract itself - but there may be other answers to this. Defines what has to be delivered. or paid. Entitlement meanwhile is a calculation based on the Contract.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CorporateChangeOfStatusEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleEvent"/>
 		<rdfs:label xml:lang="en">corporate change of status event</rdfs:label>
 		<skos:definition xml:lang="en">Some change to the status of some security.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is generally described by a corporate event message. For example, change in trading status, listing status.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateInformationAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CorporateInformationAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">corporate information action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CouponStrip">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;CouponStrip">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
@@ -470,201 +470,201 @@
 		<skos:definition xml:lang="en">Coupon stripping is the process whereby interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DECR">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DECR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">DECR</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that reduce the face value of a share or the value of fund assets</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DecreaseInValueAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DecreaseInValueAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DecreaseInValueAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;DecreaseInValueAction"/>
 		<lcc-lr:hasTag>DECR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DFLT">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DFLT">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">DFLT</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that indicate a failure by the issuer to perform obligations defined as default events under the bond agreement and that have not been remedied</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;BondDefaultAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;BondDefaultAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;BondDefaultAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;BondDefaultAction"/>
 		<lcc-lr:hasTag>DFLT</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DRIP">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DRIP">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">DRIP</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DividendReinvestmentAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DividendReinvestmentAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DividendReinvestmentAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;DividendReinvestmentAction"/>
 		<lcc-lr:hasTag>DRIP</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DSCL">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DSCL">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">DSCL</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DisclosureAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DisclosureAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DisclosureAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;DisclosureAction"/>
 		<lcc-lr:hasTag>DSCL</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DTCH">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DTCH">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">DTCH</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving parties wishing to acquire a security</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DutchAuction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DutchAuction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DutchAuction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;DutchAuction"/>
 		<lcc-lr:hasTag>DTCH</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DVCA">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DVCA">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">DVCA</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that distribute cash to shareholders in proportion to their equity holding</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CashDividendAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CashDividendAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CashDividendAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;CashDividendAction"/>
 		<lcc-lr:hasTag>DVCA</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DVOP">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DVOP">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">DVOP</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;DividendOptionAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;DividendOptionAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DividendOptionAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;DividendOptionAction"/>
 		<lcc-lr:hasTag>DVOP</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;DVSE">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DVSE">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">DVSE</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders in the form of equities of the issuing corporation</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;StockDividendAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;StockDividendAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;StockDividendAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;StockDividendAction"/>
 		<lcc-lr:hasTag>DVSE</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DecreaseInValueAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;DecreaseInValueAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">decrease in value action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action resulting in a reduction of face value of a share or the value of fund assets</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The number of circulating shares/units remains unchanged. This event may include a cash pay out to holders.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DisclosureAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;DisclosureAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">disclosure action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This event only occurs with the characteristic VOLU, otherwise it is part of the SRD II.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendOptionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;DividendOptionAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">dividend option action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Shareholders may choose to receive shares or cash. A dividend option action is distinguished from reinvestment (DRIP) as, like a cash dividend, the company creates new share capital in exchange for the dividend rather than investing the dividend in the market.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendReinvestmentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;DividendReinvestmentAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">dividend reinvestment action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Dividend reinvestment is distinguished from a cash dividend in that the issuer invests the dividend in the market rather than creating new share capital in exchange for the dividend.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;Drawing">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;Drawing">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">drawing</rdfs:label>
 		<skos:definition xml:lang="en">Redemption in part before the scheduled final maturity date of a security.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notification in advance of this happening.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DutchAuction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;DutchAuction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">dutch auction</rdfs:label>
 		<skos:definition xml:lang="en">corporate action by a party wishing to acquire a security</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Holders of the security are invited to make an offer to sell, within a specific price range. The acquiring party will buy from the holder with lowest offer.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXOF">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;EXOF">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">EXOF</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that reflect an exchange of holdings for other securities and/or cash</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ExchangeAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ExchangeAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ExchangeAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;ExchangeAction"/>
 		<lcc-lr:hasTag>EXOF</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXRI">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;EXRI">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">EXRI</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CallOnIntermediateSecurities"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CallOnIntermediateSecurities"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CallOnIntermediateSecurities"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;CallOnIntermediateSecurities"/>
 		<lcc-lr:hasTag>EXRI</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXTM">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;EXTM">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">EXTM</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve prolonging the maturity date of a bond</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;MaturityExtension"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;MaturityExtension"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;MaturityExtension"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;MaturityExtension"/>
 		<lcc-lr:hasTag>EXTM</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;EXWA">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;EXWA">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">EXWA</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that offer holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;WarrantExerciseAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;WarrantExerciseAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;WarrantExerciseAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;WarrantExerciseAction"/>
 		<lcc-lr:hasTag>EXWA</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExchangeAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ExchangeAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">exchange action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that reflects an exchange of holdings for other securities and/or cash</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The exchange can be either mandatory or voluntary involving the exchange of outstanding securities for different securities and/or cash. For example, &apos;exchange offer&apos;, &apos;capital reorganisation&apos; or &apos;funds separation&apos;.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FormalOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;FormalOffer">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">formal offer</rdfs:label>
 		<owl:equivalentClass>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;DutchAuction">
+					<rdf:Description rdf:about="&fibo-cae-ce-srca;DutchAuction">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;ExchangeAction">
+					<rdf:Description rdf:about="&fibo-cae-ce-srca;ExchangeAction">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;RepurchaseOffer">
+					<rdf:Description rdf:about="&fibo-cae-ce-srca;RepurchaseOffer">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;TenderOffer">
+					<rdf:Description rdf:about="&fibo-cae-ce-srca;TenderOffer">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -672,69 +672,69 @@
 		<skos:definition xml:lang="en">corporat action involving an offer to a holder, potential holder, or other intersted party, to enter into a trade which is or would be legally binding on the part of the party making the offer (the offeror).</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FullCallEarlyRedemptionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;FullCallEarlyRedemptionAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">full call early redemption action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
 		<skos:example xml:lang="en">Examples securities that may be subject to a full call/early redemption include bonds, preferred equity, funds, that may be redeemed by the issuer or its agent before final maturity.</skos:example>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;INFO">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;INFO">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">INFO</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;CorporateInformationAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;CorporateInformationAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CorporateInformationAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;CorporateInformationAction"/>
 		<lcc-lr:hasTag>INFO</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;INTR">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;INTR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">INTR</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve distribution of a regular interest payment to holders of an interest-bearing asset</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;InterestPaymentAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;InterestPaymentAction"/>
 		<lcc-lr:hasTag>INTR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;CorporateActionClassificationScheme"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;CorporateActionClassificationScheme"/>
 		<rdfs:label>ISO 15022 corporate action classification scheme</rdfs:label>
 		<skos:definition>scheme for classifying corporate actions according to ISO 15022 Securities - Scheme for Messages (Data Field Dictionary)</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IncomeOrientedAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionClassifier"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;IncomeOrientedAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateActionClassifier"/>
 		<rdfs:label xml:lang="en">income-oriented action</rdfs:label>
 		<skos:definition xml:lang="en">classifier of corporate actions that impacts income to shareholders</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Cash dividends are a classic example where a public company declares a dividend to be paid on each outstanding share. Bonus is another case where the shareholder is rewarded. In a stricter sense, the bonus issue should not impact the share price but in reality, in rare cases, it does and results in an overall increase in value.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;InterestPaymentAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">interest payment action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves distribution of a regular interest payment to holders of an interest-bearing asset</skos:definition>
 		<skos:editorialNote xml:lang="en">Further notes: Are there options on the Holder? Yes, you can opt to be paid in a certain currency. It is not always defined in the security terms. So if the Terms in the Security terms sheet gives you an option, there is a choice for the Holder at this point. Such choices would include: - Currency - Pay in Kind (&quot;Spinoff&quot; or PiK - see PiK corporate Action) Could be mandatory. If there were an option then the letter announcing it would require a response. This is usually stated in the message. Is there a message even if there is no option? Yes. Usually have to generate the events artificially as the Servicing organization. you can&apos;t rely on a feed or message coming in but because it is part of the security contract the above has to generate at the expected time, and arrange the payments. Q: That is the point at there was a choice you would expect to see a message, or end up still having to generate it but with the choices. A: The ones with Choices come as announcements and don&apos;t ave to be generated by the Service. Older definitin (re-scoped now: An Event in which a payment occurs. Anything can have a payment event. If a thing hits a pay date, whether it&apos;s voluntary or mandatory, that&apos;s a payment event. Divide into: Securities Cash Combination Payment or Distribution? Are these exclusive? Take an event that&apos;s always a combination of options, and an option is a combination of payouts. Generates transactions - determine what txns happen when a customer chooses that option. Distribution / delivery: generic concept Payment - implis cash distribution. So payment is specialization of distribution.</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentInKind">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;InterestPaymentInKind">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;InterestPaymentAction"/>
 		<rdfs:label xml:lang="en">interest payment in kind</rdfs:label>
 		<skos:definition xml:lang="en">Interest payment, in any kind except cash, distributed to holders of an interest bearing asset. SWIFT = PINK</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentWithPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;InterestPaymentWithPrincipal">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;InterestPaymentAction"/>
 		<rdfs:label xml:lang="en">interest payment with principal</rdfs:label>
 		<skos:definition xml:lang="en">A payment of a portion of the principal of an interest bearing asset, in addition to the interest payment. SWIFT = PRII</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestRateAdjustment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;InterestRateAdjustment">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
@@ -746,26 +746,26 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The SWIFT definition as given defines the notification of the interest rate change, not the adjustment. Adjusted to describe the event. REVIEW: Is this really an action? Usually consider that it&apos;s expected. Given definition was for the announcement. SWIFT full definition &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IntermediateSecuritiesDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">intermediate securities distribution</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en">rights distribution</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;LIQU">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;LIQU">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">LIQU</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;LiquidationAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;LiquidationAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;LiquidationAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;LiquidationAction"/>
 		<lcc-lr:hasTag>LIQU</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;LiquidationAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;LiquidationAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">liquidation action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action consisting of distribution of cash, assets, or both</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by the security.</fibo-fnd-utl-av:explanatoryNote>
@@ -773,51 +773,51 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">liquidation payment</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ListingStatusDelistingMessage">
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ListingStatusDelistingMessage">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
 		<rdfs:label xml:lang="en">listing status delisting message</rdfs:label>
 		<skos:definition xml:lang="en">Security is no longer able to comply with the listing requirements of a stock exchange and is removed from official board quotation.</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;MCAL">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;MCAL">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">MCAL</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;FullCallEarlyRedemptionAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;FullCallEarlyRedemptionAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;FullCallEarlyRedemptionAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;FullCallEarlyRedemptionAction"/>
 		<lcc-lr:hasTag>MCAL</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;MRGR">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;MRGR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">MRGR</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve the exchange of outstanding securities, initiated by the issuer which may include options, as the result of two or more companies combining assets, that is, an external, third party company</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PostMergerSecuritiesExchange"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PostMergerSecuritiesExchange"/>
 		<lcc-lr:hasTag>MRGR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;MandatoryCorporateAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">mandatory corporate action</rdfs:label>
 		<skos:definition xml:lang="en">event initiated by the board of directors of the corporation that affects all shareholders</skos:definition>
 		<skos:example xml:lang="en">Examples of mandatory corporate actions include cash dividends, stock splits, mergers, pre-refunding, return of capital, bonus issue, asset ID change, and spin-offs.</skos:example>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Mandatory means mandatory participation by all shareholders, however the shareholder is not required to do anything.  Shareholders are passive beneficiaries of mandatory actions.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;MandatoryWithChoiceCorporateAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">mandatory with choice corporate action</rdfs:label>
 		<skos:definition xml:lang="en">mandatory corporate action where shareholders are given an opportunity to choose among several options</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In case a shareholder does not submit the election, the default option will be applied.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MaturityExtension">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;MaturityExtension">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
@@ -829,70 +829,70 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval. May be mandatory or voluntary, depending on who initiates it and the surrounding circumstances.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;NotificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;NotificationEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">notification event</rdfs:label>
 		<skos:definition xml:lang="en">A notification to the shareholders that therre is a corporate action out there. This is distinct from the CA itself. not the same as Event Announcement. There are steps between when the announcement happens and the rest Announcement: at the level of sub custodians. then you gether the people who are affected by the event that&apos;s to come. Then you send the announcement - a notification to the holder, informing them of the options that are available to them. If it&apos;s mandatory these distinctions still happen, but there is no choice. So still announcement is made, then when it effects people you send out notificaiton and collect responses. &quot;EVENT&quot;: two aspects: The event itself Events within the Corporat eAction, e.g. notification, deadline when a responses is due by, payment dates, Define as: lifecycle of the Corporate Action. Sometimes have to re-notify, there may be changes in the life oc the &quot;Corporate Event&quot;. So the Corporate Event is a sequence of events.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;OddLotOffer">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">odd lot offer</rdfs:label>
 		<skos:definition xml:lang="en">Offer by issuer to allow holders of an odd lot of a security to order a commission-free transaction at market price, to sell the odd lot, or to buy an amount of shares which will bring the position to a round lot (board lot). SWIFT = ODLT</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OrganizationNameChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateInformationAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;OrganizationNameChange">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateInformationAction"/>
 		<rdfs:label xml:lang="en">organization name change</rdfs:label>
 		<skos:definition xml:lang="en">The issuing company changes it&apos;s name. Event shows the change from old name to new name and may involve surrendering physical shares with the old name to the registrar. SWIFT = NAME</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;PARI">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;PARI">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">PARI</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that occur when securities with different characteristics become identical in all respects</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PariPassuAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PariPassuAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PariPassuAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PariPassuAction"/>
 		<lcc-lr:hasTag>PARI</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;PCAL">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;PCAL">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">PCAL</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PartialRedemptionWithReductionOfNominalValueAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PartialRedemptionWithReductionOfNominalValueAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithReductionOfNominalValueAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithReductionOfNominalValueAction"/>
 		<lcc-lr:hasTag>PCAL</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;PRED">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;PRED">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">PRED</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PartialRedemptionWithoutReductionOfNominalValueAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PartialRedemptionWithoutReductionOfNominalValueAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithoutReductionOfNominalValueAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithoutReductionOfNominalValueAction"/>
 		<lcc-lr:hasTag>PRED</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;PRIO">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;PRIO">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">PRIO</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a public offer where priority is given to existing shareholders</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;PriorityIssue"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;PriorityIssue"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PriorityIssue"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PriorityIssue"/>
 		<lcc-lr:hasTag>PRIO</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PariPassuAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;PariPassuAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">pari-passu action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that occurs when securities with different characteristics become identical in all respects</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A pari-passu event includes cases, for example, when shares with different entitlements to dividend or voting rights become equivalent through assimilation or pari-passu. Such an event may be scheduled in advance, for example, when shares resulting from a bonus may become fungible after a pre-set period of time, or may result from outside events, for example, merger, reorganisation, issue of supplementary tranches, etc.</fibo-fnd-utl-av:explanatoryNote>
@@ -900,35 +900,35 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">assimilation</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialDefeasanceAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;PartialDefeasanceAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">partial defeasance action</rdfs:label>
 		<skos:definition xml:lang="en">The setting aside by a borrower of cash or bonds sufficient to service the borrower&apos;s debt.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From Free dictionary: Both the borrower&apos;s debt and the offsetting cash or bonds are removed from the balance sheet. In securities trading, where a clearing house becomes counterparty to each side of a trade, after the trade has been agreed. This is necessary to facilitate netting, and reduce counterparty risk exposure. The term has become popular recently, because of the growth of central counterparty clearing services in European cash equities markets. Origin: http://financial-dictionary.thefreedictionary.com/defeasance SWIFT: Term:PDEF; &quot;Partial Defeasance/Prefunding&quot; Definition:&quot;Issuer has money set aside to redeem a portion of an issue and the indenture states that the securities could be called earlier than the stated maturity.&quot;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialRedemptionWithReductionOfNominalValueAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;PartialRedemptionWithReductionOfNominalValueAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">partial redemption with reduction of nominal value action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The outstanding amount of securities will be reduced proportionally. May be mandatory or voluntary.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialRedemptionWithoutReductionOfNominalValueAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;PartialRedemptionWithoutReductionOfNominalValueAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">partial redemption without reduction of nominal value action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is commonly done by pool factor reduction. May be mandatory or voluntary.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PlaceOfIncorporationChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateInformationAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;PlaceOfIncorporationChange">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateInformationAction"/>
 		<rdfs:label xml:lang="en">place of incorporation change</rdfs:label>
 		<skos:definition xml:lang="en">Changes in the state of incorporation for US companies and changes in the place of incorporation for foreign companies. Where shares need to be registered following the incorporation change, the holder(s) may have to elect the registrar. SWIFT = PLAC</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PostMergerSecuritiesExchange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;PostMergerSecuritiesExchange">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
@@ -938,13 +938,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;convertsFrom"/>
+				<owl:onProperty rdf:resource="&fibo-cae-ce-srca;convertsFrom"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;convertsTo"/>
+				<owl:onProperty rdf:resource="&fibo-cae-ce-srca;convertsTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -953,66 +953,66 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an action as a result of the merger, not the merger itself, and may be mandatory or voluntary. Cash payments may accompany share exchange.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PriorityIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;PriorityIssue">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">priority issue</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that is a public offer where, due to a limited amount of securities available, priority is given to existing shareholders</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PutRedemptionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;PutRedemptionAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">put redemption action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;REDM">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;REDM">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">REDM</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities at final maturity</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;RedemptionAtMaturityAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;RedemptionAtMaturityAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RedemptionAtMaturityAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;RedemptionAtMaturityAction"/>
 		<lcc-lr:hasTag>REDM</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;REDO">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;REDO">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">REDO</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions by which the unit (currency and/or nominal) of a security is restated</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;RedenominationAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;RedenominationAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RedenominationAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;RedenominationAction"/>
 		<lcc-lr:hasTag>REDO</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;RHDI">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;RHDI">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">RHDI</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;IntermediateSecuritiesDistribution"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;IntermediateSecuritiesDistribution"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution"/>
 		<lcc-lr:hasTag>RHDI</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RedemptionAtMaturityAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;RedemptionAtMaturityAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">redemption at maturity action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves redemption of an entire issue outstanding of securities at final maturity</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RedenominationAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;RedenominationAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">redenomination action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action by which the unit (currency and/or nominal) of a security is restated</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, the nominal/par value of security in a national currency is restated in another currency.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RepurchaseOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;RepurchaseOffer">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">repurchase offer</rdfs:label>
 		<skos:definition xml:lang="en">corporate action in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The objective of the offer is to reduce the number of outstanding equities.</fibo-fnd-utl-av:explanatoryNote>
@@ -1020,8 +1020,8 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">reverse rights</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ReverseStockSplit">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;ReverseStockSplit">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
@@ -1029,85 +1029,85 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">reverse stock split</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
+		<owl:disjointWith rdf:resource="&fibo-cae-ce-srca;StockSplit"/>
 		<skos:definition xml:lang="en">corporate action involving a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equity price and nominal value are increased accordingly.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en">change in nominal value</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsExerciseEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;RightsExerciseEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">rights exercise event</rdfs:label>
 		<skos:definition xml:lang="en">Exercising the right to purchase the shares. Furhter Notes: This is an action on the part of the holder. SWIFT: Call/exercise on nil-paid securities/rights resulting from a rights distribution (RHDI) (To be used for the second event in case rights issue is dealt with in 2 events, first event being the RHDI).</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is a rights trading period overlaps with rights subscriptiuon period (you can trade the rights) Rights exercise period - expiry date. Some time after the expiry the new shares are distributed. This is the distribution.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;SHPR">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;SHPR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">SHPR</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the shares premium reserve</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;SharesPremiumDividendAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;SharesPremiumDividendAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;SharesPremiumDividendAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;SharesPremiumDividendAction"/>
 		<lcc-lr:hasTag>SHPR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;SOFF">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;SOFF">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">SOFF</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;SpinOff"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;SpinOff"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;SpinOff"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;SpinOff"/>
 		<lcc-lr:hasTag>SOFF</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;SPLF">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;SPLF">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">SPLF</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve an increase in a corporation&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;StockSplit"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;StockSplit"/>
 		<lcc-lr:hasTag>SPLF</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;SPLR">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;SPLR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">SPLR</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;ReverseStockSplit"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;ReverseStockSplit"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ReverseStockSplit"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;ReverseStockSplit"/>
 		<lcc-lr:hasTag>SPLR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SharesPremiumDividendAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;SharesPremiumDividendAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">shares premium dividend action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that pays shareholders an amount in cash issued from the shares premium reserve</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It is similar to a dividend but with different tax implications.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SpinOff">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;SpinOff">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">spin off</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Spin-off represents a form of divestiture usually resulting in an independent company or in an existing company. For example, demerger, distribution, unbundling.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;StockDividendAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;StockDividendAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">stock dividend action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves distribution of a dividend to shareholders in the form of equities of the issuing corporation</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;StockSplit">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;StockSplit">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
@@ -1121,19 +1121,19 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">subdivision</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;TEND">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;TEND">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
 		<rdfs:label xml:lang="en">TEND</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;TenderOffer"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;TenderOffer"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;TenderOffer"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;TenderOffer"/>
 		<lcc-lr:hasTag>TEND</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TenderOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;TenderOffer">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;VoluntaryCorporateAction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
@@ -1148,13 +1148,13 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">takeover</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusActiveMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;TradingStatusMessage"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;TradingStatusActiveMessage">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;TradingStatusMessage"/>
 		<rdfs:label xml:lang="en">trading status active message</rdfs:label>
 		<skos:definition xml:lang="en">Trading in security has commenced or security has been re-activated after a supsension in trading.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusMessage">
+	<owl:Class rdf:about="&fibo-cae-ce-srca;TradingStatusMessage">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -1173,55 +1173,55 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are a number of such messages. Events v Status: See e.g. Active: this relates to one state OR two transitions (transition from pre-issuance to Trading, or from Suspended to Trading).</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusSuspendedMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;TradingStatusMessage"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;TradingStatusSuspendedMessage">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;TradingStatusMessage"/>
 		<rdfs:label xml:lang="en">trading status suspended message</rdfs:label>
 		<skos:definition xml:lang="en">Trading in the security has been suspended.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;VoluntaryCorporateAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">voluntary corporate action</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+		<owl:disjointWith rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<skos:definition xml:lang="en">event in which the shareholders elect to participate and must respond in order for the issuer to process the action</skos:definition>
 		<skos:example xml:lang="en">An example of a voluntary corporate action is a tender offer, in which the issuer may request shareholders to tender their shares at a predetermined price.</skos:example>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Shareholders send responses to the issuer&apos;s agents, and the issuer will send the proceeds of the action to those shareholders who elect to participate.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-cae;WRTH">
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;BusinessStrategyOrientedAction"/>
-		<rdf:type rdf:resource="&fibo-cae-ce-cae;IncomeOrientedAction"/>
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;WRTH">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyOrientedAction"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedAction"/>
 		<rdfs:label xml:lang="en">WRTH</rdfs:label>
 		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve booking out of valueless securities</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-cae;WorthlessSecurityAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-cae;WorthlessSecurityAction"/>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;WorthlessSecurityAction"/>
+		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;WorthlessSecurityAction"/>
 		<lcc-lr:hasTag>WRTH</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-cae;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;WarrantExerciseAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;WarrantExerciseAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:label xml:lang="en">warrant exercise action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that offers holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time (which usually corresponds to the life of the issue)</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that participation by the warrant holder may be mandatory or voluntary and may involve a choice in the mandatory case.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;WorthlessSecurityAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+	<owl:Class rdf:about="&fibo-cae-ce-srca;WorthlessSecurityAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">worthless security action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves booking out of valueless securities</skos:definition>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;convertsFrom">
+	<owl:ObjectProperty rdf:about="&fibo-cae-ce-srca;convertsFrom">
 		<rdfs:label xml:lang="en">converts from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+		<rdfs:domain rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;convertsTo">
+	<owl:ObjectProperty rdf:about="&fibo-cae-ce-srca;convertsTo">
 		<rdfs:label xml:lang="en">converts to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+		<rdfs:domain rdf:resource="&fibo-cae-ce-srca;CorporateAction"/>
 		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
 	</owl:ObjectProperty>
 

--- a/CAE/MetadataCAE.rdf
+++ b/CAE/MetadataCAE.rdf
@@ -23,8 +23,8 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/">
 		<rdfs:label>Metadata about the EDMC-FIBO Corporate Actions and Events (CAE) Domain</rdfs:label>
-		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, to credit events that are relevant to investors and regulators alike. Corporate actions include actions that require some action on the part of the holder, and in these and some other cases there are process descriptions for the flow of activities involved.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
+		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, as well as more general business events that are relevant to investors and regulators alike.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
@@ -32,16 +32,24 @@
 		<sm:filename>MetadataCAE.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20200401/MetadataCAE/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20201001/MetadataCAE/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-mod;CAEDomain">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Corporate Actions and Events Domain</rdfs:label>
-		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, to credit events that are relevant to investors and regulators alike. Corporate actions include actions that require some action on the part of the holder, and in these and some other cases there are process descriptions for the flow of activities involved.</dct:abstract>
+		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, as well as more general business events that are relevant to investors and regulators alike.</dct:abstract>
 		<dct:hasPart rdf:resource="&fibo-cae-ce-mod;CorporateEventsModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:keyword>corporate actions</sm:keyword>
+		<sm:keyword>corporate events</sm:keyword>
 		<sm:moduleAbbreviation>fibo-cae</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -58,7 +58,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MetadataBPSecuritiesIssuance/" uri="./BP/SecuritiesIssuance/MetadataBPSecuritiesIssuance.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MuniIssuance/" uri="./BP/SecuritiesIssuance/MuniIssuance.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/" uri="./BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/" uri="./CAE/CorporateEvents/CorporateActionsEvents.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/" uri="./CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/" uri="./CAE/CorporateEvents/MetadataCAECorporateEvents.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/" uri="./CAE/MetadataCAE.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/CIV/" uri="./CIV/Funds/CIV.rdf"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This issue resolution involves significant clean-up to the corporate actions ontology, renaming it from CorporateActionsEvents to SecurityRelatedCorporateActions, adding ISO 15022 codes for the relevant events, and eliminating message-specific contents.  It is still provisional, but goes a long way towards enabling integration as a released ontology.

Fixes: #1194 / SEC-141


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


