### PR TITLE
FBC-269 - Missing properties in the Guaranty ontology

### DIFF
--- a/FBC/DebtAndEquities/Guaranty.rdf
+++ b/FBC/DebtAndEquities/Guaranty.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
+	<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-dae-gty "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
@@ -14,6 +15,7 @@
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-oac-ctl "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -30,6 +32,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
+	xmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-dae-gty="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
@@ -41,6 +44,7 @@
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-oac-ctl="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -57,7 +61,7 @@
 		<rdfs:label>Guaranty Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts related to contractual guaranty.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
@@ -66,6 +70,7 @@
 		<sm:filename>Guaranty.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -76,17 +81,18 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201101/DebtAndEquities/Guaranty/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/DebtAndEquities/Guaranty/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Guaranty/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181001/DebtAndEquities/Guaranty/ version of this ontology revised to add financial asset as a parent of letter of credit.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181001/DebtAndEquities/Guaranty/ version of this ontology revised to incorporate refinement of the concept of a guaranty as needed for debt securities and loans.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191201/DebtAndEquities/Guaranty/ version of this ontology revised to eliminate duplication of concepts in LCC.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/DebtAndEquities/Guaranty/ version of this ontology revised to simplify the contract party hierarchy.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/DebtAndEquities/Guaranty/ version of this ontology revised to simplify the contract party hierarchy, add properties linking controlled parties to their guarantor, and clean up definitions to eliminate ambiguity, etc.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -99,7 +105,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>collateralized guaranty</rdfs:label>
-		<skos:definition>a guaranty that takes the form of some asset that is pledged by a borrower to a lender (usually in return for a loan)</skos:definition>
+		<skos:definition>guaranty that takes the form of some asset that is pledged by a borrower to a lender (usually in return for a loan)</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In some cases, the lender may require the borrower to place pledged assets such as cash or securities in a separate account that the lender controls.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -117,10 +123,11 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>government guaranty</rdfs:label>
-		<skos:definition>a guaranty provided by a government entity, e.g. for a government-backed security</skos:definition>
+		<skos:definition>guaranty provided by a government entity, such as for a government-backed security</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;Guarantor">
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;DeJureControllingInterestParty"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -141,7 +148,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>guarantor</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
-		<skos:definition>a party that guarantees, endorses, or provides indemnity for some obligation on behalf of some other party</skos:definition>
+		<skos:definition>party that guarantees, endorses, or provides indemnity for some obligation on behalf of some other party</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>In some cases, the party acting as guarantor may also be a party to the contract, such as in the case of Fannie Mae or Freddie Mac.  In such cases, the same individual would be modeled as having both roles.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -180,8 +187,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>guaranty</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
-		<skos:definition>a commitment whereby something, such as a debt, cash flows on a debt instrument (e.g., interest payments), or performance of some obligation, is guaranteed if the person or organization with primary liability fails to perform</skos:definition>
+		<skos:definition>commitment whereby something is formally assured if a party with primary liability fails to perform</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>The commitment may cover a debt, cash flows on a debt instrument (such as interest payments), or performance of some obligation.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;InsuranceBackedGuaranty">
@@ -193,7 +201,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>insurance-backed guaranty</rdfs:label>
-		<skos:definition>a guaranty that is realized as an insurance policy</skos:definition>
+		<skos:definition>guaranty that is realized as an insurance policy</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;InsurancePolicy">
@@ -211,14 +219,14 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>insurance policy</rdfs:label>
-		<skos:definition>a contract document that (1) puts an indemnity cover into effect, (2) serves as a legal evidence of the insurance agreement, (3) sets out the exact terms on which the indemnity cover has been provided, and (4) states associated information such as the (a) specific risks and perils covered, (b) duration of coverage, (c) amount of premium, (d) mode of premium payment, and (e) deductibles, if any</skos:definition>
+		<skos:definition>contract document that (1) puts an indemnity cover into effect, (2) serves as a legal evidence of the insurance agreement, (3) sets out the exact terms on which the indemnity cover has been provided, and (4) states associated information such as the (a) specific risks and perils covered, (b) duration of coverage, (c) amount of premium, (d) mode of premium payment, and (e) deductibles, if any</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;Insurer">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
 		<rdfs:label>insurer</rdfs:label>
-		<skos:definition>a financial service provider that issues an insurance policy</skos:definition>
+		<skos:definition>financial service provider that issues an insurance policy</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;JointGuaranty">
@@ -231,7 +239,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>joint guaranty</rdfs:label>
-		<skos:definition>a guaranty provided by two or more parties, jointly and severally</skos:definition>
+		<skos:definition>guaranty provided by at least two parties, jointly and severally</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;LetterOfCredit">
@@ -244,7 +252,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>letter of credit</rdfs:label>
-		<skos:definition>a letter from a bank or other creditworthy institution guaranteeing that a buyer&apos;s payment to a seller will be received on time and for the correct amount</skos:definition>
+		<skos:definition>letter from a bank or other creditworthy institution guaranteeing that a buyer&apos;s payment to a seller will be received on time and for the correct amount</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In some states in the U.S., the issuer is not limited to financial institutions -- it is simply a written instrument, addressed by one person to another, requesting the latter to give credit to the person in whose favor it is drawn.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>In the event that the buyer is unable to make payment, the bank or other issuer is required to cover the full or remaining amount.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -258,26 +266,27 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>letter of credit guaranty</rdfs:label>
-		<skos:definition>a guaranty that takes the form of a letter of credit, i.e., a document issued by a bank guaranteeing the payment up to a stated amount for a specified period</skos:definition>
+		<skos:definition>guaranty that takes the form of a letter of credit, i.e., a document issued by a bank guaranteeing the payment up to a stated amount for a specified period</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;NegativePledge">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-gty;Guaranty"/>
 		<rdfs:label>negative pledge</rdfs:label>
-		<skos:definition>a guaranty whereby the issuer will not pledge any assets if doing so would result in less security for lender(s) or investor(s)</skos:definition>
+		<skos:definition>guaranty whereby the issuer will not pledge any assets if doing so would result in less security for lender(s) or investor(s)</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;Policyholder">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
 		<rdfs:label>policyholder</rdfs:label>
-		<skos:definition>a counterparty to and typically owner of an insurance policy; an insured party</skos:definition>
+		<skos:definition>counterparty to and typically owner of an insurance policy</skos:definition>
+		<fibo-fnd-utl-av:synonym>insured party</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;PriorityLevel">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
 		<rdfs:label>priority level</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
-		<skos:definition>the level of priority that guaranty has in the context of the contract, for example for a credit enhancement priority</skos:definition>
+		<skos:definition>relative ranking that a guaranty has in the context of a contract, for example for a credit enhancement priority</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-gty;hasGuaranteedAmount">
@@ -298,13 +307,22 @@
 		<skos:definition>relates the guarantor to the contract for which they are providing a guaranty</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-gty;hasGuarantorParty">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;hasControllingParty"/>
+		<rdfs:label>has guarantor party</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<rdfs:range rdf:resource="&fibo-fbc-dae-gty;Guarantor"/>
+		<owl:inverseOf rdf:resource="&fibo-fbc-dae-gty;isGuarantorOf"/>
+		<skos:definition>indicates a party that guarantees, endorses, or provides indemnity for some obligation on its behalf</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-gty;hasPriorityLevel">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
 		<rdfs:label>has priority level</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-gty;Guaranty"/>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-gty;PriorityLevel"/>
-		<skos:definition>relates a guaranty to some level of priority that guaranty has in the context of the contract, for example for a credit enhancement priority</skos:definition>
+		<skos:definition>relates a guaranty to some relative ranking that the guaranty has in the context of the contract, for example for a credit enhancement priority</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-gty;isGuaranteedBy">
@@ -313,6 +331,14 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-gty;Guarantor"/>
 		<skos:definition>relates guaranty to the contract guarantor, i.e., to the legal person providing the guaranty</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-gty;isGuarantorOf">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isPartyControlling"/>
+		<rdfs:label>is guarantor of</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-gty;Guarantor"/>
+		<rdfs:range rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
+		<skos:definition>identifies a party over which a guarantor has some measure of control by virtue of the guarantee</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added de jure controlling interest party as a parent of guarantor, introduced two additional properties linking the controlled party to the controlling party (the guarantor) to hook the concept of a guarantor into the control party lattice, cleaned up and eliminated ambiguity in definitions

Fixes: #1282 / FBC-269


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


