### PR TITLE
BE-218 - Need the role of managing member associated with an LLC

### DIFF
--- a/BE/OwnershipAndControl/ControlParties.rdf
+++ b/BE/OwnershipAndControl/ControlParties.rdf
@@ -74,7 +74,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/ControlParties.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to correct reasoning anomalies.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190101/OwnershipAndControl/ControlParties.rdf version of this ontology was modified to eliminate duplication of concepts with LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/ControlParties.rdf version of this ontology was modified to integrate the concept of a situation, situational roles, and corresponding relations with the definition of control and eliminate an unused and logically inconsistent property.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/ControlParties.rdf version of the ontology was modified to simplify control concepts and relations, eliminate ambiguity in definitions, and restate definitions to be ISO 704 compliant.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/ControlParties.rdf version of the ontology was modified to simplify control concepts and relations, eliminate ambiguity in definitions, restate definitions to be ISO 704 compliant, and add properties relating control parties to control situations.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -261,6 +261,15 @@
 		<skos:editorialNote>By virtue of holding 100 percent of the equity ownership, the Total Owner also holds 100 percent of the controlling equity, if there is a difference. Therefore it is both a total owner and a total controlling party.</skos:editorialNote>
 	</owl:Class>
 	
+	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;hasControllingOrganizationMember">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;hasControllingParty"/>
+		<rdfs:label>has organization member</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
+		<owl:inverseOf rdf:resource="&fibo-be-oac-cpty;isControllingMemberOf"/>
+		<skos:definition>relates a controlled party to a controlling member of the organization</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;hasMajorityControllingParty">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isControlledBy"/>
 		<rdfs:label>has majority controlling party</rdfs:label>
@@ -275,6 +284,14 @@
 		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;InvestmentBasedDeFactoControl"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-opty;InvestmentEquity"/>
 		<skos:definition>indicates investment-based de facto control, which is is based on the holding of some investment equity by some party</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;isControllingMemberOf">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isPartyControlling"/>
+		<rdfs:label>is controlling member of</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
+		<rdfs:range rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<skos:definition>identifies a controlled organization over which the member has some measure of control</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
+++ b/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
@@ -40,6 +40,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/">
 		<rdfs:label>Private Limited Companies Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for representing private limited companies -- i.e., companies that have characteristics of corporations and of partnerships but are neither.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>

--- a/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
+++ b/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
@@ -80,9 +80,59 @@
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;playsRole"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-be-oac-cpty;hasControllingOrganizationMember"/>
+						<owl:someValuesFrom rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompanyMember"/>
+					</owl:Restriction>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>limited liability company</rdfs:label>
 		<skos:definition>private limited company that combines the pass through taxation of a sole proprietorship or partnership with the limited liability of a corporation</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>LLC</fibo-fnd-utl-av:abbreviation>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-plc-plc;LimitedLiabilityCompanyMember">
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;DeJureControllingInterestParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;EntityControllingParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;EntityOwner"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-oac-cpty;isControllingMemberOf"/>
+				<owl:onClass>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+						<owl:someValuesFrom rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
+					</owl:Restriction>
+				</owl:onClass>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+				<owl:onClass rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+						<owl:someValuesFrom rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
+					</owl:Restriction>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>limited liability company member</rdfs:label>
+		<skos:definition>owner of an interest in a limited liability company</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-plc-plc;LimitedLiabilityCompanyTaxedAsACorporation">
@@ -93,36 +143,22 @@
 		<fibo-fnd-utl-av:explanatoryNote>In the United States, LLCs that elect to be taxed as a corporation do so by filing an IRS Form 8832.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-be-plc-plc;ManagerManagedLimitedLiabilityCompany">
+		<rdfs:subClassOf rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
+		<rdfs:label>manager-managed limited liability company</rdfs:label>
+		<skos:definition>limited liability company in which the members appoint one or more managers to handle the daily operations and administrative responsibilities of the organization</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>If no members are interested in managing the LLC, an external manager (someone who doesn’t own any portion of the LLC) can be hired to run the business operations, including, in some jurisdictions, a third-party entity, such as another company.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-be-plc-plc;ManagingMember">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;DeJureControllingInterestParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;EntityControllingParty"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;EntityOwner"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompanyMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-plc-plc;isManagingMemberOf"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-						<owl:someValuesFrom rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
 						<owl:someValuesFrom rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>

--- a/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
+++ b/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
@@ -2,8 +2,15 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
+	<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/">
+	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
+	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-be-plc-plc "https://spec.edmcouncil.org/fibo/ontology/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/">
+	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
+	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -14,8 +21,15 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
+	xmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"
+	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
+	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-be-plc-plc="https://spec.edmcouncil.org/fibo/ontology/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/"
+	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
+	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -26,29 +40,90 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/">
 		<rdfs:label>Private Limited Companies Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for representing private limited companies -- i.e., companies that have characteristics of corporations and of partnerships but are neither.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2018 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-be-plc-plc</sm:fileAbbreviation>
 		<sm:filename>PrivateLimitedCompanies.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20181101/PrivateLimitedCompanies/PrivateLimitedCompanies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
+	<owl:Class rdf:about="&fibo-be-plc-plc;LimitedLiabilityCompany">
+		<rdfs:subClassOf rdf:resource="&fibo-be-plc-plc;PrivateCompanyWithLimitedLiability"/>
+		<rdfs:label>limited liability company</rdfs:label>
+		<skos:definition>private limited company that combines the pass through taxation of a sole proprietorship or partnership with the limited liability of a corporation</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>LLC</fibo-fnd-utl-av:abbreviation>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-plc-plc;LimitedLiabilityCompanyTaxedAsACorporation">
+		<rdfs:subClassOf rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
+		<rdfs:label>limited liability company taxed as a corporation</rdfs:label>
+		<skos:definition>limited liability company that has elected to have corporate tax status</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>C-LLC</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>In the United States, LLCs that elect to be taxed as a corporation do so by filing an IRS Form 8832.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-plc-plc;ManagingMember">
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;DeJureControllingInterestParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;EntityControllingParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;EntityOwner"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+				<owl:onClass rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+						<owl:allValuesFrom rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
+					</owl:Restriction>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>managing member</rdfs:label>
+		<skos:definition>owner of an interest in a limited liability company who also runs the day-to-day business operations</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-be-plc-plc;PrivateCompanyWithLimitedLiability">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;BusinessEntity"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:label>private company with limited liability</rdfs:label>
-		<skos:definition>a hybrid business entity having certain characteristics of both a corporation and a partnership or sole proprietorship (depending on how many owners there are).</skos:definition>
+		<skos:definition>hybrid business entity having characteristics of both a corporation and a partnership or sole proprietorship (depending on how many owners there are)</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Limited_liability_company#Overview</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A private company with limited liability, although a business entity, is not a corporation. The primary characteristic this legal form shares with a corporation is limited liability, and the primary characteristic it shares with a partnership is the availability of pass-through income taxation. It is often more flexible than a corporation, and it is well-suited for companies with a single owner.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-plc-plc;PrivateLimitedCompany">
+		<rdfs:subClassOf rdf:resource="&fibo-be-plc-plc;PrivateCompanyWithLimitedLiability"/>
+		<rdfs:label>private limited company</rdfs:label>
+		<skos:definition>private limited company whose shareholders&apos; liability is limited to the capital they originally invested</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>Ltd.</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Private limited companies are common in countries including the U.K., Ireland, and Canada. They have one or more members, also called shareholders or owners, who buy in through private sales. Directors are company employees who keep up with all administrative tasks and tax filings but do not need to be shareholders.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
+++ b/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
@@ -60,14 +60,26 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20181101/PrivateLimitedCompanies/PrivateLimitedCompanies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/PrivateLimitedCompanies/PrivateLimitedCompanies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies, and add limited liability company, limited liability company taxed as a corporation, managing member, and private limited company.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-plc-plc;LimitedLiabilityCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-be-plc-plc;PrivateCompanyWithLimitedLiability"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;playsRole"/>
+				<owl:onClass>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-be-plc-plc;hasManagingMember"/>
+						<owl:someValuesFrom rdf:resource="&fibo-be-plc-plc;ManagingMember"/>
+					</owl:Restriction>
+				</owl:onClass>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>limited liability company</rdfs:label>
 		<skos:definition>private limited company that combines the pass through taxation of a sole proprietorship or partnership with the limited liability of a corporation</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>LLC</fibo-fnd-utl-av:abbreviation>
@@ -96,11 +108,22 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-plc-plc;isManagingMemberOf"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+						<owl:someValuesFrom rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
+					</owl:Restriction>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
-						<owl:allValuesFrom rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
+						<owl:someValuesFrom rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
 			</owl:Restriction>
@@ -125,5 +148,20 @@
 		<fibo-fnd-utl-av:abbreviation>Ltd.</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Private limited companies are common in countries including the U.K., Ireland, and Canada. They have one or more members, also called shareholders or owners, who buy in through private sales. Directors are company employees who keep up with all administrative tasks and tax filings but do not need to be shareholders.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-plc-plc;hasManagingMember">
+		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasControllingOrganizationMember"/>
+		<rdfs:label>has managing member</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-be-plc-plc;ManagingMember"/>
+		<skos:definition>indicates a managing member in a controlling role of a limited liability company that has responsibility for the day-to-day business operations</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-plc-plc;isManagingMemberOf">
+		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;isControllingMemberOf"/>
+		<rdfs:label>is managing member of</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-plc-plc;ManagingMember"/>
+		<owl:inverseOf rdf:resource="&fibo-be-plc-plc;hasManagingMember"/>
+		<skos:definition>indicates the controlled limited liability company that the managing member runs</skos:definition>
+	</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Adds a number of missing concepts to the PrivateLimitedCompanies ontology, including limited liability company (LLC), limited liability company member, limited liability company taxed as a corporation (C-LLC), manager-managed limited liability company, managing member, private limited company (Ltd.), and properties linking a managing member to the limited liability company they manage.

Fixes: #1264 / BE-218


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


