### PR TITLE
New hygiene test - dots in local names of FIBO classes and properties

### DIFF
--- a/etc/testing/hygiene/testHygiene1198_dev.sparql
+++ b/etc/testing/hygiene/testHygiene1198_dev.sparql
@@ -1,0 +1,18 @@
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+
+##
+# banner Local names of classes and properties shouldn't contain dots.
+
+SELECT DISTINCT ?warning ?resource ?resourceType
+WHERE 
+{
+    {?resource rdf:type/rdfs:subClassOf* rdf:Property .}
+    UNION
+    {?resource rdf:type/rdfs:subClassOf* rdfs:Class .}
+    ?resource rdf:type ?resourceType .
+    FILTER (CONTAINS(str(?resource), "edmcouncil"))
+    FILTER (CONTAINS(STRAFTER(str(?resource),"https://spec.edmcouncil.org/fibo/ontology/"), "."))
+    BIND (concat ("WARN: Resource ", str(?resource), " has the dot in its local name. ") AS ?warning) 
+}

--- a/etc/testing/hygiene/testHygiene1198_prod.sparql
+++ b/etc/testing/hygiene/testHygiene1198_prod.sparql
@@ -1,0 +1,18 @@
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+
+##
+# banner Local names of classes and properties shouldn't contain dots.
+
+SELECT DISTINCT ?error ?resource ?resourceType
+WHERE 
+{
+    {?resource rdf:type/rdfs:subClassOf* rdf:Property .}
+    UNION
+    {?resource rdf:type/rdfs:subClassOf* rdfs:Class .}
+    ?resource rdf:type ?resourceType .
+    FILTER (CONTAINS(str(?resource), "edmcouncil"))
+    FILTER (CONTAINS(STRAFTER(str(?resource),"https://spec.edmcouncil.org/fibo/ontology/"), "."))
+    BIND (concat ("PRODERROR: Resource ", str(?resource), " has the dot in its local name. ") AS ?error) 
+}


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This pull request adds a check that finds dots in local names of FIBO classes and properties.
Due to the current state of the infrastructure it is split into two checks:
1. one check raises warnings for DEV
2. the other check raises errors in PROD.


Fixes: #1198


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


