### PR TITLE
New hygiene test -  Classes referring to multiple concepts added

### DIFF
--- a/etc/testing/hygiene/testHygiene1292.sparql
+++ b/etc/testing/hygiene/testHygiene1292.sparql
@@ -1,0 +1,17 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+##
+# banner Classes should not refer to multiple concepts.
+
+SELECT DISTINCT ?warning ?resource
+WHERE
+{
+    ?resource ?property owl:Class .
+    FILTER regex(str(?resource), "edmcouncil")
+    FILTER (REGEX(str(?resource), "/[^/]+(And|Or)[A-Z0-9][^/]+$") )
+    FILTER (!CONTAINS(str(?resource), "InvestmentOrDepositAccount"))
+    FILTER (!CONTAINS(str(?resource), "LoanOrCreditAccount"))  
+    BIND (concat ("WARN:Resource ", str(?resource), " may refer to multiple concepts.") AS ?warning)
+}


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This test is to find classes that refer to multiple concepts by means of the logical constructs of conjunctions and disjunctions.

Fixes: #1292 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


