### PR TITLE
Correct reasoning issue in FBC US Examples related to hasDateEstablished

### DIFF
--- a/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -482,14 +482,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;BNYMellonNationalAssociationDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>BNY Mellon, National Association date established</rdfs:label>
 		<skos:definition>date that BNY Mellon, National Association (originally Mellon National Bank and Trust Company in Pennsylvania) was established according to the NIC Repository</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1869-01-01</fibo-fnd-dt-fd:hasDateValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;BNYMellonNationalAssociationDateInsured">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>BNY Mellon, National Association date insured</rdfs:label>
 		<skos:definition>date that BNY Mellon, National Association (originally Mellon National Bank and Trust Company in Pennsylvania) was initially insured with respect to deposit insurance</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1934-01-01</fibo-fnd-dt-fd:hasDateValue>
@@ -607,7 +607,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;BankOfNewYorkMellonDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>The Bank of New York Mellon Corporation date established</rdfs:label>
 		<skos:definition>date that The Bank of New York Mellon Corporation was established by Alexander Hamilton</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1784-01-01</fibo-fnd-dt-fd:hasDateValue>
@@ -725,14 +725,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CitibankNADateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Citibank, N.A. date established</rdfs:label>
 		<skos:definition>date that Citibank, N.A. (originally First National City Bank Of New York) was established</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1812-06-16</fibo-fnd-dt-fd:hasDateValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CitibankNADateInsured">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Citibank, N.A. date insured</rdfs:label>
 		<skos:definition>date that Citibank, N.A. (as First National City Bank Of New York) was initially insured with respect to deposit insurance by the FDIC</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1934-01-01</fibo-fnd-dt-fd:hasDateValue>
@@ -994,7 +994,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;FMRLLCDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>FMR LLC date established</rdfs:label>
 		<skos:definition>date that FMR LLC (originally Fidelity Management and Research Company) was first established</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1946-01-01</fibo-fnd-dt-fd:hasDateValue>
@@ -1263,14 +1263,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association date established</rdfs:label>
 		<skos:definition>date that JPMorgan Chase Bank, National Association was established</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1824-01-01</fibo-fnd-dt-fd:hasDateValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationDateInsured">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association date insured</rdfs:label>
 		<skos:definition>date that JPMorgan Chase Bank, National Association was initially insured with respect to deposit insurance by the FDIC</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1934-01-01</fibo-fnd-dt-fd:hasDateValue>
@@ -1493,14 +1493,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>State Street Bank and Trust Company date established</rdfs:label>
 		<skos:definition>date that State Street Bank and Trust (originally Second Bank - State Street Trust Company) was established as a state member bank with the FRS</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1892-12-31</fibo-fnd-dt-fd:hasDateValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyDateInsured">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>State Street Bank and Trust Company date insured</rdfs:label>
 		<skos:definition>date that State Street Bank and Trust Company was initially insured with respect to deposit insurance by the FDIC</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1934-01-01</fibo-fnd-dt-fd:hasDateValue>
@@ -1740,7 +1740,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>The Proctor &amp; Gamble Company date established</rdfs:label>
 		<skos:definition>date that The Proctor &amp; Gamble was founded</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1837-01-01</fibo-fnd-dt-fd:hasDateValue>
@@ -1962,14 +1962,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Wells Fargo Bank, National Association date established</rdfs:label>
 		<skos:definition>date that Wells Fargo Bank, National Association was established under the National Banking Act of 1863</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1870-01-01</fibo-fnd-dt-fd:hasDateValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationDateInsured">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Wells Fargo Bank, National Association date insured</rdfs:label>
 		<skos:definition>date that Wells Fargo Bank, National Association was initially insured with respect to deposit insurance by the FDIC</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1934-01-01</fibo-fnd-dt-fd:hasDateValue>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -352,7 +352,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheProctorAndGambleCompanyBusinessEntityIdentifier">
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate>1905-05-05</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-fse:hasDateEstablished rdf:resource="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyDateEstablished"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal"/>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfOhioJurisdiction"/>
@@ -549,7 +548,6 @@
 		<fibo-be-corp-corp:hasDateOfRegistration rdf:resource="&fibo-fbc-fct-usind;BankOfNewYorkMellonCorporationIncorporationDate"/>
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;BankOfNewYorkMellonCorporationAddress"/>
-		<fibo-fbc-fct-fse:hasDateEstablished rdf:resource="&fibo-fbc-fct-usind;BankOfNewYorkMellonDateEstablished"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
 		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bnymellon.com/</fibo-fnd-plc-vrt:hasWebsite>

--- a/FND/DatesAndTimes/FinancialDates.rdf
+++ b/FND/DatesAndTimes/FinancialDates.rdf
@@ -40,14 +40,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20201101/DatesAndTimes/FinancialDates/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20201201/DatesAndTimes/FinancialDates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/DatesAndTimes/FinancialDates/ version of this ontology was revised by the FIBO FND 1.2 RTF in order to introduce the definition of a time interval, which is a location, to ground some of the concepts such as a date period, and duration as well as to support the definition of business recurrence intervals for use in parametric schedules for securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20170201/DatesAndTimes/FinancialDates/ version of this ontology was revised by the FIBO 2.0 RFC in order to introduce the definition of a time instant, to eliminate a reasoning issue with relative dates, and remove a circular dependency inadvertently incorporated in the ontology with a FIBO FND 1.2 modification.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/DatesAndTimes/FinancialDates/ version of this ontology was revised to introduce a composite date datatype to allow for cases whereby the representation of a date for certain purposes, such as GLEIF LEI data, is inconsistent, and to facilitate mapping FIBO to multiple data sources in user environments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190201/DatesAndTimes/FinancialDates/ version of this ontology was revised to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/DatesAndTimes/FinancialDates/ version of this ontology was revised to add the &apos;has date added&apos; property, which is needed for the date a constituent is added to a basket, among other purposes, to add a TimeOfDay class, needed for representing rate reset times, eliminate duplication with concepts in LCC, and make AdHocScheduleEntry a child of DatedCollectionConstituent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/DatesAndTimes/FinancialDates/ version of this ontology was revised to move dated collection and dated collection constituent as well as hasObservedDateTime and hasAcquisitionDate to financial dates in order to improve usability, simplify reasoning, made definitions ISO 704 compliant, and eliminate redundant restrictions on ad hoc schedule entry.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/DatesAndTimes/FinancialDates/ version of this ontology was revised to add hasOpeningDateTime and hasClosingDateTime for use in defining trading days and sessions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/DatesAndTimes/FinancialDates/ version of this ontology was revised to add hasOpeningDateTime and hasClosingDateTime for use in defining trading days and sessions and eliminated the functional property declaration on hasExplicitDate.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the December 2014 Long Beach meeting in support of the SEC specification.  It is also needed to provide temporal relationships for Ownership and Control.
 
 These three ontologies are designed for use together:
@@ -748,7 +748,6 @@ The recurrence start date can also be relative to the starting Date of the overa
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-dt-fd;hasExplicitDate">
-		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
 		<rdfs:label>has explicit date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This turned out to be somewhat misleading, caused by hasExplicitDate being declared as functional in FND.  When we changed hasDateEstablished and hasDateInsured to have a range of explicit date (which they should have been all along), and made the properties subproperties of hasExplicitDate, rather than hasDate, the bug (which was in the FinancialDates ontology for many years) became obvious.  That declaration was removed in the context of correcting this error.

Fixes: #1286 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


