### PR TITLE
FBC-247 - Missing financial services and US government entities

### DIFF
--- a/BE/FunctionalEntities/FunctionalEntities.rdf
+++ b/BE/FunctionalEntities/FunctionalEntities.rdf
@@ -45,7 +45,7 @@
 		<rdfs:label>Functional Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for entities defined by their function, such as the relationship to the various forms which one or another functionally-defined entity may take. It also includes a number of basic types of entity defined by function, such as business and non-profit. The concepts in this ontology are intended to be extensible in other ontologies which may be dedicated to specific kinds of functionally-defined business entity or organization.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/</sm:dependsOn>
@@ -65,7 +65,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200901/FunctionalEntities/FunctionalEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/FunctionalEntities/FunctionalEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20150201/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.1 RTF report. Changes include deprecation of the SoleProprietorship class and making it equivalent to the class with the same name in the Sole Proprietorships ontology. This version also introduces a new FunctionalEntity class, as the parent of FunctionalBusinessEntity in this ontology and as the parent of Government in the GovernmentEntities ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160801/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified by the FIBO 2.0 revision to address missing labels and definitions on the deprecated sole proprietorship class to match those in the equivalent class.</skos:changeNote>
@@ -73,8 +73,21 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190201/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200301/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to revise and extend the definition of merchant, to support merchant category codes as needed for representation of credit card transactions, merge business and functional business entity and eliminate commerce and commercial activity (which are not used anywhere in FIBO), and to clean up definitions and make them ISO 704 compliant.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200901/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to add the concept of an association.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
+	
+	<owl:Class rdf:about="&fibo-be-fct-fct;Association">
+		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;NotForProfitOrganization"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;playsRole"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;CooperativeSociety"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>association</rdfs:label>
+		<skos:definition>not-for-profit organization acting on behalf of its members, typically a trade or business association, industry sector-specific group, or professional association</skos:definition>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;CooperativeSociety">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>

--- a/BE/OwnershipAndControl/ControlParties.rdf
+++ b/BE/OwnershipAndControl/ControlParties.rdf
@@ -261,6 +261,15 @@
 		<skos:editorialNote>By virtue of holding 100 percent of the equity ownership, the Total Owner also holds 100 percent of the controlling equity, if there is a difference. Therefore it is both a total owner and a total controlling party.</skos:editorialNote>
 	</owl:Class>
 	
+	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;advises">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isPartyControlling"/>
+		<rdfs:label>advises</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-oac-ctl;ControllingParty"/>
+		<rdfs:range rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<owl:inverseOf rdf:resource="&fibo-be-oac-cpty;isAdvisedBy"/>
+		<skos:definition>provides counsel or guidance to</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;hasControllingOrganizationMember">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;hasControllingParty"/>
 		<rdfs:label>has organization member</rdfs:label>
@@ -276,6 +285,14 @@
 		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cpty;MajorityControllingParty"/>
 		<skos:definition>indicates a party that owns a controlling stake (over 50 percent) in the entity</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;isAdvisedBy">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;hasControllingParty"/>
+		<rdfs:label>has advisor</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<rdfs:range rdf:resource="&fibo-fnd-oac-ctl;ControllingParty"/>
+		<skos:definition>indicates the party that acts in an advisory capacity to the controlled party</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;isBasedOnInvestmentEquity">

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -590,9 +590,9 @@
 		<skos:definition>indicates a member of the board of directors of the organization</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasPrincipalParty">
+	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasPrincipalManagingParty">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasControllingOrganizationMember"/>
-		<rdfs:label>has principal party</rdfs:label>
+		<rdfs:label>has principal managing party</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;PrincipalParty"/>
 		<owl:inverseOf rdf:resource="&fibo-be-oac-exec;isPrincipalPartyOf"/>

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -57,7 +57,7 @@
 		<rdfs:label>Executives Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts relating to executives and their formal capacities. The concepts defined in this ontology cover types of corporate officers, board members and the like, along with the capacities in terms of which those party roles are defined, and the kinds of entity (principally natural persons) that are able to perform in those roles.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/</sm:dependsOn>
@@ -86,7 +86,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200701/OwnershipAndControl/Executives/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/Executives/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/Executives.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160801/OwnershipAndControl/Executives.rdf version of this ontology was modified per the FIBO 2.0 RFC to fix reasoning issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/Executives.rdf version of this ontology was modified to clarify the definition of responsible party.</skos:changeNote>
@@ -94,6 +94,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190501/OwnershipAndControl/Executives.rdf version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/Executives.rdf version of this ontology was modified to integrate concepts related to authorization, including board membership and the concept of a signatory (moved from legal persons) to improve semantics; simplify the ontology, and normalize definitions to be ISO 704 compliant.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/Executives.rdf version of this ontology was modified to correct the label on hasAuthorizedParty.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200701/OwnershipAndControl/Executives.rdf version of this ontology was modified to add PrincipalParty as the parent of CEO and others.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -363,6 +364,7 @@
 	<owl:Class rdf:about="&fibo-be-oac-exec;ChiefExecutiveOfficer">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;CorporateOfficer"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;ExecutiveBoardMember"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;PrincipalParty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
@@ -455,6 +457,13 @@
 		<rdfs:label>non-executive board member</rdfs:label>
 		<skos:definition>member of the board of directors of an organization that has no executive responsibilities towards the running of that organization</skos:definition>
 		<fibo-fnd-utl-av:synonym>outside director</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-oac-exec;PrincipalParty">
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;Signatory"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
+		<rdfs:label>principal party</rdfs:label>
+		<skos:definition>controlling party that is responsible for the management of daily business operations of an organization</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-exec;ResponsibleParty">
@@ -560,7 +569,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasCorporateOfficer">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;isAffectedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;hasControllingParty"/>
 		<rdfs:label>has corporate officer</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;CorporateOfficer"/>
@@ -574,11 +583,20 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasDirector">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;isAffectedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;hasControllingParty"/>
 		<rdfs:label>has director</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;BoardMember"/>
 		<skos:definition>indicates a member of the board of directors of the organization</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasPrincipalParty">
+		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasControllingOrganizationMember"/>
+		<rdfs:label>has principal party</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<rdfs:range rdf:resource="&fibo-be-oac-exec;PrincipalParty"/>
+		<owl:inverseOf rdf:resource="&fibo-be-oac-exec;isPrincipalPartyOf"/>
+		<skos:definition>indicates a controlling party that is responsible for the management of daily business operations</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasResponsibility">
@@ -632,7 +650,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;isDirectorOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;actsOn"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isPartyControlling"/>
 		<rdfs:label>is director of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-exec;BoardMember"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
@@ -641,12 +659,20 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;isOfficerOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;actsOn"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isPartyControlling"/>
 		<rdfs:label>is officer of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-exec;CorporateOfficer"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
 		<owl:inverseOf rdf:resource="&fibo-be-oac-exec;hasCorporateOfficer"/>
 		<skos:definition>indicates the organization that the person has some authority over and managerial responsibility for</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;isPrincipalPartyOf">
+		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;isControllingMemberOf"/>
+		<rdfs:label>is principal party of</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-oac-exec;PrincipalParty"/>
+		<rdfs:range rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<skos:definition>identifies a legal entity (controlled party) over which a principal has some measure of control</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;nominates">

--- a/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
+++ b/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
@@ -152,7 +152,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-plc-plc;ManagingMember">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;PrincipalParty"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompanyMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
+	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
 	<!ENTITY fibo-fbc-fct-breg "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -30,6 +31,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
+	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
 	xmlns:fibo-fbc-fct-breg="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -57,7 +59,7 @@
 		<rdfs:label>Financial Instruments Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts relevant to financial instruments in general, with the intent of providing the high-level hooks for build-out in more detail in the relevant domain areas.  These include, but are not limited to, equities, options, debt instruments, and so forth, some of which may be negotiable.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
@@ -67,7 +69,9 @@
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-fbc-fi-fi</sm:fileAbbreviation>
 		<sm:filename>FinancialInstruments.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -83,7 +87,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/202001101/FinancialInstruments/FinancialInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/202001201/FinancialInstruments/FinancialInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified for the FIBO 2.0 RFC, including minor bug fixes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified as a part of organizational hierarchy simplification, to add maturity-related properties, and to add exempt security.</skos:changeNote>
@@ -91,7 +95,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190701/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to change the restriction on financial instrument identifier from some values to min 0, to allow for cases when an instrument identifier identifies a listing, eliminate duplication of concepts in LCC, and simplify addresses.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to move redemption provision from debt to financial instruments, given that it is a broader concept needed for equities.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to add a property indicating the currency that an instrument is issued in and simplify the contract party hierarchy.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to add a property indicating the currency that an instrument is issued in, simplify the contract party hierarchy and add properties relating financial instruments to shareholders.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -418,6 +422,14 @@
 		<skos:definition>indicates the date on which the principal amount of an instrument is due to be repaid to the investor and interest payments stop and/or the date on which the instrument may be redeemed</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;hasShareholder">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;isAffectedBy"/>
+		<rdfs:label>has shareholder</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
+		<rdfs:range rdf:resource="&fibo-be-oac-cown;Shareholder"/>
+		<skos:definition>indicates a party that holds shares in the issuer</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;hasTerm">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
 		<rdfs:label xml:lang="en">has term</rdfs:label>
@@ -448,6 +460,15 @@
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<skos:definition>relates an instrument to the currency its value is typically expressed in</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>This should be the same currency that was declared at the time of issuance.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;holdsSharesIn">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;actsOn"/>
+		<rdfs:label>holds shares in</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-oac-cown;Shareholder"/>
+		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
+		<owl:inverseOf rdf:resource="&fibo-fbc-fi-fi;hasShareholder"/>
+		<skos:definition>specifies the issuer in which a shareholder holds an equity position</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;isDenominatedIn">

--- a/FBC/FunctionalEntities/FinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/FinancialServicesEntities.rdf
@@ -6,7 +6,9 @@
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
+	<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
+	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -14,6 +16,7 @@
 	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
+	<!ENTITY fibo-fnd-oac-ctl "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
@@ -36,7 +39,9 @@
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
+	xmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
+	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -44,6 +49,7 @@
 	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
+	xmlns:fibo-fnd-oac-ctl="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
@@ -63,10 +69,11 @@
 		<rdfs:label>Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines basic financial service providers, such as holding companies, financial institutions (both depository and non-depository institutions), and clearing houses at a relatively general level. Nuances specific to the institutions located in a specific country are defined in jurisdiction specific dependent ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
 		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -78,6 +85,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -86,6 +95,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
@@ -93,7 +103,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200201/FunctionalEntities/FinancialServicesEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/FinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified per the FIBO 2.0 RFC, including, but not limited to, the addition of trade settlement concepts and generalizing the concept of a credit union.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified to refine the concept of a credit union and generalize the definition of an underwriter.</skos:changeNote>
@@ -101,6 +111,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190101/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to leverage the new party identifier and replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to enable merging business and functional business entity in BE.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to add missing functional entities and related properties, and eliminate circular or ambiguous definitions where possible.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -265,7 +276,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>business party prefix</rdfs:label>
-		<skos:definition>a four-character (4 alphanumeric) code associated with the individual institution or business</skos:definition>
+		<skos:definition>a four-character (4 alphanumeric) code associated with the organization</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>For new BIC registration by an organization already identified with a BIC or an affiliated organization [after the transition period ending November 2018], SWIFT will still reserve the usage of an existing party prefix to these organizations. This legacy rule will be reserved to existing BIC owners. If they wish to preserve this value, no other organization will be allowed to use the same code</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>For new BIC registration from an organization not yet identified by a BIC, the party prefix will be allocated at the discretion of the RA. The code will not have a mnemonic or acronym value anymore.</fibo-fnd-utl-av:explanatoryNote>
@@ -288,7 +299,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>business party suffix</rdfs:label>
-		<skos:definition>a two-character (2 alphanumeric) code associated with the individual institution or business</skos:definition>
+		<skos:definition>a two-character (2 alphanumeric) code associated with the organization</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>In the prior version of the standard, position 7 of the BIC determined the location of the BIC in a particular country. In a country spanning over multiple time zones, each character may have been used to define a different time zone. If an organization moved location to a different time zone within the same country, the existing BIC would normally have been deleted and replaced by a new BIC with the appropriate location code.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>With the revision of the standard [and transition period ending November 2018], the location code has been re-defined as a &apos;party suffix&apos; without any specific meaning. A new reference data attribute has been introduced in the SWIFTRef directories to indicate where the institution is located and to which time zone it refers.</fibo-fnd-utl-av:explanatoryNote>
@@ -430,7 +441,7 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>credit union</rdfs:label>
-		<skos:definition>a not-for-profit depository institution that makes personal loans and offers other consumer banking services, organized for the purpose of promoting thrift among its members and creating a source of credit for provident or productive purposes</skos:definition>
+		<skos:definition>not-for-profit depository institution that makes personal loans and offers other consumer banking services, organized for the purpose of promoting thrift among its members and creating a source of credit for provident or productive purposes</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.ncua.gov/Legal/Documents/fcu_act.pdf</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
@@ -440,6 +451,12 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<skos:definition>any financial institution engaged in the business of receiving demand deposits from the public or other institutions</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>12 U.S. Code Section 1813 - Definitions, see, for example, http://www.law.cornell.edu/uscode/text/12/1813</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-fse;DevelopmentBank">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
+		<rdfs:label>development bank</rdfs:label>
+		<skos:definition>national or regional financial institution designed to provide medium- and long-term capital for productive investment, often accompanied by technical assistance, in poor countries</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;ElectronicFundsTransferService">
@@ -466,7 +483,7 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;FinanceCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
 		<rdfs:label>finance company</rdfs:label>
-		<skos:definition>a financial intermediary in the business of making loans to individuals or businesses that obtains its financing from banks, institutions, and other money market sources rather than from deposits</skos:definition>
+		<skos:definition>financial intermediary in the business of making loans that obtains its financing from banks, institutions, and other money market sources rather than from deposits</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
@@ -540,15 +557,22 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;HoldingCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-fse;hasPortfolioCompany"/>
+				<owl:onClass rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>holding company</rdfs:label>
-		<skos:definition>a business (corporation, limited liability company, or limited partnership) that has been established to own stock in another company, typically to own enough voting shares to have some level of control over that company&apos;s policies and management</skos:definition>
+		<skos:definition>business entity established to own stock in another company, typically to own enough voting shares to have some level of control over that company&apos;s policies and management</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Holding companies protect their owners from losses to some degree, protecting assets, for example, in case of bankruptcy.  They can also be set up to own property such as real estate, patents, trademarks, stocks and other assets to limit financial and legal liability</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;InsuranceCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
 		<rdfs:label>insurance company</rdfs:label>
-		<skos:definition>a non-depository institution whose primary and predominant business activity is the writing of insurance or the reinsuring of risks underwritten by insurance companies, and that provides compensation based on the happening of one or more contingencies</skos:definition>
+		<skos:definition>non-depository institution whose primary and predominant business activity is the writing of insurance or the reinsuring of risks underwritten by insurance companies, and that provides compensation based on the happening of at least one contingency</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>In the US, insurance companies are subject to supervision by the insurance commissioner or a similar official or agency of a State; or any receiver or similar official or any liquidating agent for such a company, in his capacity as such. Common forms of insurance include life, property and casualty, and health insurance. In addition to insuring against hazards, many insurance companies also sell investments or investment-like products. The most prevalent investment products offered by insurers are annuities and life insurance policies that also feature investment elements.
@@ -604,7 +628,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;InvestmentCompany"/>
 		<rdfs:label>management company</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-fse;UnitInvestmentTrust"/>
-		<skos:definition>Any investment company that sells and manages a portfolio of securities other than a face-amount certificate company or unit investment fund.</skos:definition>
+		<skos:definition>investment company that sells and manages a portfolio of securities other than a face-amount certificate company or unit investment fund</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
 		<fibo-fnd-utl-av:explanatoryNote>Management companies allow investors to pool their capital with that of other investors in order to purchase professionally-managed groups of diversified securities.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -630,6 +654,21 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<skos:example>a central bank, the executive branch of a government, a central bank for several nations, a currency board</skos:example>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://lexicon.ft.com/Term?term=monetary-authority</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investordictionary.com/definition/monetary-authority</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-fse;MoneyServicesBusiness">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
+		<rdfs:label>money services business</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.fincen.gov/money-services-business-definition"/>
+		<skos:definition>any person doing business, whether or not on a regular basis or as an organized business concern, in one of the following capacities: (1) currency dealer or exchanger, (2) check casher, (3) issuer of traveler&apos;s checks, money orders, or stored value, (4) seller or redeemer of traveler&apos;s checks, money orders, or stored value, (5) money transmitter, or (6) postal service</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>MSB</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>This definition excludes banks and persons registered with or examined by the Securities and Exchange Commission or the Commodities Futures Trading Commission.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-fse;MortgageCompany">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdfs:label>mortgage company</rdfs:label>
+		<skos:definition>financial service provider that originates and/or funds mortgages for residential or commercial property</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;NonDepositoryInstitution">
@@ -663,8 +702,38 @@ A number of insurance companies operate brokerage arms that trade securities on 
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;PrincipalUnderwriter">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;Underwriter"/>
 		<rdfs:label>principal underwriter</rdfs:label>
-		<skos:definition>Principal underwriter of or for any investment company other than a closed-end company, or of any security issued by such a company, means any underwriter who as principal purchases from such company, or pursuant to contract has the right (whether absolute or conditional) from time to time to purchase from such company, any such security for distribution, or who as agent for such company sells or has the right to sell any such security to a dealer or to the public or both, but does not include a dealer who purchases from such company through a principal underwriter acting as agent for such company. Principal underwriter of or for a closed-end company or any issuer which is not an investment company, or of any security issued by such a company or issuer, means any underwriter who, in connection with a primary distribution of securities, (a) is in privity of contract with the issuer or an affiliated person of the issuer; (b) acting alone or in concert with one or more other persons, initiates or directs the formation of an underwriting syndicate; or (c) is allowed a rate of gross commission, spread, or other profit greater than the rate allowed another underwriter participating in the distribution.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>underwriter who as principal purchases from an investment company, or pursuant to contract has the right (whether absolute or conditional) from time to time to purchase from such company, any such security for distribution, or who as agent for such company sells or has the right to sell any such security to a dealer or to the public or both, but does not include a dealer who purchases from such company through a principal underwriter acting as agent for such company</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>Principal underwriter of or for a closed-end company or any issuer which is not an investment company, or of any security issued by such a company or issuer, means any underwriter who, in connection with a primary distribution of securities, (a) is in privity of contract with the issuer or an affiliated person of the issuer; (b) acting alone or in concert with one or more other persons, initiates or directs the formation of an underwriting syndicate; or (c) is allowed a rate of gross commission, spread, or other profit greater than the rate allowed another underwriter participating in the distribution.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-fse;RegisteredInvestmentAdvisor">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;RegisteredAgent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-oac-cpty;advises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;isRegisteredBy"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fbc-fct-ra;RegistrationAuthority">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-fct-rga;RegulatoryAgency">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>registered investment advisor</rdfs:label>
+		<skos:definition>registered agent and financial service provider that advises high net worth individuals on investments and manages their portfolios</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>RIA</fibo-fnd-utl-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;SalesFinanceCompany">
@@ -678,8 +747,8 @@ A number of insurance companies operate brokerage arms that trade securities on 
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;SavingsAssociation">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
 		<rdfs:label>savings association</rdfs:label>
-		<skos:definition>A savings association is defined as: (a) any Federal savings association, where a Federal savings association means any Federal savings association or Federal savings bank which is chartered under section 1464 of the Federal Deposit Insurance Act; (b) any State savings association, where a State savings association means any building and loan association, savings and loan association, or homestead association; or any cooperative bank (other than a cooperative bank which is a State bank as defined in subsection (a)(2)) of the Federal Deposit Insurance Act, which is organized and operating according to the laws of the State (as defined in subsection (a)(3)) in which it is chartered or organized; and (c) any corporation (other than a bank) that the Board of Directors and the Comptroller of the Currency jointly determine to be operating in substantially the same manner as a savings association.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>depository institution that is (a) any federal savings bank or association chartered under section 1464 of the Federal Deposit Insurance Act; (b) any state chartered building and loan association, savings and loan association, or homestead association; or (c) any cooperative bank (other than a cooperative bank which is a state bank as defined in subsection (a)(2)) of the Federal Deposit Insurance Act, which is organized and operating according to the laws of the State (as defined in subsection (a)(3)) in which it is chartered or organized; and (c) any corporation (other than a bank) that the board of directors and the comptroller of the currency jointly determine to be operating in substantially the same manner as such a depository institution</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;SelfRegulatingOrganization">
@@ -742,17 +811,34 @@ A number of insurance companies operate brokerage arms that trade securities on 
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-fse;hasDateEstablished">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label>has date established</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>the date that the financial service provider was established</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-fse;hasDateInsured">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label>has date insured</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>the date that the financial service provider was first insured for the purposes of protecting client accounts</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-fse;hasPortfolioCompany">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isPartyControlling"/>
+		<rdfs:label>has portfolio company</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-oac-ctl;ControllingParty"/>
+		<rdfs:range rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<owl:inverseOf rdf:resource="&fibo-fbc-fct-fse;isPortfolioCompanyOf"/>
+		<skos:definition>indicates a party in which a venture capital firm, a buyout firm, or a holding company has invested</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-fse;isPortfolioCompanyOf">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;hasControllingParty"/>
+		<rdfs:label>is portfolio company of</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<rdfs:range rdf:resource="&fibo-fnd-oac-ctl;ControllingParty"/>
+		<skos:definition>indicates a venture capital firm, a buyout firm, or a holding company that is a financial sponsor (i.e. investor in) of the party</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-fse;regulatesSupplyOf">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -133,12 +133,12 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201101/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified to integrate a financial services provider identifier for certain banking identifiers, add a property for secondary federal regulator, add individual registration schemes for state-specific business registries, improve on some definitions, normalize some of the labels, eliminate duplication of concepts in LCC, to simplify addresses, merge countries with locations in FND, eliminte the redundant notion of an InstitutionType, which can be determined using a SPARQL query or classification and results in a very large disjunction, and correct a couple of improperly defined annotations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to add tax identification number and employer identification number.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to add tax identification number, employer identification number, federal government entity and state government entity.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -370,6 +370,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaBusinessProgramsDivision">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;StateGovernmentEntity"/>
 		<rdfs:label>California Business Programs Division</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of California, Secretary of State, Business Programs Division</skos:definition>
@@ -407,6 +408,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaDepartmentOfBusinessOversight">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;StateGovernmentEntity"/>
 		<rdfs:label>California Department of Business Oversight</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of California&apos;s Department of Business Oversight</skos:definition>
@@ -438,6 +440,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CommodityFuturesTradingCommission">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Commodity Futures Trading Commission</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Commodity Futures Trading Commission (CFTC), an independent Federal agency whose mission is to foster open, transparent, competitive, and financially sound markets, to avoid systemic risk, and to protect the market users and their funds, consumers, and the public from fraud, manipulation, and abusive practices related to derivatives and other products that are subject to the Commodity Exchange Act</skos:definition>
@@ -458,6 +461,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;ConsumerFinancialProtectionBureau">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Consumer Financial Protection Bureau</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Consumer Financial Protection Bureau (CFPB), an independent Federal agency that helps consumer finance markets work by making rules more effective, by consistently and fairly enforcing those rules, and by empowering consumers to take more control over their economic lives</skos:definition>
@@ -602,6 +606,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;DelawareDivisionOfCorporations">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;StateGovernmentEntity"/>
 		<rdfs:label>Delaware Division of Corporations</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of Delaware&apos;s Division of Corporations</skos:definition>
@@ -757,6 +762,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FarmCreditAdministration">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Farm Credit Administration</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Farm Credit Administration (FCA), an independent Federal agency that regulates and examines the banks, associations, and related entities of the Farm Credit System (FCS), including the Federal Agricultural Mortgage Corporation (Farmer Mac)</skos:definition>
@@ -781,6 +787,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalDepositInsuranceCorporation">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;Instrumentality"/>
 		<rdf:type rdf:resource="&fibo-be-le-cb;Corporation"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Federal Deposit Insurance Corporation</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Deposit Insurance Corporation (FDIC), which preserves and promotes public confidence in the U.S. financial system by insuring deposits in banks and thrift institutions for at least $250,000; by identifying, monitoring and addressing risks to the deposit insurance funds; and by limiting the effect on the economy and the financial system when a bank or thrift institution fails.</skos:definition>
@@ -804,6 +811,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalFinancialInstitutionsExaminationCouncil">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Federal Financial Institutions Examination Council</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>FFIEC, a formal interagency body empowered to prescribe uniform principles, standards, and report forms for the federal examination of financial institutions by the Board of Governors of the Federal Reserve System (FRB), the Federal Deposit Insurance Corporation (FDIC), the National Credit Union Administration (NCUA), the Office of the Comptroller of the Currency (OCC), and the Consumer Financial Protection Bureau (CFPB), and to make recommendations to promote uniformity in the supervision of financial institutions</skos:definition>
@@ -830,8 +838,35 @@
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/about.htm</fibo-fnd-utl-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
+	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FederalGovernmentEntity">
+		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;GovernmentBody"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-be-ge-ge;Instrumentality">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-be-ge-ge;Polity">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-be-ge-ge;GovernmentAgency">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-be-ge-ge;GovernmentDepartment">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-ge-ge;hasJurisdiction"/>
+				<owl:hasValue rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>federal government entity</rdfs:label>
+		<skos:definition>formal organization that is an independent agency, instrumentality or other permanent or semi-permanent organization in the machinery of government in the United States, authorized by the executive branch or by Congress, that operates at the national (federal) level</skos:definition>
+	</owl:Class>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalHousingFinanceAgency">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Federal Housing Finance Agency</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Housing Finance Agency (FHFA), responsible for strengthening and securing the United States secondary mortgage markets by providing effective supervision, sound research, reliable data, and relevant policies</skos:definition>
@@ -927,6 +962,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfNewYork-US-NY">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;Instrumentality"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Federal Reserve Bank of New York US-NY</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>legal entity and instrumentality that is Federal Reserve Bank of New York</skos:definition>
@@ -984,6 +1020,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBoard">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Federal Reserve Board</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Board (FRB)</skos:definition>
@@ -1266,6 +1303,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSystem">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Federal Reserve System</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>central banking system of the U.S., comprised of the Federal Reserve Board, the 12 Federal Reserve Banks, the Federal Open Market Committee, and the national and state member banks</skos:definition>
@@ -1386,6 +1424,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FinancialStabilityOversightCouncil">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Financial Stability Oversight Council</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Financial Stability Oversight Council (FSOC), which provides comprehensive monitoring of the stability of our nation&apos;s financial system, as established under the Dodd-Frank Wall Street Reform and Consumer Protection Act</skos:definition>
@@ -1484,6 +1523,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;MassachusettsCorporationsDivision">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;StateGovernmentEntity"/>
 		<rdfs:label>Massachusetts Corporations Division</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Commonwealth of Massachusetts, Secretary of State, Corporations Division</skos:definition>
@@ -1540,6 +1580,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NationalCreditUnionAdministration">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>National Credit Union Administration</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>National Credit Union Administration (NCUA), the independent federal agency that regulates, charters and supervises federal credit unions</skos:definition>
@@ -1613,6 +1654,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NewYorkDivisionOfCorporations">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;StateGovernmentEntity"/>
 		<rdfs:label>New York State (NYS) Department of State Division of Corporations</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>New York State (NYS) Department of State&apos;s Division of Corporations</skos:definition>
@@ -1644,6 +1686,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OfficeOfThriftSupervision">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Office of Thrift Supervision</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>OTS, which is a part of the OCC, responsible for chartering, regulating, and supervising all federal savings associations</skos:definition>
@@ -1695,6 +1738,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OhioBusinessServicesDivision">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;StateGovernmentEntity"/>
 		<rdfs:label>Ohio Business Services Division</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Ohio Secretary of State, Business Services Division</skos:definition>
@@ -1803,6 +1847,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeCommission">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>Securities and Exchange Commission</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>SEC, an independent commission established by the Securities Act of 1933 and Securities Exchange Act of 1934 whose mission is to protect investors, maintain fair, orderly, and efficient markets, and facilitate capital formation</skos:definition>
@@ -1856,6 +1901,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsDivision">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;StateGovernmentEntity"/>
 		<rdfs:label>South Dakota, Secretary of State Corporations Divison</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of South Dakota&apos;s Corporations Division</skos:definition>
@@ -1884,6 +1930,48 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<lcc-lr:hasTag>RA000635</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessInformationRegistry"/>
 	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;StateGovernmentEntity">
+		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;GovernmentBody"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-be-ge-ge;Instrumentality">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-be-ge-ge;RegionalSovereignty">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-be-ge-ge;GovernmentAgency">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-be-ge-ge;GovernmentDepartment">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-ge-ge;hasJurisdiction"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-law-jur;hasReach"/>
+						<owl:someValuesFrom>
+							<owl:Restriction>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&lcc-cr;CountrySubdivision">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&lcc-cr;isSubregionOf"/>
+										<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Restriction>
+						</owl:someValuesFrom>
+					</owl:Restriction>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>state government entity or agency</rdfs:label>
+		<skos:definition>formal organization that is an independent agency, instrumentality or other permanent or semi-permanent organization in the machinery of government of any one of the states or territories of the United States</skos:definition>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;TaxpayerIdentificationNumber">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;TaxIdentifier"/>
@@ -1938,6 +2026,7 @@ A TIN must be on a withholding certificate if the beneficial owner is claiming a
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
+		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FederalGovernmentEntity"/>
 		<rdfs:label>U.S. Department of the Treasury</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>U.S. Department of the Treasury, the executive agency responsible for promoting economic prosperity and ensuring the financial security of the United States</skos:definition>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added a number of missing entities, including Association, Development Bank, Money Services Business, Mortgage Company, Registered Investment Advisor, Federal Government Entity and State Government Entity, as well as incorporating the concept of a principal party, and introducing pairs of properties linking various entities and parties through the party lattice that were gaps


Fixes: #1275 / FBC-267


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


