### PR TITLE
Release the provisional SecurityBasedDerivatives and EquitySwaps ontologies

### DIFF
--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -97,6 +97,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
 		
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquitySwaps/"/>
+		
 	<!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //

--- a/DER/AllDER-ExampleIndividuals.rdf
+++ b/DER/AllDER-ExampleIndividuals.rdf
@@ -26,27 +26,28 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ExampleIndividuals/">
-		<rdfs:label>Derivatives Domain, with Reference Individuals</rdfs:label>
+		<rdfs:label>All Derivatives, Example Individuals</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-06-28T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain, with Reference Individuals</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain, with Reference and Example Individuals</dct:title>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
 		<sm:contributor>Adaptive, Inc.</sm:contributor>
 		<sm:contributor>Bloomberg LP</sm:contributor>
 		<sm:contributor>Citigroup</sm:contributor>
 		<sm:contributor>Commodities Futures Trading Commission (CFTC)</sm:contributor>
 		<sm:contributor>Deutsche Bank</sm:contributor>
+		<sm:contributor>Federated Knowledge LLC</sm:contributor>
 		<sm:contributor>John F. Gemski</sm:contributor>
 		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>Mizuho</sm:contributor>
+		<sm:contributor>Mizuho Financial Group, Inc.</sm:contributor>
 		<sm:contributor>Nordea Bank AB</sm:contributor>
 		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
 		<sm:contributor>Quarule</sm:contributor>
 		<sm:contributor>State Street Bank and Trust</sm:contributor>
 		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
+		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
 		<sm:contributor>Working Ontologist</sm:contributor>
 		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
@@ -57,8 +58,8 @@
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-derri-all</sm:fileAbbreviation>
-		<sm:filename>AllDER-ReferenceIndividuals.rdf</sm:filename>
+		<sm:fileAbbreviation>fibo-derex-all</sm:fileAbbreviation>
+		<sm:filename>AllDER-ExampleIndividuals.rdf</sm:filename>
 		<sm:keyword>derivative instruments</sm:keyword>
 		<sm:keyword>options, futures, rights instruments, swaps</sm:keyword>
 		<sm:moduleAbbreviation>fibo-der</sm:moduleAbbreviation>
@@ -67,8 +68,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ReferenceIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ExampleIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200601/AllDER-ExampleIndividuals/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for SEC example individuals is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), Securities (SEC) and Derivatives (DER) domains, including all individuals, with examples of how to encode information for a notional interest rate swap contract.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201201/AllDER-ExampleIndividuals/"/>
+		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for DER example individuals is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), Securities (SEC) and Derivatives (DER) domains, including all individuals, with examples of how to encode information for a notional interest rate swap contract.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/DER/AllDER-ReferenceIndividuals.rdf
+++ b/DER/AllDER-ReferenceIndividuals.rdf
@@ -26,25 +26,29 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ReferenceIndividuals/">
 		<rdfs:label>Derivatives Domain, with Reference Individuals</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain, with Reference Individuals</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
 		<sm:contributor>Adaptive, Inc.</sm:contributor>
 		<sm:contributor>Bloomberg LP</sm:contributor>
 		<sm:contributor>Citigroup</sm:contributor>
 		<sm:contributor>Commodities Futures Trading Commission (CFTC)</sm:contributor>
 		<sm:contributor>Deutsche Bank</sm:contributor>
+		<sm:contributor>Federated Knowledge LLC</sm:contributor>
+		<sm:contributor>John F. Gemski</sm:contributor>
+		<sm:contributor>John F. Tierney</sm:contributor>
+		<sm:contributor>Mizuho Financial Group, Inc.</sm:contributor>
 		<sm:contributor>Nordea Bank AB</sm:contributor>
 		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
 		<sm:contributor>Quarule</sm:contributor>
 		<sm:contributor>State Street Bank and Trust</sm:contributor>
 		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
+		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
 		<sm:contributor>Working Ontologist</sm:contributor>
-		<sm:copyright>Copyright (c) 2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
@@ -62,7 +66,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/SwapsIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20180801/AllDER-ReferenceIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201201/AllDER-ReferenceIndividuals/"/>
 		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for DER is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), Securities (SEC), and Derivatives (DER) domains, including all individuals.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/DER/AllDER.rdf
+++ b/DER/AllDER.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-der-rtd-irswp "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/">
 	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/">
+	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -21,6 +22,7 @@
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-der-rtd-irswp="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"
 	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"
+	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -32,24 +34,29 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/">
 		<rdfs:label>Derivatives Domain</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain</dct:title>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
 		<sm:contributor>Adaptive, Inc.</sm:contributor>
 		<sm:contributor>Bloomberg LP</sm:contributor>
 		<sm:contributor>Citigroup</sm:contributor>
 		<sm:contributor>Commodities Futures Trading Commission (CFTC)</sm:contributor>
 		<sm:contributor>Deutsche Bank</sm:contributor>
+		<sm:contributor>Federated Knowledge LLC</sm:contributor>
+		<sm:contributor>John F. Gemski</sm:contributor>
+		<sm:contributor>John F. Tierney</sm:contributor>
+		<sm:contributor>Mizuho Financial Group, Inc.</sm:contributor>
 		<sm:contributor>Nordea Bank AB</sm:contributor>
 		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
 		<sm:contributor>Quarule</sm:contributor>
 		<sm:contributor>State Street Bank and Trust</sm:contributor>
 		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
+		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
 		<sm:contributor>Working Ontologist</sm:contributor>
-		<sm:copyright>Copyright (c) 2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
@@ -67,9 +74,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquitySwaps/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20180801/AllDER/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201201/AllDER/"/>
 		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for DER is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), Securities (SEC), and Derivatives (DER) domains, excluding individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/DER/MetadataDER.rdf
+++ b/DER/MetadataDER.rdf
@@ -38,11 +38,18 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/">
 		<rdfs:label>Metadata about the EDMC-FIBO Derivatives (DER) Domain</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-der-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataDER.rdf</sm:filename>
 		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
@@ -54,12 +61,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/MetadataDERRateDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/MetadataDERSecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20180801/MetadataDER/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201201/MetadataDER/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-der-mod;DERDomain">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Derivatives</rdfs:label>
+		<rdfs:label>Derivatives Domain</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives.</dct:abstract>
 		<dct:creator rdf:datatype="&xsd;anyURI">https://wiki.edmcouncil.org/display/DER/FIBO+-+FCT+-+Derivatives+Home</dct:creator>
 		<dct:hasPart rdf:resource="&fibo-der-com-mod;CommoditiesDerivativesModule"/>
@@ -69,29 +76,36 @@
 		<dct:hasPart rdf:resource="&fibo-der-fx-mod;FxDerivativesModule"/>
 		<dct:hasPart rdf:resource="&fibo-der-rat-mod;RateDerivativesModule"/>
 		<dct:hasPart rdf:resource="&fibo-der-sbd-mod;SecurityBasedDerivativesModule"/>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain</dct:title>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
 		<sm:contributor>Adaptive, Inc.</sm:contributor>
 		<sm:contributor>Bloomberg LP</sm:contributor>
 		<sm:contributor>Citigroup</sm:contributor>
 		<sm:contributor>Commodities Futures Trading Commission (CFTC)</sm:contributor>
 		<sm:contributor>Deutsche Bank</sm:contributor>
+		<sm:contributor>Federated Knowledge LLC</sm:contributor>
+		<sm:contributor>John F. Gemski</sm:contributor>
+		<sm:contributor>John F. Tierney</sm:contributor>
+		<sm:contributor>Mizuho Financial Group, Inc.</sm:contributor>
 		<sm:contributor>Nordea Bank AB</sm:contributor>
 		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
 		<sm:contributor>Quarule</sm:contributor>
 		<sm:contributor>State Street Bank and Trust</sm:contributor>
 		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
+		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
 		<sm:contributor>Working Ontologist</sm:contributor>
-		<sm:copyright>Copyright (c) 2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:keyword>derivative instruments</sm:keyword>
 		<sm:moduleAbbreviation>fibo-der</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>

--- a/DER/SecurityBasedDerivatives/EquitySwaps.rdf
+++ b/DER/SecurityBasedDerivatives/EquitySwaps.rdf
@@ -43,11 +43,18 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquitySwaps/">
 		<rdfs:label xml:lang="en">Equity Swaps Ontology</rdfs:label>
-		<dct:abstract>Swap contracts in which one leg gives some form of return on an equity asset, including dividend returns, total asset returns equity dispersion and correlation measurement terms. Many of these return calculations are based on a variety of calculation methods and may vary widely.</dct:abstract>
+		<dct:abstract>This ontology defines concepts specific to swap contracts in which one leg gives some form of return on an equity asset, including dividend returns, total asset returns equity dispersion and correlation measurement terms. Many of these return calculations are based on a variety of calculation methods and may vary widely.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
 		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/"/>
 		<sm:fileAbbreviation>fibo-der-sbd-eqs</sm:fileAbbreviation>
 		<sm:filename>EquitySwaps.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
@@ -62,8 +69,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquitySwaps/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201201/SecurityBasedDerivatives/EquitySwaps/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;DispersionSwapIndexConstituentsLeg">

--- a/DER/SecurityBasedDerivatives/SecurityBasedDerivatives.rdf
+++ b/DER/SecurityBasedDerivatives/SecurityBasedDerivatives.rdf
@@ -45,11 +45,17 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 		<rdfs:label>Security-Based Derivatives Ontology</rdfs:label>
-		<dct:abstract>Common concepts for derivatives based on securities as their underliers, including those based on indices or baskets of these assets.</dct:abstract>
+		<dct:abstract>This ontology defines common concepts for derivatives based on securities as their underliers, including those based on indices or baskets of these assets.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
 		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/"/>
 		<sm:fileAbbreviation>fibo-der-sbd-sbd</sm:fileAbbreviation>
 		<sm:filename>SecurityBasedDerivatives.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
@@ -64,8 +70,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201201/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-sbd;BasketOfDebtInstruments">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This issue updates two of the security-based derivatives ontologies, the core ontology and equity swaps, to change their status to 'release', and updates metadata and 'load' ontologies accordingly

Fixes: #1251 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


