### PR TITLE
SEC-146 - Need to add a property for the lot size on listing

### DIFF
--- a/DER/DerivativesContracts/Forwards.rdf
+++ b/DER/DerivativesContracts/Forwards.rdf
@@ -485,13 +485,6 @@
 		<skos:definition xml:lang="en">indicates the price of the underlier of the forward as specified in delivery terms</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasLotSize">
-		<rdfs:label xml:lang="en">lot size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;CommodityFuture"/>
-		<rdfs:range rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
-		<skos:definition xml:lang="en">How many of the underlying commodity can be sold. The groupings of certain units of measure in the underlying commodity.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;hasMultiple">
 		<rdfs:label xml:lang="en">has multiple</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-fwd;IndexFuture"/>

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -87,7 +87,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, and to add adjusted price.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, to add adjusted price and to create a more general hasLotSize property that can be used in various contexts.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -566,6 +566,14 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This method itself changes quite frequently i.e. the exchange may change the way it computes closing prices.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-fi-ip;hasLotSize">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
+		<rdfs:label xml:lang="en">has lot size</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;positiveInteger"/>
+		<skos:definition xml:lang="en">magnitude of an item (i.e., total quantity)</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The lot size, referenced in offerings, listings, orders, and trades, typically refers to the number of shares or units. In options trading, lot size represents the total number of contracts contained in one derivative security.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:DatatypeProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-ip;hasPricingSource">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
 		<rdfs:label xml:lang="en">has pricing source</rdfs:label>
@@ -574,12 +582,11 @@
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fi-ip;hasQuoteLotSize">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-fi-ip;hasLotSize"/>
 		<rdfs:label xml:lang="en">has quote lot size</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:range rdf:resource="&xsd;positiveInteger"/>
 		<skos:definition xml:lang="en">magnitude of something to which the quote price refers</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The quote lot size, referenced in offerings, orders , and trades, typically refers to the number of shares or units.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-ip;hasRateOfReturn">

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -30,6 +31,7 @@
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -63,6 +65,7 @@
 		<sm:fileAbbreviation>fibo-sec-sec-lst</sm:fileAbbreviation>
 		<sm:filename>SecuritiesListings.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
@@ -86,7 +89,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/SecuritiesListings.rdf version of this ontology was revised to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and to eliminate the redundancy between hasIssue and lists.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesListings.rdf version of this ontology was revised to incorporate the form of registration and loosen the restriction on the number of possible registration authorities for a registered security.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues) and adjust definitions to eliminate ambiguity.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues), adjust definitions to eliminate ambiguity and add a property for lot size on listing.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -151,6 +154,7 @@
 		<rdfs:label>listed security</rdfs:label>
 		<skos:definition>registered security listed on at least one exchange</skos:definition>
 		<fibo-fnd-utl-av:synonym>exchange-traded security</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:usageNote>One can, as appropriate, multiply classify a share as being a common share and listed share, and, in the case whereby multiple securities are issued in different currencies (i.e., there are multiple listed shares corresponding to a given common share that have different identifiers, including more than one ISIN, CUSIP, share class FIGI), multiply classify the listed share individuals as individuals of the same common share.</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;Listing">
@@ -180,6 +184,13 @@
 				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;hasDelistingDate"/>
 				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasLotSize"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;positiveInteger"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added new property hasLotSize as the superproperty of hasQuoteLotSize to instrument pricing; added a restriction in securities listings on listing to say that a listing might have a lot size associated with it and added a usage note on listed security regarding multiple classification of individuals.

Fixes: #1270 / SEC-146


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


