### PR TITLE
FBC-266 - The name of the class 'financial service account' was changed to 'customer account' but the definition is still too narrow

### DIFF
--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -73,7 +73,7 @@
 		<rdfs:label>Clients and Accounts Ontology</rdfs:label>
 		<dct:abstract>This ontology provides basic concepts such as account, account holder, account provider, relationship manager that are commonly used by financial services providers to describe customers and to determine counterparty identities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
@@ -110,7 +110,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/ProductsAndServices/ClientsAndAccounts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised per the FIBO 2.0 RFC with respect to the definitions for accounts and account identifiers, such as BBAN and IBAN identifiers, including but not limited to bank accounts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to support the addition of maturity-related properties to financial instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181101/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
@@ -118,6 +118,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to eliminate the disjointness between a deposit account and investment account to allow for certain portfolio management accounts that have characteristics of both.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for balance, fee, general ledger, ledger account, income and related properties, revise definitions to be ISO 704 compliant, and eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for transaction records, which are needed to represent statements of various sorts, to add the concept of an account statement, and to clean up and augment definitions related to accounts, account holders, etc. as required for the purpose of representing credit card accounts.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to generalize the definition of customer account and eliminate ambiguity in others.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -170,7 +171,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>account</rdfs:label>
-		<skos:definition>container for records associated with a business arrangement for regular transactions or services (such as personal or professional services, banking)</skos:definition>
+		<skos:definition>container for records associated with a business arrangement for regular transactions and services</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In general, an account is associated with a contractual relationship between a buyer and seller under which payment may be made at a later time. General ledger accounts are an exception to this, however, and typically do not have account holders, including internal account holders. They may, on the other hand, have responsible parties.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -223,7 +224,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>account holder</rdfs:label>
-		<skos:definition>party that owns the account</skos:definition>
+		<skos:definition>party that owns an account</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>An account holder is named on the account and is authorized to conduct transactions associated with the account. Authorization is typically evidenced by signatures maintained on file by the account provider.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Note that this concept of account holder applies to internal accounts that are non-general ledger accounts also have account holders, such as payroll accounts, internal checking accounts associated with cashier&apos;s checks, and so forth.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -276,7 +277,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>account provider</rdfs:label>
-		<skos:definition>party that provides and services the account</skos:definition>
+		<skos:definition>party that provides and services an account</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountSpecificServiceAgreement">
@@ -300,7 +301,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>account-specific service agreement</rdfs:label>
-		<skos:definition>service-agreement that is account-specific, applicable in cases where a client holds multiple accounts with differing terms and conditions</skos:definition>
+		<skos:definition>service-agreement that is account-specific, applicable in cases where a client might hold multiple accounts with differing terms and conditions</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Customers of financial service providers frequently hold multiple accounts - brokerage accounts, checking and savings accounts, trust accounts, and so forth - which may have specific terms and conditions associated with them.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -349,7 +350,7 @@
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountingTransaction">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;TransactionEvent"/>
 		<rdfs:label>accounting transaction</rdfs:label>
-		<skos:definition>event or condition recognized by an entry in the records of an account</skos:definition>
+		<skos:definition>event recognized by an entry in the records of an account</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;Balance">
@@ -460,7 +461,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">certificate of deposit</rdfs:label>
-		<skos:definition xml:lang="en">cash instrument associated with a time deposit account that cannot be withdrawn for a certain &quot;term&quot; or period of time.</skos:definition>
+		<skos:definition xml:lang="en">cash instrument associated with a time deposit account that cannot be withdrawn for a certain period of time (term)</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CD</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>When the term is over it can be withdrawn or it can be held for another term. The longer the term the better the yield on the money.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -523,7 +524,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>customer account</rdfs:label>
-		<skos:definition>account provided by a financial service provider to a customer or client that is associated with a specific financial product or service</skos:definition>
+		<skos:definition>account that represents an identified, named collection of balances and cumulative totals used to summarize customer transaction-related activity over a designated period of time</skos:definition>
 		<fibo-fnd-utl-av:synonym>financial service account</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -546,7 +547,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>customer account holder</rdfs:label>
-		<skos:definition>party that is a client or customer and that owns an account</skos:definition>
+		<skos:definition>party that owns a customer account</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;DemandDepositAccount">
@@ -776,7 +777,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>relationship manager</rdfs:label>
-		<skos:definition>responsible party who manages the client&apos;s account (or portfolio of accounts) and oversees their relationship with the service provider</skos:definition>
+		<skos:definition>responsible party who manages a client&apos;s account and oversees their relationship with the service provider</skos:definition>
 		<fibo-fnd-utl-av:synonym>account manager</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised the definition of customer account to generalize it per user suggestions and adjusted / cleaned-up a few others to eliminate ambiguity, etc.

Fixes: #1280 / FBC-266


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


