### PR TITLE
FND-323 - Need new properties for hasBuyer and hasSeller in the Products and Services ontology

### DIFF
--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -13,6 +13,7 @@
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
+	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/EconomicResources/">
@@ -41,6 +42,7 @@
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
+	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/EconomicResources/"
@@ -58,6 +60,9 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
 		<rdfs:label xml:lang="en">CreditDefaultSwaps</rdfs:label>
 		<dct:abstract>A transaction and contract in which one leg is the conditional commitment to pay out on some debt in the event that a pre-defined credit event takes place. The contract may make reference to a specific debt instrument or loan, or take effect in the event of one of a range of events that happen to the business entity that is the debtor in that debt. Includes terms for different kinds of settlement arrangement. Note that these are a swap in name only, since under normal conditions there is only one stream of payment, the fee payment leg.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-cr-cds</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
@@ -72,6 +77,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/EconomicResources/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
@@ -141,20 +147,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasDeliverySide"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -167,6 +161,18 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSubject"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -321,14 +327,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
 				<owl:onClass rdf:resource="&fibo-der-drc-swp;SwapPayingParty"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
 				<owl:onClass rdf:resource="&fibo-der-drc-swp;SwapReceivingParty"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -341,20 +347,8 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapPayingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasReferenceObligation"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -367,6 +361,18 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionCommitment"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapPayingParty"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit default swap contract</rdfs:label>
@@ -668,12 +674,6 @@
 		<skos:definition xml:lang="en">Events which... [definition needed, the FpML text doesn&apos;t define it]</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasBuyer">
-		<rdfs:label xml:lang="en">has buyer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasDeliverySide">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;hasPerspective"/>
 		<rdfs:label xml:lang="en">has delivery side</rdfs:label>
@@ -693,12 +693,6 @@
 		<rdfs:label xml:lang="en">has reference obligation</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSeller">
-		<rdfs:label xml:lang="en">has seller</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSettlementSide">

--- a/DER/DerivativesContracts/Forwards.rdf
+++ b/DER/DerivativesContracts/Forwards.rdf
@@ -13,6 +13,7 @@
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -44,6 +45,7 @@
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -65,8 +67,8 @@
 		<rdfs:label xml:lang="en">Forwards Ontology</rdfs:label>
 		<dct:abstract>Concepts defining a derivative contract in which one side represents a commitment to sell or purchase the underlier at a defined price at a given time in the future.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="http://www.w3.org/2002/07/owl#"/>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
@@ -86,7 +88,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -174,18 +176,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasValuationTerms"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardValuationTerms"/>
 			</owl:Restriction>
@@ -200,6 +190,18 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">forward</rdfs:label>
@@ -457,13 +459,6 @@
 		<skos:definition xml:lang="en">indicates costs, such as up front costs, brokerage fees and the like, that must be paid on delivery</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasBuyer">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-		<rdfs:label xml:lang="en">has buyer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;Forward"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;hasContractSize">
 		<rdfs:label xml:lang="en">has contract size</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-fwd;Forward"/>
@@ -491,13 +486,6 @@
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">indicates the multiple for determining the price of the futures contract in relation to the underlying index rate</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasSeller">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipalParty"/>
-		<rdfs:label xml:lang="en">has seller</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;Forward"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasSettlementArrangement">
 		<rdfs:label xml:lang="en">has settlement arrangement</rdfs:label>
@@ -609,18 +597,6 @@
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Future">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasValuationTerms"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardValuationTerms"/>
 			</owl:Restriction>
@@ -629,6 +605,18 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A futures contract obligates the buyer to purchase the underlying commodity, currency or financial instrument and the seller to sell it unless the contract is sold to another before settlement date which may happen if a trader waits to take a profit or cut a loss. This contrasts with options trading in which the option buyer may choose whether or not to exercise the option by the exercise date. Unlike options, futures convey an obligation to buy. The risk to the holder is unlimited, and because the payoff pattern is symmetrical, the risk to the seller is unlimited as well. Dollars lost and gained by each party on a futures contract are equal and opposite. In other words, futures trading is a zero-sum game. Futures contracts are forward contracts, meaning they represent a pledge to make a certain transaction at a future date. The exchange of assets occurs on the date specified in the contract. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearinghouses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check.</fibo-fnd-utl-av:explanatoryNote>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -69,8 +69,8 @@
 		<rdfs:label xml:lang="en">Options Ontology</rdfs:label>
 		<dct:abstract>Concepts common to all option contracts and their corresponding transactions. An option gives one party (the holder) the right to purchase or sell the underlying commodity at a given time or times in the future (as determined by the exercise convention), if they choose to do so. Includes option features, these being definitions of how the option comes into or ceases being in force when a given event occurs along with a range of other variations.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="http://www.w3.org/2002/07/owl#"/>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
@@ -182,7 +182,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -197,7 +197,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -742,7 +742,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -757,7 +757,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -841,12 +841,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasBuyer">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-		<rdfs:label xml:lang="en">has buyer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasDirection">
 		<rdfs:label xml:lang="en">has direction</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureEvent"/>
@@ -903,12 +897,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">has schedule</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
 		<rdfs:range rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasSeller">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipalParty"/>
-		<rdfs:label xml:lang="en">has seller</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasStrikeTerms">
@@ -1006,20 +994,8 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPremium"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Seller"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -1032,6 +1008,18 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasValuationTerms"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionValuationTerms"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Seller"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
+++ b/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
@@ -17,6 +17,7 @@
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
+	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
@@ -52,6 +53,7 @@
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
+	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
@@ -71,11 +73,10 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
 		<rdfs:label xml:lang="en">ExchangeTradedOptions</rdfs:label>
-		<dct:abstract>Option contracts offered on an options exchange. Includes a wide range of asset types (instruments, indices, foreign exchange, rates, commodities etc.) and the kinds of exchange traded option that are based on these.
-		Note that some of the contract types are named similarly to their OTC equivalents, such as bond option.</dct:abstract>
+		<dct:abstract>Option contracts offered on an options exchange. Includes a wide range of asset types (instruments, indices, foreign exchange, rates, commodities etc.).</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-etd-eto</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
@@ -95,6 +96,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"/>
@@ -235,12 +237,6 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasContractDuration"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDuration"/>
 			</owl:Restriction>
@@ -261,6 +257,12 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-gty;hasGuarantor"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionGuarantor"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -360,7 +362,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -575,7 +577,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasCounterparty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;hasBuyer"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
 		<rdfs:label xml:lang="en">has counterparty</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
 		<rdfs:range rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>

--- a/FND/ProductsAndServices/ProductsAndServices.rdf
+++ b/FND/ProductsAndServices/ProductsAndServices.rdf
@@ -47,9 +47,9 @@
 		<rdfs:label>Products and Services Ontology</rdfs:label>
 		<dct:abstract>This ontology defines fundamental concepts for buyers, sellers, clients, customers, products, goods and services for use in other FIBO ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/</sm:dependsOn>
@@ -76,7 +76,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/ProductsAndServices/ProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210101/ProductsAndServices/ProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20150801/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report to replace MoneyAmount with AmountOfMoney.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified for the FIBO 2.0 RFC to add NegotiableCommodity and Consumer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified to include classes to support automated inclusion of all ISO 4217 codes published as of 2018-06-04.</skos:changeNote>
@@ -85,6 +85,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/ProductsAndServices/ProductsAndServices.rdf version of this ontology was revised to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/ProductsAndServices/ProductsAndServices.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/ProductsAndServices/ProductsAndServices.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/ProductsAndServices/ProductsAndServices.rdf version of this ontology was revised to add properties for hasBuyer and hasSeller, integrate properties with the party lattice, and clean-up circular or ambiguous definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -97,9 +98,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>buyer</rdfs:label>
-		<skos:definition>a party that acquires, or agrees to acquire, ownership (in case of goods), or benefit or usage (in case of services), in exchange for money or other consideration under a contract of sale</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/buyer.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A buyer may or may not be an end user of the product, good, or service.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>party that purchases something in exchange for money or other consideration under a contract of sale</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A buyer is the party that acquires, or agrees to acquire, ownership (in case of goods), or benefit or usage (in case of rights or services), something in the context of a sale, and may or may not be an end user of the product, good, service, or right.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>buyer</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>purchaser</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -118,8 +118,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>client</rdfs:label>
-		<skos:definition>a party that purchases professional services from, or has a formal relationship to purchase services from another party</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party that purchases professional services from, or has a formal relationship to purchase services from another party</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;ClientIdentifier">
@@ -132,30 +131,28 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>client identifier</rdfs:label>
-		<skos:definition>an identifier for a client</skos:definition>
+		<skos:definition>sequence of characters uniquely identifying a client within the context of some organization</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Commodity">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Good"/>
 		<rdfs:label>commodity</rdfs:label>
-		<skos:definition>a basic good used in commerce that is interchangeable with other commodities of the same type</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/commodity.asp</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>material resource used in commerce that is interchangeable with other commodities of the same type</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Commodities are most often used as inputs in the production of other goods or services. The quality of a given commodity may differ slightly, but it is essentially uniform across producers.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Consumer">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
 		<rdfs:label>consumer</rdfs:label>
-		<skos:definition>a party that utilizes economic goods or services</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/consumer.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.merriam-webster.com/dictionary/consumes</fibo-fnd-utl-av:adaptedFrom>
+		<rdfs:seeAlso rdf:resource="http://www.oecd.org/sti/consumer/"/>
+		<skos:definition>party that utilizes economic goods or services, typically for personal, family, or household purposes</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The general notion of a consumer includes an end user, and is not limited to a purchaser, in the distribution chain of a good or service</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;ContractualProduct">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Product"/>
 		<rdfs:label>contractual product</rdfs:label>
-		<skos:definition>a product that is realized as a contract</skos:definition>
+		<skos:definition>product that takes the form of an agreement</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>This represents the case where the product itself is a contract, such as a life insurance policy or financial instrument, rather than a product or service whose terms of use, license to use, or terms of service are specified in a product.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -163,15 +160,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ContractualProduct"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;OffTheShelfProduct"/>
 		<rdfs:label>contractual template product</rdfs:label>
-		<skos:definition>a contractual product that is finalized through specification of values for parameters defined in a template</skos:definition>
+		<skos:definition>contractual product that is finalized through specification of values for parameters defined in a template</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;CustomProduct">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Product"/>
 		<rdfs:label>custom product</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-pas-pas;OffTheShelfProduct"/>
-		<skos:definition>a product that is made to an individual&apos;s order, commissioned to a customer&apos;s specifications, or designed to order</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.merriam-webster.com/dictionary/custom-made</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>product that is made to order, commissioned based on a customer&apos;s specifications</skos:definition>
 		<fibo-fnd-utl-av:synonym>bespoke product</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>custom-made product</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>made to order product</fibo-fnd-utl-av:synonym>
@@ -186,8 +182,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>customer</rdfs:label>
-		<skos:definition>a buyer that receives or consumes products (goods or services) and has the ability to choose between different products and suppliers</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/customer.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party that receives or consumes products (goods or services) and has the ability to choose between different products and suppliers</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;CustomerIdentifier">
@@ -200,30 +195,31 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>customer identifier</rdfs:label>
-		<skos:definition>an identifier for a customer</skos:definition>
+		<skos:definition>sequence of characters uniquely identifying a customer within the context of some organization</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Good">
 		<rdfs:label>good</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
 		<owl:disjointWith rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
-		<skos:definition>any tangible thing that is not money or real estate</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/good.html</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>An inherently useful and relatively scarce tangible item produced from agricultural, construction, manufacturing, or mining activities. According to the UN Convention On Contract For The International Sale Of Goods, the term &apos;good&apos; does not include (1) items bought for personal use, (2) items bought at an auction or foreclosure sale, (3) aircraft or oceangoing vessels.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>physical, produced item over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money or real estate</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://data.oecd.org/trade/trade-in-goods.htm</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/ucc/9/9-102#goods</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>An inherently useful and relatively scarce tangible item produced from agricultural, construction, manufacturing, or mining activities. Off-the-shelf products, including off-the-shelf software products and customization of software products, are generally considered to be goods. Energy, such as electricity, is also considered to be a good from a legal perspective, and meets the criteria of being manufactured or produced via some process, including but not limited to a mining process. According to the UN Convention On Contract For The International Sale Of Goods, the term &apos;good&apos; does not include (1) items bought for personal use, (2) items bought at an auction or foreclosure sale, (3) aircraft or ocean-going vessels.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>From the Universal Commercial Code (UCC) in the United States, the term &apos;good&apos; includes (i) fixtures, (ii) standing timber that is to be cut and removed under a conveyance or contract for sale, (iii) the unborn young of animals, (iv) crops grown, growing, or to be grown, even if the crops are produced on trees, vines, or bushes, and (v) manufactured homes. The term also includes a computer program embedded in goods and any supporting information provided in connection with a transaction relating to the program if (i) the program is associated with the goods in such a manner that it customarily is considered part of the goods, or (ii) by becoming the owner of the goods, a person acquires a right to use the program in connection with the goods. The term does not include a computer program embedded in goods that consist solely of the medium in which the program is embedded. The term also does not include accounts, chattel paper, commercial tort claims, deposit accounts, documents, general intangibles, instruments, investment property, letter-of-credit rights, letters of credit, money, or oil, gas, or other minerals before extraction.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;NegotiableCommodity">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Commodity"/>
 		<rdfs:label>negotiable commodity</rdfs:label>
-		<skos:definition>a commodity that can be bought or sold in some marketplace</skos:definition>
+		<skos:definition>commodity that can be bought or sold in some marketplace</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;OffTheShelfProduct">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Product"/>
 		<rdfs:label>off-the-shelf product</rdfs:label>
-		<skos:definition>a product that is readily available from merchandise in stock, or can be quickly and easily configured to order, not specially designed or custom-made</skos:definition>
+		<skos:definition>product that is readily available from merchandise in stock, or can be quickly and easily configured to order, not specially designed or custom-made</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>COTS product</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.merriam-webster.com/dictionary/off-the-shelf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>commercial off-the-shelf product</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>commercially available off-the-shelf product</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -244,7 +240,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>precious metal</rdfs:label>
-		<skos:definition>a metal that is considered to be rare and/or have a high economic value</skos:definition>
+		<skos:definition>metal that is considered to be rare and/or have a high economic value</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;PreciousMetalIdentifier">
@@ -270,7 +266,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>precious metal identifier</rdfs:label>
-		<skos:definition>the trigraph representing the precious metal</skos:definition>
+		<skos:definition>sequence of characters uniquely identifying the precious metal in some context</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Producer">
@@ -278,12 +274,11 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;produces"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Product"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Good"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>producer</rdfs:label>
-		<skos:definition>the manufacturer of a product, also called maker</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.investorwords.com/3872/producer.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>grower, maker, fabricator, or manufacturer of some product or other good</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Product">
@@ -297,15 +292,9 @@
 				</owl:unionOf>
 			</owl:Class>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProducedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Producer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>product</rdfs:label>
-		<skos:definition>A commercially distributed good that is (1) tangible property, (2) the output or result of a fabrication, manufacturing, or production process, or (3) something that passes through a distribution channel before being consumed or used.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/product.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>commercially distributed good that is (1) tangible property, (2) the output or result of a fabrication, manufacturing, or production process, or (3) something that passes through a distribution channel before being consumed or used.</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Financial products may include contracts that are developed via a financial service-specific process, such as a life insurance policy, demand deposit account or financial instrument, for example.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;ProductIdentifier">
@@ -318,7 +307,38 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product identifier</rdfs:label>
-		<skos:definition>an identifier for a product</skos:definition>
+		<skos:definition>sequence of characters uniquely identifying a product in some context</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-pas-pas;Sale">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;Situation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;TransactionEvent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Seller"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Product"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>sale</rdfs:label>
+		<skos:definition>exchange of goods or services for money</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Seller">
@@ -330,8 +350,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>seller</rdfs:label>
-		<skos:definition>a party that makes, offers or contracts to make a sale to an actual or potential buyer</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/seller.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party that makes, offers or contracts to make a sale to an actual or potential buyer</skos:definition>
+		<fibo-fnd-utl-av:synonym>purveyor</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>vendor</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -339,13 +359,14 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;isProvisionedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+				<owl:onClass rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -355,10 +376,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>service</rdfs:label>
-		<skos:definition>a type of economic activity that is intangible, is not stored and does not result in ownership; a service is consumed at the point of sale</skos:definition>
+		<skos:definition>intangible activity performed by some party for the benefit of another party</skos:definition>
 		<skos:example>Services include intangible products, such as accounting, banking, cleaning, consultancy, education, insurance, expertise, medical treatment, or transportation services.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/services.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investorwords.com/6664/service.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Sometimes services are difficult to identify because they are closely associated with a good; such as the combination of a diagnosis with the administration of a medicine. No transfer of possession or ownership takes place when services are sold, and they (1) cannot be stored or transported, (2) are instantly perishable, and (3) come into existence at the time they are bought and consumed.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -379,8 +398,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>service agreement</rdfs:label>
-		<skos:definition>a written contract between a client and service provider whereby the service provider supplies some service in the form of time, effort, and/or expertise in exchange for compensation</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/service-contract.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>written contract between a client and service provider whereby the service provider supplies some service in the form of time, effort, and/or expertise in exchange for compensation</skos:definition>
 		<fibo-fnd-utl-av:synonym>service contract</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -396,7 +414,8 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;provisions"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Service"/>
+				<owl:onClass rdf:resource="&fibo-fnd-pas-pas;Service"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -406,8 +425,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>service provider</rdfs:label>
-		<skos:definition>a party that provides and typically provisions professional services, such as consulting, financial, legal, real estate, education, communications, storage, or processing services, to other parties, typically defined in a service agreement</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://en.wikipedia.org/wiki/Service_provider</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party that provides and typically provisions professional services, such as consulting, financial, legal, real estate, education, communications, storage, or processing services, to other parties, typically defined in a service agreement</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Supplier">
@@ -419,8 +437,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>supplier</rdfs:label>
-		<skos:definition>a party that supplies goods or services</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/supplier.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party that provides goods or services that some party wants or needs, especially over a long period of time</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>A supplier may be distinguished from a contractor or subcontractor, who commonly adds specialized input to deliverables.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -435,7 +452,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>transaction confirmation</rdfs:label>
 		<skos:definition>written communication from a seller or service provider reciting the relevant details of a transaction</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;TransactionEvent">
@@ -449,7 +465,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>transaction event</rdfs:label>
 		<skos:definition>any sale, assignment, lease, license, loan, advance, contribution, or other transfer of any interest in or right to use any property (tangible or intangible) or money, however that transaction is effected, and regardless of whether the terms of the transaction are formally documented</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;buys">
@@ -460,10 +475,26 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;buysFrom">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;isAffectedBy"/>
 		<rdfs:label>buys from</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
 		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;Seller"/>
 		<skos:definition>links a party in the role of purchaser to a party from which they have made or are planning to make a purchase</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;hasBuyer">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;hasPartyInRole"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;hasUndergoer"/>
+		<rdfs:label xml:lang="en">has buyer</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
+		<skos:definition>indicates the purchasing party in the context of a sales transaction</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;hasSeller">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;hasActor"/>
+		<rdfs:label xml:lang="en">has seller</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;Seller"/>
+		<skos:definition>indicates the vendor in the context of a sales transaction</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;isProvisionedBy">
@@ -498,6 +529,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;sellsTo">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;actsOn"/>
 		<rdfs:label>sells to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-pas-pas;Seller"/>
 		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;Buyer"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added the concept of a sale, and properties including hasBuyer and hasSeller, and cleaned up circular and ambiguous definitions in the FND Products and Services ontology; replaced several hasBuyer and hasSeller properties defined in derivatives ontologies with the new properties in FND.

Fixes: #1310 / FND-323 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


