### PR TITLE
New hygiene test - direct circularity in owl imports

### DIFF
--- a/etc/testing/hygiene/testHygiene1177.sparql
+++ b/etc/testing/hygiene/testHygiene1177.sparql
@@ -2,7 +2,7 @@ PREFIX owl:   <http://www.w3.org/2002/07/owl#>
 
 
 ##
-# banner No ontology may not import itself.
+# banner No ontology may import itself.
 
 SELECT DISTINCT ?error ?ontology 
 WHERE

--- a/etc/testing/hygiene/testHygiene1177.sparql
+++ b/etc/testing/hygiene/testHygiene1177.sparql
@@ -1,0 +1,13 @@
+PREFIX owl:   <http://www.w3.org/2002/07/owl#>
+
+
+##
+# banner No ontology may not import itself.
+
+SELECT DISTINCT ?error ?ontology 
+WHERE
+{
+    ?ontology owl:imports ?ontology.
+    FILTER (CONTAINS(str(?ontology), "edmcouncil"))
+    BIND (concat ("PRODERROR: ", str(?ontology), " imports itself.") AS ?error)
+}


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz pawel.garbacz@makolab.com

## Description

This adds a check that identifies every ontology that imports itself.

Fixes: #1177


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


