### PR TITLE
Test for "min 1" cardinality restrictions

### DIFF
--- a/etc/testing/hygiene/testHygiene1293.sparql
+++ b/etc/testing/hygiene/testHygiene1293.sparql
@@ -1,0 +1,16 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+##
+# banner "min 1" cardinality restrictions should be avoided because of performance considerations.
+
+SELECT DISTINCT ?error ?class
+WHERE {
+  ?restriction  rdf:type owl:Restriction.
+  {{?restriction owl:minQualifiedCardinality ?cardinality} UNION {?restriction owl:minCardinality ?cardinality}}.
+  ?class rdfs:subClassOf ?restriction .
+  FILTER (CONTAINS(str(?class), "edmcouncil"))
+  FILTER (?cardinality = 1)
+  BIND (concat ("ERROR: OWL class", str(?class), " is a subclass of a restriction of type owl:minCardinality or owl:minQualifiedCardinality equal to 1") AS ?error)
+}


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This test searched for the min 1 cardinality restrictions - both qualified and non-qualified.

Fixes: #1293


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


