### PR TITLE
Problematic sources in citations

### DIFF
--- a/BP/SecuritiesIssuance/AgencyMBSIssuance.rdf
+++ b/BP/SecuritiesIssuance/AgencyMBSIssuance.rdf
@@ -373,13 +373,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
 				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AssessPoolSuitablilityForIssuance"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
 				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;ClassifyMortgage"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/BP/SecuritiesIssuance/DebtIssuance.rdf
+++ b/BP/SecuritiesIssuance/DebtIssuance.rdf
@@ -54,9 +54,13 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/">
-		<rdfs:label xml:lang="en">DebtIssuance</rdfs:label>
+		<rdfs:label xml:lang="en">Debt Issuance Ontology</rdfs:label>
 		<dct:abstract>General issuance process for issuance of debt instruments. Forms the basis for more detailed issuance processes such as MBS issuance and municipal bonds issue.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-bp-iss-dbti</sm:fileAbbreviation>
+		<sm:filename>DebtIssuance.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/IssuanceProcess/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MuniIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
@@ -87,20 +91,20 @@
 	<owl:Class rdf:about="&fibo-bp-iss-dbti;AdvancedRefunding">
 		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RefundingPurpose"/>
 		<rdfs:label xml:lang="en">advance refunding</rdfs:label>
-		<skos:definition xml:lang="en">A bond issuance in which new bonds are sold at a lower rate than outstanding ones. The proceeds are then invested, and when the older bonds become callable they are paid off with the invested proceeds.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin xml:lang="en">http://www.investopedia.com/terms/a/advancedrefunding.asp#ixzz4K90cVzeN</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition xml:lang="en">refunding in which bond issuance in which new bonds are sold at a lower rate than outstanding ones</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The proceeds are then invested, and when the older bonds become callable they are paid off with the invested proceeds.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-bp-iss-dbti;AssetPoolCreationProcess">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;followedBy"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-fpas;precedes"/>
 				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;isCreationOf"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProducedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -267,7 +271,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;Registration"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;isAbout"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-doc;isAbout"/>
 				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;MediumTermNoteIssuanceProgramme"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -332,6 +336,12 @@
 	
 	<owl:Class rdf:about="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor">
 		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;SecuritizationProcessActor"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
+				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">pool backed security securitization process actor</rdfs:label>
 	</owl:Class>
 	
@@ -351,13 +361,13 @@
 		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;followedBy"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-fpas;precedes"/>
 				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcess"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;isCreationOf"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProducedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -381,18 +391,6 @@
 		<skos:definition xml:lang="en">The issue of one or more securities that the announcement pertains to.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;assesses">
-		<rdfs:label xml:lang="en">assesses</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;followedBy">
-		<rdfs:label xml:lang="en">followed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;hasDebtIssuancePurpose">
 		<rdfs:label xml:lang="en">has debt issuance purpose</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;DebtIssuanceProcessInformation"/>
@@ -407,27 +405,11 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The OID is the difference between the stated redemption price at maturity and the actual issue price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;isAbout">
-		<rdfs:label xml:lang="en">is about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;MTNRegistration"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-dbti;MediumTermNoteIssuanceProgramme"/>
-		<skos:definition xml:lang="en">The registration process for a MTN registers the program ahead of the issue of individual MTN securities.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-bp-iss-dbti;isBankQualified">
 		<rdfs:label xml:lang="en">is bank qualified</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;BondOffering"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">designation given to a public purpose bond offering by the issuer if it reasonably expects to issue in the calendar year of such offering no more than $10 million par amount of bonds of the type required to be included in making such calculation under the Internal Revenue Code.  When purchased by a commercial bank for its portfolio, the bank may receive an 80% tax deduction for the interest cost of carry for the issue.  A bond that is bank qualified is also known as a qualified tax-exempt obligation.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;isCreationOf">
-		<rdfs:label xml:lang="en">is creation of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-bp-iss-dbti;lifecycleState">
-		<rdfs:label xml:lang="en">lifecycle state</rdfs:label>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;resultsIn">

--- a/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
+++ b/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
@@ -442,13 +442,13 @@
 		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
 				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AssessPoolSuitabilityForIssuance"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
 				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AssessRatings"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -43,7 +43,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20201201/Relations/Relations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Relations/Relations/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20170201/Relations/Relations.rdf version of this ontology was modified per the FIBO 2.0 RFC to include additional properties and the linkage to LCC.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Relations/Relations.owl version of the ontology submitted with 
 the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
@@ -65,12 +65,13 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and remove the unused hasDispositionDate property, whose semantics were unclear at best.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions, to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name, to loosen domain restrictions on some properties which were too narrowly specified, and to add two new properties, describes and isDescribedBy, which are more appropriate for certain cases where we were using characterizes and isCharacterizedBy.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Relations/Relations.rdf version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201201/Relations/Relations.rdf version of this ontology was modified to clean up references to external dictionaries that don&apos;t meet FIBO policies, eliminate ambiguity where possible, eliminate the superproperties of produces and is produced by, whose semantics are different from their parent properties, and improve ISO 704 compliance of definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-rel-rel;Reference">
 		<rdfs:label>reference</rdfs:label>
-		<skos:definition>concept that stands in for how something may be interpreted or understood in some context</skos:definition>
+		<skos:definition>concept that stands in for how something may be interpreted/understood in some context</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In linguistics, a reference characterizes, provides context for, or specifies the relationship of one linguistic expression to another, i.e., provides the information necessary to interpret the dependent expression.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -98,29 +99,26 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;comprises">
 		<rdfs:label>comprises</rdfs:label>
-		<skos:definition>includes, especially within a particular scope, is made up of</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.merriam-webster.com/dictionary/comprise</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>includes, especially within a particular scope</skos:definition>
 		<fibo-fnd-utl-av:usageNote>Note that something can be comprised of something(s) that may or may not be understood as separable parts, and thus is not defined as being explicitly transitive.</fibo-fnd-utl-av:usageNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;confers">
 		<rdfs:label>confers</rdfs:label>
 		<skos:definition>grants or bestows by virtue of some authority</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin>Merriam-Webster Online Dictionary</fibo-fnd-utl-av:definitionOrigin>
 		<fibo-fnd-utl-av:explanatoryNote>This property should be read as describing the conferral of some legal power or duty, some commitment or some social construct, and is a property of some social construct such as an agreement or some legal authority. These concepts, which would describe the kind of thing of which this is a property, and the kinds of thing in terms of which this property is framed, are outside the scope of this mode land so are not shown.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>invests with</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;controls">
 		<rdfs:label>controls</rdfs:label>
-		<skos:definition>exercises authoritative or dominating influence over; directs</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>The American Heritage(R) Dictionary of the English Language, Fourth Edition</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>exercises authority or influence over</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;defines">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;represents"/>
 		<rdfs:label>defines</rdfs:label>
-		<skos:definition>determines or identifies the essential qualities or meaning of, discovers and sets forth the meaning of, fixes or marks the limits of, demarcates</skos:definition>
+		<skos:definition>identifies the essential qualities of, specifies the meaning of, fixes the limits of, demarcates</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;describes">
@@ -137,7 +135,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;embodies">
 		<rdfs:label>embodies</rdfs:label>
-		<skos:definition>is an expression of, or gives a tangible or visible form to (an idea, quality, or feeling), makes concrete and perceptible</skos:definition>
+		<skos:definition>is an expression of, gives a tangible or visible form to (an idea, quality, or feeling), makes concrete and perceptible</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;evaluates">
@@ -158,29 +156,25 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;governs">
 		<rdfs:label>governs</rdfs:label>
-		<skos:definition>prevails or has decisive influence over; exercises authority</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.merriam-webster.com/dictionary/govern</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>This property should be read as being the property of a logical union of social construct (in the informative abstractions ontology) and legal person, and as referring to &apos;thing&apos;.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>has and exercises authority over, regulates</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasAlias">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>has alias</rdfs:label>
-		<skos:definition>Any other name by which an individual or organization is known</skos:definition>
-		<skos:editorialNote>Added at SME Review, to meet AML requirements</skos:editorialNote>
+		<skos:definition>indicates an alternate name of by which something is known</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasCommonName">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>has common name</rdfs:label>
-		<skos:definition>a name by which something is frequently referred, without reference to any formal usage or structure</skos:definition>
+		<skos:definition>indicates a name by which something is frequently referred, without reference to any formal usage or structure</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;hasContext">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
 		<rdfs:label>has context</rdfs:label>
-		<skos:definition>provides a context in which something is defined, expressed, or represented</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This property should be read as referring to some context (known as &apos;mediating thing&apos;) in the informative upper ontology which is not included in this model. It should also be read as being the property of some contextually defined thing (known in the informative upper ontology as &apos;relative thing&apos;).</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>indicates the setting in which something is defined, expressed, or represented</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;hasDesignation">
@@ -192,7 +186,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasFormalName">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>has formal name</rdfs:label>
-		<skos:definition>a name by which something is known for some official purpose or context, or which is structured in some way such as to always follow the same format regardless of usage</skos:definition>
+		<skos:definition>indicates a name by which something is known for some official purpose or context, or which is structured in some way such as to always follow the same format regardless of usage</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;hasIdentity">
@@ -205,7 +199,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasLegalName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasFormalName"/>
 		<rdfs:label>has legal name</rdfs:label>
-		<skos:definition>the name used to refer to an person or organization in legal communications</skos:definition>
+		<skos:definition>specifies the name used to refer to a party in legal communications</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;hasRepresentation">
@@ -308,7 +302,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isGovernedBy">
 		<rdfs:label>is governed by</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;governs"/>
-		<skos:definition>a relationship between a contract, agreement, jurisdiction, or other legal construct and the regulation, policy, procedure, or legal person that regulates or oversees (governs) it</skos:definition>
+		<skos:definition>relates a contract, agreement, jurisdiction, or other legal construct and the regulation, policy, procedure, or legal person that regulates or oversees (governs) it</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>This property should be read as being the property of some thing and as referring to a logical union of social construct (in the informative abstractions ontology) and legal person.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
@@ -328,7 +322,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
 		<rdfs:label>is issued by</rdfs:label>
 		<skos:definition>indicates a functional entity or party responsible for circulating, distributing, or publishing something</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.thefreedictionary.com/issue</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isManagedBy">
@@ -344,7 +337,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isProducedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
 		<rdfs:label>is produced by</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;produces"/>
 		<skos:definition>identifies the producer that fabricates, manufactures or otherwise creates something through some production process</skos:definition>
@@ -362,14 +354,12 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<rdfs:label>issues</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
 		<skos:definition>officially makes something available</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.merriam-webster.com/dictionary/issue</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;manages">
 		<rdfs:label>manages</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
-		<skos:definition>relates an autonomous agent to something that it directs in some way</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This property should be read as always being a property of some kind of &apos;relative thing&apos;, that is a thing defined in some context. Generally this will be a &apos;party in role&apos;. This property is not intended to be used to relate some independent thing to that which it manages, instead it must only be a property of something in the role of being that which manages some thing.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>relates a party to something that it directs in some way</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;mandates">
@@ -380,15 +370,13 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;produces">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;provides"/>
 		<rdfs:label>produces</rdfs:label>
-		<skos:definition>identifies something that is fabricated, manufactured or created via some production process</skos:definition>
+		<skos:definition>creates through a fabrication, manufacturing or production process</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;provides">
 		<rdfs:label>provides</rdfs:label>
 		<skos:definition>makes something available</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This property should be read as always being a property of some kind of &apos;relative thing&apos;, that is a thing defined in some context. Generally this will be a &apos;party in role&apos;. This property is not intended to be used to relate some independent thing to that which it provides, instead it must only be a property of something in the role of being that which provides some thing.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;refersTo">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

In Relations, cleaned up references to external dictionaries that don't meet FIBO policies, eliminated ambiguity in definitions where possible, eliminated the superproperties of produces and is produced by whose semantics are different from their parent properties, and improved ISO 704 compliance of definitions; Elsewhere - cleaned up references to external dictionaries that don't meet FIBO policies and eliminated a few duplicate properties uncovered during review

Note that the other remaining references were addressed under FBC-270 / #1325 

Fixes: #1321 / FND-331


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


