### PR TITLE
SEC-73 - An exhaustive set of classes, corresponding to the various equity feature combinations expressed in the CFI standard are needed

### DIFF
--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -61,9 +61,9 @@
 		<rdfs:label>Debt Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts that are common to all debt instruments, such as debt, borrower, lender, debtor, creditor, interest, principal, and the like. It is designed to be used by various other FIBO specifications, including but not limited to SEC/Debt and LOAN.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -89,11 +89,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210101/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away, to support collateral agreements such as deeds of trust, UCC filings and the like, to add the concept of a rate reset time of day, to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/DebtAndEquities/Debt/ version of this ontology was modified to make redemption provision a child of contractual commitment and move it to financial instruments, as such provisions apply to preferred shares and other instruments in addition to debt.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/DebtAndEquities/Debt/ version of this ontology was modified to move the concept of an extension provision from Debt to Contracts to support representation of preferred shares and other extendable contracts.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -109,7 +110,6 @@
 		<rdfs:label>accrual</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>the process of accumulating interest or other income that has been earned but not paid</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>There are legal contractual terms for the accrual of interest, as distinct from the payment of interest.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -125,7 +125,6 @@
 		<rdfs:label>amortization</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>the process of reduction of debt or other costs through periodic charges to assets or liabilities, such as through principal payments on mortgages</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;AmortizationSchedule">
@@ -170,8 +169,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>borrower</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>a party to a debt instrument that is obligated to repay the amount borrowed (principal) with interest and other fees according to the terms of the instrument</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>party to a debt instrument that is obligated to repay the amount borrowed (principal) with interest and other fees according to the terms of the instrument</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;BorrowingCapacity">
@@ -196,9 +194,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>borrowing capacity</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>an amount of money that an individual or organization can borrow</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/credit.asp</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>upper bound on the total amount of money that a lender believes a party has the ability to repay as of some point in time</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Collateral">
@@ -226,7 +222,6 @@
 		<rdfs:label>collateral</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>asset offered as security, pledged as an inducement to another party, to lend money, extend credit, or provision securities</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;CollateralAgreement">
@@ -288,7 +283,6 @@
 		<rdfs:label>credit agreement</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>a contractual agreement in which a debtor receives something of value and agrees to repay the creditor at some date in the future, in some form (e.g., cash, securities, etc.), generally with interest</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/credit.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Creditor">
@@ -308,7 +302,6 @@
 		<rdfs:label>creditor</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>a party to whom an obligation, such as an amount of money, or good, or performance of some service exists</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;DayCountConvention">
@@ -317,8 +310,6 @@
 		<rdfs:label>day-count convention</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>a business recurrence interval convention that is used to calculate the number of days in an interest payment, which applies to the amount of accrued interest or the present value for debt instruments</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investinginbonds.com/story.asp?id=3140</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/d/daycount.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Day-count conventions apply to swaps, mortgages and forward rate agreements as well as bonds, each of which has its own day-count convention, which varies depending on the type of instrument, whether the interest rate is fixed or floating, and the country of issuance. Among the most common conventions are 30/360 or 365, actual/360 or 365, and actual/actual. A 30/360 convention assumes 30 days in a month and 360 days in a year. An actual/360 convention assumes the actual number of days in the given month and 360 days in the year. An actual/ actual convention uses the actual number of days in the given interest period and year.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -429,7 +420,6 @@
 		<rdfs:label>debt</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>an obligation to pay something, such as an amount of money, good, service, or instrument</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>In cases where the debtor and payer are the same legal person, then a debt is equivalent to a payment obligation.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -459,16 +449,6 @@
 		<rdfs:label>debtor</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>a party that owes a debt or other obligation to another party</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council</fibo-fnd-utl-av:adaptedFrom>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-dbt;ExtensionProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label>extension provision</rdfs:label>
-		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>contract terms that specify the conditions under which a contract can be extended</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In the case of a debt instrument, an extension may include extending the time allowed for repayment of the principal, the maturity date, and so forth.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;FixedInterestRate">
@@ -476,7 +456,6 @@
 		<rdfs:label>fixed interest rate</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>an interest rate that does not fluctuate over the lifetime of a loan or other debt instrument</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;FloatingInterestRate">
@@ -486,7 +465,6 @@
 		<rdfs:seeAlso rdf:resource="http://recomparison.com/comparisons/100975/floating-vs-variable-vs-adjustable-interest-rate/"/>
 		<skos:definition>a variable interest rate that is based on a specific index or benchmark rate</skos:definition>
 		<skos:example>Certain revolving credit, such as credit-card related debt, may adjust after a specified period of time to an absolute rate stated in the agreement (variable but not floating) rather than based on a benchmark rate (variable, floating).</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The index used to determine the specific interest rate is generally included in the terms of the loan. In most cases, lenders will also charge a spread, or added percentage points on top of the established index rate. If a loan is billed as prime plus 2.5 percent, for a prime rate of 3.5 percent, the terms of the loan will require the borrower to pay off a 6 percent interest. Floating interest rates typically involve periodic reset dates for the loan, particularly when the index rate changes. Resets may also occur online at market predetermined intervals, with yearly adjustments being a common arrangement.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -520,7 +498,6 @@
 		<rdfs:label>interest</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>the cost of using credit, or another&apos;s money, expressed as a rate per period of time, payable by a debtor to a creditor in consideration of the credit extended to the debtor</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestPaymentTerms">
@@ -604,7 +581,6 @@
 		<rdfs:label>lender</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>a party that extends credit or money to a borrower with the expectation of being repaid, usually with interest</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;ManagedInterestRate">
@@ -618,7 +594,6 @@
 		<rdfs:label>managed interest rate</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>a variable interest rate charged by a financial institution for borrowing that is not prescribed as a margin over base rate but is set from time to time by the institution</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investorguide.com/definition/managed-rate.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;NegativeAmortization">
@@ -656,15 +631,14 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:seeAlso rdf:resource="http://www.finra.org/investors/bond-glossary#p"/>
 		<skos:definition>with respect to a debt: the value of an obligation, such as a bond or loan, raised and that must be repaid at maturity; for investments: the original amount of money invested, separate from any associated interest, dividends or capital gains</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council / Quarule</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PrincipalRepaymentTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;DebtTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasExtensionProvision"/>
-				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;ExtensionProvision"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasExtensionProvision"/>
+				<owl:onClass rdf:resource="&fibo-fnd-agr-ctr;ExtensionProvision"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -728,7 +702,6 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:disjointWith rdf:resource="&fibo-fbc-dae-dbt;FixedInterestRate"/>
 		<skos:definition>an interest rate that is allowed to vary over the maturity of a loan or other debt instrument</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>adjustable rate</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -788,25 +761,6 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition>the face value of currency units, coins, or securities</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasExtendablePeriod">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDatePeriod"/>
-		<rdfs:label>has extendable period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;ExtensionProvision"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
-		<skos:definition>indicates the date period during which an extension is allowable</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasExtensionProvision">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label>has an extension provision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;DebtInstrument"/>
-		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;ExtensionProvision"/>
-		<skos:definition>identifies a contract provision allowing extension of repayment or maturity dates</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasFinalInterestPaymentDate">
@@ -882,7 +836,6 @@
 		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;Principal"/>
 		<skos:definition>indicates the face value of an obligation, such as a bond or loan, that must be repaid at maturity, i.e., the base amount raised by a mortgage or other debt instrument</skos:definition>
 		<skos:editorialNote>This is not the balance of the debt at a point in time, but the amount drawn down at a specific point in time, after which (for interest bearing debts) interest becomes payable. Semantic Modeling note This term is over-ridden for specific kinds of debt (securities, loans) and is therefore not needed in any data model. It is included here to define part of the meaning of the Debt Finance term. It is a Relationship Fact and strictly speaking should be regarded as being specialized and over-ridden by the terms in the Loan and Security classes, however it is modeled here as a &quot;Referenceable Archetype&quot; meaning that it appears in diagrams as a textual entry not a relationship line, and so it is not possible to formally show this specialization.</skos:editorialNote>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasPrincipalPaymentDay">
@@ -921,7 +874,6 @@
 		<rdfs:label>is based on</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>relates something to something else on which it rests, or that supports it in some way</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.merriam-webster.com/dictionary/base</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;isCollateralizationOf">
@@ -929,7 +881,6 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>relates some collateral to a credit agreement or debt instrument for which the property has been pledged as security for the debt</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;isCollateralizedBy">
@@ -937,7 +888,6 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
 		<skos:definition>relates a credit agreement or debt instrument to property pledged as security for the debt</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;isInterestOn">

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -90,7 +90,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Agreements/Contracts.rdf version of this ontology was revised to add the concept of a term sheet, revise definitions to be ISO 704 compliant, and eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Agreements/Contracts.rdf version of this ontology was revised to add the concepts of breach of contract and breach of covenant.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Agreements/Contracts.rdf version of this ontology was revised to simplify the contract party hierarchy, eliminate ambiguity in definitions where feasible and add restrictions on identity documents to avoid circular dependencies.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201201/Agreements/Contracts.rdf version of this ontology was revised to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201201/Agreements/Contracts.rdf version of this ontology was revised to eliminate references to external dictionary sites that no longer resolve and move the concept of an extension provision from Debt to Contracts to support representation of preferred shares and other extendable contracts.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -315,6 +315,20 @@
 		<fibo-fnd-utl-av:explanatoryNote>The counterparty is usually the party &apos;on the other side&apos; of a contract from the perspective of the issuer or holder. The term &apos;counterparty&apos; can refer to any party to an agreement, depending on context.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ExtensionProvision">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasExtendablePeriod"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDatePeriod"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>extension provision</rdfs:label>
+		<skos:definition>contract terms that specify the conditions under which a contract can be extended</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>In the case of a debt instrument, an extension may include extending the time allowed for repayment of the principal, the maturity date, and so forth.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;MutualContractualAgreement">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;MutualAgreement"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
@@ -468,6 +482,23 @@
 		<rdfs:label>has execution date time stamp</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DateTimeStamp"/>
 		<skos:definition>indicates the date and time, including time zone, a contract has been signed by all the necessary parties</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasExtendablePeriod">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDatePeriod"/>
+		<rdfs:label>has extendable period</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ExtensionProvision"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDatePeriod"/>
+		<skos:definition>indicates the window of time during which an extension is allowed under the terms of the contract</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasExtensionProvision">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+		<rdfs:label>has extension provision</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ExtensionProvision"/>
+		<skos:definition>specifies the details of a contract provision allowing extension of some aspect of the contract</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Typically a contract extension refers to the termination date, coverage period, or, in the case of a security, may refer to extension of repayment or maturity dates.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasGoverningJurisdiction">

--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -109,7 +109,7 @@
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Alphabet Inc. class A common stock</rdfs:label>
 		<skos:definition>common share class that represents class A series shares in Alphabet Inc.</skos:definition>
@@ -140,7 +140,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonNonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Alphabet Inc. class C capital stock</rdfs:label>
 		<skos:definition>common share class that represents class C series shares in Alphabet Inc.</skos:definition>
@@ -179,7 +179,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AppleIncCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Apple Inc. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in Apple Inc.</skos:definition>
@@ -466,7 +466,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;CitigroupIncCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Citigroup Inc. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in Citigroup Inc.</skos:definition>
@@ -585,7 +585,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>International Business Machines Corporation common stock</rdfs:label>
 		<skos:definition>common share class representing shares in International Business Machines Corporation</skos:definition>
@@ -623,7 +623,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in J.P. Morgan Chase &amp; Co.</skos:definition>
@@ -670,7 +670,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>The Coca-Cola Company common stock</rdfs:label>
 		<skos:definition>common share class representing shares in The Coca-Cola Company</skos:definition>
@@ -708,7 +708,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>The Home Depot, Inc. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in The Home Depot, Inc.</skos:definition>
@@ -747,7 +747,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>The Proctor &amp; Gamble Company common stock</rdfs:label>
 		<skos:definition>common share class representing shares in The Proctor &amp; Gamble Company</skos:definition>
@@ -884,7 +884,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;WellsFargoCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<rdfs:label>Wells Fargo common stock</rdfs:label>
 		<skos:definition>Wells Fargo &amp; Company common share</skos:definition>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -63,348 +63,850 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityCFIClassificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form, and eliminate restrictions embedded in intersection related to security form.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form, eliminate embedded restrictions, and build out additional classes representing the various feature-based descriptions supported by the CFI standard.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonEnhancedVotingRestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, enhanced voting, restricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers multiple votes per share, is restricted from a sales / transfer perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonEnhancedVotingRestrictedNilPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NilPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, enhanced voting, restricted, nil paid, registered share</rdfs:label>
+		<skos:definition>common share that confers multiple votes per share, is restricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonEnhancedVotingRestrictedPartlyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, enhanced voting, restricted, partly paid, registered share</rdfs:label>
+		<skos:definition>common share that confers multiple votes per share, is restricted from a sales / transfer perspective, is partially paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonEnhancedVotingUnrestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, enhanced voting, unrestricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers multiple votes per share, is not restricted from a sales / transfer perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonEnhancedVotingUnrestrictedNilPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NilPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, enhanced voting, unrestricted, nil paid, registered share</rdfs:label>
+		<skos:definition>common share that confers multiple votes per share, is not restricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonEnhancedVotingUnrestrictedPartlyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, enhanced voting, unrestricted, partly paid, registered share</rdfs:label>
+		<skos:definition>common share that confers multiple votes per share, is not restricted from a sales / transfer perspective, is partially paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonNonVotingRestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, non-voting, restricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly 0 votes per share, is restricted from a sales / transfer perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonNonVotingRestrictedNilPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NilPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, non-voting, restricted, nil paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly 0 votes per share, is restricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonNonVotingRestrictedPartlyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, non-voting, restricted, partly paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly 0 votes per share, is restricted from a sales / transfer perspective, is partially paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonNonVotingUnrestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonNonVotingUnrestrictedNilPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NilPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted,  nil paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is nil paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonNonVotingUnrestrictedPartlyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted,  partly paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is partially paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonRestrictedVotingRestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, restricted voting, restricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers less than one vote per share, is restricted from a sales / transfer perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonRestrictedVotingRestrictedNilPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NilPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, restricted voting, restricted, nil paid, registered share</rdfs:label>
+		<skos:definition>common share that confers less than one vote per share, is restricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonRestrictedVotingRestrictedPartlyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, restricted voting, restricted, partly paid, registered share</rdfs:label>
+		<skos:definition>common share that confers less than one vote per share, is restricted from a sales / transfer perspective, is partially paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonRestrictedVotingUnrestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, restricted voting, unrestricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers less than one vote per share, is unrestricted from a sales / transfer perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonRestrictedVotingUnrestrictedNilPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NilPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, restricted voting, unrestricted, nil paid, registered share</rdfs:label>
+		<skos:definition>common share that confers less than one vote per share, is unrestricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonRestrictedVotingUnrestrictedPartlyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, restricted voting, unrestricted, partly paid, registered share</rdfs:label>
+		<skos:definition>common share that confers less than one vote per share, is unrestricted from a sales / transfer perspective, is partially paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonVotingRestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, voting, restricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly one vote per share, is restricted from a sales / transfer perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonVotingRestrictedNilPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NilPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, voting, restricted, nil paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly one vote per share, is restricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonVotingRestrictedPartlyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, voting, restricted, partly paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly one vote per share, is restricted from a sales / transfer perspective, is partially paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonVotingUnrestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, voting, unrestricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly one vote per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonVotingUnrestrictedNilPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NilPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUOR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, voting, unrestricted, nil paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly one vote per share, is unrestricted from a sales perspective, is nil paid and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonVotingUnrestrictedPartlyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUPR"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, voting, unrestricted, partly paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly one vote per share, is unrestricted from a sales perspective, is partially paid and is registered</skos:definition>
+	</owl:Class>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESETFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;EnhancedVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;EnhancedVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
 		<rdfs:label>ESETFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, restricted transfer, fully-paid, registered share</skos:definition>
 		<lcc-lr:hasTag>ESETFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESETOR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESETOR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, enhanced voting, restricted transfer, nil paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESETOR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESETPR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESETPR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, enhanced voting, restricted transfer, partly paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESETPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESEUFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;EnhancedVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;EnhancedVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
 		<rdfs:label>ESEUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, unrestricted transfer, fully-paid, registered share</skos:definition>
 		<lcc-lr:hasTag>ESEUFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESEUOR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESEUOR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, enhanced voting, unrestricted transfer, nil paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESEUOR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESEUPR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESEUPR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, enhanced voting, unrestricted transfer, partially paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESEUPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNTFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;NonVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;NonVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
 		<rdfs:label>ESNTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, restricted transfer, fully-paid, registered share</skos:definition>
 		<lcc-lr:hasTag>ESNTFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNTOR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESNTOR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, non-voting, restricted transfer, nil paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESNTOR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNTPR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESNTPR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, non-voting, restricted transfer, partially paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESNTPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNUFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare"/>
-			</owl:Restriction>
-		</rdf:type>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare"/>
-			</owl:Restriction>
-		</rdf:type>
 		<rdfs:label>ESNUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, unrestricted transfer, fully-paid, registered share</skos:definition>
 		<lcc-lr:hasTag>ESNUFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNUOR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESNUOR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, non-voting, unrestricted transfer, nil paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESNUOR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNUPR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESNUPR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, non-voting, unrestricted transfer, partially paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESNUPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRTFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
 		<rdfs:label>ESRTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, restricted transfer, fully-paid, registered share</skos:definition>
 		<lcc-lr:hasTag>ESRTFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRTOR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESRTOR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, restricted voting, restricted transfer, nil paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESRTOR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRTPR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESRTPR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, restricted voting, restricted transfer, partly paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESRTPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRUFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
 		<rdfs:label>ESRUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, unrestricted transfer, fully-paid, registered share</skos:definition>
 		<lcc-lr:hasTag>ESRUFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRUOR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESRUOR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, restricted voting, unrestricted transfer, nil paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESRUOR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRUPR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESRUPR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, restricted voting, unrestricted transfer, partly paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESRUPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVTFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;SingleVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;SingleVotingShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
-							</rdf:Description>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdf:type>
 		<rdfs:label>ESVTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, restricted transfer, fully-paid, registered share</skos:definition>
 		<lcc-lr:hasTag>ESVTFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVTOR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESVTOR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, voting, restricted transfer, nil paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESVTOR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVTPR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESVTPR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, voting, restricted transfer, partly paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESVTPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVUFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
-			</owl:Restriction>
-		</rdf:type>
-		<rdf:type>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
-			</owl:Restriction>
-		</rdf:type>
 		<rdfs:label>ESVUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, unrestricted transfer, fully-paid, registered share</skos:definition>
 		<lcc-lr:hasTag>ESVUFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVUOR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESVUOR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, voting, unrestricted transfer, nil paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESVUOR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVUPR">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+		<rdfs:label>ESVUPR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, voting, unrestricted transfer, partly paid, registered share</skos:definition>
+		<lcc-lr:hasTag>ESVUPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
 
 </rdf:RDF>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -3256,5 +3256,828 @@
 		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable, participating, registered share</rdfs:label>
 		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExchangeableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, exchangeable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExchangeableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, exchangeable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExchangeableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, exchangeable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExchangeableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, exchangeable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExchangeableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, exchangeable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExchangeableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, exchangeable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExchangeableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, exchangeable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingPerpetualAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, perpetual, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, has no fixed maturity date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingPerpetualAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, perpetual, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, has no fixed maturity date, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingPerpetualCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, perpetual, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, has no fixed maturity date, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingPerpetualCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, perpetual, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, has no fixed maturity date, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingPerpetualFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, perpetual, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, has no fixed maturity date, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingPerpetualNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, perpetual, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, has no fixed maturity date, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingPerpetualParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, voting, perpetual, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, has no fixed maturity date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable exchangeable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable exchangeable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable exchangeable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable exchangeable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable/exchangeable/extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable/exchangeable/extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable/exchangeable/extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable/exchangeable/extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable/exchangeable/extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable/exchangeable/extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable/exchangeable/extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable exchangeable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable exchangeable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable exchangeable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, voting, redeemable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers exactly one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
 
 </rdf:RDF>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -796,6 +796,15 @@
 		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, exchangeable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
@@ -864,6 +873,24 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, adjustable income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableCumulativeParticipatingRegisteredShare">
@@ -972,6 +999,15 @@
 		<skos:definition>preferred share that confers multiple votes per share, has no fixed maturity date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingPerpetualAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, perpetual, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, has no fixed maturity date, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingPerpetualCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
@@ -1042,6 +1078,24 @@
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
@@ -1099,6 +1153,25 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable exchangeable, adjustable income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable exchangeable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableCumulativeParticipatingRegisteredShare">
@@ -1160,6 +1233,25 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable/exchangeable/extendable, adjustable income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable/exchangeable/extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableCumulativeParticipatingRegisteredShare">
@@ -1340,6 +1432,24 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable extendable, adjustable income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableCumulativeParticipatingRegisteredShare">

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -305,7 +305,7 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted,  nil paid, registered share</rdfs:label>
+		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted, nil paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is nil paid and is registered</skos:definition>
 	</owl:Class>
 	
@@ -327,7 +327,7 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted,  partly paid, registered share</rdfs:label>
+		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted, partly paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is partially paid and is registered</skos:definition>
 	</owl:Class>
 	
@@ -963,6 +963,67 @@
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingPerpetualAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, perpetual, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, has no fixed maturity date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingPerpetualCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, perpetual, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, has no fixed maturity date, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingPerpetualCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, perpetual, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, has no fixed maturity date, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingPerpetualFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, perpetual, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, has no fixed maturity date, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingPerpetualNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, perpetual, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, has no fixed maturity date, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingPerpetualParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, perpetual, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, has no fixed maturity date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableAdjustableIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
@@ -1019,6 +1080,248 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, cumulative, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable exchangeable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable exchangeable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable exchangeable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable/exchangeable/extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable/exchangeable/extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable/exchangeable/extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable/exchangeable/extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable/exchangeable/extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable/exchangeable/extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable exchangeable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable exchangeable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable exchangeable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableAdjustableIncomeRegisteredShare">

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -43,8 +43,8 @@
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/</sm:dependsOn>
@@ -64,6 +64,7 @@
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityCFIClassificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form, eliminate embedded restrictions, and build out additional classes representing the various feature-based descriptions supported by the CFI standard.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to complete the set of possible common share representations corresponding to the CFI standard, complete the set of corresponding codes for common shares (non-convertible), and add the set of possible combinations for preferred shares (non-convertible).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -1518,7 +1519,6 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Class>
@@ -2059,7 +2059,7 @@
 			</owl:Class>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable/exchangeable/extendable, adjustable income, registered share</rdfs:label>
-		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableAuctionRateIncomeRegisteredShare">
@@ -2341,7 +2341,6 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableNormalIncomeRegisteredShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -2433,6 +2432,829 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable, participating, registered share</rdfs:label>
 		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExchangeableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, exchangeable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExchangeableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, exchangeable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExchangeableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, exchangeable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExchangeableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, exchangeable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExchangeableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, exchangeable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExchangeableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, exchangeable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExchangeableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, exchangeable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingPerpetualAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, perpetual, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, has no fixed maturity date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingPerpetualAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred,  restricted voting, perpetual, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, has no fixed maturity date, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingPerpetualCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, perpetual, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, has no fixed maturity date, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingPerpetualCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, perpetual, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, has no fixed maturity date, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingPerpetualFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, perpetual, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, has no fixed maturity date, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingPerpetualNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, perpetual, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, has no fixed maturity date, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingPerpetualParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, perpetual, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, has no fixed maturity date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable exchangeable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable exchangeable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable exchangeable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable exchangeable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable/exchangeable/extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable/exchangeable/extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable/exchangeable/extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable/exchangeable/extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable/exchangeable/extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable/exchangeable/extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable/exchangeable/extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable exchangeable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable exchangeable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable exchangeable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, restricted voting, redeemable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers less than one vote per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>
 
 </rdf:RDF>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -787,11 +787,81 @@
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableAdjustableIncomeRegisteredShare">
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableAdjustableIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, exchangeable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, exchangeable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, exchangeable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, exchangeable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, exchangeable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, exchangeable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, adjustable income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
 	</owl:Class>
@@ -799,10 +869,19 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, cumulative participating, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>
@@ -810,40 +889,76 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, cumulative, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableFixedIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, fixed income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, normal income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, extendable, participating, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>
@@ -851,8 +966,17 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableAdjustableIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, adjustable income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
 	</owl:Class>
@@ -862,8 +986,17 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, cumulative participating, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>
@@ -873,10 +1006,134 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, cumulative, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableFixedIncomeRegisteredShare">
@@ -884,16 +1141,34 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, fixed income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, normal income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
 	</owl:Class>
@@ -903,8 +1178,17 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, participating, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -841,6 +841,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, exchangeable, normal income, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
@@ -955,6 +956,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Class>
@@ -1043,6 +1045,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingPerpetualNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, perpetual, normal income, registered share</rdfs:label>
@@ -1320,6 +1323,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Class>
@@ -1514,6 +1518,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Class>
@@ -1604,6 +1609,830 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">preferred, enhanced voting, redeemable, participating, registered share</rdfs:label>
 		<skos:definition>preferred share that confers multiple votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExchangeableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, exchangeable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExchangeableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, exchangeable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExchangeableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, exchangeable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExchangeableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, exchangeable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExchangeableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, exchangeable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExchangeableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, exchangeable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExchangeableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, exchangeable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingPerpetualAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, perpetual, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, has no fixed maturity date, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingPerpetualAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, perpetual, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, has no fixed maturity date, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingPerpetualCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, perpetual, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, has no fixed maturity date, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingPerpetualCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, perpetual, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, has no fixed maturity date, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingPerpetualFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, perpetual, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, has no fixed maturity date, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingPerpetualNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, perpetual, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, has no fixed maturity date, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingPerpetualParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PerpetualPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, perpetual, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, has no fixed maturity date, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable exchangeable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable exchangeable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable exchangeable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable exchangeable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable/exchangeable/extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers multiple votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable/exchangeable/extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable/exchangeable/extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable/exchangeable/extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable/exchangeable/extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable/exchangeable/extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable/exchangeable/extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable exchangeable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable exchangeable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable exchangeable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be exchanged for securities of another issuer, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable extendable, adjustable income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is set periodically, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable extendable, auction rate income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic income whose dividend rate is adjusted through an auction, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableCumulativeParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable extendable, cumulative participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, dividends not paid in any year accumulate, and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableCumulativeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable extendable, cumulative, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and dividends not paid in any year accumulate, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable extendable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable extendable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable extendable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, whose issuer and/or shareholders have the option to extend the maturity date, that provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable, fixed income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable, normal income, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides the same dividends as common/ordinary shareholders, and is registered</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShare">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-eq-eq;RetractablePreferredShare">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">preferred, non-voting, redeemable, participating, registered share</rdfs:label>
+		<skos:definition>preferred share that confers zero votes per share, may be redeemed at the option of the issuer and/or of the shareholder, provides a periodic stated income and participates with common shareholders in further dividend and capital distributions, and is registered</skos:definition>
 	</owl:Class>
 
 </rdf:RDF>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -153,6 +153,18 @@
 		<fibo-fnd-utl-av:explanatoryNote>The value of the dividend from the preferred share is set by a predetermined formula to move with rates, and because of this flexibility preferred prices are often more stable then fixed-rate preferred stocks.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;AuctionRateDividend">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredDividend"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasAdjustableDividendRate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>auction rate dividend</rdfs:label>
+		<skos:definition>preferred share dividend that is periodically re-set through auctions, typically every 7, 14, 28, or 35 days</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:subClassOf>
@@ -648,6 +660,20 @@
 		<fibo-fnd-utl-av:explanatoryNote>Participating preferred shares are rare, typically only issued when needed to attract investors.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;PerpetualPreferredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasMaturityDate"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>perpetual preferred share</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedMaturityDate"/>
+		<skos:definition>preferred share that has no fixed maturity date</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;PrecedenceRight">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualRight"/>
 		<rdfs:label>precedence right</rdfs:label>
@@ -1045,7 +1071,7 @@
 		<rdfs:label>has adjustable dividend rate</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PreferredDividend"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
-		<skos:definition>indicates the pre-arranged variable dividend rate, typically specified in the prospectus as a formula based on a benchmark, for a preferred share</skos:definition>
+		<skos:definition>indicates a variable dividend rate, typically specified in the prospectus as a formula based on a benchmark or set at auction</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasDistributionMethod">

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -442,9 +442,14 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ExtendablePreferredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasExtensionProvision"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ExtensionProvision"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>extendable preferred share</rdfs:label>
 		<skos:definition>redeemable preferred share whose redemption date can be extended</skos:definition>
-		<skos:editorialNote>Need to add hasExtensionProvision, once that is moved from Debt</skos:editorialNote>
 		<fibo-fnd-utl-av:synonym>extendible preferred share</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -478,6 +483,13 @@
 		<rdfs:label>fully paid share status</rdfs:label>
 		<skos:definition>status indicating that no additional money is owed to the company by shareholders on the value of the shares</skos:definition>
 	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;HardRetractablePreferredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RetractablePreferredShare"/>
+		<rdfs:label>hard retractable preferred share</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;SoftRetractablePreferredShare"/>
+		<skos:definition>retractable preferred share whose retraction value must be paid in cash</skos:definition>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;LimitedPartnershipUnit">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
@@ -698,6 +710,19 @@
 		<skos:definition>preferred share whose dividends will vary with a benchmark, most often a T-bill rate</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;PreferredShareWithFixedMaturityDate">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasMaturityDate"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>preferred share with fixed maturity date</rdfs:label>
+		<skos:definition>preferred share whose maturity date is set, typically according to the terms of the prospectus</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
 		<rdfs:subClassOf>
@@ -734,6 +759,19 @@
 		</rdfs:subClassOf>
 		<rdfs:label>redeemable preferred share</rdfs:label>
 		<skos:definition>preferred share that gives the issuer the right to redeem the stock under specified conditions</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedMaturityDate"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasExtendableMaturityDate"/>
+				<owl:hasValue rdf:datatype="&xsd;boolean">true</owl:hasValue>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>redeemable preferred share with extendable maturity date</rdfs:label>
+		<skos:definition>redeemable preferred share with a fixed maturity date whose issuer and/or holders have the option to extend the maturity date</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;RestrictedShare">
@@ -780,13 +818,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasMaturityDate"/>
-				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasRedemptionProvision"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;EquityRedemptionProvision"/>
 			</owl:Restriction>
@@ -794,6 +825,25 @@
 		<rdfs:label>retractable preferred share</rdfs:label>
 		<skos:definition>preferred share that gives the owner (shareholder) the right to redeem the stock under specified conditions</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>When retractable preferred shares reach maturity, the shareholder has the right to sell them back to the stock issuer at the price stated on the agreement. In some cases, the issuer can force the shareholder to sell, and may have the option of exchanging retractable preferred shares for common shares instead of cash.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedMaturityDate"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RetractablePreferredShare"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasExtendableMaturityDate"/>
+				<owl:hasValue rdf:datatype="&xsd;boolean">true</owl:hasValue>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasExtensionProvision"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ExtensionProvision"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>retractable preferred share with extendable maturity date</rdfs:label>
+		<skos:definition>retractable preferred share with a fixed maturity date whose issuer and/or holders have the option to extend the maturity date</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
@@ -880,6 +930,12 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">single voting share</rdfs:label>
 		<skos:definition xml:lang="en">share that has the right to exactly one vote</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;SoftRetractablePreferredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RetractablePreferredShare"/>
+		<rdfs:label>soft retractable preferred share</rdfs:label>
+		<skos:definition>retractable preferred share whose retraction value may be paid in cash or in an equal value of common stock of the issuer, at the option of the issuer</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;SpecialDividend">
@@ -1009,6 +1065,13 @@
 		<fibo-fnd-utl-av:synonym>has ex-date</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>has expected dividend date</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasExtendableMaturityDate">
+		<rdfs:label>has extendable maturity date</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition>indicates whether the issuer and/or holders of redeemable shares with a fixed maturity date have the option to extend the maturity date</skos:definition>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasFixedDividendRate">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -130,7 +130,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments, including features specific to preferred shares.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, clean up ambiguous definitions, and eliminate redundant restrictions related to security form.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add the concept of a retractable preferred share and move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add concepts covering additional features of preferred shares and move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -162,7 +162,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>auction rate dividend</rdfs:label>
-		<skos:definition>preferred share dividend that is periodically re-set through auctions, typically every 7, 14, 28, or 35 days</skos:definition>
+		<skos:definition>preferred share dividend whose rate is periodically reset through an auction, typically every 7, 14, 28, or 35 days</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonShare">
@@ -745,7 +745,20 @@
 		</rdfs:subClassOf>
 		<rdfs:label>preferred share with adjustable rate dividend</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
-		<skos:definition>preferred share whose dividends will vary with a benchmark, most often a T-bill rate</skos:definition>
+		<skos:definition>preferred share whose dividend rate varies according to some benchmark</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasDividend"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;AuctionRateDividend"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>preferred share with auction rate dividend</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
+		<skos:definition>preferred share whose dividend rate is periodically reset through an auction, such as a Dutch auction</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;PreferredShareWithFixedMaturityDate">

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -424,6 +424,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasExtendableRedemptionDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;isRedeemableAtIssuerOption"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;boolean"/>
@@ -440,17 +447,22 @@
 		<skos:definition xml:lang="en">redemption provision that specifies the conditions under which the issuer or shareholder may redeem the shares</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;ExtendablePreferredShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
+	<owl:Class rdf:about="&fibo-sec-eq-eq;EquityRedemptionProvisionWithExtendableRedemptionDate">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EquityRedemptionProvision"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasExtensionProvision"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ExtensionProvision"/>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasExtendableRedemptionDate"/>
+				<owl:hasValue rdf:datatype="&xsd;boolean">true</owl:hasValue>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>extendable preferred share</rdfs:label>
-		<skos:definition>redeemable preferred share whose redemption date can be extended</skos:definition>
-		<fibo-fnd-utl-av:synonym>extendible preferred share</fibo-fnd-utl-av:synonym>
+		<rdfs:label xml:lang="en">equity redemption provision with extendable redemption date</rdfs:label>
+		<skos:definition xml:lang="en">equity redemption provision that allows modification of the redemption date beyond the original specified date</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;ExchangeablePreferredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
+		<rdfs:label>exchangeable preferred share</rdfs:label>
+		<skos:definition>preferred share that may be exchanged for a security of another issuer</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;FixedRateDividend">
@@ -762,8 +774,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableMaturityDate">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedMaturityDate"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasExtendableMaturityDate"/>
@@ -771,7 +783,20 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>redeemable preferred share with extendable maturity date</rdfs:label>
-		<skos:definition>redeemable preferred share with a fixed maturity date whose issuer and/or holders have the option to extend the maturity date</skos:definition>
+		<skos:definition>redeemable preferred share with a fixed maturity date whose issuer has the option to extend the maturity date</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;RedeemablePreferredShareWithExtendableRedemptionDate">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RedeemablePreferredShare"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasExtensionProvision"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;EquityRedemptionProvisionWithExtendableRedemptionDate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>redeemable preferred share with extendable redemption date</rdfs:label>
+		<skos:definition>redeemable preferred share whose redemption date can be modified</skos:definition>
+		<fibo-fnd-utl-av:synonym>extendible preferred share</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;RestrictedShare">
@@ -838,12 +863,32 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasExtendableMaturityDate"/>
+				<owl:hasValue rdf:datatype="&xsd;boolean">true</owl:hasValue>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasExtensionProvision"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ExtensionProvision"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>retractable preferred share with extendable maturity date</rdfs:label>
+		<skos:definition>retractable preferred share with a fixed maturity date whose holders have the option to extend the maturity date</skos:definition>
 		<skos:definition>retractable preferred share with a fixed maturity date whose issuer and/or holders have the option to extend the maturity date</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableRedemptionDate">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RetractablePreferredShare"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasExtensionProvision"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;EquityRedemptionProvisionWithExtendableRedemptionDate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>retractable preferred share with extendable redemption date</rdfs:label>
+		<skos:definition>retractable preferred share whose redemption date can be modified</skos:definition>
+		<fibo-fnd-utl-av:synonym>extendible preferred share</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
@@ -1071,6 +1116,13 @@
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether the issuer and/or holders of redeemable shares with a fixed maturity date have the option to extend the maturity date</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasExtendableRedemptionDate">
+		<rdfs:label>has extendable redemption date</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;EquityRedemptionProvision"/>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition>indicates whether the issuer and/or holders of redeemable shares with a specified redemption date have the option to extend that date</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasFixedDividendRate">

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -130,7 +130,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments, including features specific to preferred shares.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, clean up ambiguous definitions, and eliminate redundant restrictions related to security form.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add the concept of a retractable preferred share.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add the concept of a retractable preferred share and move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -153,16 +153,6 @@
 		<fibo-fnd-utl-av:explanatoryNote>The value of the dividend from the preferred share is set by a predetermined formula to move with rates, and because of this flexibility preferred prices are often more stable then fixed-rate preferred stocks.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
-		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted, fully-paid, registered share</rdfs:label>
-		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:subClassOf>
@@ -177,16 +167,6 @@
 		<skos:definition>share that signifies a unit of ownership in a corporation and represents a claim on part of the corporation&apos;s assets and earnings</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In the event that the corporation is liquidated, claims of secured and unsecured creditors and owners of bonds and preferred shares take precedence over claims of common share holders.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en-GB">ordinary share</fibo-fnd-utl-av:synonym>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;FullyPaidShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
-		<rdfs:label xml:lang="en-US">common, voting, unrestricted, fully-paid, registered share</rdfs:label>
-		<skos:definition>common share that confers exactly 1 vote per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ConvertibleCommonShare">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Augmented the reference Equity CFI Classification ontology to include a complete set of classes covering sections 6.2.2 Equities - Common/ordinary shares and 6.2.3 Equities - Preferred/preference shares, for those that are classified as registered securities with respect to the fourth attribute.  This does not yet include all of the codes for preferred shares, only those that apply to common shares.  We anticipate building out those codes as well as the classes covering sections 6.2.4 Equities - Common/ordinary convertible shares, and 6.2.5 Equities - Preferred/preference convertible shares over the coming months.

Note that this change adds 196 classes for preferred shares alone, and, due to numerous hasValue restrictions, increases the time it takes for a DL reasoner to complete processing accordingly.

Fixes: #1319 / SEC-73


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


