### PR TITLE
SEC-145 - Listed security is improperly inferred to be a listing

### DIFF
--- a/SEC/Securities/SecuritiesIdentification.rdf
+++ b/SEC/Securities/SecuritiesIdentification.rdf
@@ -389,7 +389,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>security registry entry</rdfs:label>
-		<skos:definition>record for a security in a securities repository</skos:definition>
+		<skos:definition>record for a security in a securities registry</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;TickerSymbol">

--- a/SEC/Securities/SecuritiesIdentification.rdf
+++ b/SEC/Securities/SecuritiesIdentification.rdf
@@ -51,14 +51,14 @@
 		<rdfs:label>Securities Identification Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts required to identify securities, including a number of well-known securities identifiers and related schemes, registries, and registration authorities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-sec-sec-id</sm:fileAbbreviation>
 		<sm:filename>SecuritiesIdentification.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
@@ -75,13 +75,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200901/Securities/SecuritiesIdentification/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesIdentification/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20180801/Securities/SecuritiesIdentification.rdf version of this ontology was modified to use the hasCoverageArea property rather than hasJurisdiction for coverage of national numbering agencies, and eliminate redundant subclass relationships for two of the schemes defined herein.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20181101/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was modified to add the concept of a ticker symbol and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesIdentification/ version of this ontology was modified to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesIdentification/ version of this ontology was modified to correct the target of a ticker symbol, which identifies a listing not a listed security, refine the restriction on financial instrument identifier to say that it identifies an instrument or listing, normalize definitions to be ISO 704 compliant, eliminate duplication of concepts in LCC, and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesIdentification/ version of this ontology was modified to make a ticker symbol reassignable and address circular or ambiguous definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200901/Securities/SecuritiesIdentification.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -89,16 +90,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;Listing">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>
@@ -167,7 +159,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;Listing"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>listed security identifier</rdfs:label>
@@ -225,19 +217,13 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>National Securities Identifying Number</rdfs:label>
 		<skos:definition>generic, nine-digit alpha numeric code which identifies a fungible security, assigned by a national numbering agency under the ISO 6166 standard</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>NSIN</fibo-fnd-utl-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;NationalSecuritiesIdentifyingNumberRegistry">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;Registry"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;SecurityRegistry"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isCharacterizedBy"/>
@@ -263,13 +249,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;NationalSecuritiesIdentifyingNumberRegistryEntry">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;RegistryEntry"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;SecurityRegistryEntry"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
@@ -333,12 +313,6 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>proprietary security identifier</rdfs:label>
 		<skos:definition>identifier supplied by a commercial entity</skos:definition>
 	</owl:Class>
@@ -367,16 +341,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fbc-fi-fi;Security">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;Listing">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>security identifier</rdfs:label>
@@ -401,7 +366,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-ra;RegistrationAuthority"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>security registry</rdfs:label>
@@ -414,17 +379,17 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-id;ListedSecurityIdentifier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-id;SecurityIdentifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>security registry entry</rdfs:label>
-		<skos:definition>record for a listed security in a securities repository</skos:definition>
+		<skos:definition>record for a security in a securities repository</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;TickerSymbol">
@@ -433,7 +398,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;Listing"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>ticker symbol</rdfs:label>

--- a/SEC/Securities/SecuritiesIdentification.rdf
+++ b/SEC/Securities/SecuritiesIdentification.rdf
@@ -86,15 +86,6 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-fbc-fi-fi;FinancialInstrumentIdentifier">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-sec-id;FinancialInstrumentIdentificationScheme">
 		<rdfs:subClassOf rdf:resource="&lcc-lr;IdentificationScheme"/>
 		<rdfs:subClassOf>
@@ -279,19 +270,6 @@
 		<fibo-fnd-utl-av:explanatoryNote>generally incorporated into the ISIN scheme as well</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-sec-id;PreferredListedSecurityIdentifier">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;ListedSecurityIdentifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-id;isPreferredByExchange"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>preferred listed identification scheme</rdfs:label>
-		<skos:definition>listed security identifier for a given security that is preferred by some exchange</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is the preferred security ID if a security has more than one identifier on a specific exchange.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;SecurityIdentificationScheme"/>
 		<rdfs:subClassOf>
@@ -394,34 +372,26 @@
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;TickerSymbol">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-id;ReassignableIdentifier"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;ListedSecurityIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;ListedSecurity">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;Listing">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>ticker symbol</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/t/tickersymbol.asp"/>
-		<skos:definition>exchange-specific identifier for a particular security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Every listed security has a unique ticker symbol, facilitating the vast array of trade orders that flow through the financial markets every day.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>exchange-specific identifier for a particular security or listing for that security, depending on the country</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Every listed security has at least one unique ticker symbol, facilitating the vast array of trade orders that flow through the financial markets every day. However, in some countries this relationship may be indirect, through the listing, rather than direct, as is the case in the United States.  In the US, the relationship between a ticker symbol and the listed security is one-to-one.  This is not, however, the case in Singapore, where there may be unique ticker symbols for the same security based on the lot size.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:usageNote>Ticker symbols are reusable, assigned to a given instrument by an exchange for some period of time.</fibo-fnd-utl-av:usageNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-sec-id;isPreferredByExchange">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-		<rdfs:label>is preferred by exchange</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
-		<skos:definition>indicates the exchange that prefers a specific identifier for a security</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-sec-sec-lst;ListedSecurity">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;Listing">

--- a/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
+++ b/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
@@ -59,7 +59,7 @@
 		<rdfs:label>Securities Identification Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts and primarily individuals required to identify securities, including the individuals that represent a number of well-known securities identifiers and related schemes, registries, and registration authorities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
@@ -89,12 +89,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/SecuritiesIdentificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesIdentificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was updated to represent identifiers as classes rather than individuals and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to eliminate duplication of concepts with LCC and eliminate punning in individual definitions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to replace &apos;characterizes&apos; with &apos;describes&apos;, which more accurately expresses the intent.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -350,7 +351,6 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;FinancialInstrumentIdentifier"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;RegistryIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -376,9 +376,25 @@
 				<owl:hasValue rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierScheme"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;Listing">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>financial instrument global identifier</rdfs:label>
 		<skos:definition>financial instrument identifier that is defined as specified in the Object Management Group (OMG) Financial Instrument Global Identifier (FIGI) Specification</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>FIGI</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explantoryNote>While in most cases, a FIGI uniquely identifies a security, there are situations outside of the U.S. where it instead identifies a listing for a security, similarly to a ticker symbol.</fibo-fnd-utl-av:explantoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry">
@@ -394,12 +410,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;RegistryEntry"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
 				<owl:hasValue rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 			</owl:Restriction>
@@ -408,6 +418,21 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIncludedIn"/>
 				<owl:hasValue rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;Listing">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>Financial Instrument Global Identifier (FIGI) registry entry</rdfs:label>
@@ -419,7 +444,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationScheme"/>
 		<rdf:type rdf:resource="&fibo-sec-sec-id;FinancialInstrumentIdentificationScheme"/>
 		<rdfs:label>financial instrument global identifier scheme</rdfs:label>
-		<skos:definition>standard identification scheme for financial instrument identifiers (not limited to securities) published by the Object Management Group (OMG)</skos:definition>
+		<skos:definition>standard identification scheme for financial instrument identifiers (not limited to securities) and, in some cases, related listings, published by the Object Management Group (OMG)</skos:definition>
 		<fibo-fnd-rel-rel:describes rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry"/>
 		<fibo-fnd-utl-av:abbreviation>FIGI scheme</fibo-fnd-utl-av:abbreviation>
 	</owl:NamedIndividual>

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -149,7 +149,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>listed security</rdfs:label>
-		<skos:definition>registered security listed on some exchange</skos:definition>
+		<skos:definition>registered security listed on one or more exchanges</skos:definition>
 		<fibo-fnd-utl-av:synonym>exchange-traded security</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -210,7 +210,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">listing</rdfs:label>
-		<skos:definition>registry entry for a security that is managed by an exchange and that provides registration information regarding the eligibility for making that security available for trading</skos:definition>
+		<skos:definition>registry entry for a security that is managed by an exchange and that documents that the security meets the requirements for making that security available for trading on that exchange</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en">market listing</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -267,8 +267,10 @@
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
 		<rdfs:label>has home exchange</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
-		<skos:definition>indicates the current exchange that is considered the primary trading venue for a security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A security may have been originally listed on the Frankfurt exchange, but its current home is the London Stock Exchange, for example.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>indicates the exchange that is considered the primary market for a security; typically, but not always, in the country in which the security was originally issued</skos:definition>
+		<skos:example>A security may have been originally listed on the Frankfurt exchange, but its current home is the London Stock Exchange, for example.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote>A primary market is one that issues new securities on an exchange for companies, governments, and other groups to obtain financing through debt-based or equity-based securities.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>has primary market</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>has primary trading market</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -53,11 +53,12 @@
 		<rdfs:label>Securities Listings Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for listing securities, such as registered, listed, and exchange-traded security, the notion of a securities exchange, and related services.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-sec-sec-lst</sm:fileAbbreviation>
 		<sm:filename>SecuritiesListings.rdf</sm:filename>
@@ -78,13 +79,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesListings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesListings.rdf version of this ontology was revised to reuse the composite date value datatype and add disjointness between registered security and exempt security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate an extraneous subclass axiom.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesListings.rdf version of this ontology was revised to rename isIssuedIn to isIssuedOn, which is more natural to most securities SMEs, generalized certain references to securities exchanges, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/SecuritiesListings.rdf version of this ontology was revised to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and to eliminate the redundancy between hasIssue and lists.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesListings.rdf version of this ontology was revised to incorporate the form of registration and loosen the restriction on the number of possible registration authorities for a registered security.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues) and adjust definitions to eliminate ambiguity.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -125,7 +127,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;ListedSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;hasHomeExchange"/>
@@ -147,7 +149,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>listed security</rdfs:label>
-		<skos:definition>registered security listed on one or more exchanges</skos:definition>
+		<skos:definition>registered security listed on some exchange</skos:definition>
 		<fibo-fnd-utl-av:synonym>exchange-traded security</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -207,25 +209,13 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;isTradedOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">listing</rdfs:label>
-		<skos:definition>registry entry for a security that provides information regarding the eligibility for making that security available for trading</skos:definition>
+		<skos:definition>registry entry for a security that is managed by an exchange and that provides registration information regarding the eligibility for making that security available for trading</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en">market listing</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;mayBeTradedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;hasRegistrationDate"/>
@@ -246,7 +236,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>registered security</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fi-fi;ExemptSecurity"/>
-		<skos:definition>security that is registered with some registration authority and that may be traded in some trading venue (market) or over the counter</skos:definition>
+		<skos:definition>security that is registered with some registration authority</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;RegisteredSecurityForm">
@@ -278,7 +268,7 @@
 		<rdfs:label>has home exchange</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<skos:definition>indicates the current exchange that is considered the primary trading venue for a security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A security may have been originally listed on the Frankfort exchange, but its current home is the London Stock Exchange, for example.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>A security may have been originally listed on the Frankfurt exchange, but its current home is the London Stock Exchange, for example.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>has primary trading market</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
@@ -306,7 +296,7 @@
 		<rdfs:label xml:lang="en">has tick size</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;Listing"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">specifies a minimum price movement for the contract or security with respect to an exchange</skos:definition>
+		<skos:definition xml:lang="en">specifies a minimum price movement for the security with respect to an exchange</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;isListedVia">
@@ -321,12 +311,13 @@
 		<rdfs:label>is seasoned</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition>indicates that the security has been publicly traded long enough to eliminate any short-term price or trading volume volatility from its initial public offering</skos:definition>
+		<skos:definition>indicates that the security has been publicly traded long enough to eliminate any short-term volume volatility from its initial public offering</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Short-term volatility may be with respect to price or trading volume.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;isTradedOn">
 		<rdfs:label>is traded on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;Listing"/>
+		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<skos:definition>identifies the trading facility on which the security is traded</skos:definition>
 	</owl:ObjectProperty>

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -149,7 +149,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>listed security</rdfs:label>
-		<skos:definition>registered security listed on one or more exchanges</skos:definition>
+		<skos:definition>registered security listed on at least one exchange</skos:definition>
 		<fibo-fnd-utl-av:synonym>exchange-traded security</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminated confusion between listed security and listing which caused reasoning errors, corrected ticker symbol as identifying a listed security rather than listing, streamlined hierarchy for registered securities, and eliminated ambiguity in definitions

Fixes: #1244 / SEC-145

## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


