### PR TITLE
SEC-107 - Distinctions between the various ways that a security may be registered / listed are missing or need revision

### DIFF
--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -6,10 +6,12 @@
 	<!ENTITY fibo-fbc-fct-mkti "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MarketsIndividuals/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fct-usind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/">
+	<!ENTITY fibo-fbc-fct-usjrga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/">
 	<!ENTITY fibo-fbc-fct-usmkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-4217 "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-eq-10962 "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
@@ -35,10 +37,12 @@
 	xmlns:fibo-fbc-fct-mkti="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MarketsIndividuals/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fct-usind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"
+	xmlns:fibo-fbc-fct-usjrga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"
 	xmlns:fibo-fbc-fct-usmkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-4217="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-eq-10962="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
@@ -61,7 +65,7 @@
 		<rdfs:label>Equities Example Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontologyprovides examples of how to represent simple equities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2019-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2019-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
@@ -82,10 +86,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MarketsIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
@@ -95,22 +101,31 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201001/Equities/EquitiesExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquitiesExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was modified to add CFI codes to the example equity instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to add the share class to some of the examples.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to add the share class to some of the examples, replace registered form with book entry (registered) form, and add detail to the common share and listing individuals.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Alphabet Inc. class A common stock</rdfs:label>
 		<skos:definition>common share class that represents class A series shares in Alphabet Inc.</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fbc-fct-ra:hasRegistrationDate>2015-10-02</fibo-fbc-fct-ra:hasRegistrationDate>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
 		<fibo-sec-eq-eq:hasShareClass>A</fibo-sec-eq-eq:hasShareClass>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
+		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNASListedAlphabetIncClassACommonStock"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
@@ -126,14 +141,23 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Alphabet Inc. class C capital stock</rdfs:label>
 		<skos:definition>common share class that represents class C series shares in Alphabet Inc.</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fbc-fct-ra:hasRegistrationDate>2015-10-02</fibo-fbc-fct-ra:hasRegistrationDate>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
 		<fibo-sec-eq-eq:hasShareClass>C</fibo-sec-eq-eq:hasShareClass>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNASListedAlphabetIncClassCCapitalStock"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESNUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassCFinancialInstrumentShortName">
@@ -156,13 +180,22 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AppleIncCommonStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Apple Inc. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in Apple Inc.</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fbc-fct-ra:hasRegistrationDate>1980-12-01</fibo-fbc-fct-ra:hasRegistrationDate>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-sec-eq-eqind;AppleIncEquityIssuer"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AppleIncEquityIssuer"/>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XLOMListedAppleIncCommonStock"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNASListedAppleIncCommonStock"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
@@ -434,13 +467,22 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;CitigroupIncCommonStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Citigroup Inc. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in Citigroup Inc.</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fbc-fct-ra:hasRegistrationDate>1998-09-29</fibo-fbc-fct-ra:hasRegistrationDate>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-sec-eq-eqind;CitigroupIncEquityIssuer"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;CitigroupIncEquityIssuer"/>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BearerAndRegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedCitigroupIncCommonStock"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
@@ -544,13 +586,21 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>International Business Machines Corporation common stock</rdfs:label>
 		<skos:definition>common share class representing shares in International Business Machines Corporation</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfNewYorkJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationEquityIssuer"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationEquityIssuer"/>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BearerAndRegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedInternationalBusinessMachinesCorporationCommonStock"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
@@ -574,20 +624,29 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. common stock</rdfs:label>
-		<skos:definition>common share class representing shares in JPMorgan Chase &amp; Co.</skos:definition>
+		<skos:definition>common share class representing shares in J.P. Morgan Chase &amp; Co.</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fbc-fct-ra:hasRegistrationDate>2000-12-28</fibo-fbc-fct-ra:hasRegistrationDate>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoEquityIssuer"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoEquityIssuer"/>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BearerAndRegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedJPMorganChaseAndCoCommonStock"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStockFinancialInstrumentShortName">
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
-		<rdfs:label>JPMorgan Chase &amp; Co. common stock financial instrument short name</rdfs:label>
-		<skos:definition>JPMorgan Chase &amp; Co. common stock financial instrument short name (FISN)</skos:definition>
+		<rdfs:label>J.P. Morgan Chase &amp; Co. common stock financial instrument short name</rdfs:label>
+		<skos:definition>J.P. Morgan Chase &amp; Co. common stock financial instrument short name (FISN)</skos:definition>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>JPMORGAN CHASE</fibo-sec-sec-iss:hasIssuerShortName>
 		<lcc-lr:hasTag>JPMORGAN CHASE/SH</lcc-lr:hasTag>
@@ -596,8 +655,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;JPMorganChaseAndCoEquityIssuer">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
-		<rdfs:label>JPMorgan Chase &amp; Co. common stock issuer</rdfs:label>
-		<skos:definition>JPMorgan Chase &amp; Co. functional entity that is an issuer of common stock</skos:definition>
+		<rdfs:label>J.P. Morgan Chase &amp; Co. common stock issuer</rdfs:label>
+		<skos:definition>J.P. Morgan Chase &amp; Co. functional entity that is an issuer of common stock</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCo-US-DE"/>
 		<fibo-sec-sec-iss:hasIssuerShortName>JPMORGAN CHASE</fibo-sec-sec-iss:hasIssuerShortName>
 	</owl:NamedIndividual>
@@ -612,13 +671,21 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>The Coca-Cola Company common stock</rdfs:label>
 		<skos:definition>common share class representing shares in The Coca-Cola Company</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyEquityIssuer"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyEquityIssuer"/>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BearerAndRegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheCoca-ColaCompanyCommonStock"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
@@ -642,13 +709,22 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>The Home Depot, Inc. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in The Home Depot, Inc.</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fbc-fct-ra:hasRegistrationDate>1981-09-22</fibo-fbc-fct-ra:hasRegistrationDate>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncEquityIssuer"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncEquityIssuer"/>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BearerAndRegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheHomeDepotIncCommonStock"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
@@ -672,13 +748,21 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>The Proctor &amp; Gamble Company common stock</rdfs:label>
 		<skos:definition>common share class representing shares in The Proctor &amp; Gamble Company</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfOhioJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyEquityIssuer"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyEquityIssuer"/>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BearerAndRegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheProctorAndGambleCompanyCommonStock"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
@@ -801,13 +885,22 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;WellsFargoCommonStock">
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Wells Fargo common stock</rdfs:label>
 		<skos:definition>Wells Fargo &amp; Company common share</skos:definition>
+		<fibo-fbc-fi-fi:isDenominatedIn rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
+		<fibo-fbc-fct-ra:hasRegistrationDate>1998-09-11</fibo-fbc-fct-ra:hasRegistrationDate>
+		<fibo-fnd-agr-ctr:hasPrincipalParty rdf:resource="&fibo-fbc-fct-usind;WellsFargoAndCompany"/>
+		<fibo-fnd-agr-ctr:isAssignable rdf:datatype="&xsd;boolean">false</fibo-fnd-agr-ctr:isAssignable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-fbc-fct-usind;WellsFargoAndCompany"/>
-		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BearerAndRegisteredForm"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;BookEntryForm"/>
+		<fibo-sec-sec-iss:isRegisteredWith rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
+		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedWellsFargoCommonStock"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
@@ -825,6 +918,7 @@
 		<rdfs:label>XNAS-listed Alphabet Inc. class A common stock</rdfs:label>
 		<skos:definition>Alphabet Inc. class A common share listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<fibo-sec-sec-lst:hasListingDate>2004-08-01</fibo-sec-sec-lst:hasListingDate>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
@@ -834,6 +928,7 @@
 		<rdfs:label>XNAS-listed Alphabet Inc. class C capital stock</rdfs:label>
 		<skos:definition>Alphabet Inc. class C capital stock listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<fibo-sec-sec-lst:hasListingDate>2004-08-01</fibo-sec-sec-lst:hasListingDate>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
@@ -843,6 +938,7 @@
 		<rdfs:label>XNAS-listed Apple Inc. common stock</rdfs:label>
 		<skos:definition>Apple Inc. common share listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<fibo-sec-sec-lst:hasListingDate>1980-12-12</fibo-sec-sec-lst:hasListingDate>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
@@ -852,6 +948,7 @@
 		<rdfs:label>XNYS-listed Citigroup Inc. common stock</rdfs:label>
 		<skos:definition>Citigroup Inc. common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<fibo-sec-sec-lst:hasListingDate>1988-10-08</fibo-sec-sec-lst:hasListingDate>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
@@ -861,6 +958,7 @@
 		<rdfs:label>XNYS-listed IBM common stock</rdfs:label>
 		<skos:definition>IBM common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<fibo-sec-sec-lst:hasListingDate>1924-02-14</fibo-sec-sec-lst:hasListingDate>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
@@ -870,6 +968,7 @@
 		<rdfs:label>XNYS-listed JPMorgan Chase &amp; Co. common stock</rdfs:label>
 		<skos:definition>JPMorgan Chase &amp; Co. common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<fibo-sec-sec-lst:hasListingDate>1978-10-06</fibo-sec-sec-lst:hasListingDate>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
@@ -879,6 +978,7 @@
 		<rdfs:label>XNYS-listed The Coca-Cola Company common stock</rdfs:label>
 		<skos:definition>The Coca-Cola Company common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<fibo-sec-sec-lst:hasListingDate>1919-09-05</fibo-sec-sec-lst:hasListingDate>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
@@ -888,6 +988,7 @@
 		<rdfs:label>XNYS-listed The Home Depot, Inc. common stock</rdfs:label>
 		<skos:definition>The Home Depot, Inc. common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<fibo-sec-sec-lst:hasListingDate>1984-04-19</fibo-sec-sec-lst:hasListingDate>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
@@ -897,6 +998,7 @@
 		<rdfs:label>XNYS-listed The Proctor &amp; Gamble Company common stock</rdfs:label>
 		<skos:definition>The Proctor &amp; Gamble Company common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<fibo-sec-sec-lst:hasListingDate>1978-01-13</fibo-sec-sec-lst:hasListingDate>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -61,9 +61,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201101/Equities/EquityCFIClassificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityCFIClassificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form, and eliminate restrictions embedded in intersection related to security form.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -79,16 +79,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;EnhancedVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
@@ -108,16 +100,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;EnhancedVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -145,16 +129,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;EnhancedVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -174,16 +150,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;EnhancedVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -211,16 +179,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;NonVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -240,16 +200,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;NonVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -270,35 +222,13 @@
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare">
-							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-								<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-							</owl:Restriction>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare"/>
 			</owl:Restriction>
 		</rdf:type>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare">
-							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-								<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-							</owl:Restriction>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare"/>
 			</owl:Restriction>
 		</rdf:type>
 		<rdfs:label>ESNUFR CFI common/ordinary share classifier</rdfs:label>
@@ -319,16 +249,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -348,16 +270,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -385,16 +299,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -414,16 +320,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -451,16 +349,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;SingleVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -480,16 +370,8 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;SingleVotingShare">
 							</rdf:Description>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -510,35 +392,13 @@
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare">
-							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-								<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-							</owl:Restriction>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 			</owl:Restriction>
 		</rdf:type>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare">
-							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-								<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-							</owl:Restriction>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 			</owl:Restriction>
 		</rdf:type>
 		<rdfs:label>ESVUFR CFI common/ordinary share classifier</rdfs:label>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -124,12 +124,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201101/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments, including features specific to preferred shares.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, and clean up ambiguous definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, clean up ambiguous definitions, and eliminate redundant restrictions related to security form.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -158,12 +158,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted, fully-paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
 	</owl:Class>
@@ -190,12 +184,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, voting, unrestricted, fully-paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly 1 vote per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
 	</owl:Class>

--- a/SEC/Securities/SecuritiesIssuance.rdf
+++ b/SEC/Securities/SecuritiesIssuance.rdf
@@ -65,7 +65,7 @@
 		<rdfs:label>Securities Issuance Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for issuing securities, including securities offering, offering document, offering statement, securities underwriter, prospectus, and so forth.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
@@ -99,11 +99,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Securities/SecuritiesIssuance/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesIssuance/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIssuance/ version of this ontology was modified to refine the concept of a securities underwriter.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20181201/Securities/SecuritiesIssuance/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesIssuance/ version of this ontology was modified to add the concept of the form the security is issued in, namely bearer or registered.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesIssuance/ version of this ontology was modified to refactor conversion terms as a child of redemption provision, move redemption provision to financial instruments, and eliminate the unnecessary securities contract terms class.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Securities/SecuritiesIssuance/ version of this ontology was modified to add book entry form as a kind of registered security, make registered security a class with two individuals, namely book entry and &apos;bearer and registered&apos;, and clean up definitions to eliminate ambiguity where possible and conform to ISO 704.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -146,7 +147,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;BearerAndRegisteredForm">
 		<rdf:type rdf:resource="&fibo-fnd-arr-doc;Certificate"/>
-		<rdf:type rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<rdfs:label>bearer and registered form</rdfs:label>
 		<skos:definition>form of a security that may be issued in both bearer and registered form but with the same identification number</skos:definition>
 	</owl:NamedIndividual>
@@ -162,10 +163,17 @@
 	<owl:Class rdf:about="&fibo-sec-sec-iss;BestEffortsOffering">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecuritiesOffering"/>
 		<rdfs:label>best efforts offering</rdfs:label>
-		<skos:definition>a securities offering that is sold on a best efforts, rather than firm commitment, basis, whereby investment bankers commit to doing their best to sell the securities offered, but do not assume the full risk of an underwriter</skos:definition>
+		<skos:definition>securities offering whereby investment bankers commit to doing their best to sell the securities offered, but do not assume the full risk of an underwriter</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In a best efforts offering, the agreement is strictly an agency arrangement, with no obligation on the part of the agent to purchase the securities.  They act as a broker, in other words.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>In a best efforts offering, the agreement is strictly an agency arrangement, with no obligation on the part of the agent to purchase the securities. They act as a broker, in other words.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;BookEntryForm">
+		<rdf:type rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+		<rdfs:label>book entry form</rdfs:label>
+		<skos:definition>form of a security in which ownership is recorded electronically by a central depository</skos:definition>
+		<fibo-fnd-utl-av:synonym>registered form</fibo-fnd-utl-av:synonym>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;ConversionTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;RedemptionProvision"/>
@@ -194,7 +202,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>convertible security</rdfs:label>
-		<skos:definition>a security that can be converted into another security</skos:definition>
+		<skos:definition>security that can be converted into another security</skos:definition>
 		<skos:example>Convertible securities may be convertible bonds or preferred stocks that pay regular interest and can be converted into shares of common stock (sometimes conditioned on the stock price appreciating to a predetermined level).</skos:example>
 		<skos:example>Warrants are equity convertible securities. They give the owner the option to buy newly issued shares at a determined exercise price and date.</skos:example>
 	</owl:Class>
@@ -202,7 +210,7 @@
 	<owl:Class rdf:about="&fibo-sec-sec-iss;ExemptIssuer">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
 		<rdfs:label>exempt issuer</rdfs:label>
-		<skos:definition>a securities issuer that issues securities that are exempt from certain regulatory reporting requirements</skos:definition>
+		<skos:definition>issuer that issues securities that are excused from certain regulatory reporting requirements</skos:definition>
 		<skos:example>In general, these include governments and issuers of tax exempt securities such as municipalities, banks and depository institutions, and authorized insurance companies, railroads and public utilities, and certain non-profit organizations.</skos:example>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/exam-guide/series-66/regulation-of-securities/exempt-securities.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
@@ -224,15 +232,16 @@
 			</owl:Class>
 		</rdfs:subClassOf>
 		<rdfs:label>exempt offering</rdfs:label>
-		<skos:definition>a public offering involving securities that are exempt from certain regulatory reporting requirements, either because the issuer is exempt or the transaction specific to the offering is exempt</skos:definition>
+		<skos:definition>public offering involving securities that are excused from certain regulatory reporting requirements</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/exam-guide/series-66/regulation-of-securities/exempt-securities.asp</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>Such an offering may be considered exempt either because the issuer is exempt or the transaction specific to the offering is exempt.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;ExemptTransaction">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;SecuritiesTransaction"/>
 		<rdfs:label>exempt transaction</rdfs:label>
-		<skos:definition>a securities transaction for which there is no requirement to register the transaction with a regulatory agency</skos:definition>
+		<skos:definition>securities transaction for which there is no requirement to register the transaction with a regulatory agency</skos:definition>
 		<skos:example>Examples include non-issuer transactions in outstanding securities, other isolated non-issuer transactions, certain unsolicited  / de minimis transactions, fiduciary transactions, transactions with financial institutions, private placement transactions that meet certain conditions, and so forth.</skos:example>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/e/exempttransaction.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
@@ -254,7 +263,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>financial instrument short name</rdfs:label>
-		<skos:definition>an identifier that is a short name for any kind of financial instrument within a defined structure as specified in ISO 18774</skos:definition>
+		<skos:definition>abbreviated name for a financial instrument within a defined structure as specified in ISO 18774</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>FISN</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 18774:2015(E), Securities and related financial instruments - Financial Instrument Short Name (FISN)</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
@@ -263,14 +272,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecuritiesOffering"/>
 		<rdfs:label>firm commitment offering</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-sec-iss;BestEffortsOffering"/>
-		<skos:definition>a securities offering whereby the underwriter purchases the securities outright for their own account</skos:definition>
+		<skos:definition>securities offering whereby the underwriter purchases the securities outright for their own account</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;MiscellaneousForm">
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
 		<rdfs:label>miscellaneous form</rdfs:label>
-		<skos:definition>form of a security that is not identified as registered or bearer</skos:definition>
+		<skos:definition>form of a security that is not categorized</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Miscellaneous form is used to describe securities wherein the form is not stated as being bearer or registered.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;OfferingDocument">
@@ -304,7 +314,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>offering document</rdfs:label>
-		<skos:definition>a legal document that states the objectives, risks and terms of an investment</skos:definition>
+		<skos:definition>legal document that states the objectives, risks and terms of an investment</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>EDM Council</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>There are many variations, including offering memorandum, which is typically used in the context of a private placement, offering statement, which has slightly different meanings depending on the context (for securities, for bonds, etc.) and so forth.  This concept is intended to act as a more abstract parent for these more nuanced concepts.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -312,7 +322,7 @@
 	<owl:Class rdf:about="&fibo-sec-sec-iss;OfferingStatement">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;OfferingDocument"/>
 		<rdfs:label>offering statement</rdfs:label>
-		<skos:definition>an offering memorandum that conforms to Regulation A, Offering Statement, of the Securities Act of 1933</skos:definition>
+		<skos:definition>offering memorandum that conforms to Regulation A, Offering Statement, of the Securities Act of 1933</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>See https://www.sec.gov/about/forms/form1-a.pdf for the actual form detail</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -325,7 +335,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>private offering</rdfs:label>
-		<skos:definition>an offering of securities made privately to a limited number of qualified potential investors</skos:definition>
+		<skos:definition>offering of securities made privately to a limited number of qualified potential investors</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>EDM Council / Quarule</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Unlike a public offering, a private placement does not have to be registered with a regulatory agency if the securities are purchased for investment rather than resale.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>private placement</fibo-fnd-utl-av:synonym>
@@ -334,7 +344,7 @@
 	<owl:Class rdf:about="&fibo-sec-sec-iss;PrivatePlacementMemorandum">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;OfferingDocument"/>
 		<rdfs:label>private placement memorandum</rdfs:label>
-		<skos:definition>a legal document stating the objectives, risks and terms of investment involved with a private placement</skos:definition>
+		<skos:definition>legal document stating the objectives, risks and terms of investment involved with a private placement</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>PPM</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/o/offeringmemorandum.asp</fibo-fnd-utl-av:adaptedFrom>
@@ -346,7 +356,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;OfferingDocument"/>
 		<rdfs:label>prospectus</rdfs:label>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/prospectus.asp</rdfs:seeAlso>
-		<skos:definition>a formal, written offering document to sell securities that provides the facts an investor needs to make an informed investment decision</skos:definition>
+		<skos:definition>formal, written offering document to sell securities that provides the facts an investor needs to make an informed investment decision</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom>The Securities Act of 1933, as amended 5 April 2012, see http://www.sec.gov/about/laws/sa33.pdf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A prospectus may specify the facts about an offering of securities, mutual funds, or limited partnerships for investments in oil, gas, equipment leasing, or other kinds of limited partnerships.</fibo-fnd-utl-av:explanatoryNote>
@@ -362,18 +372,18 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>public offering</rdfs:label>
-		<skos:definition>an offering of securities for sale to the investment public, after compliance with registration requirements of the relevant regulatory authorities</skos:definition>
+		<skos:definition>offering of securities for sale to the investment public, after compliance with registration requirements of the relevant regulatory authorities</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.nasdaq.com/investing/glossary/p/http%3a%2f%2fwww.nasdaq.com%2finvesting%2fglossary%2fp%2fpublic-offering</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>In the US, public offerings generally require approval of the Securities Exchange Commission and/or relevant state regulators, unless the issuer is an exempt issuer, and are usually conducted by an investment banker or a syndicate made up of several investment bankers, at a price agreed upon between the issuer and the investment bankers.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;RegisteredForm">
-		<rdf:type rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+	<owl:Class rdf:about="&fibo-sec-sec-iss;RegisteredForm">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
 		<rdfs:label>registered form</rdfs:label>
 		<skos:definition>form of a security whereby ownership is recorded in the name of the owner on the books of the issuer or the issuer&apos;s registrar and can only be transferred to another owner when endorsed by the registered owner</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>With registered securities, a ledger is kept by the issuing company or agent which records the owners of all the securities. Transfer of ownership can only occur when names are changed in the ledger.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:NamedIndividual>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;SecuritiesOffering">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;Offering"/>
@@ -433,8 +443,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>securities offering</rdfs:label>
-		<skos:definition>an offering of a security (or securities) for sale</skos:definition>
-		<skos:editorialNote>This term is defined as the common concept which brings together MBS deals, Bond With Warrant issues, MTN issues and so on, along with issues of more than one class of share in an equities issue. Many detailed terms have been provided for specific types of issue, most notably Municipal bond issues (from DTCC) and MBS issues from the MBS PoC project.</skos:editorialNote>
+		<skos:definition>offering of a security (or securities) for sale</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>If the offering is public, then it can only be made after regulatory registration requirements have been met. The securities may be new or a secondary offering of a previously issued security, and may include stock, multiple classes of equity shares, municipal or other government bonds, and so forth. Offerings, especially to the investment public, are typically made by an investment banker, or syndicate of investment bankers.</fibo-fnd-utl-av:explanatoryNote>
@@ -455,8 +464,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>security form</rdfs:label>
-		<skos:definition>contract document and certificate that is evidence for ownership of a security and that may be digital or physical</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Securities are typically issued in one of two forms, registered or bearer. Most securities issued today are in registered form, which enables the issuing firm or registrar to keep records of a security&apos;s owner and mail them any dividend, coupon, or other payments.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>the form that evidence of ownership of a security takes</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Securities are typically issued in one of two forms, registered or bearer. Most securities issued today are in registered form, which enables the issuing firm or registrar to keep records of a security&apos;s owner and mail them any dividend, coupon, or other payments. Registered securities may be issued in book entry (digital only) or certificate (physical) form, but most today are entirely digital.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<rdfs:Datatype rdf:about="&fibo-sec-sec-iss;SecurityOfferingDistributionType">
@@ -506,7 +515,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>security underwriter</rdfs:label>
-		<skos:definition>a party that has purchased from an issuer with a view to, or sells for an issuer in connection with, the distribution of any security, or participates or has a direct or indirect participation in any such undertaking, or participates or has a participation in the direct or indirect underwriting of any such undertaking</skos:definition>
+		<skos:definition>party that has purchased from an issuer with a view to, or sells for an issuer in connection with, the distribution of any security, or participates or has a direct or indirect participation in any such undertaking, or participates or has a participation in the direct or indirect underwriting of any such undertaking</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
@@ -519,15 +528,16 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>security underwriting arrangement</rdfs:label>
-		<skos:definition>an underwriting arrangement between an organization (typically an investment bank) and a securities issuer that commits the underwriter to assuming risk involved in buying a new issue of securities from an issuing corporation or government entity and reselling it to the public, either directly or through dealers</skos:definition>
+		<skos:definition>underwriting agreement between an organization (typically an investment bank) and a securities issuer that commits the underwriter to assuming risk involved in buying a new issue of securities and reselling it to the public</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>Sales may be made either directly or through third-party dealers.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-iss;hasActualClosingDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
 		<rdfs:label>has actual closing date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-		<skos:definition>indicates the date on which an offering or transaction officially closes, in contrast with an intended or planned closing date</skos:definition>
+		<skos:definition>indicates the date on which an offering or transaction officially closes, in contrast with an intended closing date</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-iss;hasAnnouncementDate">
@@ -617,6 +627,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-iss;isIssuedInForm">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isEvidencedBy"/>
 		<rdfs:label>is issued in form</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Security"/>
 		<rdfs:range rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
@@ -641,7 +652,7 @@
 		<rdfs:label>is underwritten by</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-iss;SecuritiesOffering"/>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-fse;Underwriter"/>
-		<skos:definition>relates an offering to one or more underwriters involved in raising capital for or distributing the instruments that are the subject of the offering</skos:definition>
+		<skos:definition>relates an offering to an underwriter involved in raising capital for or distributing the instruments that are the subject of the offering</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-iss;specifiesConversionInto">

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -181,13 +181,6 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;hasDelistingDate"/>
-				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasLotSize"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;positiveInteger"/>
@@ -195,15 +188,15 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;lists"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Security"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;hasDelistingDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;lists"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Security"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -250,13 +243,11 @@
 		<skos:definition>security that is registered with some registration authority</skos:definition>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;hasDelistingDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+	<owl:DatatypeProperty rdf:about="&fibo-sec-sec-lst;hasDelistingDate">
 		<rdfs:label>has delisting date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;Listing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition>specifies the date set by the exchange for delisting a security</skos:definition>
-	</owl:ObjectProperty>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;hasHomeExchange">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
@@ -313,6 +304,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;isTradedOn">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
 		<rdfs:label>is traded on</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -89,7 +89,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/SecuritiesListings.rdf version of this ontology was revised to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and to eliminate the redundancy between hasIssue and lists.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesListings.rdf version of this ontology was revised to incorporate the form of registration and loosen the restriction on the number of possible registration authorities for a registered security.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues), adjust definitions to eliminate ambiguity and add a property for lot size on listing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues), adjust definitions to eliminate ambiguity, add a property for lot size on listing, and eliminate the now redundant and confusing registered security form class.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -236,7 +236,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -248,22 +248,6 @@
 		<rdfs:label>registered security</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fi-fi;ExemptSecurity"/>
 		<skos:definition>security that is registered with some registration authority</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-sec-lst;RegisteredSecurityForm">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
-		<rdfs:label>registered security form</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:oneOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-sec-sec-iss;BearerAndRegisteredForm">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-sec-iss;RegisteredForm">
-					</rdf:Description>
-				</owl:oneOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition>form that a registered security can take</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;hasDelistingDate">

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -281,6 +281,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;hasTickSize">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 		<rdfs:label xml:lang="en">has tick size</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;Listing"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Streamlined representation of the registered form of shares in securities issuance and securities listings and incorporated the concept of a book entry form; adjusted definitions in securities issuance to eliminate ambiguity, revised equity instruments to eliminate restrictions made redundant by the changes, revised CFI and example individuals to incorporate the changes and augment the equities examples with additional content; also cleaned-up delisting date and isTradedOn based on FCT discussion

Fixes: #1273 / SEC-107 / SEC-129


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


