### PR TITLE
SEC-73 - Build out the classes related to payment status of shares

### DIFF
--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -41,7 +41,7 @@
 		<rdfs:label>Equities CFI Classification Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology covers the ISO 10962, Fourth edition, 2019-10 classification codes for instruments that represent an ownership interest in an entity or pool of assets. It is intended to cover sections most of the codes included in section 6.2 of the standard, with the exception of structured instruments, section 6.2.8, which will be covered under derivatives.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/2002/07/owl#</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
 		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
@@ -63,7 +63,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201101/Equities/EquityCFIClassificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -89,12 +89,10 @@
 									</owl:Restriction>
 								</owl:intersectionOf>
 							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -122,10 +120,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -161,10 +157,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -192,10 +186,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -231,10 +223,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -262,10 +252,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -343,10 +331,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -374,10 +360,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -413,10 +397,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -444,10 +426,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -483,10 +463,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -514,10 +492,8 @@
 							</owl:Class>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-							</owl:Restriction>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+							</rdf:Description>
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -81,7 +81,7 @@
 		<rdfs:label xml:lang="en">Equity Instruments Ontology</rdfs:label>
 		<dct:abstract>Core terms are those fundamental to all equity instruments. This ontology also distinguishes between privately held and publicly traded equity instruments, and defines a number of related concepts, such as voting rights.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/2002/07/owl#</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
@@ -129,7 +129,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments, including features specific to preferred shares.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights, and clean up ambiguous definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, and clean up ambiguous definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -154,15 +154,10 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
@@ -191,15 +186,10 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
@@ -501,6 +491,18 @@
 		<fibo-fnd-utl-av:explanatoryNote>In other words, the return is not variable depending on whether or not the company makes a profit.  Annual dividends are calculated as a percentage of the par value, which is the price of the preferred stock at the time it was issued. Most preferred shares have fixed rate dividends.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">fully paid share</rdfs:label>
+		<skos:definition xml:lang="en">share whose payment status indicates that no additional money is owed to the company by shareholders on the value of the shares</skos:definition>
+	</owl:Class>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eq;FullyPaidShareStatus">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
 		<rdfs:label>fully paid share status</rdfs:label>
@@ -547,6 +549,18 @@
 		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/l/listedsecurity.asp"/>
 		<skos:definition xml:lang="en">share that is listed on at least one platform</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Listing requirements vary by exchange and include minimum stockholder&apos;s equity, a minimum share price and a minimum number of shareholders. Exchanges have listing requirements to ensure that only high quality securities are traded on them and to uphold the exchange&apos;s reputation among investors.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;NilPaidShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-eq;NilPaidShareStatus"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">nil paid share</rdfs:label>
+		<skos:definition xml:lang="en">share whose payment status indicates that none of the market value has been received by the company for the shares</skos:definition>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eq;NilPaidShareStatus">
@@ -604,6 +618,18 @@
 		<skos:definition>dividend that is paid to shareholders periodically</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Most dividends are considered ordinary, unless they are specifically designated as qualified dividends.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Note that the terms related to ordinary dividend payment are typically specified in the context of a board resolution rather than contractually.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;PartiallyPaidShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShareStatus"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">partially paid share</rdfs:label>
+		<skos:definition xml:lang="en">share whose payment status indicates that only a portion of the market value has been received by the company for the shares</skos:definition>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eq;PartiallyPaidShareStatus">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added subclasses to cover share payment status to eliminate the need for certain restrictions on CFI individuals

Fixes: #1234 / SEC-73


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


