### PR TITLE
New hygiene test - property hierarchy cycles

### DIFF
--- a/etc/testing/hygiene/testHygiene1190_properties.sparql
+++ b/etc/testing/hygiene/testHygiene1190_properties.sparql
@@ -1,0 +1,13 @@
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+##
+# banner Property subPropertyOf hierarchy shouldn't be circular.
+
+SELECT DISTINCT ?error ?property
+WHERE 
+{
+  FILTER (CONTAINS(str(?property), "edmcouncil"))
+  ?property rdfs:subPropertyOf+ ?property
+
+  BIND (concat ("PRODERROR: There is a hierarchy cycle around property ", str(?property)) AS ?error)
+}


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This PR adds a check for cycles in property hierarchy.
It was suggested by @rivettp as a twin to the check discussed in https://github.com/edmcouncil/fibo/issues/1190.

Fixes: #1190


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


