### PR TITLE
FND-322 - Contract party is missing a restriction and the class hierarchy related to contract parties is overly complex

### DIFF
--- a/BE/LegalEntities/LegalPersons.rdf
+++ b/BE/LegalEntities/LegalPersons.rdf
@@ -71,7 +71,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200601/LegalEntities/LegalPersons/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201101/LegalEntities/LegalPersons/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/LegalEntities/LegalPersons.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/LegalEntities/LegalPersons.rdf version of this ontology was modified per the FIBO 2.0 RFC to normalize restrictions on business license.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/LegalEntities/LegalPersons.rdf version of this ontology was modified to rationalize natural person and legally capable person in a new concept, namely legally competent natural person, simplify / merge the legal person and formal organization class hierarchies, and correct certain definitions, including power of attorney.</skos:changeNote>
@@ -79,6 +79,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190401/LegalEntities/LegalPersons.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/LegalEntities/LegalPersons.rdf version of this ontology was modified to clarify the definition of legal person.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200101/LegalEntities/LegalPersons.rdf version of this ontology was modified to move the concept of a signatory and related properties to the executives ontology for better semantic integration.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/LegalEntities/LegalPersons.rdf version of this ontology was modified to augment the definition of a contract party to be a legal person.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -282,5 +283,15 @@
 		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<skos:definition>indicates the jurisdiction in which a legal person is considered competent to enter into a contract, conduct business, or participate in other activities, or in which an agreement may be acknowledged and possibly enforceable</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractParty">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
 
 </rdf:RDF>

--- a/BE/OwnershipAndControl/CorporateOwnership.rdf
+++ b/BE/OwnershipAndControl/CorporateOwnership.rdf
@@ -61,12 +61,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200901/OwnershipAndControl/CorporateOwnership/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201101/OwnershipAndControl/CorporateOwnership/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified per the FIBO 2.0 RFC to reference shareholders&apos; equity in the definition of a shareholder.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to generalize the definition of beneficial owner rather than limiting it to shareholding and eliminate a duplicate restriction on shareholder.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190201/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to modify the inheritance hierarchy for beneficial owner to replace owner with controlling party as one of its parent classes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to replace isEquityHeldBy with its parent, isHeldBy, eliminate redundant classes that were not used anywhere, and clean up a few definitions to be less ambiguous, not circular, and to conform with ISO 704.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200901/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was revised to simplify the contract party hierarchy.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -99,7 +100,7 @@
 	
 	<owl:Class rdf:about="&fibo-be-oac-cown;Shareholder">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;ConstitutionalOwner"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
 		<rdfs:label xml:lang="en">shareholder</rdfs:label>
 		<skos:definition>party that owns shares in and has rights and responsibilities with respect to some asset, provided in exchange for investment</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The shares represent an ownership interest in a corporation, mutual fund, or partnership, or a unit of ownership in a structured product, such as a real estate investment trust.</fibo-fnd-utl-av:explanatoryNote>

--- a/CIV/Funds/CIV.rdf
+++ b/CIV/Funds/CIV.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
+	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/CIV/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-fi-stl "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/">
@@ -53,6 +54,7 @@
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
+	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/CIV/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-fi-stl="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"
@@ -112,6 +114,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
@@ -228,7 +231,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-civ-fnd-civ;EquityAsset">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;SecurityHolding"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
@@ -661,24 +664,6 @@
 		<rdfs:label xml:lang="en">fund investment policy</rdfs:label>
 		<skos:definition xml:lang="en">policy that the fund implements in order to achieve the stated fund objectives</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">EFAMA Note: Model distinguishes between strategy (what you intend to invest in) and portfolio structure (what is held). This semantics matches the EFAMA DD &quot;Fund Investment Policy&quot; No stated definition in EFAMA DD (&quot;Further discussion required&quot;).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestor">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isUnitHolder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund investor</rdfs:label>
-		<skos:definition xml:lang="en">A party which invests in the Fund. It does this by holding some tradable unit (which represents some stake) in that fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Facts about investor tolerance and so on, are facts about Investor.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestorType">
-		<rdfs:label xml:lang="en">fund investor type</rdfs:label>
-		<skos:definition xml:lang="en">The type of party that is eligible to invest in a fund.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundLegalContract">
@@ -1598,13 +1583,6 @@
 		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;InvestmentAdvisor"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;allowedInvestorType">
-		<rdfs:label xml:lang="en">allowed investor type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestorType"/>
-		<skos:definition xml:lang="en">Type of investor that can invest in the fund class.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;anticipatedVolatility">
 		<rdfs:label xml:lang="en">anticipated volatility</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
@@ -2297,7 +2275,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isUnitHolder">
 		<rdfs:label xml:lang="en">is unit holder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+		<rdfs:domain rdf:resource="&fibo-be-oac-opty;Investor"/>
 		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
 	</owl:ObjectProperty>
 	

--- a/DER/DerivativesContracts/RightsAndWarrants.rdf
+++ b/DER/DerivativesContracts/RightsAndWarrants.rdf
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
+	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-der-drc-raw "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -22,6 +24,8 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
+	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-der-drc-raw="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -45,6 +49,8 @@
 		<rdfs:label xml:lang="en">Rights and Warrants Ontology</rdfs:label>
 		<dct:abstract>This covers a range of special contracts or arrangement with selected holders such as company participants. These include rights (privileges) extended to existing security holders to make new securities available to them at reduced prices or free, and warrants whereby the holder can purchase or sell back a given quantity of the instrument, commodity or currency during a specified period at a pre-defined price.</dct:abstract>
 		<sm:fileAbbreviation>fibo-der-drc-raw</sm:fileAbbreviation>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -81,7 +87,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;AllotmentRightHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;SecurityHolder"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;Investor"/>
 		<rdfs:label xml:lang="en">allotment right holder</rdfs:label>
 		<skos:definition xml:lang="en">The party which is the holder of an allotment right. This is identified as being a party which is also an existing holder of the security identified as the underlying security.</skos:definition>
 	</owl:Class>
@@ -209,7 +215,16 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;SecurityHolder"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-be-oac-opty;Investor">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-be-oac-cown;Shareholder">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">stockholders rights instrument</rdfs:label>

--- a/FBC/DebtAndEquities/Guaranty.rdf
+++ b/FBC/DebtAndEquities/Guaranty.rdf
@@ -81,11 +81,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20191201/DebtAndEquities/Guaranty/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201101/DebtAndEquities/Guaranty/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Guaranty/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181001/DebtAndEquities/Guaranty/ version of this ontology revised to add financial asset as a parent of letter of credit.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181001/DebtAndEquities/Guaranty/ version of this ontology revised to incorporate refinement of the concept of a guaranty as needed for debt securities and loans.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191201/DebtAndEquities/Guaranty/ version of this ontology revised to eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/DebtAndEquities/Guaranty/ version of this ontology revised to simplify the contract party hierarchy.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -215,7 +216,7 @@
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;Insurer">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractOriginator"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
 		<rdfs:label>insurer</rdfs:label>
 		<skos:definition>a financial service provider that issues an insurance policy</skos:definition>
 	</owl:Class>

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -91,7 +91,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190701/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to change the restriction on financial instrument identifier from some values to min 0, to allow for cases when an instrument identifier identifies a listing, eliminate duplication of concepts in LCC, and simplify addresses.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to move redemption provision from debt to financial instruments, given that it is a broader concept needed for equities.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to add a property indicating the currency that an instrument is issued in.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to add a property indicating the currency that an instrument is issued in and simplify the contract party hierarchy.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -231,14 +231,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Issuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractOriginator"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
@@ -251,8 +244,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>issuer</rdfs:label>
-		<skos:definition>any party who issues (or proposes to issue, in a formal filing) any financial instrument, where a party can be a natural person, company, government, or political subdivision, agency, or instrumentality of a government</skos:definition>
+		<skos:definition>party that issues (or proposes to issue in a formal filing) a financial instrument</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Securities Exchange Act of 1934, as amended 12 August 2012</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>An issuer can be any legal person, including a legally competent natural person, company, government, or political subdivision, agency, or instrumentality of a government, depending on the nature of the instrument. A person might provide a loan directly to another party, but most instruments are issued by legal entities.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>With respect to certificates of deposit for securities, voting-trust certificates, or collateral- trust certificates, or with respect to certificates of interest or shares in an unincorporated investment trust not having a board of directors or of the fixed, restricted management, or unit type, the term issuer means the person or persons performing the acts and assuming the duties of depositor or manager pursuant to the provisions of the trust or other agreement or instrument under which such securities are issued; and except that with respect to equipment-trust certificates or like securities, the term issuer means the person by whom the equipment or property is, or is to be, used.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -81,7 +81,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Agreements/Contracts.rdf version of this ontology was revised to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Agreements/Contracts.rdf version of this ontology was revised to add the concept of a term sheet, revise definitions to be ISO 704 compliant, and eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Agreements/Contracts.rdf version of this ontology was revised to add the concepts of breach of contract and breach of covenant.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Agreements/Contracts.rdf version of this ontology was revised to eliminate ambiguity in definitions where feasible.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Agreements/Contracts.rdf version of this ontology was revised to simplify the contract party hierarchy and eliminate ambiguity in definitions where feasible.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -322,7 +322,7 @@
 					</owl:Restriction>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-						<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
+						<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
 					</owl:Restriction>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasPrincipalParty"/>
@@ -333,13 +333,6 @@
 		</owl:equivalentClass>
 		<skos:definition>contract in which the rights and obligations of one party (the holder) may be transferred to another party, which thereby takes on the same rights and obligations with respect to the other party to the contract</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Note that the ability to transfer ownership of one side of a contract, and the concept of assignability, are distinct. In one case the contract may be freely traded; in the other case, some legal transfer of rights to a third party takes place, without a change in who are the signatories of a (typically bilateral) contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;TransferableContractHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
-		<rdfs:label>transferable contract holder</rdfs:label>
-		<skos:definition>party that holds a transferable contract and enjoys the benefits defined in that contract while they hold it</skos:definition>
-		<skos:editorialNote>This party may transfer the contract to another party without reference to the issuer, for example by selling it in some marketplace.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;UnilateralContract">

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -195,12 +195,6 @@
 		<skos:scopeNote>Written here does not necessarily mean a paper document but includes situations in which the contract is expressed electronically, whether as an electronic representation of a formal document such as in PDF form or as an electronic message, provided in the latter case that the message is expressly given formal contractual standing, for example as indicated in a separate covering agreement between the parties.</skos:scopeNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractOriginator">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<rdfs:label>contract originator</rdfs:label>
-		<skos:definition>party that originates a contract and acts as principal</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractParty">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
 		<rdfs:subClassOf>
@@ -221,8 +215,8 @@
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractPrincipal">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
 		<rdfs:label>contract principal</rdfs:label>
-		<skos:definition>party identified as the first party to a contract, in the event that the contract distinguishes any party as such</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The principal to a contract is often the issuer.  In law, the principal is the party that has the primary responsibility in a liability or obligation, as opposed to an endorser, guarantor, or surety.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>party that originates a contract and is identified as the first party to that contract, in the event that the contract distinguishes any party as such</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The principal to a contract is typically the originator and, in the case of a security, the issuer.  In law, the principal is the party that has the primary responsibility in a liability or obligation, as opposed to an endorser, guarantor, or surety.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractThirdParty">
@@ -326,7 +320,7 @@
 					</owl:Restriction>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasPrincipalParty"/>
-						<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractOriginator"/>
+						<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
 					</owl:Restriction>
 				</owl:intersectionOf>
 			</owl:Class>

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -67,7 +67,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Agreements/Contracts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20201101/Agreements/Contracts/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Agreements/Contracts.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
    (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -81,6 +81,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Agreements/Contracts.rdf version of this ontology was revised to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Agreements/Contracts.rdf version of this ontology was revised to add the concept of a term sheet, revise definitions to be ISO 704 compliant, and eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Agreements/Contracts.rdf version of this ontology was revised to add the concepts of breach of contract and breach of covenant.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Agreements/Contracts.rdf version of this ontology was revised to eliminate ambiguity in definitions where feasible.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -125,8 +126,8 @@
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ConditionPrecedent">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
 		<rdfs:label>condition precedent</rdfs:label>
-		<skos:definition>condition that must be met, or an event or state of affairs that must occur, before a contract is considered in effect or certain obligations are expected of some party to that contract</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Condition precedents are common in wills and trusts.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>stipulation that specifies conditions that must be met before some aspect of a contract takes effect</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Condition precedents are common in wills and trusts. They include events or states of affairs that act as triggers for the contract to come into effect, such as a beneficiary reaching the age of maturity, or death of a trustor, as well as define obligations on a party to the contract, such as those required of a trustee on the death of a trustor.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>There may also be condition precedents in the ongoing life of a contract, which state that if condition X occurs, event Y will then occur. Condition X is the condition precedent.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -181,7 +182,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>contract</rdfs:label>
-		<skos:definition>voluntary, deliberate agreement between two or more competent parties to which those parties agree to be legally bound, and to which the parties must have provided valuable consideration</skos:definition>
+		<skos:definition>voluntary, deliberate agreement between competent parties to which the parties agree to be legally bound, and for which the parties provide valuable consideration</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/contract.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A contractual relationship is evidenced by (1) an offer, (2) acceptance of the offer, and a (3) valid (legal and valuable) consideration. A contract is a kind of agreement, and as such it embodies the assertion that it has been negotiated, such negotiation having included the presence of some offer and the acceptance of that offer on the part of either or both of the parties.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Contracts are usually written but may be spoken or implied, and generally have to do with employment, sale or lease, or tenancy.</fibo-fnd-utl-av:explanatoryNote>
@@ -214,20 +215,20 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>contract party</rdfs:label>
-		<skos:definition>legally competant person or organization that has entered into the binding agreement, accepting and/or conceding obligations, responsibilities, and benefits as specified</skos:definition>
+		<skos:definition>legally competant party that has entered into a binding agreement, accepting and conceding obligations, responsibilities, and benefits as specified</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractPrincipal">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
 		<rdfs:label>contract principal</rdfs:label>
-		<skos:definition>party identified as being the principal or first party to a contract, in the event that the contract distinguishes any party as the principal</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In law, the principal is the party that has the primary responsibility in a liability or obligation, as opposed to an endorser, guarantor, or surety.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>party identified as the first party to a contract, in the event that the contract distinguishes any party as such</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The principal to a contract is often the issuer.  In law, the principal is the party that has the primary responsibility in a liability or obligation, as opposed to an endorser, guarantor, or surety.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractThirdParty">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
 		<rdfs:label>contract third party</rdfs:label>
-		<skos:definition>someone that may be indirectly involved but is not a principal party to an arrangement, contract, deal, lawsuit, or transaction</skos:definition>
+		<skos:definition>party that is indirectly involved in, but not a counterparty to, an agreement</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
@@ -246,29 +247,28 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>contractual commitment</rdfs:label>
-		<skos:definition>terms and conditions that define the commitment made by the contracting parties, such as rights and obligations when a contract is awarded or entered into</skos:definition>
-		<skos:scopeNote>These include general conditions which are common to all types of contracts, such as general and special arrangements, provisions, requirements, rules, specifications, and standards that form an integral part of an agreement or contract, as well as special conditions which are peculiar to a specific contract (such as, contract change conditions, payment conditions, price variation clauses, penalties).</skos:scopeNote>
+		<skos:definition>provision specifying something that the contracting parties agree to</skos:definition>
+		<skos:scopeNote>Contractual commitments include general conditions which are common to all types of contracts, such as general and special arrangements, provisions, requirements, rules, rights and obligations, specifications, and standards that form an integral part of an agreement or contract, as well as special conditions which are peculiar to a specific contract (such as, contract change conditions, payment conditions, price variation clauses, penalties).</skos:scopeNote>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/conditions-of-contract.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualDefinition">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
 		<rdfs:label>contractual definition</rdfs:label>
-		<skos:definition>contractual element that defines something in a contract or other legal instrument</skos:definition>
-		<skos:editorialNote>These are agreed definitions which are then referred to in terms in contracts or other legal instruments.</skos:editorialNote>
+		<skos:definition>contractual element that specifies the meaning of a term in a legal document, whose definition is substitutable for the term whenever it occurs in the body of that document</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualElement">
 		<rdfs:label>contractual element</rdfs:label>
-		<skos:definition>general and special arrangements, provisions, requirements, rules, specifications, and standards that form an integral part of an agreement or contract</skos:definition>
+		<skos:definition>element, such as an arrangement, provision, requirement, rule, specification, and standard that forms an integral part of an agreement</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/terms-and-conditions.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;Counterparty">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
 		<rdfs:label>counterparty</rdfs:label>
-		<skos:definition>party or parties with whom one negotiates on a given agreement</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The term &apos;counterparty&apos; can refer to any party to an agreement, depending on context.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>party to a contract with whom one negotiates on a given agreement</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The counterparty is usually the party &apos;on the other side&apos; of a contract from the perspective of the issuer or holder. The term &apos;counterparty&apos; can refer to any party to an agreement, depending on context.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;MutualContractualAgreement">
@@ -276,22 +276,22 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
 		<rdfs:label>mutual contractual agreement</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-agr-ctr;UnilateralContract"/>
-		<skos:definition>contract between two or more specific named parties; the rights and obligations pertaining to either party cannot be transferred to another party without prior written permission or a change to the contract itself</skos:definition>
+		<skos:definition>contract between named parties whose individual rights and obligations are not transferable to another party without prior written permission</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A mutual contractual agreement involves an exchange of a promises in which the promises made by each party represent considerations supporting the promises of the other party(ies).</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>bilateral contract</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;NonBindingTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label>non-binding terms</rdfs:label>
-		<skos:definition>contractual commitments that do not have binding legal standing on the issuer or holder</skos:definition>
+	<owl:Class rdf:about="&fibo-fnd-agr-ctr;NonBindingTerm">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
+		<rdfs:label>non-binding term</rdfs:label>
+		<skos:definition>contractual element that is not legally binding on any party to the agreement</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;PromissoryNote">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;UnilateralContract"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
 		<rdfs:label>promissory note</rdfs:label>
-		<skos:definition>unconditional and unsecured promise by one party (the issuer or promisor) to another (the payee or promisee) that commits the issuer to pay a specified sum on demand, or on a fixed or a determinable date</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Promissory notes (such as bank or currency notes) are negotiable instruments.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>negotiable instrument that is an unconditional and unsecured promise by one party to another that commits the principal party to pay a specified sum within a specified time frame under specified terms</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Unlike a contract, a Promissory Note does not need to be signed by both parties. It is essentially a promise from one party to the holder, of some good or benefit. Promissory notes are generally fully fungible.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -299,8 +299,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasNonBindingTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;NonBindingTerms"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasNonBindingTerm"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;NonBindingTerm"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>term sheet</rdfs:label>
@@ -351,10 +351,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>unilateral contract</rdfs:label>
-		<skos:definition>contract in which only one party makes an express promise, or undertakes a performance without first securing a reciprocal agreement from the other party</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In a unilateral, or one-sided, contract, one party, known as the offeror, makes a promise in exchange for an act (or abstention from acting) by another party, known as the offeree. If the offeree acts on the offeror&apos;s promise, the offeror is legally obligated to fulfill the contract, but an offeree cannot be forced to act (or not act), because no return promise has been made to the offeror. After an offeree has performed, only one enforceable promise exists, that of the offeror.
-
-A unilateral contract differs from a Bilateral Contract, in which the parties exchange mutual promises. Bilateral contracts are commonly used in business transactions; a sale of goods is a type of bilateral contract.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>contract in which one party makes an express promise without securing a reciprocal agreement from the other party(ies)</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>In a unilateral, or one-sided, contract, one party, known as the offeror, makes a promise in exchange for an act (or abstention from acting) by another party, known as the offeree. If the offeree acts on the offeror&apos;s promise, the offeror is legally obligated to fulfill the contract, but an offeree cannot be forced to act (or not act), because no return promise has been made to the offeror. After an offeree has performed, only one enforceable promise exists, that of the offeror.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;VerbalContract">
@@ -387,7 +385,7 @@ A unilateral contract differs from a Bilateral Contract, in which the parties ex
 		<rdfs:label>has contract party</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
 		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<skos:definition>indicates a person or organization that has entered into the binding agreement, accepting and/or conceding obligations, responsibilities, and benefits as specified</skos:definition>
+		<skos:definition>indicates a party that has entered into a binding agreement, accepting and conceding obligations, responsibilities, and benefits as specified</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasContractualElement">
@@ -395,7 +393,7 @@ A unilateral contract differs from a Bilateral Contract, in which the parties ex
 		<rdfs:label>has contractual element</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
 		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<skos:definition>indicates an element, such as a contractual definition, term describing a commitment, right or obligation, that forms part of an agreement or contract</skos:definition>
+		<skos:definition>indicates something that is a component of an agreement</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasCounterparty">
@@ -403,7 +401,7 @@ A unilateral contract differs from a Bilateral Contract, in which the parties ex
 		<rdfs:label>has counterparty</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
 		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
-		<skos:definition>identifies a counterparty to a contract</skos:definition>
+		<skos:definition>identifies a party to a contract, typically not the contract principal</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasEffectiveDate">
@@ -417,7 +415,7 @@ A unilateral contract differs from a Bilateral Contract, in which the parties ex
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDateTimeStamp"/>
 		<rdfs:label>has effective date time stamp</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DateTimeStamp"/>
-		<skos:definition>indicates the date and time, including time zone, a contract, relationship, or policy comes into force</skos:definition>
+		<skos:definition>indicates the date and time, including time zone, something comes into force</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasExecutionDate">
@@ -445,12 +443,12 @@ A unilateral contract differs from a Bilateral Contract, in which the parties ex
 		<fibo-fnd-utl-av:explanatoryNote>In a written contract this is generally identified, for example, as Governing Law, namely the jurisdiction in which any disputes arising from the contract are to be resolved.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasNonBindingTerms">
+	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasNonBindingTerm">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label>has non-binding terms</rdfs:label>
+		<rdfs:label>has non-binding term</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;NonBindingTerms"/>
-		<skos:definition>refers to terms that are included in an agreement that are not considered legally binding</skos:definition>
+		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;NonBindingTerm"/>
+		<skos:definition>refers to a term that is included in an agreement that is not considered legally binding</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In other words, a breach of such terms in the future would not be considered to be a breach of the contract.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
@@ -505,10 +503,11 @@ A unilateral contract differs from a Bilateral Contract, in which the parties ex
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;supersedes">
+		<rdf:type rdf:resource="&owl;TransitiveProperty"/>
 		<rdfs:label>supersedes</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
 		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<skos:definition>the or any earlier contract which this contract replaces</skos:definition>
+		<skos:definition>indicates a contract that was executed prior to and is replaced by this contract</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/MD/CIVTemporal/FundsTemporal.rdf
+++ b/MD/CIVTemporal/FundsTemporal.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/CIV/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -14,6 +15,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/CIV/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -29,6 +31,7 @@
 		<rdfs:label xml:lang="en">FundsTemporal</rdfs:label>
 		<dct:abstract>Terms which have a time component (either real time, intra-day or dated terms). These include Net Present Value (NPV) and related analytics.</dct:abstract>
 		<sm:fileAbbreviation>fibo-md-civx-fun</sm:fileAbbreviation>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/CIV/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -70,7 +73,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-md-civx-fun;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-oac-opty;Investor"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">funds tax</rdfs:label>
@@ -102,7 +105,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;appliesTo">
 		<rdfs:label xml:lang="en">applies to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundsTax"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+		<rdfs:range rdf:resource="&fibo-be-oac-opty;Investor"/>
 		<owl:inverseOf rdf:resource="&fibo-md-civx-fun;incursTax"/>
 	</owl:ObjectProperty>
 	
@@ -159,7 +162,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursFees">
 		<rdfs:label xml:lang="en">incurs fees</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+		<rdfs:domain rdf:resource="&fibo-be-oac-opty;Investor"/>
 		<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
 	</owl:ObjectProperty>
 	
@@ -171,7 +174,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursTax">
 		<rdfs:label xml:lang="en">incurs tax</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+		<rdfs:domain rdf:resource="&fibo-be-oac-opty;Investor"/>
 		<rdfs:range rdf:resource="&fibo-md-civx-fun;FundsTax"/>
 	</owl:ObjectProperty>
 	

--- a/SEC/Debt/AssetBackedSecurities/CDOs.rdf
+++ b/SEC/Debt/AssetBackedSecurities/CDOs.rdf
@@ -436,7 +436,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;MBSInstrumentSlice">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;SecurityHolding"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>

--- a/SEC/Securities/SecurityAssets.rdf
+++ b/SEC/Securities/SecurityAssets.rdf
@@ -63,8 +63,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecurityAssets/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201101/Securities/SecurityAssets/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecurityAssets.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecurityAssets.rdf version of this ontology was revised to simplify the contract party hierarchy and eliminate complexity introduced by &apos;security holding&apos;.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -149,48 +150,6 @@
 		<fibo-fnd-utl-av:explanatoryNote>Portfolio holdings may cover a variety of investment products, including stocks, bonds and mutual funds to options, futures and exchange-traded funds, and relatively esoteric instruments such as private equity and hedge funds. 
 
 The number and nature of holdings contribute to the degree of diversification of a portfolio.  A mix of stocks across different sectors, bonds of different maturities, and other investments would suggest a well-diversified portfolio, while concentrated holdings in a handful of stocks within a single sector indicates a portfolio with limited diversification.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-sec-ast;SecurityHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
-		<rdfs:subClassOf>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-be-oac-opty;Investor">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;SecurityHolding"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>security holder</rdfs:label>
-		<skos:definition>a party that holds a transferable contract (security), and has the rights defined in that contract</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The holder is anonymous to the issuer and may transfer their holding in the open marketplace without reference to the issuer (subject to any holding restrictions set out for the security either in the security contractual terms or in the laws of the applicable jurisdiction).</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>bearer</fibo-fnd-utl-av:synonym>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-sec-ast;SecurityHolding">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-sec-ast;SecurityHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>security holding</rdfs:label>
-		<skos:definition>a (tradable) security held in a portfolio</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-ast;hasAcquisitionPrice">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

# Description

The current contract party hierarchy is overly complicated and should be streamlined for ease of representing parties to a contract.  This issue cleans that up, eliminating concepts that had no additional semantics, such as transferable contract holder, security holder, and contract originator in favor of contract principal (retaining loan originator, however, which has specific meaning in the context of loans).  It adds a missing restriction on contract party, which was duplicated on some subclasses, and also cleans up ambiguous definitions in the contracts ontology to the degree that is feasible.

Fixes: #1212 / FND-322


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


