### PR TITLE
Fix to the test on circular definitions

### DIFF
--- a/etc/testing/hygiene/testHygiene1068.sparql
+++ b/etc/testing/hygiene/testHygiene1068.sparql
@@ -4,18 +4,18 @@ prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
 
 ##
-# banner Definitions shouldn't be circular.
+# banner Definitions shouldn't be circular - this finds direct circularities therein.
 
 SELECT DISTINCT ?error ?definition ?label
 WHERE {
   ?s rdfs:label ?label .
   ?s skos:definition ?definition .
   FILTER NOT EXISTS {?s a owl:NamedIndividual} .
-  FILTER (CONTAINS(?definition, ?label))
+  FILTER (REGEX(?definition, "\\W"+?label+"\\W"))
   FILTER (CONTAINS(str(?s), "edmcouncil"))
 
   BIND (
-    concat ("WARN: Definition of ", str(?s), " is circular ")
+    concat ("WARN: Definition of ", str(?s), " is immediately circular ")
       AS ?error
     )
 }


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This is to remove false positives in the check for circular definitions.

Fixes: #1261 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


