### PR TITLE
BE-231 - Wrong label on hasControllingOrganizationMember

### DIFF
--- a/BE/OwnershipAndControl/ControlParties.rdf
+++ b/BE/OwnershipAndControl/ControlParties.rdf
@@ -48,8 +48,8 @@
 		<dct:abstract>This ontology defines concepts relating to types of controlling parties. The concepts defined here are party in role concepts, which define the nature of some entity such as an organization or a legal person, in some role such as that of owning a controlling interest in the entity or of controlling that entity. These roles are defined in terms of the types of control enjoyed by the party, for example de facto or de jure control. An important feature of this ontology is the distinction between the holding of a controlling interest (such as voting shares), and the de facto existence of control of one body by another as asserted in company filings or as a conclusion drawn from computational analysis of controlling interests.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/</sm:dependsOn>
@@ -75,6 +75,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190101/OwnershipAndControl/ControlParties.rdf version of this ontology was modified to eliminate duplication of concepts with LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/ControlParties.rdf version of this ontology was modified to integrate the concept of a situation, situational roles, and corresponding relations with the definition of control and eliminate an unused and logically inconsistent property.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/ControlParties.rdf version of the ontology was modified to simplify control concepts and relations, eliminate ambiguity in definitions, restate definitions to be ISO 704 compliant, and add properties relating control parties to control situations.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/ControlParties.rdf version of the ontology was modified to correct the label on hasControllingOrganizationMember.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -272,7 +273,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;hasControllingOrganizationMember">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;hasControllingParty"/>
-		<rdfs:label>has organization member</rdfs:label>
+		<rdfs:label>has controlling organization member</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
 		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
 		<owl:inverseOf rdf:resource="&fibo-be-oac-cpty;isControllingMemberOf"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Corrected label on hasControllingOrganizationMember

Fixes: #1303 / BE-231


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


