### PR TITLE
New hygiene test - Test for diconnected elements

### DIFF
--- a/etc/testing/hygiene/testHygiene1290.sparql
+++ b/etc/testing/hygiene/testHygiene1290.sparql
@@ -1,0 +1,18 @@
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+
+##
+# banner All classes should be rooted in FND, LCC or FBC domain.
+
+SELECT DISTINCT ?warning ?class ?domainIdentifier
+WHERE 
+{
+    ?class a owl:Class .
+    FILTER NOT EXISTS {?class rdfs:subClassOf ?classParent}
+    FILTER (CONTAINS(str(?class), "edmcouncil"))
+    BIND (STRBEFORE(STRAFTER(str(?class),"https://spec.edmcouncil.org/fibo/ontology/"),"/") As ?domainIdentifier)
+    FILTER (?domainIdentifier NOT IN ('FND', 'LCC', 'FBC'))
+    BIND (concat ("WARN: Class ", str(?class), " is a top-level class outside FIBO foundations.") AS ?warning)
+}
+ORDER BY ?domainIdentifier


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz pawel.garbacz@makolab.com

## Description

This test finds all top-level classes outside FND, FBC and LCC domains.

Fixes: #1290


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


