### PR TITLE
DER-83 - Simplify the contract party tree in derivatives

### DIFF
--- a/DER/CommoditiesDerivatives/CommodityOptions.rdf
+++ b/DER/CommoditiesDerivatives/CommodityOptions.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/">
 	<!ENTITY fibo-der-com-opt "https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommodityOptions/">
 	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -17,6 +18,7 @@
 	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/"
 	xmlns:fibo-der-com-opt="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommodityOptions/"
 	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -31,6 +33,7 @@
 		<sm:fileAbbreviation>fibo-der-com-opt</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -43,7 +46,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;governs"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-com-opt;CommodityOTCOptionTransaction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -272,13 +272,6 @@
 		<skos:definition xml:lang="en">A schedule expressing payment events and dates.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapParty"/>
-		<rdfs:label xml:lang="en">credit default swap party</rdfs:label>
-		<skos:definition xml:lang="en">Either party to a Credit Default Swap contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This term identifies either party to the CDS contract (the protection seller and the protection buyer). Party roles such as &quot;Notification Party&quot; may be defined as one or the other or both CDS party.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
 		<rdfs:label xml:lang="en">credit default swap periodic payment schedule</rdfs:label>
@@ -329,14 +322,14 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
-				<owl:onClass rdf:resource="&fibo-der-cr-cds;ProtectionBuyer"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-swp;SwapPayingParty"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
-				<owl:onClass rdf:resource="&fibo-der-cr-cds;ProtectionSeller"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-swp;SwapReceivingParty"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -349,7 +342,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ProtectionBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapPayingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -361,7 +354,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ProtectionSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -532,9 +525,9 @@
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionBuyer">
+							<rdf:Description rdf:about="&fibo-der-drc-swp;SwapPayingParty">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionSeller">
+							<rdf:Description rdf:about="&fibo-der-drc-swp;SwapReceivingParty">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -558,21 +551,6 @@
 		<rdfs:label xml:lang="en">obligation default</rdfs:label>
 		<skos:definition xml:lang="en">One or more of the obligations have become capable of being declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a Credit Event. ISDA 2003 Term: Obligation Default. FpML full definition: &apos;A credit event. One or more of the obligations have become capable of being declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay. ISDA 2003 Term: Obligation Default.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ProtectionBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
-		<rdfs:label xml:lang="en">protection buyer</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-cr-cds;ProtectionSeller"/>
-		<skos:definition xml:lang="en">The party which buys protection against a default on the Reference Obligation, from the Protection Seller.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ProtectionSeller">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
-		<rdfs:label xml:lang="en">protection seller</rdfs:label>
-		<skos:definition xml:lang="en">The party which sells protection against a default on the Reference Obligation, to the Protection Buyer. This party commits to purchase the Refernce Obligation or some agreed alternative (the Deliverable Obligation), or settle for an equivalent amount in cash, in the event that the Credit Event defined in the contract takes place.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;ReferenceEntity">

--- a/DER/DerivativesContracts/DerivativesBasics.rdf
+++ b/DER/DerivativesContracts/DerivativesBasics.rdf
@@ -104,7 +104,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201101/DerivativesContracts/DerivativesBasics/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and eliminate a redundant subclass declaration in observable value.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200401/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to loosen the domain of the hasUnderlier property, which could be either an instrument or leg, refine the definition of Underlier and hasUnderlier based on recent work on swaps, and add the definition of a contract for difference (CFD).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200401/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to loosen the domain of the hasUnderlier property, which could be either an instrument or leg, refine the definition of Underlier and hasUnderlier based on recent work on swaps, add the definition of a contract for difference (CFD), and simplify the contract party hierarchy where the subclasses of contract party do not add semantics.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -160,30 +160,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 		<rdfs:label>delivery terms</rdfs:label>
 		<skos:definition>settlement terms specifying what (cash, an asset, etc.) is to be delivered when, to whom, under what conditions at the time of settlement</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-bsc;DerivativeContractParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-pty-pty;isAPartyTo"/>
-						<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>derivative contract party</rdfs:label>
-		<skos:definition>a party to a derivative instrument</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;DerivativeTransactionTerms">
@@ -318,7 +294,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;OTCTransactionParty"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -330,30 +306,6 @@
 		<rdfs:label>over-the-counter (OTC) transaction confirmation</rdfs:label>
 		<skos:definition>a formal confirmation document that codifies the terms and conditions of the transaction between the parties</skos:definition>
 		<skos:editorialNote>This effectively supersedes the (implied) contract that is brought into being by the transaction. It makes reference to the terms and conditions under which the transaction is deemed to have been conducted. The confirmation references the master agreement under which the transaction has been conducted along with any ISDA standard terms referenced (if applicable), and adds terms and conditions specific to the transaction.  The confirmation generally supersedes all terms in the ISDA standard definitions and the master agreement in the event of any inconsistency between them.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-bsc;OTCTransactionParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-pty-pty;isAPartyTo"/>
-						<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>over-the-counter (OTC) transaction party</rdfs:label>
-		<skos:definition>a party to an over-the-counter agreement</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;ObservableValue">
@@ -374,6 +326,22 @@
 		</rdfs:subClassOf>
 		<rdfs:label>parametric cashflow terms</rdfs:label>
 		<skos:definition>terms for a set of cashflows defined according to a mathematical formula</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-bsc;PayingParty">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;Payer"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
+		<rdfs:label>paying party</rdfs:label>
+		<skos:definition>party responsible for making payments in a transaction specified in a contract</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-bsc;ReceivingParty">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;Payee"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Seller"/>
+		<rdfs:label>receiving counterparty</rdfs:label>
+		<skos:definition>party that receives payments in a transaction specified in a contract</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;Underlier">

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -140,11 +140,6 @@
 		<skos:example xml:lang="en">Example text: Default Interest; Other Amounts. Prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party that defaults in the performance of any payment obligation will, to the extent permitted by law and subject to Section 6(c), be required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment, at the Default Rate. Such interest will be calculated on the basis of daily compounding and the actual number of days elapsed. If, prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party defaults in the performance of any obligation required to be settled by delivery, it will compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement. &quot; Note that this last sentence relates to a separate Obligation, labeled as Other Amount Obligation.</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;DefaultingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<rdfs:label xml:lang="en">defaulting party</rdfs:label>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ma;DeliveryObligation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-txnx;MasterAgreementObligation"/>
 		<rdfs:label xml:lang="en">delivery obligation</rdfs:label>
@@ -283,18 +278,6 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-ma;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;NonDefaultingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-ma;specifies.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;DefaultingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">master agreement right to termination following default event</rdfs:label>
 		<skos:definition xml:lang="en">the right to terminate a master agreement following an event of default</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a right which may be invoked by either party to the Master Agreement; in so doing they acome the &quot;Non Defaulting Party&quot; with respect to this Right. ISDA Definition in full: Right to Terminate Following Event of Default. If at any time an Event of Default with respect to a party (the &quot;Defaulting Party&quot;) has occurred and is then continuing, the other party (the &quot;Non-defaulting Party&quot;) may, by not more than 20 days notice to the Defaulting Party specifying the relevant Event of Default, designate a day not earlier than the day such notice is effective as an Early Termination Date in respect of all outstanding Transactions. If, however, &quot;Automatic Early Termination&quot; is specified in the Schedule as applying to a party, then an Early Termination Date in respect of all outstanding Transactions will occur immediately upon the occurrence with respect to such party of an Event of Default specified in Section 5(a)(vii)(1), (3), (5), (6) or, to the extent analogous thereto, (8), and as of the time immediately preceding the institution of the relevant proceeding or the presentation of the relevant petition upon the occurrence with respect to such party of an Event of Default specified in Section 5(a)(vii)(4) or, to the extent analogous thereto, (8).</fibo-fnd-utl-av:explanatoryNote>
@@ -344,11 +327,6 @@
 		<rdfs:label xml:lang="en">netting terms</rdfs:label>
 		<skos:definition xml:lang="en">Terms setting out how Netting may or may not take place and the Obligations on each party in respect of that Netting.</skos:definition>
 		<skos:editorialNote xml:lang="en">These terms are set out as text in the Sample Master Agreement and may be difficult (and unproductive) to model). Here they are: Example Text: &quot;Netting. If on any date amounts would otherwise be payable:- (i) in the same currency; and (ii) in respect of the same Transaction, by each party to the other, then, on such date, each party’s obligation to make payment of any such amount will be automatically satisfied and discharged and, if the aggregate amount that would otherwise have been payable by one party exceeds the aggregate amount that would otherwise have been payable by the other party, replaced by an obligation upon the party by whom the larger aggregate amount would have been payable to pay to the other party the excess of the larger aggregate amount over the smaller aggregate amount. The parties may elect in respect of two or more Transactions that a net amount will be determined in respect of all amounts payable on the same date in the same currency in respect of such Transactions, regardless of whether such amounts are payable in respect of the same Transaction. The election may be made in the Schedule or a Confirmation by specifying that subparagraph (ii) above will not apply to the Transactions identified as being subject to the election, together with the starting date (in which case subparagraph (ii) above will not, or will cease to, apply to such Transactions from such date). This election may be made separately for different groups of Transactions and will apply separately to each pairing of Offices through which the parties make and receive payments or deliveries. &quot;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;NonDefaultingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<rdfs:label xml:lang="en">non-defaulting party</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;ObligationInRespectOfNetting">
@@ -653,18 +631,6 @@
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition xml:lang="en">Any obligation (whether present or future, contingent or otherwise, as principal or surety or otherwise) in respect of borrowed money. May not include obligations in respect of deposits received in the ordinary course of a party’s banking business. FpML: In Schedule: &quot;Specified Indebtedness&quot; will have the meaning specified in Section 14 except that such term shall not include obligations in respect of deposits received in the ordinary course of a party’s banking business. Section 14: &quot;Specified Indebtedness&quot; means, subject to the Schedule, any obligation (whether present or future, contingent or otherwise, as principal or surety or otherwise) in respect of borrowed money. Modeling note: Could extend this to have a yes/no option on the exclusion described in the Schedule to the sample Master Agreement</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;specifies">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementRightToTerminationFollowingDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-ma;NonDefaultingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;specifies.1">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementRightToTerminationFollowingDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-ma;DefaultingParty"/>
-	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;statementCalculationRequirements">
 		<rdfs:label xml:lang="en">statement calculation requirements</rdfs:label>

--- a/DER/DerivativesContracts/Forwards.rdf
+++ b/DER/DerivativesContracts/Forwards.rdf
@@ -123,13 +123,13 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -165,20 +165,6 @@
 		<rdfs:label xml:lang="en">forward contract</rdfs:label>
 		<skos:definition xml:lang="en">A cash market transaction in which a seller agrees to deliver a specific cash commodity to a buyer at some point in the future.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Unlike futures contracts (which occur through a clearing firm), forward contracts are privately negotiated and are not standardized. Further, the two parties must bear each other&apos;s credit risk, which is not the case with a futures contract. Also, since the contracts are not exchange traded, there is no marking to market requirement, which allows a buyer to avoid almost all capital outflow initially (though some counterparties might set collateral requirements). Given the lack of standardization in these contracts, there is very little scope for a secondary market in forwards. The price specified in a forward contract for a specific commodity. The forward price makes the forward contract have no value when the contract is written. However, if the value of the underlying commodity changes, the value of the forward contract becomes positive or negative, depending on the position held. Forwards are priced in a manner similar to futures. Like in the case of a futures contract, the first step in pricing a forward is to add the spot price to the cost of carry (interest forgone, convenience yield, storage costs and interest/dividend received on the underlying). Unlike a futures contract though, the price may also include a premium for counterparty credit risk, and the fact that there is not daily marking to market process to minimize default risk. If there is no allowance for these credit risks, then the forward price will equal the futures price.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardContractBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
-		<rdfs:label xml:lang="en">forward contract buyer</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardContractSeller">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<rdfs:label xml:lang="en">forward contract seller</rdfs:label>
-		<skos:definition xml:lang="en">A seller of the underlying instrument in a Forward contract.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardDeliveryCommitment">
@@ -320,7 +306,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
 		<rdfs:label xml:lang="en">has buyer</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;hasContractSize">
@@ -334,7 +320,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipalParty"/>
 		<rdfs:label xml:lang="en">has seller</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasValuationTerms">

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -15,6 +15,7 @@
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
+	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -48,6 +49,7 @@
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
+	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -66,7 +68,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
-		<rdfs:label xml:lang="en">Options</rdfs:label>
+		<rdfs:label xml:lang="en">Options Ontology</rdfs:label>
 		<dct:abstract>Concepts common to all option contracts and their corresponding transactions. An option gives one party (the holder) the right to purchase or sell the underlying commodity at a given time or times in the future (as determined by the exercise convention), if they choose to do so. Includes option features, these being definitions of how the option comes into or ceases being in force when a given event occurs along with a range of other variations.</dct:abstract>
 		<sm:fileAbbreviation>fibo-der-der-opt</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
@@ -82,6 +84,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
@@ -105,7 +108,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;AsianExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ex;EuropeanExerciseTerms"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ex;hasExerciseDate"/>
@@ -174,7 +177,16 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-der-der-opt;OptionHolder">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-der-drc-bsc;PayingParty">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -193,9 +205,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">call option</rdfs:label>
-		<skos:definition xml:lang="en">Contracts between a buyer and a seller giving the buyer (holder) the right, but not the obligation, to buy the assets specified at a fixed price or formula, on or before a specified date. The seller of the call option assumes the obligation of delivering the assets specified should the buyer exercise his option.</skos:definition>
-		<skos:editorialNote xml:lang="en">ISO FIBIM has same (ISO CFI-derived) written definition for the &quot;Call&quot; selection entry in the selection list &quot;OptionTypeCode&quot;. Additional modeling Dec 2010: this is now deprecated for the former OTC Call Option. Combine the definition and consnsus from here, and the Simple Fact, befpre de;eting. the formerly OTC term has the required relationship facts.</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the case of a call option, the issuer has the obligation to act as the seller of the option underlier, and the buyer has the option, but not the obligation, to purchase the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to buy the assets specified at a fixed price or formula, on or before a specified date. The seller of the call option assumes the obligation of delivering the assets specified should the buyer exercise his option.</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller (issuer) of the call option assumes the obligation of delivering the assets specified should the buyer exercise his option. The buyer has the option, but not the obligation, to purchase the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;CashOrNothingPayoutCommitment">
@@ -374,7 +386,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;LinearPayoutCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -488,13 +500,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionBarrierFeatureTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;EarlyExerciseCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
@@ -507,6 +513,12 @@
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionFeature"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;EarlyExerciseCommitment"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option barrier feature terms</rdfs:label>
 		<skos:definition xml:lang="en">Formal terms setting out when and under what circumstances the option contract is deemed to be in force. This takes the form of an event and the relationship between the event and the applicability of the option.</skos:definition>
 		<skos:editorialNote xml:lang="en">After some research it was determined that the nature of the thing normally called &quot;Feature&quot; in an option is a contractual term defining when and under what circumstances the option itself is deemed be in force. In other words this is a set of contractual terms. Option features in this sense are &quot;Knock In&quot; or &quot;Knock Out&quot;, each relating to a market event (usually a price reaching a given level). A third feature, &quot;Knock In Knock Out&quot; is really two of these and is represented as such in the Option terms i.e. there may be two of this Option Feature Terms term. The term &quot;Barrier Option&quot; applies to both of these, i.e. Knock In and Knock Out are types of Barrier Option. An option contract may or may not have a barrier option. If it does not, none of this applies. Others: knock in a knock out, knock in a digitale, if it exceeds one barrier you get a call; for another you get a put, and so on.</skos:editorialNote>
@@ -516,18 +528,12 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;BinaryPayoutCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option binary payout terms</rdfs:label>
 		<skos:definition xml:lang="en">Terms governing a binary payout commitment.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
-		<rdfs:label xml:lang="en">option buyer</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Obligations incude: Obligation to inform the seller by a certain time if the holder wishes to exercise. Once the instrument is exercised there are separate obligations in settlement as part of that transactions; that is not covered here. If you want to exercise you have to do it in a certain way - review whether any of this is contractually defined as obligations on the part of the holder.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionCallTransaction">
@@ -554,7 +560,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -562,21 +568,23 @@
 		<skos:definition xml:lang="en">Terms governing a conditional payment commitment on an option.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionExerciseTimeTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option exercise time terms</rdfs:label>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionFeature">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label xml:lang="en">option feature</rdfs:label>
 		<skos:definition xml:lang="en">Types of feature for an option. This itemizes whether the option comes into force (Knock In) or ceases being in force (Knock Out) when the stated event occurs.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-der-opt;OptionHolder">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Owner"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">option holder</rdfs:label>
+		<skos:definition xml:lang="en">party that owns an option</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In a call, the option holder has the right, but not the obligation, to buy the underlying asset, while, in a put, the option holder has the right to sell the underlying asset. An option holder may sell the option contract itself, at which point the buyer becomes the option holder. The holder has an obligation to inform the seller by a certain time if they wish to exercise. Once the instrument is exercised there are typically additional, relevant obligations with regard to settlement.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionIssuer">
@@ -609,7 +617,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -628,13 +636,13 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPayer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasReceiver"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PremiumReceiver"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -715,6 +723,12 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeTransactionTerms"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option terms</rdfs:label>
 	</owl:Class>
 	
@@ -783,24 +797,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">percentage strike price specification</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;PostpaidPremiumType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPreOrPostType"/>
-		<rdfs:label xml:lang="en">postpaid premium type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PremiumPayer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;isUsually"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">premium payer</rdfs:label>
-		<skos:definition xml:lang="en">The party responsible for making the payment of an Equity Option Premium.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review 17 Feb: Not clear whether this can ever go the other way. Is it possible to create an option where you pay as well as delive rthe option? See for example Zero Cost Options. It may be that this is in FpML simply because the original model wanted ot be explicit a bout who paid what, just to avoid any confusion perhaps. Legally: you are buying the rights and obligations in the Option... FpML: &apos;A reference to the party responsible for making the payments defined by this structure.&apos;</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-opt;PremiumPercentageOfNotionalExpression">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
 		<rdfs:label xml:lang="en">premium percentage of notional expression</rdfs:label>
@@ -815,33 +811,42 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Specifically this is expressed as a monetary amount, where that monetary amount is the amount per option. FpML: &apos;The amount of premium to be paid expressed as a function of the number of options.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;PremiumReceiver">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
-		<rdfs:label xml:lang="en">premium receiver</rdfs:label>
-		<skos:definition xml:lang="en">The party that receives the payments of an Equity Option Premium. FpML: &apos;A reference to the party that receives the payments corresponding to this structure.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PrepaidPremiumType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPreOrPostType"/>
-		<rdfs:label xml:lang="en">prepaid premium type</rdfs:label>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-opt;PutOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-der-der-opt;OptionHolder">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-der-drc-bsc;ReceivingParty">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-der-der-opt;OptionIssuer">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-der-drc-bsc;PayingParty">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">put option</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the case of a put option, the issuer has the obligation to purchase the option underlier, and the buyer has the option, but not the obligation, to sell the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to to sell the assets specified at a fixed price or formula, on or before a specified date</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller of the put option assumes the obligation of buying the assets specified should the buyer exercise his or her option.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;ResetableStrikeTerms">
@@ -860,7 +865,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;accruesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionHolder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -891,7 +896,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;accruesTo">
 		<rdfs:label xml:lang="en">accrues to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionHolder"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;definesOptional">
@@ -923,20 +928,12 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
 		<rdfs:label xml:lang="en">has buyer</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasDirection">
 		<rdfs:label xml:lang="en">has direction</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureEvent"/>
 		<rdfs:range rdf:resource="&fibo-der-der-opt;UpOrDown"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFeature">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has feature</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionTypeElectionDate">
@@ -950,8 +947,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPayer">
 		<rdfs:label xml:lang="en">has payer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPremium">
@@ -969,8 +965,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasReceiver">
 		<rdfs:label xml:lang="en">has receiver</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;PremiumReceiver"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasRelativePaymentDate">
@@ -997,7 +992,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipalParty"/>
 		<rdfs:label xml:lang="en">has seller</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasStrikeTerms">
@@ -1036,12 +1030,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">is right to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
 		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;isUsually">
-		<rdfs:label xml:lang="en">is usually</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;lookbackPeriod">
@@ -1109,19 +1097,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:range rdf:resource="&fibo-der-der-opt;PayoffAssetsList"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;setsOut">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;setsOutContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;setsOut.1">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;EarlyExerciseCommitment"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;strikeCurrency">
 		<rdfs:label xml:lang="en">strike currency</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
@@ -1161,7 +1136,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFeature"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 				<owl:onClass rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
 			</owl:Restriction>
@@ -1175,7 +1150,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionHolder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -1206,6 +1181,12 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-dbt-ex;hasExerciseTerms"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option contract</rdfs:label>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -13,15 +13,14 @@
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionEvents/">
 	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
@@ -47,15 +46,14 @@
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
-	xmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionEvents/"
 	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
@@ -82,6 +80,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
@@ -90,8 +89,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
@@ -220,7 +217,13 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
+				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionTypeElectionDate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;governs"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -231,12 +234,6 @@
 						</owl:unionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionTypeElectionDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">chooser option</rdfs:label>
@@ -483,6 +480,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionBarrierFeatureEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasDirection"/>
@@ -540,14 +538,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;makes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
+				<owl:onProperty rdf:resource="&fibo-der-der-opt;receives"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;receives"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option call transaction</rdfs:label>
@@ -627,10 +625,26 @@
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremium">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;CalculatedPrice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;expressedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasFormula"/>
+				<owl:onClass rdf:resource="&fibo-der-der-opt;OptionPremiumFormula"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-qt-qtu;hasQuantityValue"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -652,20 +666,19 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option premium</rdfs:label>
-		<skos:definition xml:lang="en">The amount paid for an option.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review notes (Equity Options): This is just the price. not specific to Equities Options. See Pricing for Exchange Traded Derivatives where we already have similar terms. In forward Fx, premium relates to whether or not the price of the forward is greater or less than the price of the PSpo. In Bonds, whether or not the capital price is more or less than face value (see Bonds Proicing model). In THIS context: the money you pay for the option. FpML: A type used to describe the amount paid for an equity option.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
-		<rdfs:label xml:lang="en">option premium expression</rdfs:label>
-		<skos:definition xml:lang="en">The formal expression of the Option Premium.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a choice between expressing amount of premium paid as either price per option, or percentage of notional amount. FpML: &apos;Choice between expressing amount of premium paid as either price per option, or percentage of notional amount.&apos;</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">price of a premium on the option, if any</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumFixed">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumVariability"/>
 		<rdfs:label xml:lang="en">option premium fixed</rdfs:label>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumFormula">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Formula"/>
+		<rdfs:label xml:lang="en">option premium formula</rdfs:label>
+		<skos:definition xml:lang="en">formula used to calculate the premium</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a choice between expressing amount of premium paid as either price per option, or percentage of notional amount. FpML: &apos;Choice between expressing amount of premium paid as either price per option, or percentage of notional amount.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumPaymentArrangement">
@@ -697,14 +710,14 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;makes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
+				<owl:onProperty rdf:resource="&fibo-der-der-opt;receives"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;receives.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option put transaction</rdfs:label>
@@ -772,14 +785,14 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;hasTransactionParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionTransactionParty"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;hasTransactionParty"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionTransactionParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">optional underlying transaction</rdfs:label>
@@ -795,20 +808,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	<owl:Class rdf:about="&fibo-der-der-opt;PercentageStrikePriceSpecification">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikePrice"/>
 		<rdfs:label xml:lang="en">percentage strike price specification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PremiumPercentageOfNotionalExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
-		<rdfs:label xml:lang="en">premium percentage of notional expression</rdfs:label>
-		<skos:definition xml:lang="en">The expression of the premium as a percentage of the notional value of the transaction.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A percentage of 5% would be expressed as 5%. Note that FpML recasts the percentage as a fractional amount. FpML: &apos;The amount of premium to be paid expressed as a percentage of the notional value of the transaction. A percentage of 5% would be expressed as 0.05.&apos; note that in OTC markets the options are traded on volatility which ultimately calculkates to a premium. This allows for prices to be made generically.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PremiumPricePerOptionExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
-		<rdfs:label xml:lang="en">premium price per option expression</rdfs:label>
-		<skos:definition xml:lang="en">The expression of the premium as a function of the number of options.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Specifically this is expressed as a monetary amount, where that monetary amount is the amount per option. FpML: &apos;The amount of premium to be paid expressed as a function of the number of options.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;PutOption">
@@ -860,24 +859,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">resetable strike terms</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;SecuritiesTransactionOption">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualOption"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;accruesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;isRightTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities transaction option</rdfs:label>
-		<skos:definition xml:lang="en">The option itself, that is the right but not the obligation to proceed with a transaction at some time in the future under terms defined in the option contract. This option is held and exercised by the party to the contract which is defined as the option holder or option buyer.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-opt;StrikeFormula">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CashflowFormula"/>
 		<rdfs:label xml:lang="en">strike formula</rdfs:label>
@@ -893,29 +874,10 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">up or down</rdfs:label>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;accruesTo">
-		<rdfs:label xml:lang="en">accrues to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionHolder"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;definesOptional">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-sec;governs"/>
-		<rdfs:label xml:lang="en">defines optional</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;enteredIntoBy">
 		<rdfs:label xml:lang="en">entered into by</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
 		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;expressedAs">
-		<rdfs:label xml:lang="en">expressed as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-opt;fixedStrikeAmount">
@@ -1026,29 +988,11 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:range rdf:resource="&fibo-der-der-opt;LookbackStrikeObservable"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;isRightTo">
-		<rdfs:label xml:lang="en">is right to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;lookbackPeriod">
 		<rdfs:label xml:lang="en">lookback period</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
 		<skos:definition xml:lang="en">The period in which the strike</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;makes">
-		<rdfs:label xml:lang="en">makes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;makes.1">
-		<rdfs:label xml:lang="en">makes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-opt;numberOfOptions">
@@ -1058,37 +1002,9 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<skos:definition xml:lang="en">The price per asset, index or basket observed on the trade or effective date. FpML: &apos;The price per asset, index or basket observed on the trade or effective date.&apos;</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;paymentAmount">
-		<rdfs:label xml:lang="en">payment amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The monetary amount paid as the Premium.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;percentageOfNotional">
-		<rdfs:label xml:lang="en">percentage of notional</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;PremiumPercentageOfNotionalExpression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
-		<skos:definition xml:lang="en">The amount of premium to be paid expressed as a percentage of the notional value of the transaction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;pricePerOption">
-		<rdfs:label xml:lang="en">price per option</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;PremiumPricePerOptionExpression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount of premium to be paid expressed as a monetary amount to be paid per option.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;receives">
 		<rdfs:label xml:lang="en">receives</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;receives.1">
-		<rdfs:label xml:lang="en">receives</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
+		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;references">
@@ -1133,18 +1049,11 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Option">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 				<owl:onClass rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -1179,8 +1088,8 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;governs"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -1189,9 +1098,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option contract</rdfs:label>
-		<skos:definition xml:lang="en">A financial derivative which represents a contract sold by one party (option writer) to another party (option holder). The contract offers the buyer the right, but not the obligation, to buy (call) or sell (put) a security or other financial asset at an agreed-upon price (the strike price) during a certain period of time or on a specific date (exercise date).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Options may be created Over the Counter, or through an Exchange (in which case the Option Holder may transfer the Option to another party).</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -105,17 +105,17 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;AsianExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWriterCommitment"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ex;EuropeanExerciseTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ex;hasExerciseWindow"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
+				<owl:onProperty rdf:resource="&fibo-sec-dbt-ex;hasExerciseDate"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">asian exercise terms</rdfs:label>
-		<skos:definition xml:lang="en">Commitment to pay out on an option on the basis of a rolling average strike, which the other party may or may not choose to exercise against.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Definition of Asian Exercise Convention: Exercise convention whereby exercise tracks an underlying on a defined time period, anchored to a given time. The Asian Exercise Convention takes the European Date Exercise Convention but commits to a strike which is determined according to an average (or rolling average) value.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label xml:lang="en">Asian exercise terms</rdfs:label>
+		<skos:definition xml:lang="en">exercise terms whereby the payoff is determined by the average underlying price over some pre-set period of time</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Because of the averaging feature, Asian options reduce the volatility inherent in the option; therefore, Asian options are typically cheaper than European or American options.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;AssetMaximumOrMinimumPayoutCommitment">
@@ -263,14 +263,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackExpression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;subtracts"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasMinuend"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedStrikeAmount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;subtractsFrom"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedStrikeAmount"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasSubtrahend"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fixed lookback strike formula expression</rdfs:label>
@@ -312,14 +312,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackExpression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;subtracts.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasMinuend"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableFinalValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;subtractsFrom.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableFinalValue"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasSubtrahend"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">floating lookback formula expression</rdfs:label>
@@ -633,14 +633,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPaymentDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;Date"/>
+				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasReceiver"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PremiumReceiver"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasReceiver"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PremiumReceiver"/>
+				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasRelativePaymentDate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option premium</rdfs:label>
@@ -649,6 +649,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumExpression">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
 		<rdfs:label xml:lang="en">option premium expression</rdfs:label>
 		<skos:definition xml:lang="en">The formal expression of the Option Premium.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a choice between expressing amount of premium paid as either price per option, or percentage of notional amount. FpML: &apos;Choice between expressing amount of premium paid as either price per option, or percentage of notional amount.&apos;</fibo-fnd-utl-av:explanatoryNote>
@@ -702,6 +703,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionStrikeResetSchedule">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
 		<rdfs:label xml:lang="en">option strike reset schedule</rdfs:label>
 	</owl:Class>
 	
@@ -712,8 +714,8 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-		<rdfs:label xml:lang="en">option contract terms</rdfs:label>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeTransactionTerms"/>
+		<rdfs:label xml:lang="en">option terms</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionTransactionParty">
@@ -774,10 +776,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;SecurityUnderlier"/>
 		<rdfs:label xml:lang="en">payoff assets list</rdfs:label>
 		<skos:definition xml:lang="en">The list of n assets which are used to determine a best or worst value in determining conditinal payoff commitments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PayoffCommitmentReferenceAsset">
-		<rdfs:label xml:lang="en">payoff commitment reference asset</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;PercentageStrikePriceSpecification">
@@ -890,12 +888,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">up or down</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;VariablePremiumDeterminationFormula">
-		<rdfs:label xml:lang="en">variable premium determination formula</rdfs:label>
-		<skos:definition xml:lang="en">Formula for agreed determination of the variable premium.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can be defined just as text. One could extend this but there is not need to at this point.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;accruesTo">
 		<rdfs:label xml:lang="en">accrues to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
@@ -907,13 +899,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">defines optional</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;effectiveDate">
-		<rdfs:label xml:lang="en">effective date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The effective date for the option, that is the date from which the derivative contract is valid,</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;enteredIntoBy">
@@ -969,14 +954,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:range rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPaymentDate">
-		<rdfs:label xml:lang="en">has payment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The payment date for the Option Premium.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can be expressed as either an adjustable or relative date. FpML: &apos;The payment date, which can be expressed as either an adjustable or relative date.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPremium">
 		<rdfs:label xml:lang="en">has premium</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
@@ -994,6 +971,14 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">has receiver</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
 		<rdfs:range rdf:resource="&fibo-der-der-opt;PremiumReceiver"/>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasRelativePaymentDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasRelativeDate"/>
+		<rdfs:label xml:lang="en">has relative payment date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
+		<skos:definition xml:lang="en">The payment date for the Option Premium.</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can be expressed as either an adjustable or relative date. FpML: &apos;The payment date, which can be expressed as either an adjustable or relative date.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasResetSchedule">
@@ -1163,30 +1148,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
 		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
 		<skos:definition xml:lang="en">The price or level expressed as a percentage of the forward starting spot price.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtracts">
-		<rdfs:label xml:lang="en">subtracts</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtracts.1">
-		<rdfs:label xml:lang="en">subtracts</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtractsFrom">
-		<rdfs:label xml:lang="en">subtracts from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FixedStrikeAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtractsFrom.1">
-		<rdfs:label xml:lang="en">subtracts from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;ObservableFinalValue"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-opt;threshold">

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
@@ -21,6 +22,7 @@
 	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -37,6 +39,7 @@
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
@@ -51,6 +54,7 @@
 	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -419,7 +423,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;LookbackStrikeObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ObservableUnderlier"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
@@ -479,13 +483,6 @@
 		<rdfs:label xml:lang="en">observable final value</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;ObservableUnderlier">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-		<rdfs:label xml:lang="en">observable underlier</rdfs:label>
-		<skos:definition xml:lang="en">An underlying observable which is in numeric form and does not represent a deliverable asset.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Derivatives which are based on an observable underlying are settled in some way other than by delivery of the underlying, since the underlying is not in the nature of something that can be delivered.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionBarrierFeatureEvent">
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -496,7 +493,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/MarketRate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ind-ind;MarketRate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option barrier feature event</rdfs:label>
@@ -565,7 +562,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;makes"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -717,7 +714,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;receives.1"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option put transaction</rdfs:label>
@@ -949,31 +946,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<skos:definition xml:lang="en">The strike price for the option is the agreed price for the transaction if this takes place. Applies to all options types. Action: Make sure that&apos;s there for all Options types.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;UnderlyingOnOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/Basket">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/MarketRate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-pas-pas;NegotiableCommodity">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">underlying on option</rdfs:label>
-		<skos:definition xml:lang="en">The instrument or parameter, or combinations thereof, that are used as the basis for the Option Instrument.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-opt;UpOrDown">
 		<rdfs:label xml:lang="en">up or down</rdfs:label>
 	</owl:Class>
@@ -1187,7 +1159,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;makes">
 		<rdfs:label xml:lang="en">makes</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;makes.1">
@@ -1233,7 +1205,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;receives.1">
 		<rdfs:label xml:lang="en">receives</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;references">
@@ -1321,12 +1293,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFeature"/>
 				<owl:onClass rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -931,7 +931,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasRelativePaymentDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasRelativeDate"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
 		<rdfs:label xml:lang="en">has relative payment date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
 		<skos:definition xml:lang="en">The payment date for the Option Premium.</skos:definition>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -39,6 +40,7 @@
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -71,6 +73,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -166,48 +169,33 @@
 		<owl:disjointWith rdf:resource="&fibo-der-der-opt;LinearPayoutCommitment"/>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;CallOptionBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-		<rdfs:label xml:lang="en">call option buyer</rdfs:label>
-		<skos:definition xml:lang="en">The Party which is the buyer of the Call Option. This party has the option but not the obligation to transact as the Buyer of the Option Underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;CallOptionContract">
+	<owl:Class rdf:about="&fibo-der-der-opt;CallOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;CallOptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;CallOptionType"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;CallOptionWritingParty"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-der-der-opt;OptionIssuer">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-der-drc-bsc;ReceivingParty">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">call option contract</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;ChooserOptionContract"/>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;PutOptionContract"/>
+		<rdfs:label xml:lang="en">call option</rdfs:label>
 		<skos:definition xml:lang="en">Contracts between a buyer and a seller giving the buyer (holder) the right, but not the obligation, to buy the assets specified at a fixed price or formula, on or before a specified date. The seller of the call option assumes the obligation of delivering the assets specified should the buyer exercise his option.</skos:definition>
 		<skos:editorialNote xml:lang="en">ISO FIBIM has same (ISO CFI-derived) written definition for the &quot;Call&quot; selection entry in the selection list &quot;OptionTypeCode&quot;. Additional modeling Dec 2010: this is now deprecated for the former OTC Call Option. Combine the definition and consnsus from here, and the Simple Fact, befpre de;eting. the formerly OTC term has the required relationship facts.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;CallOptionType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionType"/>
-		<rdfs:label xml:lang="en">call option type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;CallOptionWritingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-		<rdfs:label xml:lang="en">call option writing party</rdfs:label>
-		<skos:definition xml:lang="en">The Party which is the writer of the Call Option. This party has the obligation to transact as the Seller of the Option Underlying.</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the case of a call option, the issuer has the obligation to act as the seller of the option underlier, and the buyer has the option, but not the obligation, to purchase the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;CashOrNothingPayoutCommitment">
@@ -216,7 +204,7 @@
 		<skos:definition xml:lang="en">A commitment to pay out on a binary option, as cash or nothing.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;ChooserOptionContract">
+	<owl:Class rdf:about="&fibo-der-der-opt;ChooserOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -236,11 +224,10 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionTypeElectionDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;Date"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">chooser option contract</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;PutOptionContract"/>
+		<rdfs:label xml:lang="en">chooser option</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;ConditionalPayoutCommitment">
@@ -265,7 +252,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikeFormula"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExpression"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasExpression"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -293,7 +280,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFormula"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasFormula"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormula"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -342,7 +329,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikeFormula"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExpression.1"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasExpression"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -358,7 +345,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFormula.1"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasFormula"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeFormula"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -538,22 +525,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
 		<rdfs:label xml:lang="en">option buyer</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionBuyerCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;madeBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionUnderlyingBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option buyer commitment</rdfs:label>
-		<skos:definition xml:lang="en">Commitments, if any, on the part of the holder (buyer) of the Option.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Obligations incude: Obligation to inform the seller by a certain time if the holder wishes to exercise. Once the instrument is exercised there are separate obligations in settlement as part of that transactions; that is not covered here. If you want to exercise you have to do it in a certain way - review whether any of this is contractually defined as obligations on the part of the holder.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -606,9 +579,16 @@
 		<skos:definition xml:lang="en">Types of feature for an option. This itemizes whether the option comes into force (Knock In) or ceases being in force (Knock Out) when the stated event occurs.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
-		<rdfs:label xml:lang="en">option party</rdfs:label>
+	<owl:Class rdf:about="&fibo-der-der-opt;OptionIssuer">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;issues"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">option issuer</rdfs:label>
+		<skos:definition xml:lang="en">issuer granting the rights defined in the option in exchange for some consideration</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionPayoutCommitment">
@@ -616,7 +596,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;enteredIntoBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option payout commitment</rdfs:label>
@@ -638,6 +618,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremium">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;expressedAs"/>
@@ -736,21 +717,10 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionTransactionParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
 		<rdfs:label xml:lang="en">option transaction party</rdfs:label>
 		<skos:definition xml:lang="en">The party to an Option transaction.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is identified as also being a party to the contract that underlies that transaction. Definition OriginLSR Draft</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
-		<rdfs:label xml:lang="en">option type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionTypeSelection">
-		<rdfs:label xml:lang="en">OptionTypeSelection</rdfs:label>
-		<skos:definition xml:lang="en">Whether it is a call option (right to purchase a specific underlying asset) or a put option (right to sell a specific underlying asset).</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionUnderlyingBuyer">
@@ -780,14 +750,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
 		<rdfs:label xml:lang="en">option writer commitment</rdfs:label>
 		<skos:definition xml:lang="en">Commitment on the part of the writer (issuing party) of the Option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionWritingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<rdfs:label xml:lang="en">option writing party</rdfs:label>
-		<skos:definition xml:lang="en">The writing party of an OTC Option, i.e. the seller of a contract. This is the party that grants the rights defined by this instrument and in return receives a payment for it.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See 2000 ISDA definitions Article 11.1 (a). In the case of an option, these rights are the rights to buy or sell the instrument at the stated terms. FpML: &apos;A reference to the party that sells (&quot;writes&quot;) this instrument, i.e. that grants the rights defined by this instrument and in return receives a payment for it. See 2000 ISDA definitions Article 11.1 (a). In the case of FRAs this is the floating rate payer.&apos; Seller; Also known as Short Side.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionalUnderlyingTransaction">
@@ -829,7 +791,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;PremiumPayer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;isUsually"/>
@@ -856,7 +818,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;PremiumReceiver">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 		<rdfs:label xml:lang="en">premium receiver</rdfs:label>
 		<skos:definition xml:lang="en">The party that receives the payments of an Equity Option Premium. FpML: &apos;A reference to the party that receives the payments corresponding to this structure.&apos;</skos:definition>
 	</owl:Class>
@@ -866,44 +828,22 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">prepaid premium type</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;PutOptionBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-		<rdfs:label xml:lang="en">put option buyer</rdfs:label>
-		<skos:definition xml:lang="en">The Party which is the buyer of the Put Option. This party has the option but not the obligation to transact as the Seller of the Option Underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PutOptionContract">
+	<owl:Class rdf:about="&fibo-der-der-opt;PutOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PutOptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PutOptionType"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PutOptionWritingParty"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">put option contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PutOptionType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionType"/>
-		<rdfs:label xml:lang="en">put option type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PutOptionWritingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-		<rdfs:label xml:lang="en">put option writing party</rdfs:label>
-		<skos:definition xml:lang="en">The Party which is the writer of the Put Option. This party has the obligation to transact as the Buyer of the Option Underlying.</skos:definition>
+		<rdfs:label xml:lang="en">put option</rdfs:label>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the case of a put option, the issuer has the obligation to purchase the option underlier, and the buyer has the option, but not the obligation, to sell the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;ResetableStrikeTerms">
@@ -979,7 +919,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;enteredIntoBy">
 		<rdfs:label xml:lang="en">entered into by</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;expressedAs">
@@ -1007,18 +947,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:range rdf:resource="&fibo-der-der-opt;UpOrDown"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExpression">
-		<rdfs:label xml:lang="en">has expression</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormula"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExpression.1">
-		<rdfs:label xml:lang="en">has expression</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeFormula"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFeature">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 		<rdfs:label xml:lang="en">has feature</rdfs:label>
@@ -1026,29 +954,11 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFormula">
-		<rdfs:label xml:lang="en">has formula</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFormula.1">
-		<rdfs:label xml:lang="en">has formula</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionType">
-		<rdfs:label xml:lang="en">has option type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionType"/>
-		<skos:definition xml:lang="en">Whether it is a call option (right to purchase a specific underlying asset) or a put option (right to sell a specific underlying asset)</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionTypeElectionDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label xml:lang="en">has option type election date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;ChooserOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdfs:domain rdf:resource="&fibo-der-der-opt;ChooserOption"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition xml:lang="en">The date on which the holder of the Chooser option contract determines a choice of either a Call or a Put,</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML: &apos;Date where the holder of a Chooser option contract determines a choice of either a Call or a Put&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
@@ -1102,7 +1012,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipalParty"/>
 		<rdfs:label xml:lang="en">has seller</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasStrikeTerms">
@@ -1316,7 +1226,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/DER/DerivativesContracts/Spots.rdf
+++ b/DER/DerivativesContracts/Spots.rdf
@@ -3,6 +3,8 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-der-sp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Spots/">
+	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-fi-stl "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -21,6 +23,8 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-der-sp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Spots/"
+	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-fi-stl="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -39,7 +43,9 @@
 		<rdfs:label xml:lang="en">Spots</rdfs:label>
 		<dct:abstract>Spot transactions, along with their corresponding or implied contracts. These are not a derivative but rather define simple transactions that are immediately settled by both sides, for a given kind of asset or commodity. These are the concepts common to other variants of spot such as commodities spots.</dct:abstract>
 		<sm:fileAbbreviation>fibo-der-der-sp</sm:fileAbbreviation>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -57,20 +63,20 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPayer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotPayer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasReceiver"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotReceiver"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">spot cash settlement terms</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-sp;SpotContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
@@ -78,17 +84,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">spot contract</rdfs:label>
-		<skos:definition xml:lang="en">A contract relating to a transaction which is for immediate settlement. Further notes: A spot transaction simply means a transaction in which some goods or currency are exchanged for some other goods or currency, with no future delivery provision. A Spot contract is the usually unwritten contract which by definition underlies that kind of transaction. Spot means for immediate settlement. Immediate here means the minimum number of days that are possible. This includes general retail transactions as well as the specialixed types of spot transactiojn foud in the financial services and treasury trading contexts, such as Fx Spots (a sub type of this) and commodity spot transactions. However the settlement date is still some time in the future. Also given different time zones, the settlement would be at some time in the future anyway Formerly a financial e.g. currency Spot would have been 2 (working) days settlement for example. Canadian v USD would be 1 day. Follows a settlement convention from the relevant market. Action: Add reference to Settlement Convention for the given market.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-sp;SpotPayer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;Payer"/>
-		<rdfs:label xml:lang="en">spot payer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-sp;SpotReceiver">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;Payee"/>
-		<rdfs:label xml:lang="en">spot receiver</rdfs:label>
+		<skos:definition xml:lang="en">contract relating to a transaction which is for immediate settlement. Further notes: A spot transaction simply means a transaction in which some goods or currency are exchanged for some other goods or currency, with no future delivery provision. A Spot contract is the usually unwritten contract which by definition underlies that kind of transaction. Spot means for immediate settlement. Immediate here means the minimum number of days that are possible. This includes general retail transactions as well as the specialixed types of spot transactiojn foud in the financial services and treasury trading contexts, such as Fx Spots (a sub type of this) and commodity spot transactions. However the settlement date is still some time in the future. Also given different time zones, the settlement would be at some time in the future anyway Formerly a financial e.g. currency Spot would have been 2 (working) days settlement for example. Canadian v USD would be 1 day. Follows a settlement convention from the relevant market. Action: Add reference to Settlement Convention for the given market.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-sp;SpotTransaction">

--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -92,7 +92,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/Swaps/ version of this ontology was modified to refine the concept of a unique swap identifier (USI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20190201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate the property &apos;hasPaymentSchedule&apos; from this ontology in favor of the equivalent property with the same name from FND, adding concepts related to statistical swaps, and revising definitions to be ISO 704 compliant.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200901/DerivativesContracts/Swaps/ version of this ontology was modified to integrate return swaps and connect swap legs to the swap they comprise, as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200901/DerivativesContracts/Swaps/ version of this ontology was modified to integrate return swaps and connect swap legs to the swap they comprise, as appropriate, and to simplify the contract party hierarchy.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -477,7 +477,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;SwapParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
@@ -494,17 +494,15 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;SwapPayingParty">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Debtor"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;Payer"/>
 		<rdfs:label>swap paying party</rdfs:label>
 		<skos:definition>swap party responsible for making payments for a given leg of the transaction as defined in the contract</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;SwapReceivingParty">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Creditor"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;Payee"/>
 		<rdfs:label>swap receiving party</rdfs:label>
 		<skos:definition>swap party that receives payments for a given leg of the transaction as defined in the contract</skos:definition>
 	</owl:Class>

--- a/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
+++ b/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
@@ -178,7 +178,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-eto;EquityIndexOptionUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
@@ -210,7 +210,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-eto;EquityOptionUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
@@ -337,7 +337,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-eto;FxOptionUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
@@ -477,7 +477,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-eto;OptionOnFuturesUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
@@ -587,7 +587,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-eto;TradedOptionPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionsExchangeParticipant"/>
 		<rdfs:label xml:lang="en">traded option principal</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
@@ -660,22 +660,6 @@
 		<rdfs:range rdf:resource="&xsd;integer"/>
 		<skos:definition xml:lang="en">The minimum number of options contracts that may be traded at any one time.</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;optionType">
-		<rdfs:label xml:lang="en">option type</rdfs:label>
-		<rdfs:domain>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-eto;ExchangeTradedOptionContract">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-eto;StandardizedOptionsTerms">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:domain>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionTypeSelection"/>
-		<skos:definition xml:lang="en">Whether the option is a call or a put option.</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;pricingToBeDeterminedBy">
 		<rdfs:label xml:lang="en">pricing to be determined by</rdfs:label>

--- a/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
+++ b/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
@@ -253,12 +253,6 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
 			</owl:Restriction>
@@ -285,6 +279,12 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-gty;hasGuarantor"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionGuarantor"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;governs"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionTransaction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -595,7 +595,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-eto;TradedOptionsCounterparty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionHolder"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionsExchangeParticipant"/>
 		<rdfs:label xml:lang="en">traded options counterparty</rdfs:label>
 	</owl:Class>

--- a/DER/RateDerivatives/IROptions.rdf
+++ b/DER/RateDerivatives/IROptions.rdf
@@ -76,7 +76,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rat-iro;InterestRateOptionStrikeTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;includesSpecificationTerm"/>

--- a/DER/SecurityBasedDerivatives/BondOptions.rdf
+++ b/DER/SecurityBasedDerivatives/BondOptions.rdf
@@ -88,7 +88,7 @@
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-sbd-bnd;definesOptionalBondOptionUnderlyingTransaction">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;definesOptional"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;governs"/>
 		<rdfs:label xml:lang="en">defines optional bond option underlying transaction</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-sbd-bnd;OTCBondOption"/>
 		<rdfs:range rdf:resource="&fibo-der-sbd-bnd;BondOptionUnderlyingTransaction"/>

--- a/DER/SecurityBasedDerivatives/EquityOptions.rdf
+++ b/DER/SecurityBasedDerivatives/EquityOptions.rdf
@@ -189,14 +189,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-eqo;EquityOTCOptionTransaction"/>
+				<owl:onProperty rdf:resource="&fibo-der-sbd-eqo;hasRelevantJurisdiction"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-sbd-eqo;hasRelevantJurisdiction"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;governs"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-eqo;EquityOTCOptionTransaction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">equity option o t c contract</rdfs:label>

--- a/DER/SecurityBasedDerivatives/EquityOptions.rdf
+++ b/DER/SecurityBasedDerivatives/EquityOptions.rdf
@@ -158,7 +158,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqo;EquityOptionExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
 		<rdfs:label xml:lang="en">equity option exercise terms set</rdfs:label>
 		<skos:definition xml:lang="en">Contractual terms setting out the price or level at which the Equity option is to be struck.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML equityStrike (complex type): A type for defining the strike price for an equity option. The strike price is either: (i) in respect of an index option transaction, the level of the relevant index specified or otherwise determined in the transaction; or (ii) in respect of a share option transaction, the price per share specified or otherwise determined in the transaction. This can be expressed either as a percentage of notional amount or as an absolute value.</fibo-fnd-utl-av:explanatoryNote>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This resolution takes advantage of recent streamlining in FND with respect to contract parties, and takes it a step further to clean up the derivatives contract party hierarchy as well as to simplify out a number of redundant elements (classes and properties) related to Options in particular.

Fixes: #1214 / DER-83


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


