### PR TITLE
Hygine test for isA candidates

### DIFF
--- a/etc/testing/hygiene/testHygiene1289.sparql
+++ b/etc/testing/hygiene/testHygiene1289.sparql
@@ -1,0 +1,15 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+##
+# banner Object properties should not play the role of the isA relationship.
+
+SELECT ?warning ?resource
+WHERE
+{
+    ?resource rdf:type owl:ObjectProperty.
+    FILTER regex(str(?resource), "edmcouncil")
+    FILTER (REGEX(LCASE(str(?resource)), "/isa$") || REGEX(LCASE(str(?resource)), "/may[^/]*$") || REGEX(LCASE(str(?resource)), "/[^/]*(become|also)[^/]*$") )
+    BIND (concat ("WARN:Property ", str(?resource), " may be an isA impostor.") AS ?warning)
+}


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This test searches for object properties that may be isA impostors.
As per discussion in the [underlying issue](https://github.com/edmcouncil/fibo/issues/1289) the search looks for object properties whose local names:
- are identical to 'isA' string
- start with 'may' string 
- contain either 'become' or 'also' strings.

Fixes: #1289


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


