### PR TITLE
SEC-147 - FIBO does not allow representation of adjusted and unadjusted prices for equities

### DIFF
--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -85,11 +85,18 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201101/FinancialInstruments/InstrumentPricing/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, and to address ambiguity in some definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, and to add adjusted price.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
+	
+	<owl:Class rdf:about="&fibo-fbc-fi-ip;AdjustedClosingPrice">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;ClosingPrice"/>
+		<rdfs:label xml:lang="en">adjusted closing price</rdfs:label>
+		<skos:definition xml:lang="en">amended closing price to reflect a security&apos;s value after accounting for any corporate actions, such as stock splits, dividends, and rights offerings</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A particularly dramatic change in price occurs when a company announces a stock split. When the change is made, the price displayed will immediately reflect the split. For example, if a company splits its stock 2-for-1, the last closing price will be cut in half. That&apos;s the adjusted closing price.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;BestBid">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;BidPrice"/>
@@ -139,6 +146,12 @@
 		<owl:disjointWith rdf:resource="&fibo-fbc-fi-ip;OfferPrice"/>
 		<skos:definition xml:lang="en">price a prospective buyer is willing to pay</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The term &apos;bid price&apos; is used by traders / market makers with respect to a given security, and that are prepared to buy or sell round lots at publicly quoted prices, and by specialists in certain instruments that perform similar functions on an exchange.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fi-ip;ClosingPrice">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
+		<rdfs:label xml:lang="en">closing price</rdfs:label>
+		<skos:definition xml:lang="en">cash value of the last transacted price before the market closes</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;ClosingPriceDeterminationMethod">
@@ -300,7 +313,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;OfficialClosingPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;ClosingPrice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasClosingPriceDeterminationMethod"/>
@@ -309,6 +322,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">official closing price</rdfs:label>
 		<skos:definition xml:lang="en">price of the final trade of a security at the end of a trading day on a given exchange</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A stock&apos;s closing price is the standard benchmark used by investors to track its performance over time.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en">end-of-day price</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added AdjustedClosingPrice as well as a more general ClosingPrice, and made OfficialClosingPrice a subclass of closing price, with an explanatory note.

Fixes: #1134 / SEC-147


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


