### PR TITLE
BE-229 - A number of key classes are missing in the trusts ontology

### DIFF
--- a/BE/Trusts/Trusts.rdf
+++ b/BE/Trusts/Trusts.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
+	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
 	<!ENTITY fibo-be-tr-tr "https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/">
 	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
@@ -21,6 +22,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
+	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
 	xmlns:fibo-be-tr-tr="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/"
 	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
@@ -39,57 +41,64 @@
 		<rdfs:label>Trusts Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental common terms for trusts. Trusts are entities set up in terms of the applicable local statutes goerning trusts, and have as a minimum three specific, defined parties, known in many jurisdictions as trustor (sometimes sponsor), trustee and beneficiary. The terms in this ontology may be extended as necessary to represent specific types of trust, for example in the funds arena.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-be-tr-tr</sm:fileAbbreviation>
 		<sm:filename>Trusts.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20181101/Trusts/Trusts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/Trusts/Trusts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/Trusts/Trusts.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20150201/Trusts/Trusts.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/Trusts/Trusts.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20181101/Trusts/Trusts.rdf version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200301/Trusts/Trusts.rdf version of this ontology was modified to add a number of kinds of trusts, clean-up extraneous concepts, and eliminate circularity and ambiguity in definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-be-tr-tr;FundUnitHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-be-tr-tr;TrustBeneficiary"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-pty-pty;isAPartyTo"/>
-						<owl:onClass rdf:resource="&fibo-be-tr-tr;TrustFundTrust"/>
-						<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-					</owl:Restriction>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>fund unit holder</rdfs:label>
-		<skos:definition>a party that holds some unit in a fund</skos:definition>
+	<owl:Class rdf:about="&fibo-be-tr-tr;IrrevocableTrust">
+		<rdfs:subClassOf rdf:resource="&fibo-be-tr-tr;Trust"/>
+		<rdfs:label>irrevocable trust</rdfs:label>
+		<skos:definition>trust that cannot be modified, amended or terminated except under certain legal circumstances and typically not without the permission of the grantor&apos;s named beneficiary or beneficiaries</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Irrevocable trusts also offer asset protection from future creditors and lawsuits.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-tr-tr;LivingTrust">
+		<rdfs:subClassOf rdf:resource="&fibo-be-tr-tr;Trust"/>
+		<rdfs:label>living trust</rdfs:label>
+		<skos:definition>trust created during an individual&apos;s lifetime where a designated person, the trustee, is given responsibility for managing that individual&apos;s assets for the benefit of the eventual beneficiary</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A living trust is designed to allow for the easy transfer of the trust creator or settlor&apos;s assets while bypassing the often complex and expensive legal process of probate. Living trust agreements designate a trustee who holds legal possession of assets and property that flow into the trust.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-tr-tr;RevocableTrust">
+		<rdfs:subClassOf rdf:resource="&fibo-be-tr-tr;Trust"/>
+		<rdfs:label>revocable trust</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-be-tr-tr;IrrevocableTrust"/>
+		<skos:definition>trust in which legal ownership of the trust property is transferred to the trustee, but the trustor retains full power to revoke, modify or amend the trust</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-tr-tr;TestamentaryTrust">
+		<rdfs:subClassOf rdf:resource="&fibo-be-tr-tr;IrrevocableTrust"/>
+		<rdfs:label>testamentary trust</rdfs:label>
+		<skos:definition>trust established in accordance with the instructions contained in a last will and testament</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A will could have more than one testamentary trust. The trustee named is responsible for managing and distributing the trustor&apos;s assets to the beneficiaries as directed in the will. Sometimes called a will trust, the testamentary trust is irrevocable.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;Trust">
+		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;BusinessEntity"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -117,8 +126,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trust</rdfs:label>
-		<skos:definition>A fiduciary relationship in which one party, known as a trustor, gives another party, the trustee, the right to hold title to property or assets for the benefit of a third party, the beneficiary.</skos:definition>
-		<skos:editorialNote>This is a legal agreement between parties that someone owns, and is thereby an asset that they own. They can be taxed on this as any other asset. There are generally accepted things such as the source of funds that will determine who the revenue agency will go after. Definition reference URL: http://www.investopedia.com/terms/t/trust.asp</skos:editorialNote>
+		<skos:definition>fiduciary relationship and legal entity in which one party, known as a trustor, gives another party, the trustee, the right to hold title to and manage assets for the benefit of a third party, the beneficiary</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;TrustAgreement">
@@ -142,9 +151,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trust agreement</rdfs:label>
-		<skos:definition>Formal agreement through which a trustor vests the ownership rights (title) to one or more assets to one or more trustees for conservation and protection on behalf of one or more beneficiaries of the trust. It normally states the (1) purpose for which the trust was established and fulfillment of which will terminate the trust, (2) details of the assets placed in the trust, (3) powers and limitations of the trustees, their reporting requirements, and other associated provisions, and (4) may also specify the trustees&apos; compensation, if any. A trust agreement involving real estate requires its exact description and the trustor&apos;s express, written consent to create the trust to be valid. A will admitted to probate may also act like a trust agreement.</skos:definition>
-		<skos:editorialNote>See also Deed. These are distinct from Contracts in that they impose obligations but without necessarily reciprocating rights.</skos:editorialNote>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/trust-agreement.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>formal agreement that establishes a trust, whereby the trustor(s) gives the trustee(s) the responsibility to hold and manage assets for the beneficiary(ies)</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>A trust agreement typically states the (1) purpose for which the trust was established and fulfillment of which will terminate the trust, (2) details of the assets placed in the trust, (3) powers and limitations of the trustees, their reporting requirements, and other associated provisions, and (4) may also specify the trustees&apos; compensation, if any. A trust agreement involving real estate requires its exact description and the trustor&apos;s express, written consent to create the trust to be valid.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>trust deed</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>trust document</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>trust instrument</fibo-fnd-utl-av:synonym>
@@ -164,18 +173,13 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trust beneficiary</rdfs:label>
-		<skos:definition>Person or organization for whose present or future interest (benefit) an annuity, assignment (such as a letter of credit), contract, insurance policy, judgment, promise, trust, will, etc., is made</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/beneficiary.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>party for whose interest (benefit) an annuity, assignment (such as a letter of credit), contract, insurance policy, judgment, promise, trust, will, etc., is made</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/beneficiary.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;TrustFundManager">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
@@ -188,36 +192,12 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trust fund manager</rdfs:label>
-		<skos:definition>A trust fund manager acts on behalf of the Trustee to manage the assets of the Trust.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-tr-tr;TrustFundTrust">
-		<rdfs:subClassOf rdf:resource="&fibo-be-tr-tr;Trust"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-tr-tr;TrustFundManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-pty;hasPartyInRole"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-tr-tr;FundUnitHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>trust fund trust</rdfs:label>
-		<skos:definition>A trust which forms the basis for a fund.</skos:definition>
-		<skos:editorialNote>The fund is identified as being a kind of Trust Fund.</skos:editorialNote>
+		<skos:definition>party empowered to act on behalf of the trustee to manage the assets of the trust</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;Trustee">
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
@@ -253,8 +233,10 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trustee</rdfs:label>
-		<skos:definition>An individual or organization which holds or manages and invests assets for the benefit of another. The trustee is legally obliged to make all trust-related decisions with the beneficiary&apos;s interests in mind, and may be liable for damages in the event of not doing so. Trustees may be entitled to a payment for their services, if specified in the trust deed. In the specific case of the bond market, a trustee administers a bond issue for a borrower, and ensures that the issuer meets all the terms and conditions associated with the borrowing.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.investorwords.com/5086/trustee.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>party that holds, manages, invests assets for the benefit of another</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investorwords.com/5086/trustee.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>The trustee is legally obliged to make all trust-related decisions with the beneficiary&apos;s interests in mind, and may be liable for damages in the event of not doing so. Trustees may be entitled to a payment for their services, if specified in the trust agreement. In the specific case of the bond market, a trustee administers a bond issue for a borrower, and ensures that the issuer meets all the terms and conditions associated with the borrowing.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;Trustor">
@@ -278,10 +260,46 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trustor</rdfs:label>
-		<skos:definition>Entity that establishes a trust and place property under the protection and management of one or more trustees for the immediate or eventual benefit of ascertainable one or more beneficiaries. It is not always necessary to identify the trustor who may be also be a trustee and/or one of the beneficiaries. In legal parlance, a trustor is called a settlor in the UK and a grantor in the US, whereas in common usage he or she may also be called a creator, donor, initiator, owner, or Trust maker.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/trustor.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>party that establishes a trust and places property under the protection and management of one or more trustees for the benefit of at least one beneficiary</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/trustor.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>It is not always necessary to identify the trustor who may be also be a trustee and/or one of the beneficiaries. In legal parlance, a trustor is called a settlor in the UK and a grantor in the US, whereas in common usage he or she may also be called a creator, donor, initiator, owner, or trust maker.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>grantor</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>settlor</fibo-fnd-utl-av:synonym>
 	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-tr-tr;hasBeneficiary">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;actsOn"/>
+		<rdfs:label>has beneficiary</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-tr-tr;Trust"/>
+		<rdfs:range rdf:resource="&fibo-be-tr-tr;TrustBeneficiary"/>
+		<owl:inverseOf rdf:resource="&fibo-be-tr-tr;isBeneficiaryOf"/>
+		<skos:definition>links a trust to a named beneficiary</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-tr-tr;hasTrustee">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;isAffectedBy"/>
+		<rdfs:label>has trustee</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-tr-tr;Trust"/>
+		<rdfs:range rdf:resource="&fibo-be-tr-tr;Trustee"/>
+		<owl:inverseOf rdf:resource="&fibo-be-tr-tr;isTrusteeOf"/>
+		<skos:definition>links a trust to a named trustee</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-tr-tr;isBeneficiaryOf">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;isAffectedBy"/>
+		<rdfs:label>is beneficiary of</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-tr-tr;TrustBeneficiary"/>
+		<rdfs:range rdf:resource="&fibo-be-tr-tr;Trust"/>
+		<skos:definition>specifies the trust that a beneficiary is named in</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-tr-tr;isTrusteeOf">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;actsOn"/>
+		<rdfs:label>is trustee of</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-tr-tr;Trustee"/>
+		<rdfs:range rdf:resource="&fibo-be-tr-tr;Trust"/>
+		<skos:definition>identifies the trust over which a trustee has some measure of control</skos:definition>
+	</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added several kinds of trusts, refined definitions based on multiple sources and moved some content to explanatory notes, improved integration of trust parties, cleaned up unused concepts

Fixes: #1259  / BE-229


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


