### PR TITLE
FND-328 - Two of the public dictionary sites referenced in FIBO have been taken down and references no longer resolve

### DIFF
--- a/BE/Corporations/Corporations.rdf
+++ b/BE/Corporations/Corporations.rdf
@@ -45,9 +45,9 @@
 		<rdfs:label>Corporations Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for companies incorporated by the issuance of shares. Terms defined in this ontology are those which are applicable to all such entities. Many of these concepts form the basis of the relationships of ownership and control which obtain between entities of this type.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
@@ -66,7 +66,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200201/Corporations/Corporations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/Corporations/Corporations/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/Corporations/Corporations.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/Corporations/Corporations.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180901/Corporations/Corporations.rdf version of this ontology was modified per the FIBO 2.0 RFC to generalize certain unions where they were no longer required.</skos:changeNote>
@@ -74,6 +74,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190401/Corporations/Corporations.rdf version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190701/Corporations/Corporations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/Corporations/Corporations.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/Corporations/Corporations.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve and eliminate circular and ambiguous definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -84,20 +85,19 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-corp-corp;JointStockCompany">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;BusinessEntity"/>
 		<rdfs:label>joint stock company</rdfs:label>
-		<skos:definition>1. In the UK, the original (17th century) name for a corporation in which the liability of the owners is limited to the nominal value of the stock (shares) held by them.
-2. In the US, a corporation with unlimited liability for the shareholders. Investors in a US joint stock company receive stock (shares) which can be transferred, and can elect a board of directors, but are jointly-and-severally liable for companys debts and obligations. A US joint stock company cannot hold title to a real property.</skos:definition>
+		<skos:definition>for-profit, unincorporated business that has some charcteristics of a corporation and some features of a partnership, with ownership interests represented by shares of stock</skos:definition>
 		<skos:editorialNote>There are two kinds of joint stock company. The private company kind and the open market. The shares are usually only held by the directors and Company Secretary.</skos:editorialNote>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/joint-stock-company.html</fibo-fnd-utl-av:definitionOrigin>
+		<fibo-fnd-utl-av:explanatoryNote>1. In the UK, the original (17th century) name for a corporation in which the liability of the owners is limited to the nominal value of the stock (shares) held by them.
+2. In the US, a joint stock company is similar to a corporation, but with unlimited liability for the shareholders. Investors in a US joint stock company receive stock (shares) which can be transferred, and can elect a board of directors, but are jointly-and-severally liable for the company&apos;s debts and obligations. A US joint stock company cannot hold title to a real property.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-corp-corp;PrivatelyHeldCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-cb;StockCorporation"/>
 		<rdfs:label>privately held company</rdfs:label>
-		<skos:definition>A firm whose issued shares are all held by a family or a small group of investors and, therefore, cannot be bought by the public.</skos:definition>
-		<skos:editorialNote>Wikipedia: definition for British or Commonwealth version: A private company limited by shares is a type of company incorporated under the laws of England and Wales, Scotland, that of certain Commonwealth countries and the Republic of Ireland. It has shareholders with limited liability and its shares may not be offered to the general public, unlike those of public limited companies. Additional notes from Wikipedia: Limited by shares means that the company has shareholders, and that the liability of the shareholders to creditors of the company is limited to the capital originally invested, i.e. the nominal value of the shares and any premium paid in return for the issue of the shares by the company. A shareholders personal assets are thereby protected in the event of the companys insolvency, but money invested in the company will be lost. A limited company may be private or public. A private limited companys disclosure requirements are lighter, but for this reason its shares may not be offered to the general public (and therefore cannot be traded on a public stock exchange). This is the major distinguishing feature between a private limited company and a public limited company. Most companies, particularly small companies, are private. Private companies limited by shares are required to have the suffix Limited (often written Ltd or Ltd.) or Incorporated (Inc.) as part of their name, though the latter cannot be used in the UK or the Republic of Ireland. In the Republic of Ireland, Teoranta (Teo.) may be used instead, largely by Gaeltacht companies. Cyfyngedig (Cyf.) may be used by Welsh companies in a similar fashion.</skos:editorialNote>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/closed-corporation.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>corporation whose issued shares are all held by a family or a small group of investors and, therefore, cannot be bought by the public</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>For British or Commonwealth companies, a privately held company limited by shares is a type of company incorporated under the laws of England and Wales, Scotland, that of certain Commonwealth countries and the Republic of Ireland. It has shareholders with limited liability and its shares may not be offered to the general public, unlike those of public limited companies. Limited by shares means that the company has shareholders, and that the liability of the shareholders to creditors of the company is limited to the capital originally invested, i.e. the nominal value of the shares and any premium paid in return for the issue of the shares by the company. A shareholders personal assets are thereby protected in the event of the companys insolvency, but money invested in the company will be lost. A limited company may be private or public. A private limited companys disclosure requirements are lighter, but for this reason its shares may not be offered to the general public (and therefore cannot be traded on a public stock exchange). This is the major distinguishing feature between a private limited company and a public limited company. Most companies, particularly small companies, are private. Private companies limited by shares are required to have the suffix Limited (often written Ltd or Ltd.) or Incorporated (Inc.) as part of their name, though the latter cannot be used in the UK or the Republic of Ireland. In the Republic of Ireland, Teoranta (Teo.) may be used instead, largely by Gaeltacht companies. Cyfyngedig (Cyf.) may be used by Welsh companies in a similar fashion.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>closed corporation</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>privately held corporation</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -157,8 +157,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>religious corporation</rdfs:label>
-		<skos:definition>a not for profit organization whose objective is specific to some fundamental set of beliefs and practices generally agreed upon by a number of people, and that is incorporated under the law</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Religious_corporation</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>not-for-profit corporation whose objective is specific to some fundamental set of beliefs and practices generally agreed upon by a number of people, and that is incorporated under the law</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Often religious corporations are recognized under the law on a sub-national level, for instance by a state or provincial government. The government agency responsible for regulating such corporations is usually the official holder of records, for instance a state department of corporations.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -166,22 +165,22 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
 		<rdfs:label>has date of incorporation</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>the formal date of incorporation as stated in filing documents</skos:definition>
+		<skos:definition>indicates the formal date of incorporation as stated in filing documents</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-corp-corp;hasDateOfRegistration">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
 		<rdfs:label>has date of registration</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>a date on which the corporation has registered in some jurisdiction for regulatory and / or for tax purposes</skos:definition>
+		<skos:definition>indicates the date on which the corporation has registered in some jurisdiction for regulatory and / or for tax purposes</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-corp-corp;hasIssuedCapital">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-corp-corp;hasNominalCapital"/>
 		<rdfs:label>has issued capital</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition>The total of a corporation&apos;s shares that are held by shareholders. A corporation can, at any time, issue new shares up to the full amount of authorized share capital.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/issued-share-capital.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>indicates the aggregate value of all shares held by shareholders</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A corporation can, at any time, issue new shares up to the full amount of authorized share capital.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>has subscribed capital</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>has subscribed share capital</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
@@ -190,8 +189,8 @@
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
 		<rdfs:label>has nominal capital</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition>Nominal capital is an alternate term for authorized share capital. The maximum value of securities that a company can legally issue. This number is specified in the memorandum of association (or articles of incorporation in the US) when a company is incorporated, but can be changed later with shareholders approval.  Authorized share capital may be divided into (1) Issued capital - par value of the shares actually issued, (2) Paid up capital - money received from the shareholders in exchange for shares, and (3) Uncalled capital - money remaining unpaid by the shareholders for the shares they have bought.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/authorized-share-capital.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>indicates the aggregate value of all shares that have been authorized by a board of directors, including shares held by investors, shares held internally by the company and any unissued shares</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Nominal capital is an alternate term for authorized share capital. The maximum value of securities that a company can legally issue. This number is specified in the memorandum of association (or articles of incorporation in the US) when a company is incorporated, but can be changed later with shareholders approval.  Authorized share capital may be divided into (1) Issued capital - par value of the shares actually issued, (2) Paid up capital - money received from the shareholders in exchange for shares, and (3) Uncalled capital - money remaining unpaid by the shareholders for the shares they have bought.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>has authorized capital</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>has authorized stock</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>has nominal share capital</fibo-fnd-utl-av:synonym>

--- a/BE/FunctionalEntities/Publishers.rdf
+++ b/BE/FunctionalEntities/Publishers.rdf
@@ -35,9 +35,9 @@
 		<rdfs:label>Publishers Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for publishers of information, including entities whose primary function is to publish, and entities (whether or not they are publishers in that sense) which are in the role of the publisher of some information. This ontology also includes the published information itself, i.e. the publication.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2018 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-be-fct-pub</sm:fileAbbreviation>
@@ -49,9 +49,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20180801/FunctionalEntities/Publishers/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/FunctionalEntities/Publishers/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20140501/FunctionalEntities/Publishers.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/FunctionalEntities/Publishers.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/FunctionalEntities/Publishers.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -59,7 +60,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Document"/>
 		<rdfs:label>publication</rdfs:label>
 		<skos:definition>anything made public by print (such as a newspaper, magazine, pamphlet, letter, telegram, via computer modem or program, or in a poster, brochure or pamphlet), orally, or by broadcast (radio, television)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://legal-dictionary.thefreedictionary.com/Publication</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-fct-pub;Publisher">
@@ -72,8 +72,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>publisher</rdfs:label>
-		<skos:definition>a party responsible for the printing or distribution of digital or printed information</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/publisher.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party responsible for the printing or distribution of digital or printed information</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Typically this role is filled by some entity whose function is that of a publishing house (sometimes also referred to as a publisher, in that different sense). Publishers may also include banks, government agencies and the like.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -87,7 +86,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>publishing house</rdfs:label>
-		<skos:definition>some organization whose principal role is to publish information</skos:definition>
+		<skos:definition>formal organization whose principal business is to publish information</skos:definition>
 		<skos:scopeNote>Publishing house in the sense intended here includes any organization whose role is to make information publicly available whether by disemminating it directly or indirectly and regardless of the type of information. These include organizations whose primary function is that of a market data vendor.</skos:scopeNote>
 	</owl:Class>
 	
@@ -96,7 +95,7 @@
 		<rdfs:domain rdf:resource="&fibo-be-fct-pub;Publication"/>
 		<rdfs:range rdf:resource="&fibo-be-fct-pub;Publisher"/>
 		<owl:inverseOf rdf:resource="&fibo-be-fct-pub;publishes"/>
-		<skos:definition>some person or organization whose role it has been to publish this information</skos:definition>
+		<skos:definition>indicates the party in the role of issuing the information</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-fct-pub;isPublishedBy">
@@ -111,7 +110,6 @@
 		<rdfs:domain rdf:resource="&fibo-be-fct-pub;Publisher"/>
 		<rdfs:range rdf:resource="&fibo-be-fct-pub;Publication"/>
 		<skos:definition>prepares and issues material for public consumption</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.thefreedictionary.com/publish</fibo-fnd-utl-av:definitionOrigin>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/BE/GovernmentEntities/GovernmentEntities.rdf
+++ b/BE/GovernmentEntities/GovernmentEntities.rdf
@@ -53,9 +53,9 @@
 		<rdfs:label>Government Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for representing polities and government entities and their relations.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/</sm:dependsOn>
@@ -78,7 +78,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200701/GovernmentEntities/GovernmentEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/GovernmentEntities/GovernmentEntities/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was added to Business Entities, per the issue resolutions identified in the FIBO BE 1.1 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.2 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20170201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
@@ -86,14 +86,14 @@
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20181201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to reflect the move of hasObjective to FND to enable higher level reuse and eliminate a reasoning error.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20190501/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to eliminate duplication of concepts in LCC and merge the countries ontology with locations.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200301/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to replace isAppointedBy with isDesignatedBy due to a name change in Relations, and to add a class for devolved government.</skos:changeNote>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200701/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve and revise circular or ambiguous definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;BranchOfGovernment">
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;GovernmentBody"/>
 		<rdfs:label>branch of government</rdfs:label>
-		<skos:definition>a division of the government of a state, with separate and independent powers and areas of responsibility so that the powers of one branch are not in conflict with the powers associated with the other branches</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Separation_of_powers</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>division of the government of a state, with separate and independent powers and areas of responsibility so that the powers of one branch are not in conflict with the powers associated with the other branches</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.usa.gov/branches-of-government</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
@@ -101,16 +101,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;Government"/>
 		<rdfs:label>devolved government</rdfs:label>
 		<skos:definition>government and the politicians that that run a subnational territory with powers that may be temporary and reversible, ultimately residing with the central government</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Devolution</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;ExecutiveBranch">
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;BranchOfGovernment"/>
 		<rdfs:label>executive branch</rdfs:label>
-		<skos:definition>the branch of government that has its authority and responsibility for the daily administration of the state</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Executive_(government)</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>the branch of government that is authorized and responsible for the daily administration of the government</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.usa.gov/branches-of-government</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The executive branch executes, or enforces the law.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>The executive branch executes and enforces the law.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;FederalGovernment">
@@ -132,8 +130,7 @@
 			</owl:Class>
 		</rdfs:subClassOf>
 		<rdfs:label>federal government</rdfs:label>
-		<skos:definition>a union of states under a central government distinct from the individual governments of the separate states</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Federation</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>union of states under a central government distinct from the individual governments of the separate states</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>A federation is a political entity characterized by a union of partially self-governing states or regions under a central (federal) government. In a federation, the self-governing status of the component states, as well as the division of power between them and the central government, are typically constitutionally entrenched and may not be altered by a unilateral decision of either party, the states or the federal political body.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -171,9 +168,8 @@
 			</owl:Class>
 		</rdfs:subClassOf>
 		<rdfs:label>federated sovereignty</rdfs:label>
-		<skos:definition>a political entity characterized by a union of partially self-governing states or regions under a central (federal) government</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Federation</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Federal entity in the sense of a legal entity, that is, what it is that incurs debt for a federal government, i.e. the Federal entity in the sense of the legal entity, as distinct from the Federal government. It is identified as a legal entity because it is able to incur debt in its own right.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>polity characterized by a union of partially self-governing states or regions under a central (federal) government</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The federated sovereignty is the legal entity that can incur debt for a federal government, as distinct from the Federal government.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;Government">
@@ -218,8 +214,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>government agency</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
-		<skos:definition>a permanent or semi-permanent organization, often an appointed commission, in the machinery of government that is responsible for the oversight and administration of specific functions</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Government_agency</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>permanent or semi-permanent organization, often an appointed commission, in the machinery of government that is responsible for the oversight and administration of specific functions</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>There is a notable variety of agency types. Although usage differs, a government agency is normally distinct both from a department or ministry, and other types of public body established by government. The functions of an agency are normally executive in character, since different types of organizations (such as commissions) are most often constituted in an advisory role; this distinction is often blurred in practice however.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -238,7 +233,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>government appointee</rdfs:label>
-		<skos:definition>an individual appointed by government decree to lead, or participate in some capacity in a government body</skos:definition>
+		<skos:definition>individual decignated by government decree to lead, or participate in some capacity in a government body</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;GovernmentBody">
@@ -250,8 +245,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>government body</rdfs:label>
-		<skos:definition>a formal organization that is an agency, instrumentality, or other body of supranational, national, federal, state, or local government, including certain multijurisdictional agencies and departments that carry out the business of government</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://definitions.uslegal.com/g/government-entity/</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>formal organization that is an agency, instrumentality, or other body of a supranational, national, federal, state, or local government, including certain multijurisdictional agencies and departments that carry out the business of government</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Identifying government bodies is a pre-requisite for identifying government officials.  This information is needed to help ensure compliance with applicable laws relating to bribery or corruption, including the U.S. Foreign Corrupt Practices Act (FCPA), the UK Bribery Act 2010 (UKBA), the U.S. Bank Bribery Act (Bribery Act), and other anti-bribery and corruption laws in the jurisdictions where financial institutions conduct business.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -264,8 +258,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>government department</rdfs:label>
-		<skos:definition>a specialized organization responsible for a sector of government public administration</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Ministry</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>specialized organization responsible for a sector of government public administration</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;GovernmentMinister">
@@ -274,7 +267,6 @@
 		<rdfs:label>government minister</rdfs:label>
 		<skos:definition>government official that is an executive, who is either appointed or elected to a high office in the government</skos:definition>
 		<skos:example>Minister of Finance, Secretary of State, Attorney General of California</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.thefreedictionary.com/government+minister</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;GovernmentOfficial">
@@ -298,8 +290,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>government official</rdfs:label>
-		<skos:definition>a person elected or appointed to administer some aspect of a government</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.thefreedictionary.com/government+officials</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>person elected or appointed to administer some aspect of a government</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;Instrumentality">
@@ -318,8 +309,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>instrumentality</rdfs:label>
-		<skos:definition>an organization that serves a public purpose and is closely tied to a government, but is not a government agency</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/i/instrumentality.asp</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>organization that serves a public purpose and is closely tied to a government, but is not a government agency</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Many instrumentalities are private companies, and some are chartered directly by state or federal government. Instrumentalities are subject to a unique set of laws that shape their activities.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -332,8 +322,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>judiciary</rdfs:label>
-		<skos:definition>a branch of government that comprises the system of courts that interprets and applies the law in the name of the supranational, national, federal, or regional government, depending on its jurisdiction</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Judiciary</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>branch of government that comprises the system of courts that interprets and applies the law in the name of the supranational, national, federal, or regional government, depending on its jurisdiction</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The judiciary also provides a mechanism for the resolution of disputes. Under the doctrine of the separation of powers, the judiciary generally does not make law (that is, in a plenary fashion, which is the responsibility of the legislature) or enforce law (which is the responsibility of the executive), but rather interprets law and applies it to the facts of each case.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -341,7 +330,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;BranchOfGovernment"/>
 		<rdfs:label>legislature</rdfs:label>
 		<skos:definition>the law-making body of a political unit, usually a national government, that has power to enact, amend, and repeal public policy</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Legislature</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Laws enacted by legislatures are known as legislation. Legislatures observe and steer governing actions and usually have exclusive authority to amend the budget or budgets involved in the process.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -360,8 +348,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>municipal entity</rdfs:label>
-		<skos:definition>a polity that typically represents a city, township, or other administrative subdivision having corporate status and powers of self-government or jurisdiction</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Municipality</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>polity that typically represents a city, township, or other administrative subdivision having corporate status and powers of self-government or jurisdiction</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Municipal entity in the sense of a legal entity, that is, what it is that incurs debt for a municipality, as distinct from the Municipal government. A municipal entity has a Government which sets laws applicable within the geographical area corresponding to its jurisdiction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>municipality</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -375,8 +362,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>municipal government</rdfs:label>
-		<skos:definition>the government of a municipality</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.thefreedictionary.com/municipal+government</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>regional government of a city, township, or other administrative subdivision</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;NationalGovernment">
@@ -388,9 +374,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>national government</rdfs:label>
-		<skos:definition>a government and the politicians that that run a country as a whole (as opposed to local government)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://dictionary.reference.com/browse/national+government</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.collinsdictionary.com/dictionary/english/national-government</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>government and the politicians that that run a country as a whole (as opposed to local government)</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;Polity">
@@ -409,8 +393,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>polity</rdfs:label>
-		<skos:definition>a legal person that is a supranational entity, crown, state, or subordinate civil authority, such as a province, prefecture, county, municipality, city, or district representing the people of that entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Polity</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>legal person that is a supranational entity, crown, state, or subordinate civil authority, such as a province, prefecture, county, municipality, city, or district representing the people of that entity</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;RegionalGovernment">
@@ -422,8 +405,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>regional government</rdfs:label>
-		<skos:definition>an administrative body for a small geographic area, such as a county, smaller town, or other similar community</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/local-government.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>administrative body for a geographic area, such as a county, smaller town, or other similar community</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>A local government will typically only have control over their specific geographical region, and cannot pass or enforce laws that will affect a wider area. Local governments can elect officials, enact taxes, and do many other things that a national government would do, just on a smaller scale.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>local government</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -444,9 +426,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>regional sovereignty</rdfs:label>
-		<skos:definition>the legal person that corresponds to an administrative division, administrative unit, administrative entity or country subdivision (or, sometimes, geopolitical division or subnational entity), that has the capacity to incur debt, issue contracts, and enter into relations with other similar entities</skos:definition>
+		<skos:definition>legal person that corresponds to an administrative division, administrative unit, administrative entity or country subdivision (or, sometimes, geopolitical division or subnational entity), that has the capacity to incur debt, issue contracts, and enter into relations with other similar entities</skos:definition>
 		<skos:example>A country may be divided into provinces, which, in turn, are divided into counties, which, in turn, may be divided in whole or in part into municipalities; and so on.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://en.wikipedia.org/wiki/Administrative_division</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;SovereignState">
@@ -464,8 +445,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>sovereign state</rdfs:label>
-		<skos:definition>a nonphysical juridical entity that is represented by one centralized government that has sovereignty over a geographic area</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/sovereign-authority.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>non-physical juridical entity that is represented by one centralized government that has sovereignty over a geographic area</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>A legal entity that is represented by one centralized government, has a permanent population, defined territory, and the capacity to enter into relations with other sovereign states.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -485,7 +465,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>supranational entity</rdfs:label>
-		<skos:definition>a governmental or non-governmental entity that is established by international law or treaty or incorporated at an international level</skos:definition>
+		<skos:definition>governmental or non-governmental entity that is established by international law or treaty or incorporated at an international level</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 20275:2017, Financial services - Entity legal forms (ELF), First Edition, July 2017.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom>Kiljunen, Kimmo (2004). The European Constitution in the Making. Centre for European Policy Studies. pp. 21-26. ISBN 978-92-9079-493-6</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A supranational union is a supranational polity which lies somewhere between a confederation that is an association of states and a federation that is a state.  Unlike states in a federal super-state, member states retain ultimate sovereignty, although some sovereignty is shared with, or ceded to, the supranational body.</fibo-fnd-utl-av:explanatoryNote>
@@ -494,15 +474,14 @@
 	<owl:Class rdf:about="&fibo-be-ge-ge;TribalArea">
 		<rdfs:subClassOf rdf:resource="&lcc-cr;GeopoliticalEntity"/>
 		<rdfs:label>tribal area</rdfs:label>
-		<skos:definition>a designation for an area of land managed by a group of indigenous people (tribe) rather than by the sovereign state or regional governmental entity in which the tribal area is geographically located</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Indian_reservation</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>designation for geographic region administered by a group of indigenous people rather than by a sovereign state or regional governmental entity</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;TribalEntity">
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;Polity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-ge-ge;hasPartialSovereigntyOver"/>
+				<owl:onProperty rdf:resource="&fibo-be-ge-ge;hasSharedSovereigntyOver"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;TribalArea"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -513,8 +492,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>tribal entity</rdfs:label>
-		<skos:definition>a legal entity that represents fundamental unit of sovereign tribal (indigenous) government</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/List_of_federally_recognized_tribes_by_state</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>legal entity that represents fundamental unit of sovereign tribal (indigenous) government</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Any indigenous group or community which is recognized as having rights and obligations independent of the central government.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -527,8 +505,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>tribal government</rdfs:label>
-		<skos:definition>a government representing a group of indigenous people that has legal authority to govern those people, including authority to legislate the existance of tribal entities</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/local-government.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>government representing a group of indigenous people that has legal authority to govern those people, including authority to legislate the existance of tribal entities</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-ge-ge;hasFullSovereigntyOver">
@@ -562,7 +539,6 @@
 		<rdfs:domain rdf:resource="&fibo-be-ge-ge;Polity"/>
 		<rdfs:range rdf:resource="&lcc-cr;GeopoliticalEntity"/>
 		<skos:definition>relates a polity to a geopolitical entity where the polity exercises dominion and authority of a political state</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/sovereignty.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-ge-ge;isElectedBy">
@@ -588,7 +564,6 @@
 	<owl:ObjectProperty rdf:about="&fibo-be-ge-ge;isRepresentedBy">
 		<rdfs:label>is represented by</rdfs:label>
 		<skos:definition>relates a system of governance to its chosen representatives</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://dictionary.reference.com/browse/representative</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-fnd-aap-ppl;IdentityDocument">

--- a/BE/LegalEntities/LegalPersons.rdf
+++ b/BE/LegalEntities/LegalPersons.rdf
@@ -51,9 +51,9 @@
 		<rdfs:label>Legal Persons Ontology</rdfs:label>
 		<dct:abstract>This ontology defines legal personhood concepts. A legal person as defined here is any natural person or organization which is capable of accruing liability on its own part.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-be-le-lp</sm:fileAbbreviation>
 		<sm:filename>LegalPersons.rdf</sm:filename>
@@ -71,7 +71,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201101/LegalEntities/LegalPersons/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/LegalEntities/LegalPersons/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/LegalEntities/LegalPersons.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/LegalEntities/LegalPersons.rdf version of this ontology was modified per the FIBO 2.0 RFC to normalize restrictions on business license.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/LegalEntities/LegalPersons.rdf version of this ontology was modified to rationalize natural person and legally capable person in a new concept, namely legally competent natural person, simplify / merge the legal person and formal organization class hierarchies, and correct certain definitions, including power of attorney.</skos:changeNote>
@@ -80,6 +80,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/LegalEntities/LegalPersons.rdf version of this ontology was modified to clarify the definition of legal person.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200101/LegalEntities/LegalPersons.rdf version of this ontology was modified to move the concept of a signatory and related properties to the executives ontology for better semantic integration.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/LegalEntities/LegalPersons.rdf version of this ontology was modified to augment the definition of a contract party to be a legal person.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201101/LegalEntities/LegalPersons.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -99,9 +100,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>business entity</rdfs:label>
-		<skos:definition>an entity that is formed and administered as per commercial law in order to engage in business activities</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://en.wikipedia.org/wiki/Types_of_business_entity</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>entity that is formed and administered as per commercial law in order to engage in business activities</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>There are many types of business entities defined in the legal systems of various countries. These include corporations, cooperatives, partnerships, sole proprietorships, sole traders, limited liability companies, certain trusts and trust companies, and so forth. The rules vary by country and by state or province. Some of the more widely recognized types in the US, UK, and EU are defined in FIBO, by region. However, the regulations governing particular types of entity, even those described as roughly equivalent, differ from jurisdiction to jurisdiction.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -121,8 +120,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>business license</rdfs:label>
-		<skos:definition>a license that allows the holder to conduct business or carry out a specific profession within some jurisdiction for some period of time</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>license that allows the holder to conduct business or carry out a specific profession within some jurisdiction for some period of time</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;CharteredLegalPerson">
@@ -145,7 +143,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>legal entity</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
-		<skos:definition>a legal person that is a partnership, corporation, or other organization having the capacity to negotiate contracts, assume financial obligations, and pay off debts, organized under the laws of some jurisdiction</skos:definition>
+		<skos:definition>legal person that is a partnership, corporation, or other organization having the capacity to negotiate contracts, assume financial obligations, and pay off debts, organized under the laws of some jurisdiction</skos:definition>
 		<skos:example>Examples of eligible legal entities include, without limitation:
 -   all financial intermediaries;
 -   banks and finance companies;
@@ -155,8 +153,6 @@
 -   all entities under the purview of a financial regulator and their affiliates, subsidiaries and holding companies;
 -   counterparties to financial transactions.</skos:example>
 		<skos:scopeNote>The term &apos;legal entities&apos; includes, but is not limited to, unique parties that are legally or financially responsible for the performance of financial transactions or have the legal right in their jurisdiction to enter independently into legal contracts, regardless of whether they are incorporated or constituted in some other way (e.g. trust, partnership, contractual). It excludes natural persons, but includes governmental organizations and supranationals.</skos:scopeNote>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012, definition of legal entity</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>Black&apos;s Law Dictionary Free Online, see http://thelawdictionary.org/juridical-person/</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 17442, Financial services - Legal Entity Identifier (LEI), first edition, 2012-06-01, section 3.1</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>artificial person</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>juridical entity</fibo-fnd-utl-av:synonym>
@@ -188,9 +184,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-aap-ppl;Person"/>
 		<rdfs:label>legally competent natural person</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-aap-ppl;IncapacitatedAdult"/>
-		<skos:definition>a person who is considered competent, under the circumstances, to enter into a contract, conduct business, or participate in other activities that generally require the mental ability to understand problems and make decisions on his or her own behalf</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Black&apos;s Law Dictionary (U.S.)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>the Contract Act of 1872 (India)</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>person who is considered competent, under the circumstances, to enter into a contract, conduct business, or participate in other activities that generally require the mental ability to understand problems and make decisions on his or her own behalf</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The definition of mental competence, and potentially of the age of majority, is a function of the situation and law in a given jurisdiction.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -198,9 +192,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Objective"/>
 		<rdfs:label>not for profit objective</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-be-le-lp;ProfitObjective"/>
-		<skos:definition>an objective that reflects the charitable, educational, religious, humanitarian, public services, or other not for profit goals of an organization</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/n/not-for-profit.asp</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>objective that reflects the charitable, educational, religious, humanitarian, public services, or other not for profit goals of an organization</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The objective of all business activities is not to earn profits for its owners. All of the money earned by or donated to a not for profit organization is used in pursuing the organization&apos;s objectives.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>nonprofit objective</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -222,17 +214,13 @@
 		</rdfs:subClassOf>
 		<rdfs:label>power of attorney</rdfs:label>
 		<skos:definition>legal authorization given by one party (the principal) to another (the agent or attorney-in-fact) to perform certain acts on the principal&apos;s behalf</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/power-of-attorney.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The appointment can be effective immediately or if the principal is unable to make decisions or perform certain actions on their own.  It may be a (1) general power of attorney that authorizes the agent to act generally on behalf of the principal, such as to transfer funds from one account to another, pay debts, make investments, and so forth, or (2) limited to a specific act or situation, such as for management of an individual&apos;s finances in a single account, such as a brokerage account, or for management of healthcare. Decisions made and actions taken by an attorney in fact (within the scope of his or her authority) are legally binding on the principal.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;ProfitObjective">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;BusinessObjective"/>
 		<rdfs:label>profit objective</rdfs:label>
-		<skos:definition>an objective that reflects pursuit of a financial benefit that may be realized when the amount of revenue gained from a business activity exceeds the expenses, costs and taxes needed to sustain that activity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/profit.asp</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>objective that reflects pursuit of a financial benefit that may be realized when the amount of revenue gained from a business activity exceeds the expenses, costs and taxes needed to sustain that activity</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Any profit that is gained goes to the business&apos;s owners, who may or may not decide to spend it on the business.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>for profit objective</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>profit motive</fibo-fnd-utl-av:synonym>
@@ -241,23 +229,20 @@
 	<owl:Class rdf:about="&fibo-be-le-lp;PublicPurpose">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Objective"/>
 		<rdfs:label>public purpose</rdfs:label>
-		<skos:definition>an objective that reflects values generally thought to be shared by and that is intended to benefit the populace as a whole</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.yourdictionary.com/public-purpose</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>objective that reflects values generally thought to be shared by and that is intended to benefit the populace as a whole</skos:definition>
 		<fibo-fnd-utl-av:synonym>public interest</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;ReligiousObjective">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;NotForProfitObjective"/>
 		<rdfs:label>religious objective</rdfs:label>
-		<skos:definition>a not for profit objective that reflects the religious goals of an organization</skos:definition>
+		<skos:definition>not-for-profit objective that reflects the religious goals of an organization</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;StatutoryBody">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:label>statutory body</rdfs:label>
-		<skos:definition>a body set up by a government to consider evidence and make judgements in some field of activity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.collinsdictionary.com/dictionary/english/statutory-body</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>legal entity established by a government to consider evidence and make judgements in some field of activity</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lp;isOrganizedIn">

--- a/BE/OwnershipAndControl/CorporateOwnership.rdf
+++ b/BE/OwnershipAndControl/CorporateOwnership.rdf
@@ -46,8 +46,8 @@
 		<dct:abstract>This ontology defines concepts relating to corporation-specific ownership. Roles are defined in terms of the ownership enjoyed by the party, and are the specific examples of these concepts as they apply to companies incorporated by the issuance of shares.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/</sm:dependsOn>
@@ -68,13 +68,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/CorporateOwnership/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/OwnershipAndControl/CorporateOwnership/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified per the FIBO 2.0 RFC to reference shareholders&apos; equity in the definition of a shareholder.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to generalize the definition of beneficial owner rather than limiting it to shareholding and eliminate a duplicate restriction on shareholder.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190201/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to modify the inheritance hierarchy for beneficial owner to replace owner with controlling party as one of its parent classes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to replace isEquityHeldBy with its parent, isHeldBy, eliminate redundant classes that were not used anywhere, and clean up a few definitions to be less ambiguous, not circular, and to conform with ISO 704.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200901/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was revised to simplify the contract party hierarchy and add concepts related to beneficial ownership.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was revised to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -158,7 +159,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>shareholding</rdfs:label>
 		<skos:definition>financial asset that takes the form of shares considered as a unit</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/company-shareholdings.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The legal power of a shareholder varies in proportion to their shareholding. Typically, ten percent and below stockholding provides no protection. Fifteen percent stockholding may give the power to petition courts against changing the shares class rights. Up to 49.9 percent stockholding normally gives power to demand calling of an extraordinary general meeting. Fifty percent and over stockholding gives power to fire a director and force out minority stockholders by acquiring their shares as per the rules of the firm. Holder of 75 percent of the stock has the power to change the articles and memorandum of association and the firms name, reduce the share capital, allow the firm to buy its own shares from other stockholders, and to shut down the business. One hundred percent stockholding of course gives total power under the corporate legislation.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -58,8 +58,8 @@
 		<dct:abstract>This ontology defines concepts relating to executives and their formal capacities. The concepts defined in this ontology cover types of corporate officers, board members and the like, along with the capacities in terms of which those party roles are defined, and the kinds of entity (principally natural persons) that are able to perform in those roles.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
@@ -86,7 +86,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/Executives/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/OwnershipAndControl/Executives/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/Executives.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160801/OwnershipAndControl/Executives.rdf version of this ontology was modified per the FIBO 2.0 RFC to fix reasoning issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/Executives.rdf version of this ontology was modified to clarify the definition of responsible party.</skos:changeNote>
@@ -95,6 +95,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/Executives.rdf version of this ontology was modified to integrate concepts related to authorization, including board membership and the concept of a signatory (moved from legal persons) to improve semantics; simplify the ontology, and normalize definitions to be ISO 704 compliant.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/Executives.rdf version of this ontology was modified to correct the label on hasAuthorizedParty.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200701/OwnershipAndControl/Executives.rdf version of this ontology was modified to add PrincipalParty as the parent of CEO and others.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/Executives.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -379,7 +380,6 @@
 		<rdfs:label>chief executive officer</rdfs:label>
 		<skos:definition>top corporate officer responsible for an organization&apos;s overall operations and performance</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CEO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/chief-executive-officer-CEO.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>He or she is the leader of the firm, serves as the main link between the board of directors (the board) and the firm&apos;s various parts or levels, and is held solely responsible for the firm&apos;s success or failure. One of the major duties of a CEO is to maintain and implement corporate policy, as established by the board. Also called President or managing director, he or she may also be the chairman (or chairperson) of the board.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -389,7 +389,6 @@
 		<rdfs:label>chief financial officer</rdfs:label>
 		<skos:definition>senior-most corporate officer responsible for financial control and planning for an organization or project</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CFO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/chief-financial-officer-CFO.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>He or she is in charge of all accounting functions including (1) credit control, (2) preparing budgets and financial statements, (3) coordinating financing and fund raising, (4) monitoring expenditure and liquidity, (5) managing investment and taxation issues, (6) reporting financial performance to the board, and (7) providing timely financial data to the CEO. Also called chief finance officer, comptroller, controller, or finance controller.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -397,7 +396,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
 		<rdfs:label>company law</rdfs:label>
 		<skos:definition>legislation under which the formation, registration or incorporation, governance, and dissolution of a firm is administered and controlled</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/company-law.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>corporate law</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -405,7 +403,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;CorporateOfficer"/>
 		<rdfs:label>company secretary</rdfs:label>
 		<skos:definition>corporate officer appointed by the directors of an organization, responsible for ensuring compliance with legal obligations related to corporate governance</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/company-secretary.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>His or her formal duties include (1) calling meetings, (2) recording minutes of the meetings, (3) keeping statutory record books, (4) proper payment of dividend and interest payments, and (5) proper drafting and execution of agreements, contracts, and resolutions.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>corporate secretary</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -429,7 +426,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>executive</rdfs:label>
 		<skos:definition>person appointed and given the responsibility to manage the affairs of an organization and the authority to make decisions within specified role-specific boundaries</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/executive.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-exec;ExecutiveBoardMember">
@@ -548,8 +544,6 @@
 		<skos:definition>chooses someone, or a group of individuals, to hold office or some other position by voting</skos:definition>
 		<skos:editorialNote>In the case of an election of the members of a board of directors, the bylaws state the manner in which that process is effected. The candidate members may be recommended by the board or other proxy and are then elected by the shareholders. A similar process may be conducted to elect outside auditors.</skos:editorialNote>
 		<skos:example>the election of officers of an association, the election of directors by the shareholders</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/elect.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investorwords.com/9558/election.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasAuthorizedParty">
@@ -604,8 +598,7 @@
 		<rdfs:label>has responsibility</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
 		<rdfs:range rdf:resource="&fibo-fnd-law-lcap;Duty"/>
-		<skos:definition>identifies a particular burden of obligation upon one who is responsible</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://dictionary.reference.com/browse/responsibility</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>specifies a commitment or obligation that an independent party has</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasResponsibleParty">
@@ -613,7 +606,7 @@
 		<rdfs:label>has responsible party</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;ResponsibleParty"/>
-		<skos:definition>some party that has some defined responsibility with respect to the formal organization</skos:definition>
+		<skos:definition>identifies a party that has some assignment, commitment or obligation with respect to the formal organization</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasSigningAuthorityFor">
@@ -680,8 +673,7 @@
 		<rdfs:domain rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
 		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
 		<skos:definition>appoints or proposes for appointment to an office or place</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.merriam-webster.com/dictionary/nominate</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Note that nominates is defined as a relation between two parties-in-role (the range of which could be a corporation or partnership in the case of an auditor), whereas appoints between independent parties.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:usageNote>Note that nominates is defined as a relation between two parties-in-role (the range of which could be a corporation or partnership in the case of an auditor), whereas appoints between independent parties.</fibo-fnd-utl-av:usageNote>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/BE/Trusts/Trusts.rdf
+++ b/BE/Trusts/Trusts.rdf
@@ -42,8 +42,8 @@
 		<dct:abstract>This ontology defines the fundamental common terms for trusts. Trusts are entities set up in terms of the applicable local statutes goerning trusts, and have as a minimum three specific, defined parties, known in many jurisdictions as trustor (sometimes sponsor), trustee and beneficiary. The terms in this ontology may be extended as necessary to represent specific types of trust, for example in the funds arena.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/</sm:dependsOn>
@@ -60,12 +60,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/Trusts/Trusts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/Trusts/Trusts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/Trusts/Trusts.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20150201/Trusts/Trusts.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/Trusts/Trusts.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20181101/Trusts/Trusts.rdf version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200301/Trusts/Trusts.rdf version of this ontology was modified to add a number of kinds of trusts, clean-up extraneous concepts, and eliminate circularity and ambiguity in definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/Trusts/Trusts.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -127,7 +128,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trust</rdfs:label>
 		<skos:definition>fiduciary relationship and legal entity in which one party, known as a trustor, gives another party, the trustee, the right to hold title to and manage assets for the benefit of a third party, the beneficiary</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;TrustAgreement">
@@ -152,7 +152,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trust agreement</rdfs:label>
 		<skos:definition>formal agreement that establishes a trust, whereby the trustor(s) gives the trustee(s) the responsibility to hold and manage assets for the beneficiary(ies)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A trust agreement typically states the (1) purpose for which the trust was established and fulfillment of which will terminate the trust, (2) details of the assets placed in the trust, (3) powers and limitations of the trustees, their reporting requirements, and other associated provisions, and (4) may also specify the trustees&apos; compensation, if any. A trust agreement involving real estate requires its exact description and the trustor&apos;s express, written consent to create the trust to be valid.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>trust deed</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>trust document</fibo-fnd-utl-av:synonym>
@@ -174,8 +173,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trust beneficiary</rdfs:label>
 		<skos:definition>party for whose interest (benefit) an annuity, assignment (such as a letter of credit), contract, insurance policy, judgment, promise, trust, will, etc., is made</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/beneficiary.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;TrustFundManager">
@@ -233,9 +230,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trustee</rdfs:label>
-		<skos:definition>party that holds, manages, invests assets for the benefit of another</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investorwords.com/5086/trustee.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party that holds and manages assets for the benefit of another</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The trustee is legally obliged to make all trust-related decisions with the beneficiary&apos;s interests in mind, and may be liable for damages in the event of not doing so. Trustees may be entitled to a payment for their services, if specified in the trust agreement. In the specific case of the bond market, a trustee administers a bond issue for a borrower, and ensures that the issuer meets all the terms and conditions associated with the borrowing.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -261,8 +256,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trustor</rdfs:label>
 		<skos:definition>party that establishes a trust and places property under the protection and management of one or more trustees for the benefit of at least one beneficiary</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/trustor.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>It is not always necessary to identify the trustor who may be also be a trustee and/or one of the beneficiaries. In legal parlance, a trustor is called a settlor in the UK and a grantor in the US, whereas in common usage he or she may also be called a creator, donor, initiator, owner, or trust maker.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>grantor</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>settlor</fibo-fnd-utl-av:synonym>

--- a/FBC/FunctionalEntities/FinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/FinancialServicesEntities.rdf
@@ -70,8 +70,8 @@
 		<dct:abstract>This ontology defines basic financial service providers, such as holding companies, financial institutions (both depository and non-depository institutions), and clearing houses at a relatively general level. Nuances specific to the institutions located in a specific country are defined in jurisdiction specific dependent ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/</sm:dependsOn>
@@ -103,7 +103,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/FinancialServicesEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210101/FunctionalEntities/FinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified per the FIBO 2.0 RFC, including, but not limited to, the addition of trade settlement concepts and generalizing the concept of a credit union.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified to refine the concept of a credit union and generalize the definition of an underwriter.</skos:changeNote>
@@ -112,6 +112,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to enable merging business and functional business entity in BE.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to add missing functional entities and related properties, and eliminate circular or ambiguous definitions where possible.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201201/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to eliminate references to external dictionary sites that no longer resolve and address additional circular definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -156,7 +157,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>banking product</rdfs:label>
 		<skos:definition>a product provided to consumers and businesses by a bank or similar depository institution such as a checking account, savings account, certificate of deposit, debit or pre-paid card, or credit card</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/r/retailbanking.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BankingService">
@@ -169,7 +169,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>banking service</rdfs:label>
 		<skos:definition>a financial service offered by a bank or similar depository institution, such as a cash management service, foreign exchange service, lending or credit service, investment service, insurance service, merchant service, payroll service, etc.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/r/retailbanking.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BrokerageFirm">
@@ -316,8 +315,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>central bank</rdfs:label>
 		<skos:definition>a financial institution that is the monetary authority and major regulatory bank for a country (or group of countries)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://lexicon.ft.com/Term?term=central-bank</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/centralbank.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Its functions include issuing and managing the country&apos;s currency, controlling monetary policy and supervising money market operations, managing exchange and gold reserves, acting as lender of last resort to commercial banks, and providing banking services to the government. Central banks are state-controlled but are increasingly being given an independent status to insulate them from partisan politics.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -327,7 +324,6 @@
 		<rdfs:seeAlso rdf:resource="http://www.esma.europa.eu/system/files/EACH2.pdf"/>
 		<skos:definition>a clearing house that helps facilitate trading in derivatives and equities markets</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CCP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/ccph.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>These clearing houses are often operated by the major banks in the country. The house&apos;s prime responsibility is to provide efficiency and stability to the financial markets that they operate in.
 
 There are two main processes that are carried out by CCPs: clearing and settlement of market transactions. Clearing relates to identifying the obligations of both parties on either side of a transaction. Settlement occurs when the final transfer of securities and funds occur.
@@ -399,7 +395,6 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<rdfs:label>commercial bank</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm"/>
 		<skos:definition>a bank that provides services, such as accepting deposits, giving business loans and auto loans, mortgage lending, and basic investment products like savings accounts and certificates of deposit</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/commercialbank.asp</fibo-fnd-utl-av:definitionOrigin>
 		<fibo-fnd-utl-av:explanatoryNote>A commercial bank is a financial institution that is owned by stockholders, operates for a profit, and engages in various lending activities.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>The traditional commercial bank is a brick and mortar institution with tellers, safe deposit boxes, vaults and ATMs. However, some commercial banks do not have any physical branches and require consumers to complete all transactions by phone or Internet. In exchange, they generally pay higher interest rates on investments and deposits, and charge lower fees.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -473,7 +468,6 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;FaceAmountCertificateCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;InvestmentCompany"/>
 		<rdfs:label>face amount certificate company</rdfs:label>
-		<rdfs:seeAlso rdf:resource="http://www.investopedia.com/study-guide/series-99/chapters-46/chapter-5-investment-companies/introduction-investment-companies/"/>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-fse;ManagementCompany"/>
 		<skos:definition>an investment company which is engaged or proposes to engage in the business of issuing face-amount certificates of the installment type, or which has been engaged in such business and has any such certificate outstanding</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
@@ -603,14 +597,12 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		</rdfs:subClassOf>
 		<rdfs:label>investment bank</rdfs:label>
 		<skos:definition>a financial service provider that performs a variety of services. Investment banks specialize in large and complex financial transactions such as underwriting, acting as an intermediary between a securities issuer and the investing public, facilitating mergers and other corporate reorganizations, and acting as a broker and/or financial adviser for institutional clients.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/i/investmentbank.asp</fibo-fnd-utl-av:definitionOrigin>
 		<fibo-fnd-utl-av:explanatoryNote>Major investment banks include Barclays, BofA Merrill Lynch, Warburgs, Goldman Sachs, Deutsche Bank, JP Morgan, Morgan Stanley, Salomon Brothers, UBS, Credit Suisse, Citibank and Lazard. Some investment banks specialize in particular industry sectors. Many investment banks also have retail operations that serve small, individual customers.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;InvestmentCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
 		<rdfs:label>investment company</rdfs:label>
-		<rdfs:seeAlso rdf:resource="http://www.investopedia.com/study-guide/series-99/chapters-46/chapter-5-investment-companies/introduction-investment-companies/"/>
 		<skos:definition>Any issuer which: (a) is or holds itself out as being engaged primarily, or proposes to engage primarily, in the business of investing, reinvesting, or trading in securities; (b) is engaged or proposes to engage in the business of issuing face-amount certificates of the installment type, or has been engaged in such business and has any such certificate outstanding; or (c) is engaged or proposes to engage in the business of investing, reinvesting, owning, holding, or trading in securities, and owns or proposes to acquire investment securities having a value exceeding 40 per centum of the value of such issuer&amp;apos;s total assets (exclusive of Government securities and cash items) on an unconsolidated basis</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
 		<fibo-fnd-utl-av:explanatoryNote>An investment company is organized as either a corporation or as a trust. Individual investors&apos; money is then pooled together in a single account and used to purchase securities that will have the greatest chance of helping the investment company reach its objectives. All investors jointly own the portfolio that is created through these pooled funds, and each investor has an undivided interest in the securities.</fibo-fnd-utl-av:explanatoryNote>
@@ -702,7 +694,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;PrincipalUnderwriter">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;Underwriter"/>
 		<rdfs:label>principal underwriter</rdfs:label>
-		<skos:definition>underwriter who as principal purchases from an investment company, or pursuant to contract has the right (whether absolute or conditional) from time to time to purchase from such company, any such security for distribution, or who as agent for such company sells or has the right to sell any such security to a dealer or to the public or both, but does not include a dealer who purchases from such company through a principal underwriter acting as agent for such company</skos:definition>
+		<skos:definition>underwriter who, as principal, purchases from an investment company, or pursuant to some contract has the right to purchase from such company, any security for distribution, or who as agent for such company sells or has the right to sell any security to a dealer or to the public, excluding any dealer who purchases from such company through sn underwriter acting as an agent for such company</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Principal underwriter of or for a closed-end company or any issuer which is not an investment company, or of any security issued by such a company or issuer, means any underwriter who, in connection with a primary distribution of securities, (a) is in privity of contract with the issuer or an affiliated person of the issuer; (b) acting alone or in concert with one or more other persons, initiates or directs the formation of an underwriting syndicate; or (c) is allowed a rate of gross commission, spread, or other profit greater than the rate allowed another underwriter participating in the distribution.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -760,10 +752,8 @@ A number of insurance companies operate brokerage arms that trade securities on 
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>self-regulating organization</rdfs:label>
-		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Self-regulatory_organization"/>
 		<skos:definition>a non-governmental organization that has the power to create and exercise some degree of regulatory authority over an industry or profession in some country or group of countries</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SRO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/s/sro.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;Underwriter">
@@ -807,7 +797,6 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
 		<rdfs:label>wealth management service</rdfs:label>
 		<skos:definition>a high-level financial service that combines financial and investment advice, accounting and tax services, retirement planning and legal or estate planning for one set fee</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/w/wealthmanagement.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-fse;hasDateEstablished">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -88,8 +88,8 @@
 		<dct:abstract>This ontology extends the primary regulatory agencies ontology in FBC with additional regulators that are specific to the United States and augments certain U.S. financial services entities based on who regulates them.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
@@ -133,12 +133,13 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210101/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified to integrate a financial services provider identifier for certain banking identifiers, add a property for secondary federal regulator, add individual registration schemes for state-specific business registries, improve on some definitions, normalize some of the labels, eliminate duplication of concepts in LCC, to simplify addresses, merge countries with locations in FND, eliminte the redundant notion of an InstitutionType, which can be determined using a SPARQL query or classification and results in a very large disjunction, and correct a couple of improperly defined annotations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to add tax identification number, employer identification number, federal government entity and state government entity.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -323,7 +324,6 @@
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;AmericanBankersAssociation"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;ABAIINRegistry"/>
 		<fibo-fnd-utl-av:abbreviation>ABA RA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/i/issuer-identification-number-iin.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem">
@@ -1228,7 +1228,6 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<skos:definition>regulatory agency and registration authority role of the Federal Reserve System</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSystem"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investorwords.com/1914/Federal_Reserve_System.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSecondDistrict">
@@ -1407,7 +1406,6 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and self-regulatory organizational role of the Financial Industry Regulatory Authority (FINRA)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;FinancialIndustryRegulatoryAuthority"/>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.finra.org/about/what-we-do</fibo-fnd-utl-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
@@ -1418,7 +1416,6 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<skos:definition>largest non-governmental regulator of securities firms in the United States, namely, the Financial Industry Regulatory Authority (FINRA)</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.finra.org/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-utl-av:abbreviation>FINRA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.finra.org/about/what-we-do</fibo-fnd-utl-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
@@ -1476,7 +1473,6 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/ISO/IEC_7812"/>
 		<skos:definition>a numbering system that allows a credit, debit, or other card to be identified as having been issued by a particular financial institution</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>IIN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/i/issuer-identification-number-iin.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>IINs are issued directly by the American Banker&apos;s Association (ABA) in the US. The ABA is the Registration Authority (RA) for ISO/IEC 7812, which defines the IIN, in other words.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>The issuer identification number (IIN) is a six digit number that is unique to a single card issuer. The number is only used to identify the card issuer, and is not used to identify a particular product, service, or region associated with the card issuer.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -1838,7 +1834,6 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:seeAlso rdf:resource="http://www.accuity.com/aba-registrar/"/>
 		<skos:definition>a unique nine digit identifier, used in the United States, to identify a banking or other financial institution to clear funds or process checks; the routing transit number, as it appears on a check, specifically denotes the banking institution that holds the account in which funds from the check are to be drawn.</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>RTN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/r/routing_transit_number.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Routing transit numbers are issued by Accuity on behalf of the American Bankers Association (ABA).</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>The ABA RTN was originally designed to facilitate the sorting, bundling, and shipment of paper checks back to the drawer&apos;s (check writer&apos;s) account. As new payment methods were developed (ACH and Wire), the system was expanded to accommodate these payment methods.
 

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -77,9 +77,9 @@
 		<rdfs:label>Financial Products and Services Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts that extend the Foundations (FND) Products and Services concepts specifically for the financial industry, including financial product, financial service, and financial service provider.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -113,7 +113,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/ProductsAndServices/FinancialProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified by the FIBO 2.0 RFC, including, but not limited to, the addition of lifecycle events, concepts related to trade settlement, and the definition of a unique transaction identifier (UTI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified as a part of organizational hierarchy simplification and to correct a logical inconsistency with respect to the representation of baskets.</skos:changeNote>
@@ -122,6 +122,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to add the notion of a weighted basket, whose consituents are weighted.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191101/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate duplication with concepts in LCC and eliminated a redundant superclass on FinancialServiceProvider.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to replace the property &apos;characterizes&apos; with &apos;describes&apos; with respect to restrictions on catalogs, and to correct the label on terminated trade.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve and eliminate circular and ambiguous definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -135,7 +136,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>agency agreement</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.sos.state.tx.us/corp/registeredagents.shtml"/>
-		<rdfs:seeAlso rdf:resource="https://thelawdictionary.org/agent/"/>
 		<skos:definition>an agreement that designates a party as a registered agent to represent and act on behalf of another party in some, typically legal, financial, or medical capacity</skos:definition>
 	</owl:Class>
 	
@@ -151,7 +151,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;AmendedTrade">
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleStage"/>
 		<rdfs:label>amended trade</rdfs:label>
-		<skos:definition>individual representing an amended trade state</skos:definition>
+		<skos:definition>stage in the lifecycle of a trade indicating that a change or addition has been made to the terms of the trade, leaving the original terms largely intact</skos:definition>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Basket">
@@ -164,8 +164,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>basket</rdfs:label>
 		<skos:definition>collection of goods, services, or other things (e.g., financial contracts) that can be purchased and sold in some marketplace</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/m/market_basket.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.merriam-webster.com/dictionary/market%20basket</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A basket may be associated with a specific market sector, and may be delineated for the purposes of statistical analysis, such as for calculating CPI. According to the US Bureau of Labor Statistics (BLS), with respect to the CPI, a market basket is a package of goods and services that consumers purchase for day-to-day living. The weight of each item is based on the amount of expenditure reported by a sample of households.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>From a securities perspective, a basket is a collection of products or securities that are designated to mimic the performance of a market. For investors, the market basket is the principal idea behind index funds, which are essentially a broad sample of stocks, bonds or other securities in the market; this provides investors with a benchmark against which to compare their investment returns.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -197,7 +195,6 @@
 		<rdfs:label>broker</rdfs:label>
 		<skos:definition>any party that acts as an intermediary between a buyer and a seller, usually charging a commission</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A broker that specializes in stocks, bonds, commodities, or certain derivatives must be registered with the exchange in which the securities are traded.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -215,7 +212,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>broker-dealer</rdfs:label>
 		<skos:definition>any party in the business of buying and selling securities, operating as both a broker and a dealer, depending on the transaction</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
@@ -234,20 +230,20 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>catalog</rdfs:label>
-		<skos:definition>a list of goods and/or services available for sale with their description and possibly prices, published as a printed or  electronic document (e-catalog)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/catalog.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>publication including a list of products available for sale with their descriptions and possibly prices</skos:definition>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;ClearedTrade">
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleStage"/>
 		<rdfs:label>cleared trade</rdfs:label>
-		<skos:definition>individual representing a cleared trade state</skos:definition>
+		<skos:definition>stage in the lifecycle of a trade indicating that a third-party clearing house, acting as an intermediary, has reconciled the orders involved in the trade</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Clearing validates the availability of funds, records the transfer, and in the case of securities ensures the delivery of the security to the buyer.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;ClosedTrade">
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleStage"/>
 		<rdfs:label>closed trade</rdfs:label>
-		<skos:definition>individual representing a closed trade state</skos:definition>
+		<skos:definition>stage in the lifecycle of a trade indicating that the trade has been finalized, and that there is no longer a corresponding open position on the books of the trader, eliminating any exposure</skos:definition>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Dealer">
@@ -264,7 +260,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>dealer</rdfs:label>
 		<skos:definition>any party that purchases goods or services for resale and acts on their own behalf in a transaction</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A dealer is a counterparty or principal in the transaction with the customer.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -272,7 +267,6 @@
 		<rdfs:label>exposure</rdfs:label>
 		<skos:definition>the extent to which an individual or organization is unprotected and open to damage, danger, risk of suffering a loss, or uncertainty</skos:definition>
 		<skos:example>Examples include financial exposure, credit exposure, legal exposure, credit rating exposure, reputational exposure, and so forth.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/exposure.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;FinancialExposure">
@@ -286,8 +280,6 @@
 		<rdfs:label>financial exposure</rdfs:label>
 		<skos:definition>the extent to which an individual or organization is open to risk of suffering a loss in a transaction, or with respect to some investment or set of investments, e.g., some holding; the amount one stands to lose in that transaction or investment</skos:definition>
 		<skos:example>Examples in banking include the total amount of unsecured loans, the amount of loans advanced to a single borrower, group, industry, or country, and the probability of loss from devaluation, revaluation, or foreign exchange fluctuations.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/exposure.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;FinancialIntermediationService">
@@ -307,8 +299,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>financial product</rdfs:label>
-		<skos:definition>a product provided to consumers and businesses by financial institutions such as banks, insurance companies, brokerage firms, consumer finance companies, and investment companies all of which comprise the financial services industry</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investorwords.com/19080/financial_services.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>product provided to consumers and businesses by financial institutions such as banks, insurance companies, brokerage firms, consumer finance companies, and investment companies</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;FinancialProductCatalog">
@@ -333,8 +324,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>financial service</rdfs:label>
-		<skos:definition>a service provided to consumers and businesses by financial institutions such as banks, insurance companies, brokerage firms, consumer finance companies, and investment companies all of which comprise the financial services industry</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.investorwords.com/19080/financial_services.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>service provided to consumers and businesses by financial institutions such as banks, insurance companies, brokerage firms, consumer finance companies, and investment companies</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
@@ -353,8 +343,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>financial service provider</rdfs:label>
-		<skos:definition>a functional entity either licensed to provide financial services to consumers and/or businesses or established by law to provide financial services, such as a central bank</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investorwords.com/19080/financial_services.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>functional entity either licensed to provide financial services to consumers and/or businesses or established by law to provide financial services, such as a central bank</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Holding">
@@ -367,8 +356,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>holding</rdfs:label>
 		<skos:definition>real or personal property (assets), including but not limited to financial assets, to which one holds title and of which one has possession</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://legal-dictionary.thefreedictionary.com/Holding</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Note that a holding may refer to a single asset, such as a piece of real estate, a portfolio of assets, multiple portfolios, and so forth, and is frequently aggregated over multiple assets.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -388,7 +375,6 @@
 		<rdfs:label>legal agent</rdfs:label>
 		<skos:definition>any party that has been legally empowered to act on behalf of another party</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;LicensedAgent">
@@ -399,13 +385,12 @@
 		<skos:definition>any individual who is licensed to perform a legally binding function, and who has been legally empowered to act on behalf of another party</skos:definition>
 		<skos:example>Insurance agents, realtors, financial advisors, certain attorneys, and brokers are examples of legal agents.</skos:example>
 		<fibo-fnd-utl-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;MaturedTrade">
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleStage"/>
 		<rdfs:label>matured trade</rdfs:label>
-		<skos:definition>individual representing a matured trade state</skos:definition>
+		<skos:definition>stage in the lifecycle of a trade indicating that the trade, and related instrument(s) has ended (expired)</skos:definition>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Offeree">
@@ -422,8 +407,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>offeree</rdfs:label>
-		<skos:definition>a party that receives an offer from something from someone (i.e., an offerer) based on the terms of the offering</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.merriam-webster.com/dictionary/offer</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party that receives an offer from something from someone (i.e., an offerer) based on the terms of the offering</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Offering">
@@ -453,7 +437,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>offering</rdfs:label>
 		<skos:definition>an expression of interest in providing something to someone that is contigent upon acceptance, forbearance, or some other consideration, as desired by the offeree(s)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://legal-dictionary.thefreedictionary.com/offer</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The making of an offer is the first of three steps in the traditional process of forming a valid contract: an offer, an acceptance of the offer, and an exchange of consideration. (Consideration is the act of doing something or promising to do something that a person is not legally required to do, or the forbearance or the promise to forbear from doing something that he or she has the legal right to do.)</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -478,13 +461,12 @@
 		</rdfs:subClassOf>
 		<rdfs:label>offeror</rdfs:label>
 		<skos:definition>a party that proposes to make something available to someone (i.e., an offeree) based on the terms of the offering</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.merriam-webster.com/dictionary/offer</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;OpenTrade">
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleStage"/>
 		<rdfs:label>open trade</rdfs:label>
-		<skos:definition>individual representing an open trade state</skos:definition>
+		<skos:definition>stage in the lifecycle of a trade indicating that the trade has been established and there is an associated open position on the books of the trader as a consequence</skos:definition>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Position">
@@ -498,8 +480,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>position</rdfs:label>
 		<skos:definition>an investor&apos;s stake, i.e., a holding, in a particular asset (such as an individual security)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investorwords.com/3748/position.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A position can be long or short, and it can be in any asset class, such as stocks, bonds, futures, or options. A position can be open (current) or closed (past), but in general use, unless a position is specifically referred to as closed, the assumption is that it references an open position.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -526,8 +506,6 @@
 		<rdfs:label>product lifecycle</rdfs:label>
 		<skos:definition>a lifecycle specific to a product or product family</skos:definition>
 		<skos:example>The product life cycle describes the period of time over which an item is developed, brought to market and eventually removed from the market. The cycle is broken into four stages: introduction, growth, maturity and decline. The idea of the product life cycle is used in marketing to decide when it is appropriate to advertise, reduce prices, explore new markets or create new packaging.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/life-cycle.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/product-life-cycle.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ProductLifecycleEvent">
@@ -541,7 +519,6 @@
 		<rdfs:label>product lifecycle event</rdfs:label>
 		<skos:definition>a kind of event that occurs during one or more stages of a product lifecycle</skos:definition>
 		<skos:example>a call notification or coupon payment as a part of a bond lifecycle</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/product-life-cycle.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ProductLifecycleEventOccurrence">
@@ -611,8 +588,6 @@
 		<rdfs:label>product lifecycle stage</rdfs:label>
 		<skos:definition>a phase in a product lifecycle</skos:definition>
 		<skos:example>a research and development phase of a product lifecycle, the introduction phase in a marketing lifecycle, a growth stage in an economic lifecycle, or the origination phase in the lifecycle of a loan</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/life-cycle.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/product-life-cycle.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ProductLifecycleStageOccurrence">
@@ -687,7 +662,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>regulated commodity</rdfs:label>
 		<skos:definition>a commodity under the jurisdiction of the regulatory agency, such as the Commodities Futures Trading Commission (CFTF), which includes any commodity traded in an organized contracts market</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The CFTC polices matters of information and disclosure, fair trading practices, registration of firms and individuals, protection of customer funds, record keeping, and maintenance of orderly options and futures markets in the United States.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -701,7 +675,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>settlement terms</rdfs:label>
 		<skos:definition>contract terms that define the commitment to and mechanism for settling one or more sides of a transaction</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>In general, settlement involves arrangement of disposition of property, typically for legal reasons.  With respect to financial transactions, it involves completion of a trade, either between brokers or agents, or beween a broker and client. This may include settlement in cash, either for the entire transaction or for the cash leg of a transaction, either now or at some specified time in the future.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -719,8 +692,6 @@
 		<rdfs:label>third-party agent</rdfs:label>
 		<skos:definition>any service provider that is licensed to perform a legally binding function and has been legally empowered to act on behalf of another party</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://thelawdictionary.org/agent/</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:usageNote>Note that third-party agent is defined as a service provider (organization) acting in an agency capacity, such as a law firm, accountancy, or investment bank.  This is distinct from the concept of an individual (licensed agent), for example one who works for a broker-dealer, that is a registered agent licensed to sell securities.</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
@@ -780,7 +751,6 @@
 		<rdfs:label>trade</rdfs:label>
 		<skos:definition>an agreement between parties participating in a voluntary action of buying and selling goods and services</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Deutsche Bank Presentation on the Lifecycle of a Trade, available at http://www.slideshare.net/ahaline/23512555-tradelifecycle</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The advent of money as a medium of exchange has allowed trade to be conducted in a manner that is much simpler and effective compared to earlier forms of trade, such as bartering. In financial markets, trading also can mean performing a transaction that involves the selling and purchasing of a security.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>The seller must deliver the commodity sold to the buyer; the buyer must pay the agreed purchase price, which could be in the form of other goods or services, on the agreed date.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Trading activities typically include (a) regularly underwriting or dealing in securities; interest rate, foreign exchange rate, commodity, equity, and credit derivative contracts; other financial instruments; and other assets for resale, (b) acquiring or taking positions in such items principally for the purpose of selling in the near term or otherwise with the intent to resell in order to profit from short-term price movements, and (c) acquiring or taking positions in such items as an accommodation to customers or for other trading purposes. (Source: Instructions for Preparation of Consolidated Reports of Condition and Income (FFIEC 031 and 041), Schedule RC-D - Trading Assets and Liabilities, 2013.</fibo-fnd-utl-av:explanatoryNote>
@@ -822,8 +792,6 @@
 		<rdfs:label>trade lifecycle</rdfs:label>
 		<skos:definition>a lifecycle that defines the evolution of a trade, from initiation through settlement</skos:definition>
 		<skos:example>The trade life cycle describes the period of time over which a trade is initiated, typically as a part of a broader deal, consumated, processed and executed, settled or closed for other reasons, and reported.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/life-cycle.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/post-trade-processing.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycleEvent">
@@ -843,7 +811,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle event</rdfs:label>
 		<skos:definition>a kind of event that occurs during one or more stages of the lifecycle of a trade</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/post-trade-processing.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycleEventOccurrence">
@@ -926,8 +893,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle stage</rdfs:label>
 		<skos:definition>a phase in the lifecycle of a trade</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/life-cycle.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/post-trade-processing.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycleStageOccurrence">
@@ -982,8 +947,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trader</rdfs:label>
-		<skos:definition>an individual or organization or representative thereof that engages in the transfer of financial assets in any financial market on behalf of a client or the financial services provider</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/t/trader.asp</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party that engages in the transfer of financial assets in any financial market on behalf of a client or the financial services provider</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;UniqueTransactionIdentifier">
@@ -995,10 +959,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>unique transaction identifier</rdfs:label>
-		<skos:definition>a globally unique identifier for a reportable transaction, whose primary purpose is to uniquely identify individual OTC derivatives transactions in reports to trade repositories</skos:definition>
+		<skos:definition>globally unique identifier for a reportable transaction, whose primary purpose is to uniquely identify individual OTC derivatives transactions in reports to trade repositories</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>UTI</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom>Harmonization of the Unique Transaction Identifier - Technical Guidance, 20 Feb 2017, described in https://www.bis.org/cpmi/publ/d158.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>Unique Trade Identifier (UTI): Generation, Communication and Matching, as of 20 July 2015, described in http://www2.isda.org/attachment/NzczMg==/2015%20July%2020%20UTI%20Best%20Practice%20v11.6_final.pdf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>In particular, a UTI will help to ensure the consistent aggregation of OTC derivatives transactions by minimising the likelihood that the same transaction will be counted more than once (for instance, because it is reported by more than one counterparty to a transaction, or to more than one trade repository (TR)).</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -1036,7 +999,6 @@
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;facilitates">
 		<rdfs:label>facilitates</rdfs:label>
 		<skos:definition>provides the context in which an event, a task, a conversation or something else can occur</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.webster-dictionary.org/definition/facilitate</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;hasGeneratingEntity">
@@ -1079,7 +1041,6 @@
 		<rdfs:range rdf:resource="&fibo-fbc-pas-fpas;Offering"/>
 		<owl:inverseOf rdf:resource="&fibo-fbc-pas-fpas;isOfferingOf"/>
 		<skos:definition>relates something to a voluntary but conditional promise submitted by a buyer or seller (offeror) to another (offeree) for acceptance, and which becomes legally enforceable if accepted by the offeree</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/offer.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;hasOfferingAmount">
@@ -1108,7 +1069,6 @@
 		<rdfs:label>has settlement date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CalculatedDate"/>
 		<skos:definition>indicates the date by which an executed order or transaction must be settled</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Settlement might involve either a buyer paying in cash or a seller delivering the relevant instrument(s) and receiving the proceeds as specified by the terms of a given transaction.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
@@ -1116,22 +1076,19 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
 		<rdfs:label>has trade date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>indicates the date on which a security or commodity future trade actually takes place</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>indicates the date on which a security or other instrument-specific trade actually takes place</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;isEmbodiedIn">
 		<rdfs:label>is embodied in</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;embodies"/>
 		<skos:definition>identifies the representation or tangible form of something in some context</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.collinsdictionary.com/dictionary/english/embodies</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;isFacilitatedBy">
 		<rdfs:label>is facilitated by</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fbc-pas-fpas;facilitates"/>
 		<skos:definition>identifies someone or something that expedites some event, transaction, conversation or something else in some context</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.webster-dictionary.org/definition/facilitate</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;isOfferingOf">
@@ -1144,13 +1101,11 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-fpas;relatesTo"/>
 		<rdfs:label>precedes</rdfs:label>
 		<skos:definition>relates a product, organization, stage in a lifecycle, an event, or occurrence, such as a trade, to one that occurs before it</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.merriam-webster.com/dictionary/precede</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;relatesTo">
 		<rdfs:label>relates to</rdfs:label>
 		<skos:definition>has a logical or causal connection with</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.merriam-webster.com/dictionary/relates</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;succeeds">
@@ -1158,7 +1113,6 @@
 		<rdfs:label>succeeds</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fbc-pas-fpas;precedes"/>
 		<skos:definition>relates a product, organization, stage in a lifecycle, an event, or occurrence, such as a trade, to one that follows it</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.merriam-webster.com/dictionary/succeed</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Product">

--- a/FND/Accounting/CurrencyAmount.rdf
+++ b/FND/Accounting/CurrencyAmount.rdf
@@ -69,7 +69,7 @@ The definition of currency provided herein is compliant with the definitions giv
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Accounting/CurrencyAmount/ version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Accounting/CurrencyAmount/ version of this ontology was modified to improve definitions for notional amount and currency identifier.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191201/Accounting/CurrencyAmount/ version of this ontology was modified to correct the explanatory note on currency identifier.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191201/Accounting/CurrencyAmount/ version of this ontology was modified to eliminate duplication with concepts in LCC and the dependencies on a couple of ontologies that were unnecessary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191201/Accounting/CurrencyAmount/ version of this ontology was modified to eliminate duplication with concepts in LCC, dependencies on a couple of ontologies that were unnecessary, eliminate references to external dictionary sites that no longer resolve, clean up ambiguity in definitions and eliminate a redundant property.</skos:changeNote>
 		<skos:editorialNote>(1) The present version of the ontology covers the English sections of the ISO 4217 standard only, and (2) UTF-8 character encodings are employed in names in the currency codes ontology to support the broadest number of tools.</skos:editorialNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -78,12 +78,13 @@ The definition of currency provided herein is compliant with the definitions giv
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasBaseMoneyUnit"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>amount of money</rdfs:label>
-		<skos:definition>a sum of money</skos:definition>
+		<skos:definition>amount of readily available cash in banknotes and coins</skos:definition>
 		<skos:editorialNote>This is an actual sum of money, not the measure of a sum of money in monetary units, although it has the same basic properties (decimal number with a currenct unit).</skos:editorialNote>
 		<fibo-fnd-utl-av:synonym>cash</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -98,8 +99,7 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>calculated price</rdfs:label>
-		<skos:definition>a monetary price determined by a formula</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/price.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>monetary price determined by a formula</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-cur;Currency">
@@ -143,7 +143,7 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>currency basket</rdfs:label>
-		<skos:definition>a selected group of currencies, in which the weighted average is used as a measure of the value or the amount of an obligation</skos:definition>
+		<skos:definition>selected group of currencies, in which the weighted average is used as a measure of the value or the amount of an obligation</skos:definition>
 		<skos:note>A currency basket functions as a benchmark for regional currency movements; its composition and weighting depends on its purpose.</skos:note>
 		<fibo-fnd-utl-av:definitionOrigin>Codes for the representation of currencies and funds, ISO 4217, Eighth edition, 2015-08-01, section 3.2</fibo-fnd-utl-av:definitionOrigin>
 	</owl:Class>
@@ -206,9 +206,8 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>exchange rate</rdfs:label>
-		<skos:definition>a rate at which one currency can be exchanged for another</skos:definition>
+		<skos:definition>rate at which one currency can be exchanged for another</skos:definition>
 		<skos:example>The exchange rate between the U.S. dollar and British pound is distinct from the exchange rate between the U.S. dollar and the euro.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-cur;Funds">
@@ -221,7 +220,7 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>funds</rdfs:label>
-		<skos:definition>an artificial currency used as calculation basis for another currency (or currencies) and/or for accounting purposes</skos:definition>
+		<skos:definition>artificial currency used as calculation basis for another currency(s) and accounting purposes</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Codes for the representation of currencies and funds, ISO 4217, Eighth edition, 2015-08-01, section 3.3</fibo-fnd-utl-av:definitionOrigin>
 	</owl:Class>
 	
@@ -248,7 +247,8 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>funds identifier</rdfs:label>
-		<skos:definition>the trigraph representing the funds</skos:definition>
+		<skos:definition>sequence of characters that can be used to uniquely identify funds</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Codes for the representation of currencies and funds, ISO 4217, Eighth edition, 2015-08-01, section 3.2</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-cur;InterestRate">
@@ -267,8 +267,7 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>interest rate</rdfs:label>
-		<skos:definition>an amount charged, expressed as a percentage of principal, by a lender to a borrower for the use of assets</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>amount charged, expressed as a percentage of principal, in exchange for the use of assets</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Interest rates are typically noted on an annual basis, known as the annual percentage rate (APR). The assets borrowed could include cash, consumer goods, and large assets such as a vehicle or building. The rate is derived by dividing the amount of interest by the amount of principal borrowed. Interest rates are quoted on bills, notes, bonds, credit cards, and many kinds of consumer and business loans.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -289,7 +288,7 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>monetary amount</rdfs:label>
-		<skos:definition>the measure which is an amount of money specified in monetary units</skos:definition>
+		<skos:definition>measure that is an amount of money specified in monetary units</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-cur;MonetaryMeasure">
@@ -303,16 +302,14 @@ The definition of currency provided herein is compliant with the definitions giv
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;Price"/>
 		<rdfs:label>monetary price</rdfs:label>
-		<skos:definition>a price that that is expressed as a monetary amount</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/price.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oxforddictionaries.com/definition/english/price</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>price that that is expressed as a monetary amount</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>As the consideration given in exchange for transfer of ownership, price forms the essential basis of commercial transactions. It may be fixed by a contract, left to be determined by an agreed upon formula at a future date, or discovered or negotiated during the course of dealings between the parties involved. In commerce, price is determined by what (1) a buyer is willing to pay, (2) a seller is willing to accept, and (3) the competition is allowing to be charged.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-cur;PercentageMonetaryAmount">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
 		<rdfs:label>percentage monetary amount</rdfs:label>
-		<skos:definition>a measure of some amount of money expressed as a percentage of some other amount, some notional amount or some concrete money amount</skos:definition>
+		<skos:definition>measure of some amount of money expressed as a percentage of some other amount, some notional amount or some concrete money amount</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-cur;Price">
@@ -324,9 +321,7 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>price</rdfs:label>
-		<skos:definition>an amount of money, goods, or services requested, expected, required, or given in exchange for something else</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/price.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oxforddictionaries.com/definition/english/price</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>amount of money, goods, or services requested, expected, required, or given in exchange for something else</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-cur;UnitOfAccount">
@@ -345,7 +340,7 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>unit of account</rdfs:label>
-		<skos:definition>a nominal monetary unit of measure used to represent the real value (or cost) of any economic item; i.e. goods, services, assets, liabilities, income, expenses</skos:definition>
+		<skos:definition>nominal monetary unit of measure used to represent the real value (or cost) of any economic item; i.e. goods, services, assets, liabilities, income, expenses</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-cur;UnitOfAccountIdentifier">
@@ -371,14 +366,14 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>unit of account identifier</rdfs:label>
-		<skos:definition>the trigraph representing the unit of account</skos:definition>
+		<skos:definition>sequence of characters that can be used to uniquely identify a unit of account</skos:definition>
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-acc-cur;hasAmount">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
 		<rdfs:label>has amount</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
-		<skos:definition>a total number or quantity</skos:definition>
+		<skos:definition>total number or quantity</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-acc-cur;hasBaseCurrency">
@@ -386,29 +381,21 @@ The definition of currency provided herein is compliant with the definitions giv
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
 		<rdfs:label>has base currency</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition>a predicate indicating the base currency in an exchange rate; one unit of this currency represents R units of the dealt currency, where R is the exchange rate value</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-acc-cur;hasBaseMoneyUnit">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasMeasurementUnit"/>
-		<rdfs:label>has base money unit</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition>the currency in which the money amount is denominated</skos:definition>
+		<skos:definition>specifies a unit of currency representing R units of the dealt currency, where R is the exchange rate value, in an exchange rate</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-acc-cur;hasCurrency">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasMeasurementUnit"/>
 		<rdfs:label>has currency</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition>a medium of exchange value in which something, such as a monetary amount is defined</skos:definition>
+		<skos:definition>specifies the medium of exchange value in which something, such as a monetary amount is denominated</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-acc-cur;hasDealtCurrency">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
 		<rdfs:label>has dealt currency</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition>a predicate indicating the dealt currency in an exchange rate; R units of this currency represent one unit of the base currency</skos:definition>
+		<skos:definition>specifies a unit of currency representing the exchanged (target) currency in an exchange rate; R units of this currency represent one unit of the base currency</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-acc-cur;hasFundsType">
@@ -451,11 +438,10 @@ The definition of currency provided herein is compliant with the definitions giv
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-acc-cur;hasNumericCode">
-		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasTag"/>
 		<rdfs:label>has numeric code</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition>relates a numeric code to the currency or fund</skos:definition>
-		<skos:scopeNote>The numeric currency code is derived, where possible, from the United Nations Standard Country or Area Code. Additional codes to meet special requirements (as described in 5.1.3) and in respect of funds will be allocated as necessary from within the user-assigned range of codes 950 to 998. Funds codes are allocated in descending order commencing at 998.</skos:scopeNote>
+		<skos:definition>relates a numeric code to something, such as a currency or fund</skos:definition>
+		<skos:scopeNote>In the case of currency codes, the numeric currency code is derived, where possible, from the United Nations Standard Country or Area Code. Additional codes to meet special requirements (as described in 5.1.3) and in respect of funds will be allocated as necessary from within the user-assigned range of codes 950 to 998. Funds codes are allocated in descending order commencing at 998.</skos:scopeNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-acc-cur;hasPrice">
@@ -476,8 +462,7 @@ The definition of currency provided herein is compliant with the definitions giv
 		<rdfs:label>is tender in</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<skos:definition>a jurisdiction in which the currency is exchangeable for goods and services</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Commonly referred to also as legal tender, however this definition does not hold literally in some countries e.g. Scotland.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>indicates a jurisdiction in which the currency is exchangeable for goods and services</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -47,9 +47,9 @@
 		<rdfs:label>Contracts Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts relating to contracts, for use in other FIBO ontology elements. These include written contracts which are the concrete evidence of agreements between parties, along with verbal contracts. Contracts are further broken down into bilateral and transferable contracts, the latter being the basis for most financial instruments. Properties of contracts are also defined, in particular contractual terms and contract parties. These concepts all form the basis of concepts in the financial services industry, for example interest payment terms are a kind of contract terms set, and security holders are a kind of contract counterparty.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/</sm:dependsOn>
@@ -75,7 +75,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20201201/Agreements/Contracts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210101/Agreements/Contracts/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Agreements/Contracts.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
    (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -90,6 +90,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Agreements/Contracts.rdf version of this ontology was revised to add the concept of a term sheet, revise definitions to be ISO 704 compliant, and eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Agreements/Contracts.rdf version of this ontology was revised to add the concepts of breach of contract and breach of covenant.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Agreements/Contracts.rdf version of this ontology was revised to simplify the contract party hierarchy, eliminate ambiguity in definitions where feasible and add restrictions on identity documents to avoid circular dependencies.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201201/Agreements/Contracts.rdf version of this ontology was revised to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -235,7 +236,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>contract</rdfs:label>
 		<skos:definition>voluntary, deliberate agreement between competent parties to which the parties agree to be legally bound, and for which the parties provide valuable consideration</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/contract.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A contractual relationship is evidenced by (1) an offer, (2) acceptance of the offer, and a (3) valid (legal and valuable) consideration. A contract is a kind of agreement, and as such it embodies the assertion that it has been negotiated, such negotiation having included the presence of some offer and the acceptance of that offer on the part of either or both of the parties.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Contracts are usually written but may be spoken or implied, and generally have to do with employment, sale or lease, or tenancy.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -295,7 +295,6 @@
 		<rdfs:label>contractual commitment</rdfs:label>
 		<skos:definition>provision specifying something that the contracting parties agree to</skos:definition>
 		<skos:scopeNote>Contractual commitments include general conditions which are common to all types of contracts, such as general and special arrangements, provisions, requirements, rules, rights and obligations, specifications, and standards that form an integral part of an agreement or contract, as well as special conditions which are peculiar to a specific contract (such as, contract change conditions, payment conditions, price variation clauses, penalties).</skos:scopeNote>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/conditions-of-contract.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualDefinition">
@@ -307,7 +306,6 @@
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualElement">
 		<rdfs:label>contractual element</rdfs:label>
 		<skos:definition>element, such as an arrangement, provision, requirement, rule, specification, and standard that forms an integral part of an agreement</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/terms-and-conditions.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;Counterparty">

--- a/FND/Arrangements/Documents.rdf
+++ b/FND/Arrangements/Documents.rdf
@@ -31,9 +31,9 @@
 		<rdfs:label>Documents Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation documents for use in other FIBO ontology elements.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2014-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
@@ -44,7 +44,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Arrangements/Documents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210101/Arrangements/Documents/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Arrangements/Documents.rdf version of this ontology was introduced as a part of the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/ in advance of the Long Beach meeting in December 2014.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Arrangements/Documents.rdf version of this ontology was revised as a part of the issue resolutions identified in the FIBO FND 1.1 RTF report to add a parent of hasDate to date properties.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/Arrangements/Documents.rdf version of this ontology was revised as a part of the issue resolutions identified in the FIBO FND 1.2 RTF report to add a definition for a record.</skos:changeNote>
@@ -53,6 +53,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20181201/Arrangements/Documents.rdf version of this ontology was revised to eliminate deprecated properties.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Documents.rdf version of this ontology was revised to integrate additional document concepts, including certificate, draft, and notice and eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Documents.rdf version of this ontology was revised to add a hasRecord property.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Arrangements/Documents.rdf version of this ontology was revised to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -71,8 +72,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>document</rdfs:label>
 		<skos:definition>something tangible that records something, such as a recording or a photograph, or a writing that can be used to furnish evidence or information</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/document.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.oxforddictionaries.com/definition/document</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>A document serves to establish one or several facts, and can be relied upon as a proof thereof.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -94,7 +93,6 @@
 		<rdfs:label>record</rdfs:label>
 		<skos:definition>a memorialization and objective evidence of activities performed, events occurred, results achieved, or statements made, regardless of its characteristics, media, physical form, or the manner in which it is recorded or stored</skos:definition>
 		<skos:example>Records include accounts, agreements, books, drawings, letters, magnetic/optical disks, memos, micrographics, etc.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/record.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Records are created or received by an organization in routine transaction of its business or in pursuance of its legal obligations.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/FND/Arrangements/Lifecycles.rdf
+++ b/FND/Arrangements/Lifecycles.rdf
@@ -39,9 +39,9 @@
 		<rdfs:label>Lifecycles Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a set of basic concepts for lifecycles, including the various stages and events that make up a given lifecycle, for use in describing product, trade, instrument, production, and other lifecycles in FIBO.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2017-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2017-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/</sm:dependsOn>
@@ -59,10 +59,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200501/Arrangements/Lifecycles/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210101/Arrangements/Lifecycles/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Arrangements/Lifecycles.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Arrangements/Lifecycles.rdf version of this ontology was revised to define lifecycle status, normalize definitions per ISO 704 and eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Lifecycles.rdf version of this ontology was revised to add lifecycle stage as the superclass of maturity level.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200501/Arrangements/Lifecycles.rdf version of this ontology was revised to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -89,8 +90,6 @@
 		<rdfs:label>lifecycle</rdfs:label>
 		<skos:definition>arrangement that compares the cyclical nature of families, organizations, processes, products, marketing, and order management, portfolio management or other systems with the cradle to grave life stages (birth, growth, maturity, decay, and death) of living organisms</skos:definition>
 		<skos:example>The product life cycle describes the period of time over which an item is developed, brought to market and eventually removed from the market. The cycle is broken into four stages: introduction, growth, maturity and decline. The idea of the product life cycle is used in marketing to decide when it is appropriate to advertise, reduce prices, explore new markets or create new packaging.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/life-cycle.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/product-life-cycle.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-lif;LifecycleEvent">
@@ -167,8 +166,6 @@
 		<rdfs:label>lifecycle stage</rdfs:label>
 		<skos:definition>phase in a lifecycle</skos:definition>
 		<skos:example>a research and development phase of a product lifecycle, the introduction phase in a marketing lifecycle, a growth stage in an economic lifecycle, or the origination phase in the lifecycle of a loan</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/life-cycle.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/product-life-cycle.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-lif;LifecycleStageOccurrence">

--- a/FND/Arrangements/Reporting.rdf
+++ b/FND/Arrangements/Reporting.rdf
@@ -35,9 +35,9 @@
 		<rdfs:label>Reporting Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the notion of a Report and related party concepts.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2019 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2019 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/</sm:dependsOn>
@@ -52,9 +52,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Reporting/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210101/Arrangements/Reporting/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Arrangements/Reporting.rdf version of this ontology was modified to incorporate evaluates and isEvaluatedBy.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Reporting.rdf version of this ontology was modified to eliminate references to deprecated elements.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Reporting.rdf version of this ontology was modified to eliminate references to deprecated elements and to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -100,8 +100,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>report</rdfs:label>
-		<skos:definition>a document organized in a narrative, graphic, or tabular form, prepared on ad hoc, periodic, recurring, regular, or as required basis</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/report.html</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>document organized in a narrative, graphic, or tabular form, prepared on ad hoc, periodic, recurring, regular, or as required basis</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Reports may refer to specific periods, events, occurrences, or subjects, and may be communicated or presented in oral, electronic, or written form.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -114,7 +113,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>reporting party</rdfs:label>
-		<skos:definition>a party providing a report, typically in response to some contractual, legal, regulatory or other business requirement</skos:definition>
+		<skos:definition>party providing a report, typically in response to some contractual, legal, regulatory or other business requirement</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-rep;Submitter">
@@ -126,7 +125,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>submitter</rdfs:label>
-		<skos:definition>a party presenting something, such as a regulatory report</skos:definition>
+		<skos:definition>party presenting something, such as a regulatory report</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-rep;isReportedTo">
@@ -161,7 +160,6 @@
 		<rdfs:label>submits</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-arr-rep;Submitter"/>
 		<skos:definition>presents something (a proposal, application, report, or other document) for consideration or review</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.merriam-webster.com/dictionary/submit</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/FND/OwnershipAndControl/Control.rdf
+++ b/FND/OwnershipAndControl/Control.rdf
@@ -38,8 +38,8 @@
 		<dct:abstract>This ontology defines high-level, control-related concepts for use in other FIBO ontology elements.  The ontology covers basic concepts around control, along with a distinction between de jure and de facto control, the former being derived with reference to terms in the LegalCapacity ontology.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/</sm:dependsOn>
@@ -56,7 +56,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20201201/OwnershipAndControl/Control/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210101/OwnershipAndControl/Control/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/OwnershipAndControl/Control.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
    (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -66,6 +66,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20130801/OwnershipAndControl/Control.rdf version of the ontology was was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/OwnershipAndControl/Control.rdf version of the ontology was modified to integrate the concept of a situation, situational roles, and corresponding relations with the definition of control and eliminate minimum cardinality of 1 restrictions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200601/OwnershipAndControl/Control.rdf version of the ontology was modified to simplify control concepts and relations, complete the control patterns, and eliminate ambiguity in definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201201/OwnershipAndControl/Control.rdf version of the ontology was modified to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -128,7 +129,6 @@
 		<rdfs:label>de facto control</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-oac-ctl;DeJureControl"/>
 		<skos:definition>control that exists informally and is accepted, although not formally recognized</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://dictionary.cambridge.org/dictionary/english/de-facto</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>For example, de facto acquisition or change of control means the acquisition, directly or indirectly, by any person or group of persons acting jointly or in concert, of beneficial ownership of, or control or direction over, sufficient voting shares of some legal entity to permit such person or persons to exercise, or to control or direct the voting of, 50 percent or more of the total number of votes in that entity.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -137,7 +137,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-ctl;Control"/>
 		<rdfs:label>de jure control</rdfs:label>
 		<skos:definition>control that exists as a matter of law, i.e., legitimate, legal control of something</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/de-jure.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-ctl;hasControllingParty">

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -79,9 +79,9 @@
 		<rdfs:label>Economic Indicators Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the parameters which make up the various types of market economic indicators, along with basic facts about these such as the economies or countries they apply to.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2014-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -117,7 +117,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20200901/EconomicIndicators/EconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20211201/EconomicIndicators/EconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the FIBO 2.0 RFC. Primary changes include the addition of a number of statistical measures (mean, total, etc.) and their use in existing and new indicators, and the addition of several more economic indicators.</skos:changeNote>
@@ -127,6 +127,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190901/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate duplicatation with concepts in LCC and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200301/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to reflect the change in name and definition of numeric index to numeric index value in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200401/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to add definitions for alternative unemployment calculations and correct a circular property definition.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200901/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -616,7 +617,6 @@
 		<rdfs:label>enterprise</rdfs:label>
 		<skos:definition>a functional business entity that produces and/or sells goods or services</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/opub/hom/glossary.htm#E</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/establishment.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>An enterprise (a private firm, government, or nonprofit organization) can consist of a single establishment or multiple establishments. All establishments in an enterprise may be classified in one industry (e.g., a chain), or they may be classified in different industries (e.g., a conglomerate).</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -652,7 +652,6 @@
 		<skos:definition>an enterprise (or part of an enterprise) that operates from a single physical location</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=857</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/opub/hom/glossary.htm#E</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/establishment.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/concepts/units</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The physical location of a certain economic activity - for example, a factory, mine, store, or office. An individual establishment is generally classified by having one NAICS code associated with it for statistical purposes, whereas an enterprise may be classified by multiple NAICS codes. The statistical structure is defined based on the operating structure and the accounting data produced by that entity.  A given location may only need to publish revenues, whereas an operating unit (establishment) has employment statistics, etc.  An establishment is defined as a producing unit at a single geographical location at which or from which economic activity is conducted and for which, at a minimum, employment data are available.  In the case of a home-based business, the actual physical location would be specified as two distinct institutional units - as a household from a personal living and consumer perspective and as an establishment / operating unit due to the statistics required of the business.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

In order to address these now bad links, eliminated references to external dictionaries that no longer resolve, corrected circular definitions in several of the ontologies that these references impacted, and eliminated a redundant property in currency amount (whose definition was circular)

Fixes: #1316 / FND-328


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


