### PR TITLE
DER-71 - Need the definition of a valoren as an instrument identifier

### DIFF
--- a/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
@@ -61,11 +61,15 @@
 		<rdfs:label>International Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with additional kinds of entities that provide services internationally, such as international market data providers, organizations that provide exchanges in multiple countries, etc.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2017-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2017-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
@@ -89,14 +93,87 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to eliminate usage of deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to eliminate duplication of concepts in LCC, simplify addresses and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to add the SIX Group and SIX Financial Information, which owns and operates a number of exchanges and issues the valoren, which is a commonly used financial instrument identifier, as well as to update the LEI data for all LEIs to correspond to the content published by the GLEIF on data.world.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-213800D1EI4B9WTWWD28-LEI">
+		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+		<rdfs:label>London Stock Exchange plc. legal entity identifier</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier for London Stock Exchange plc.</skos:definition>
+		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchange"/>
+		<lcc-lr:hasTag>213800D1EI4B9WTWWD28</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangePlc"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-222100T6ICDIY8V4VX70-LEI">
+		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+		<rdfs:label>LuxCSD S.A. legal entity identifier</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier for LuxCSD S.A.</skos:definition>
+		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-eufseind;LuxCSD"/>
+		<lcc-lr:hasTag>222100T6ICDIY8V4VX70</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDSA"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-506700D369548LQDC335-LEI">
+		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+		<rdfs:label>SIX Financial Information AG legal entity identifier</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier for SIX Financial Information AG</skos:definition>
+		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-eufseind;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmann"/>
+		<lcc-lr:hasTag>506700D369548LQDC335</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;SIXFinancialInformationAG"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-5299000J2N45DDNE4Y28-LEI">
+		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+		<rdfs:label>Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann GmbH &amp; Co. KG legal entity identifier</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier for Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann GmbH &amp; Co. KG</skos:definition>
+		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-eufseind;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmann"/>
+		<lcc-lr:hasTag>5299000J2N45DDNE4Y28</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmannGmbHAndCoKG-DE"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-529900ZMNQFCPP762W05-LEI">
+		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+		<rdfs:label>SIX Group AG legal entity identifier</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier for SIX Group AG</skos:definition>
+		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-eufseind;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmann"/>
+		<lcc-lr:hasTag>529900ZMNQFCPP762W05</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;SIXGroupAG"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-549300CBNW05DILT6870-LEI">
+		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+		<rdfs:label>Euroclear SA/NV legal entity identifier</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier for Euroclear SA/NV</skos:definition>
+		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-eufseind;BusinessEntityData"/>
+		<lcc-lr:hasTag>549300CBNW05DILT6870</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;EuroclearSANV"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-549300OL514RA0SXJJ44-LEI">
+		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+		<rdfs:label>Clearstream Banking S.A. legal entity identifier</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier for Clearstream Banking S.A.</skos:definition>
+		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-eufseind;LuxCSD"/>
+		<lcc-lr:hasTag>549300OL514RA0SXJJ44</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;ClearstreamBankingSA"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-EVK05KS7XY1DEII3R011-LEI">
+		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+		<rdfs:label>Business Entity Data (BED) B.V. legal entity identifier</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier for Business Entity Data (BED) B.V.</skos:definition>
+		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-eufseind;BusinessEntityData"/>
+		<lcc-lr:hasTag>EVK05KS7XY1DEII3R011</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;BusinessEntityData-NL"/>
+	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;BusinessEntityData">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LocalOperatingUnit"/>
@@ -106,7 +183,7 @@
 		<skos:definition>individual representing Business Entity Data (BED) B.V.</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-eufseind;BusinessEntityData-NL"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-utl-av:explanatoryNote>a wholly owned subsidiary of DTCC that owns and operates the Global Market Entity Identifier Utility (GMEI) legal entity identifier (LEI) solution in the federated Global LEI system (GLEIS)</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>wholly-owned subsidiary of DTCC that owns and operates the Global Market Entity Identifier Utility (GMEI) legal entity identifier (LEI) registration service</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;BusinessEntityData-NL">
@@ -144,13 +221,12 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Business Entity Data (BED) B.V. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier Global LEI Index registry entry for Business Entity Data (BED) B.V.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:54:07.648</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:54:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2017-12-19T00:32:07.885</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2018-12-19T00:32:07.594</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2020-08-11T08:03:00.000</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-08-11T15:27:00.000</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
-		<fibo-fnd-rel-rel:comprises rdf:resource="https://www.gleif.org/lei/EVK05KS7XY1DEII3R011"/>
-		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
+		<fibo-fnd-rel-rel:comprises rdf:resource="https://rdf.gleif.org/L1/L-EVK05KS7XY1DEII3R011-LEI"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;Clearstream">
@@ -188,11 +264,10 @@
 		<skos:definition>individual representing the legal entity identifier Global LEI Index registry entry for Clearstream Banking S.A.</skos:definition>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2015-01-09T22:33:24.097</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2017-06-10T01:45:57.630</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2018-05-31T07:45:48.293</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2020-11-19T09:52:28.373</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-06-06T00:00:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
-		<fibo-fnd-rel-rel:comprises rdf:resource="https://www.gleif.org/lei/549300OL514RA0SXJJ44"/>
-		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDLEIRegistry"/>
+		<fibo-fnd-rel-rel:comprises rdf:resource="https://rdf.gleif.org/L1/L-549300OL514RA0SXJJ44-LEI"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;ClearstreamBankingSA">
@@ -244,13 +319,12 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Euroclear SA/NV legal entity identifier registry entry</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier Global LEI Index registry entry for Euroclear SA/NV</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2014-01-07T03:04:29.521</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2014-01-07T03:04:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2017-10-04T23:31:26.361</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2018-08-08T07:42:16.609</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2020-07-27T07:24:00.000</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-07-27T07:34:00.000</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
-		<fibo-fnd-rel-rel:comprises rdf:resource="https://www.gleif.org/lei/549300CBNW05DILT6870"/>
-		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
+		<fibo-fnd-rel-rel:comprises rdf:resource="https://rdf.gleif.org/L1/L-549300CBNW05DILT6870-LEI"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;EuroclearSANV">
@@ -339,11 +413,10 @@
 		<skos:definition>individual representing the legal entity identifier Global LEI Index registry entry for London Stock Exchange plc.</skos:definition>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2013-09-13T00:00:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2017-09-18T10:37:31.723</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2018-09-18T00:00:00</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2020-07-23T15:28:43.987</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-09-18T00:00:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
-		<fibo-fnd-rel-rel:comprises rdf:resource="https://www.gleif.org/lei/213800D1EI4B9WTWWD28"/>
-		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangeUnaVistaRegistry"/>
+		<fibo-fnd-rel-rel:comprises rdf:resource="https://rdf.gleif.org/L1/L-213800D1EI4B9WTWWD28-LEI"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;LondonStockExchangePlc">
@@ -361,7 +434,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistry"/>
 		<rdfs:label>London Stock Exchange UnaVista Registry</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.lseg.com/LEI"/>
-		<skos:definition>individual representing the UnaVista registry service provided by the London Stock Exchange, wherein LEIs are registered and managed</skos:definition>
+		<skos:definition>individual representing the UnaVista registry service provided by the London Stock Exchange supporting LEI registration</skos:definition>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;LuxCSD">
@@ -387,11 +460,10 @@
 		<skos:definition>individual representing the legal entity identifier Global LEI Index registry entry for LuxCSD S.A.</skos:definition>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2014-06-03T01:45:01.523</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2017-04-22T02:10:21.720</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2018-03-13T08:18:28.680</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2020-02-05T09:45:01.090</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-03-13T00:00:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
-		<fibo-fnd-rel-rel:comprises rdf:resource="https://www.gleif.org/lei/222100T6ICDIY8V4VX70"/>
-		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDLEIRegistry"/>
+		<fibo-fnd-rel-rel:comprises rdf:resource="https://rdf.gleif.org/L1/L-222100T6ICDIY8V4VX70-LEI"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;LuxCSDSA">
@@ -412,6 +484,91 @@
 		<rdfs:seeAlso rdf:resource="http://www.nasdaqomxnordic.com/"/>
 		<skos:definition>a corporation that is a subsidiary of Nasdaq, Inc. that manages Nasdaq exchanges in Helsinki, Copenhagen, Stockholm, Iceland, Riga, Tallinn and Vilnius</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.nasdaqomx.com/</fibo-fnd-utl-av:adaptedFrom>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXFinancialInformation">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LocalOperatingUnit"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationAuthority"/>
+		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdfs:label>SIX Financial Information</rdfs:label>
+		<skos:definition>individual representing the SIX Financial Information functional entity, which provides market data gathered from the world&apos;s major trading venues directly and in real-time, and is an LEI Local Operating Unit (LOU), and the Valoren issuer and registration authority as well as the national numbering agency (NNA) for Switzerland, Belgium, and Liechtenstein, and the former TELEKURS ID financial instrument identifier issuer and registration authority</skos:definition>
+		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-eufseind;SIXFinancialInformationAG"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXFinancialInformationAG">
+		<rdf:type rdf:resource="&fibo-be-le-cb;Corporation"/>
+		<rdfs:label>SIX Financial Information AG</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.six-group.com/en/home.html"/>
+		<skos:definition>individual representing the SIX Financial Information AG legal entity</skos:definition>
+		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-eufseind;SIXGroupAGHeadquartersAddress"/>
+		<fibo-be-le-lei:hasLegalFormAbbreviation>Public Limited Company</fibo-be-le-lei:hasLegalFormAbbreviation>
+		<fibo-be-oac-cctl:hasGlobalUltimateParent rdf:resource="&fibo-fbc-fct-eufseind;SIXGroup"/>
+		<fibo-fbc-fct-breg:hasPriorLegalName>Telekurs AG</fibo-fbc-fct-breg:hasPriorLegalName>
+		<fibo-fbc-fct-breg:hasPriorLegalName>Telekurs Holding AG</fibo-fbc-fct-breg:hasPriorLegalName>
+		<fibo-fbc-fct-breg:hasPriorLegalName>Telekurs Holding Ltd.</fibo-fbc-fct-breg:hasPriorLegalName>
+		<fibo-fbc-fct-breg:hasPriorLegalName>Telekurs Holding SA</fibo-fbc-fct-breg:hasPriorLegalName>
+		<fibo-fbc-fct-breg:hasPriorLegalName>Telekurs Ltd</fibo-fbc-fct-breg:hasPriorLegalName>
+		<fibo-fbc-fct-breg:hasPriorLegalName>Telekurs SA</fibo-fbc-fct-breg:hasPriorLegalName>
+		<fibo-fbc-fct-breg:hasTradingOrOperationalName>SIX Financial Information Ltd</fibo-fbc-fct-breg:hasTradingOrOperationalName>
+		<fibo-fbc-fct-breg:hasTradingOrOperationalName>SIX SIX Financial Information SA</fibo-fbc-fct-breg:hasTradingOrOperationalName>
+		<fibo-fnd-rel-rel:hasLegalName>SIX Financial Information AG</fibo-fnd-rel-rel:hasLegalName>
+		<fibo-fnd-utl-av:explanatoryNote>The company name SIX is an abbreviation and stands for Swiss Infrastructure and Exchange.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXFinancialInformationAGLegalEntityIdentifierRegistryEntry">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
+		<rdfs:label>SIX Financial Information AG legal entity identifier registry entry</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier registry entry for SIX Financial Information AG</skos:definition>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2019-06-17T08:09:38+02:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
+		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2020-07-09T13:00:45+02:00</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-07-15T00:00:00+02:00</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
+		<fibo-fnd-rel-rel:comprises rdf:resource="https://rdf.gleif.org/L1/L-506700D369548LQDC335-LEI"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXGroup">
+		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdfs:label>SIX Group</rdfs:label>
+		<skos:definition>individual representing the SIX Group functional entity, which offers exchange services, financial information and banking services with the aim of increasing efficiency, quality and innovative capacity along the entire Swiss banking value chain</skos:definition>
+		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-eufseind;SIXGroupAG"/>
+		<fibo-fnd-utl-av:abbreviation>SIX</fibo-fnd-utl-av:abbreviation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXGroupAG">
+		<rdf:type rdf:resource="&fibo-be-le-cb;Corporation"/>
+		<rdfs:label>SIX Group AG</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.six-group.com/en/home.html"/>
+		<skos:definition>individual representing the SIX Group AG legal entity</skos:definition>
+		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-eufseind;SIXGroupAGHeadquartersAddress"/>
+		<fibo-be-le-lei:hasLegalFormAbbreviation>Public Limited Company</fibo-be-le-lei:hasLegalFormAbbreviation>
+		<fibo-be-oac-cctl:hasSubsidiary rdf:resource="&fibo-fbc-fct-eufseind;SIXFinancialInformation"/>
+		<fibo-fbc-fct-breg:hasTradingOrOperationalName>SIX Group Ltd</fibo-fbc-fct-breg:hasTradingOrOperationalName>
+		<fibo-fbc-fct-breg:hasTradingOrOperationalName>SIX Group SA</fibo-fbc-fct-breg:hasTradingOrOperationalName>
+		<fibo-fnd-rel-rel:hasLegalName>SIX Group AG</fibo-fnd-rel-rel:hasLegalName>
+		<fibo-fnd-utl-av:explanatoryNote>The company name SIX is an abbreviation and stands for Swiss Infrastructure and Exchange.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXGroupAGHeadquartersAddress">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<rdfs:label>SIX Group AG headquarters address</rdfs:label>
+		<skos:definition>individual representing the headquarters address for SIX Group AG</skos:definition>
+		<fibo-fnd-plc-adr:hasAddressLine1>Hardturmstrasse 201</fibo-fnd-plc-adr:hasAddressLine1>
+		<fibo-fnd-plc-adr:hasPostalCode>8005</fibo-fnd-plc-adr:hasPostalCode>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;Switzerland"/>
+		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Zurich"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXGroupAGLegalEntityIdentifierRegistryEntry">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
+		<rdfs:label>SIX Group AG legal entity identifier registry entry</rdfs:label>
+		<skos:definition>individual representing the legal entity identifier registry entry for SIX Group AG</skos:definition>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2013-12-09T09:40:03+01:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
+		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2020-12-10T07:01:20+01:00</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-02-07T00:00:00+01:00</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
+		<fibo-fnd-rel-rel:comprises rdf:resource="https://rdf.gleif.org/L1/L-529900ZMNQFCPP762W05-LEI"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SwedishBankersAssociation">
@@ -444,69 +601,14 @@
 		<skos:definition>individual representing the legal entity identifier registry entry for Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann GmbH &amp; Co. KG</skos:definition>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2013-04-03T13:47:18+02:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2017-05-04T08:09:54+02:00</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2018-04-04T13:47:18+02:00</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate rdf:datatype="&xsd;dateTime">2020-03-31T12:13:49+02:00</fibo-fbc-fct-breg:hasRegistrationStatusRevisionDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-04-04T13:47:18+02:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
-		<fibo-fnd-rel-rel:comprises rdf:resource="https://www.gleif.org/lei/5299000J2N45DDNE4Y28"/>
-		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-eufseind;WMDatenserviceEntityIdentifierRegistry"/>
+		<fibo-fnd-rel-rel:comprises rdf:resource="https://rdf.gleif.org/L1/L-5299000J2N45DDNE4Y28-LEI"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;DTCC-US-DE">
 		<fibo-be-oac-cctl:hasSubsidiary rdf:resource="&fibo-fbc-fct-eufseind;BusinessEntityData"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="https://www.gleif.org/lei/213800D1EI4B9WTWWD28">
-		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
-		<rdfs:label>London Stock Exchange plc. legal entity identifier</rdfs:label>
-		<skos:definition>individual representing the legal entity identifier for London Stock Exchange plc.</skos:definition>
-		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangeUnaVistaRegistry"/>
-		<lcc-lr:hasTag>213800D1EI4B9WTWWD28</lcc-lr:hasTag>
-		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangePlc"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="https://www.gleif.org/lei/222100T6ICDIY8V4VX70">
-		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
-		<rdfs:label>LuxCSD S.A. legal entity identifier</rdfs:label>
-		<skos:definition>individual representing the legal entity identifier for LuxCSD S.A.</skos:definition>
-		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDLEIRegistry"/>
-		<lcc-lr:hasTag>222100T6ICDIY8V4VX70</lcc-lr:hasTag>
-		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDSA"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="https://www.gleif.org/lei/5299000J2N45DDNE4Y28">
-		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
-		<rdfs:label>Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann GmbH &amp; Co. KG legal entity identifier</rdfs:label>
-		<skos:definition>individual representing the legal entity identifier for Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann GmbH &amp; Co. KG</skos:definition>
-		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-eufseind;WMDatenserviceEntityIdentifierRegistry"/>
-		<lcc-lr:hasTag>5299000J2N45DDNE4Y28</lcc-lr:hasTag>
-		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmannGmbHAndCoKG-DE"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="https://www.gleif.org/lei/549300CBNW05DILT6870">
-		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
-		<rdfs:label>Euroclear SA/NV legal entity identifier</rdfs:label>
-		<skos:definition>individual representing the legal entity identifier for Euroclear SA/NV</skos:definition>
-		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<lcc-lr:hasTag>549300CBNW05DILT6870</lcc-lr:hasTag>
-		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;EuroclearSANV"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="https://www.gleif.org/lei/549300OL514RA0SXJJ44">
-		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
-		<rdfs:label>Clearstream Banking S.A. legal entity identifier</rdfs:label>
-		<skos:definition>individual representing the legal entity identifier for Clearstream Banking S.A.</skos:definition>
-		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDLEIRegistry"/>
-		<lcc-lr:hasTag>549300OL514RA0SXJJ44</lcc-lr:hasTag>
-		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;ClearstreamBankingSA"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="https://www.gleif.org/lei/EVK05KS7XY1DEII3R011">
-		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
-		<rdfs:label>Business Entity Data (BED) B.V. legal entity identifier</rdfs:label>
-		<skos:definition>individual representing the legal entity identifier for Business Entity Data (BED) B.V.</skos:definition>
-		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<lcc-lr:hasTag>EVK05KS7XY1DEII3R011</lcc-lr:hasTag>
-		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;BusinessEntityData-NL"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
+++ b/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
@@ -95,7 +95,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to eliminate duplication of concepts with LCC and eliminate punning in individual definitions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to replace &apos;characterizes&apos; with &apos;describes&apos;, which more accurately expresses the intent.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues) and add the Telekurs Id (now retired) and Valoren as securities identifiers.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -115,6 +115,11 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;LondonStockExchange">
 		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationAuthority"/>
+		<rdf:type rdf:resource="&fibo-ind-ind-ind;FinancialInformationPublisher"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-id;NationalNumberingAgency"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXFinancialInformation">
 		<rdf:type rdf:resource="&fibo-ind-ind-ind;FinancialInformationPublisher"/>
 		<rdf:type rdf:resource="&fibo-sec-sec-id;NationalNumberingAgency"/>
 	</owl:NamedIndividual>
@@ -544,11 +549,80 @@
 		<fibo-fnd-utl-av:abbreviation>SEDOL scheme</fibo-fnd-utl-av:abbreviation>
 	</owl:NamedIndividual>
 	
+	<owl:Class rdf:about="&fibo-sec-sec-idind;TelekursId">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;isRegisteredBy"/>
+				<owl:hasValue rdf:resource="&fibo-fbc-fct-eufseind;SIXFinancialInformation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
+				<owl:hasValue rdf:resource="&fibo-fbc-fct-eufseind;SIXFinancialInformation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDefinedIn"/>
+				<owl:hasValue rdf:resource="&fibo-sec-sec-idind;TelekursSecurityIdentifierScheme"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>Telekurs Id</rdfs:label>
+		<skos:definition>identifier used to identify financial instruments owned, managed, and distributed by SIX Financial Information (formerly Telekurs AG and subsequently SIX Telekurs Ltd.)</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The Telekurs Id was phased out in favor of the Valoren (Valor Nummer in Swiss German) in 2013.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;TelekursSecurityIdentifierScheme">
 		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
 		<rdfs:label>Telekurs security identifier scheme</rdfs:label>
-		<skos:definition>proprietary identification scheme for securities identifiers managed by SIX Telekurs Ltd, a subsidiary of the SIX Group (Swiss Infrastructure and eXchange)</skos:definition>
+		<skos:definition>proprietary identification scheme for securities identifiers formerly managed by SIX Telekurs Ltd, a subsidiary of the SIX Group (Swiss Infrastructure and eXchange), now SIX Financial Information AG</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>Telekurs security ID scheme</fibo-fnd-utl-av:abbreviation>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-sec-sec-idind;Valoren">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;ListedSecurityIdentifier"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;NationalSecuritiesIdentifyingNumber"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;isRegisteredBy"/>
+				<owl:hasValue rdf:resource="&fibo-fbc-fct-eufseind;SIXFinancialInformation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
+				<owl:hasValue rdf:resource="&fibo-fbc-fct-eufseind;SIXFinancialInformation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDefinedIn"/>
+				<owl:hasValue rdf:resource="&fibo-sec-sec-idind;ValorenScheme"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>Valoren</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.six-group.com/en/products-services/financial-information.html"/>
+		<skos:definition>identification number assigned to financial instruments in Switzerland, Liechtenstein and Belgium, issued by SIX Financial Information, that is the National Securities Identifying Number (NSIN) for securities issued in those countries and is also part of the ISIN for the security it identifies</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.isin.net/valoren/</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>A VALOR code is between six and nine characters in length and like other securities identification codes (like ISIN, CUSIPs etc). A VALOR is utilized for identification purposes as well as clearing and settlement - similar to an ISIN code – and identifies debt and equity securities.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="de">Valor</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">Valor</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">Valor Code</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="de">Valor Nummer</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">Valoren Code</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">Valoren Number</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;ValorenScheme">
+		<rdf:type rdf:resource="&fibo-sec-sec-id;NationalSecurityIdentificationScheme"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-id;SecurityIdentificationScheme"/>
+		<rdfs:label>Valoren scheme</rdfs:label>
+		<skos:definition>national security identification scheme used to identify equity and debt securities in Switzerland, Liechtenstein and Belgium for the purposes of facilitating clearing and settlement of trades</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The VALOR number is a numeric code that intrinsically has no meaning. When a new VALOR is needed, the next one from the list is simply allocated. An instrument&apos;s number indicates nothing about the instrument itself.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 
 </rdf:RDF>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added SIX FinancialInformation AG (the issuer) and SIX Group AG to the European financial services entities individuals and updated LEI data for the individuals represented in this ontology to reflect the latest GLEIF published LEI data; completed the details for the Telekurs Id and added the Valoren to the securities identification individuals.


Fixes: #1268 / DER-71


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


