### PR TITLE
BE-232 - Smart quote in a note in private limited companies

### DIFF
--- a/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
+++ b/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
@@ -42,8 +42,8 @@
 		<dct:abstract>This ontology defines the fundamental concepts for representing private limited companies -- i.e., companies that have characteristics of corporations and of partnerships but are neither.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/</sm:dependsOn>
@@ -64,6 +64,7 @@
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/PrivateLimitedCompanies/PrivateLimitedCompanies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies, and add limited liability company, limited liability company taxed as a corporation, managing member, and private limited company.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified to eliminate a smart quote in an explanatory note on manager-managed limited liability company.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -148,7 +149,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-plc-plc;LimitedLiabilityCompany"/>
 		<rdfs:label>manager-managed limited liability company</rdfs:label>
 		<skos:definition>limited liability company in which the members appoint one or more managers to handle the daily operations and administrative responsibilities of the organization</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>If no members are interested in managing the LLC, an external manager (someone who doesn’t own any portion of the LLC) can be hired to run the business operations, including, in some jurisdictions, a third-party entity, such as another company.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>If no members are interested in managing the LLC, an external manager (someone who doesn&apos;t own any portion of the LLC) can be hired to run the business operations, including, in some jurisdictions, a third-party entity, such as another company.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-plc-plc;ManagingMember">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminated the smart quote in the explanatory note on manager-managed limited liability company

Fixes: #1307 / BE-232


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


