### PR TITLE
FBC-271 - Eliminate properties that include "may", "is also" and similar phrases, which violate our hygiene test for masquerading properties

### DIFF
--- a/BE/GovernmentEntities/GovernmentEntities.rdf
+++ b/BE/GovernmentEntities/GovernmentEntities.rdf
@@ -78,7 +78,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/GovernmentEntities/GovernmentEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/GovernmentEntities/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was added to Business Entities, per the issue resolutions identified in the FIBO BE 1.1 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.2 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20170201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
@@ -86,7 +86,7 @@
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20181201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to reflect the move of hasObjective to FND to enable higher level reuse and eliminate a reasoning error.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20190501/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to eliminate duplication of concepts in LCC and merge the countries ontology with locations.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200301/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to replace isAppointedBy with isDesignatedBy due to a name change in Relations, and to add a class for devolved government.</skos:changeNote>
-		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200701/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve and revise circular or ambiguous definitions.</skos:changeNote>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200701/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, revise circular or ambiguous definitions, and to eliminate &apos;hasPartialSovereigntyOver&apos; in favor of &apos;hasSharedSovereigntyOver&apos;.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -519,12 +519,6 @@
 		<rdfs:label>has jurisdiction</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<skos:definition>relates a polity or government entity to one or more jurisdictions, over which it has some level of legal authority</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-ge-ge;hasPartialSovereigntyOver">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-ge-ge;hasSovereigntyOver"/>
-		<rdfs:label>has partial sovereignty over</rdfs:label>
-		<skos:definition>relates a polity to a geopolitical entity where the polity exercises partial dominion and authority of a political state</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-ge-ge;hasSharedSovereigntyOver">

--- a/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions.rdf
@@ -43,9 +43,9 @@
 		<rdfs:label>Canadian Government Entities and Jurisdictions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the set of basic federal government, provincial, and territory level entities and jurisdictions for use in other Canada-specific FIBO ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
@@ -63,7 +63,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200201/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"/>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200201/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to replace &apos;hasPartialSovereigntyOver&apos; with &apos;hasSharedSovereigntyOver&apos;.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -74,19 +75,19 @@
 		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/index.html"/>
 		<skos:definition>individual representing the federated sovereignty and polity that is Canada</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Canada"/>
-		<fibo-be-ge-ge:hasPartialSovereigntyOver rdf:resource="&lcc-3166-2-ca;NorthwestTerritories"/>
-		<fibo-be-ge-ge:hasPartialSovereigntyOver rdf:resource="&lcc-3166-2-ca;Nunavut"/>
-		<fibo-be-ge-ge:hasPartialSovereigntyOver rdf:resource="&lcc-3166-2-ca;Yukon"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;Alberta"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;BritishColumbia"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;Manitoba"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;NewBrunswick"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;NewfoundlandAndLabrador"/>
+		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;NorthwestTerritories"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;NovaScotia"/>
+		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;Nunavut"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;Ontario"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;PrinceEdwardIsland"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;Quebec"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;Saskatchewan"/>
+		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-ca;Yukon"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 	</owl:NamedIndividual>
 	
@@ -98,7 +99,6 @@
 		<skos:definition>individual representing the overall jurisdiction for Canada</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Canada"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Canada#Government_and_politics</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Canada&apos;s federal structure divides government responsibilities between the federal government and the ten provinces. Provincial legislatures are unicameral and operate in parliamentary fashion similar to the House of Commons. Canada&apos;s three territories also have legislatures, but these are not sovereign and have fewer constitutional responsibilities than the provinces. The territorial legislatures also differ structurally from their provincial counterparts.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
@@ -130,7 +130,6 @@
 		<skos:definition>individual representing the federal parliamentary democracy and constitutional monarchy of Canada</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Canada"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Canada</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Canada is a federal parliamentary democracy and a constitutional monarchy, with Queen Elizabeth II being the head of state. The country is officially bilingual at the federal level. It is one of the world&apos;s most ethnically diverse and multicultural nations, the product of large-scale immigration from many countries. Its advanced economy is the eleventh largest in the world, relying chiefly upon its abundant natural resources and well-developed international trade networks.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	

--- a/BE/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions.rdf
@@ -43,9 +43,9 @@
 		<rdfs:label>Mexican Government Entities and Jurisdictions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the set of basic federal government, provincial, and territory level entities and jurisdictions for use in other Mexico-specific FIBO ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2020-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
@@ -63,20 +63,21 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-MX/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200701/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions/"/>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200701/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to replace &apos;hasPartialSovereigntyOver&apos; with &apos;hasSharedSovereigntyOver&apos;.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-mxj;FederalGovernmentOfMexico">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;FederalGovernment"/>
-		<rdfs:label>Federal Government of Mexico</rdfs:label>
+		<rdfs:label xml:lang="en">Federal Government of Mexico</rdfs:label>
+		<rdfs:label xml:lang="es-MX">Gobierno Federal de México</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions/"/>
 		<rdfs:seeAlso rdf:resource="http://www.gob.mx/"/>
-		<skos:definition>the Gobierno de la República, a federal democracy including three branches: executive, legislative, and judicial, which functions per the Constitution of the United Mexican States</skos:definition>
+		<skos:definition>federal presidential constitutional republic with shared sovereignty over the republic with the governments of the 31 individual Mexican states, which functions per the Constitution of the United Mexican States</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-mxj;MexicanJurisdiction"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Mexico"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Federal_government_of_Mexico</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The Federal government of Mexico (alternately known as the Government of the Republic or Gobierno de la República) is the national government of the United Mexican States, the central government established by its constitution to share sovereignty over the republic with the governments of the 31 individual Mexican states.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="es-MX">Gobierno de la República</fibo-fnd-utl-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-mxj;MexicanEntity">
@@ -86,10 +87,10 @@
 		<rdfs:seeAlso rdf:resource="http://www.gob.mx/"/>
 		<skos:definition>federated sovereignty and polity that is Mexico</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Mexico"/>
-		<fibo-be-ge-ge:hasPartialSovereigntyOver rdf:resource="&lcc-3166-2-mx;Aguascalientes"/>
-		<fibo-be-ge-ge:hasPartialSovereigntyOver rdf:resource="&lcc-3166-2-mx;BajaCalifornia"/>
-		<fibo-be-ge-ge:hasPartialSovereigntyOver rdf:resource="&lcc-3166-2-mx;Campeche"/>
+		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-mx;Aguascalientes"/>
+		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-mx;BajaCalifornia"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-mx;BajaCaliforniaSur"/>
+		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-mx;Campeche"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-mx;Chiapas"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-mx;Chihuahua"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-mx;CiudadDeMexico"/>
@@ -126,10 +127,9 @@
 		<rdfs:label>Mexican jurisdiction</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions/"/>
 		<rdfs:seeAlso rdf:resource="https://www.scjn.gob.mx/"/>
-		<skos:definition>jurisdiction of the Suprema Corte de Justicia de la Nación</skos:definition>
+		<skos:definition>jurisdiction of the Supreme Court of Justice of the Nation, including the system of courts that interprets and applies the law at the federal level in Mexico</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-mxj;FederalGovernmentOfMexico"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Mexico"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Supreme_Court_of_Justice_of_the_Nation</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The Supreme Court of Justice of the Nation (SCJN) is the Mexican institution serving as the country&apos;s federal high court and the spearhead organisation for the judiciary of the Mexican Federal Government. It consists of eleven magistrates, known as ministers of the court, one of whom is designated the court&apos;s president.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 

--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -88,12 +88,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210101/DerivativesContracts/Swaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210201/DerivativesContracts/Swaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/Swaps/ version of this ontology was modified to refine the concept of a unique swap identifier (USI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20190201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate the property &apos;hasPaymentSchedule&apos; from this ontology in favor of the equivalent property with the same name from FND, adding concepts related to statistical swaps, and revising definitions to be ISO 704 compliant.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200901/DerivativesContracts/Swaps/ version of this ontology was modified to integrate return swaps and connect swap legs to the swap they comprise, as appropriate, simplify the contract party hierarchy, add basic fixed and floating legs as higher level concepts common to many swaps, and eliminate ambiguity in definitions.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/DerivativesContracts/Swaps/ version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/DerivativesContracts/Swaps/ version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only, and facilitate the elimination of the property &apos;mayBeTradedIn&apos;, which was only used in one place and was redundant with the concept of a ListedSecurity / Listing in SEC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -326,13 +326,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;mayBeTradedIn"/>
-				<owl:onClass rdf:resource="&fibo-der-drc-swp;SwapExecutionFacility"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-der-drc-swp;UniqueSwapIdentifier"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -361,7 +354,6 @@
 		<rdfs:label>swap</rdfs:label>
 		<skos:definition>derivative instrument whereby two counterparties agree to exchange periodic streams of cash flows with each other</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/s/swap.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The underlying instruments can be almost anything, representing various asset classes, but most swaps involve cash flows (streams of payments or other commitments over time) based on a notional principal amount that both parties agree to.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Usually, the principal does not change hands. Each cash flow comprises one leg of the swap. One cash flow is generally fixed, while the other is variable, that is, based on a a benchmark interest rate, floating currency exchange rate or index price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -406,9 +398,8 @@
 	<owl:Class rdf:about="&fibo-der-drc-swp;SwapExecutionFacility">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:label>swap execution facility</rdfs:label>
-		<skos:definition>exchange that enables many participants to execute and trade swaps</skos:definition>
+		<skos:definition>exchange that enables participants to execute and trade swaps</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SEF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/s/swap-execution-facility-sef.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Swap execution facilities, including trading systems and other platforms, allow for greater transparency and represent a significant shift in the way derivative trading has been done. The Dodd-Frank Act lays the foundation for this change of derivative execution.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -459,7 +450,6 @@
 		<rdfs:label>swap leg</rdfs:label>
 		<skos:definition>terms defining and the commitment to fulfill cashflow requirements (e.g., interest payments, coupon payments, etc.) for one side of a swap</skos:definition>
 		<skos:editorialNote>For some swaps this may be a commitment to net up the difference between a strike and an outcome, rather than to make a series of cashflows over time. For credit default swaps there are conditional commitments, contingent on the occurrence of a credit event.</skos:editorialNote>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/i/interestrateswap.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>swap stream terms</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -589,7 +579,6 @@
 		<skos:definition>identifier for a swap that is used in recordkeeping and swap data reporting</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USI</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom>CFTC Data Management Branch &apos;Unique Swap Identifier (USI) Data Standard&apos;, October 1, 2012, usidatastandards100112.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/cfr/text/17/45.5</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-swp;hasFundingLeg">

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -96,7 +96,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to change the restriction on financial instrument identifier from some values to min 0, to allow for cases when an instrument identifier identifies a listing, eliminate duplication of concepts in LCC, and simplify addresses.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to move redemption provision from debt to financial instruments, given that it is a broader concept needed for equities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to add a property indicating the currency that an instrument is issued in, simplify the contract party hierarchy and add properties relating financial instruments to shareholders.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to incorporate a hasMaturityDate property given that it can apply to debt instruments and preferred shares, as well as to other financial instruments, eliminated the redundant hasScheduledMaturityDate property, and cleaned up circular definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to incorporate a hasMaturityDate property given that it can apply to debt instruments and preferred shares, as well as to other financial instruments, eliminated the redundant hasScheduledMaturityDate property, cleaned up circular definitions, and eliminated the property &apos;mayBeTradedIn&apos;, which was only used in one place and was redundant with the concept of a ListedSecurity / Listing in SEC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -486,12 +486,5 @@
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>specifies whether a particular financial instrument is or is not transferable</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;mayBeTradedIn">
-		<rdfs:label>may be traded in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Security"/>
-		<rdfs:range rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
-		<skos:definition>optionally identifies one or more markets in which the security may be traded</skos:definition>
-	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities.rdf
@@ -141,7 +141,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;subordinatedTo"/>
+				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;isSubordinatedTo"/>
 				<owl:onClass rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
@@ -525,13 +525,6 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;IndexLinkedPrincipalDeterminationTerms"/>
 		<rdfs:range rdf:resource="&fibo-ind-ei-ei;InflationRate"/>
 		<skos:definition>indicates the index specified in the formula for determination of principal paydown amounts</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;subordinatedTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbti;mayBeSubordinatedTo"/>
-		<rdfs:label xml:lang="en">subordinated to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-abs;tranche">

--- a/SEC/Debt/AssetBackedSecurities/CDOs.rdf
+++ b/SEC/Debt/AssetBackedSecurities/CDOs.rdf
@@ -215,7 +215,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;subordinatedTo"/>
+				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;isSubordinatedTo"/>
 				<owl:onClass rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
@@ -742,13 +742,6 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure"/>
 		<skos:definition xml:lang="en">The source of funds for the CDO is market value. This means that principal and interest payments to investors come from both collateral cash flows as well as sales of collateral.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;subordinatedTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbti;mayBeSubordinatedTo"/>
-		<rdfs:label xml:lang="en">subordinated to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-cdo;tranche">

--- a/SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities.rdf
@@ -726,7 +726,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;providesCreditSupportTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbti;mayBeSubordinatedTo"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbti;isSubordinatedTo"/>
 		<rdfs:label xml:lang="en">provides credit support to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>

--- a/SEC/Debt/DebtInstruments.rdf
+++ b/SEC/Debt/DebtInstruments.rdf
@@ -89,7 +89,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to support integration of the bonds ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Debt/DebtInstruments.rdf version of this ontology was modified to correct the declaration of the property &apos;has estate or death put feature&apos; to remove an erroneous subproperty relationship and integrate the instrument pricing ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Debt/DebtInstruments.rdf version of this ontology was modified to reflect a change to make redemption provision a child of contractual commitment and move it to financial instruments, as such provisions apply to preferred shares and other instruments in addition to debt, and eliminate non-tradable and tradable debt instrument redemption provisions, which are synonymous, and adjust the hierarchy for call feature, notification provision, and put feature accordingly.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, hasMaturityDate, to Financial Instruments, since a maturity date can apply to a preferred share in addition to a debt instrument or offering.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, hasMaturityDate, to Financial Instruments, since a maturity date can apply to a preferred share in addition to a debt instrument or offering and rename &apos;mayBeSubordinatedTo&apos;, which violates the policy related to masquerading properties.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -530,15 +530,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;mayBeSubordinatedTo"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-gty;hasGuarantor"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-gty;Guarantor"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-gty;hasGuarantor"/>
-				<owl:onClass rdf:resource="&fibo-fbc-dae-gty;Guarantor"/>
+				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;isSubordinatedTo"/>
+				<owl:onClass rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -796,8 +796,8 @@
 		<skos:definition>indicates whether the security is a subordinated security, meaning that the security has a lower priority than another security so that when the assets are liquidated this one is not first in line</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbti;mayBeSubordinatedTo">
-		<rdfs:label>may be subordinated to</rdfs:label>
+	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbti;isSubordinatedTo">
+		<rdfs:label>is subordinated to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 		<skos:definition>indicates the target security (i.e., the one in the range) has a higher priority than the security in question</skos:definition>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Several properties in production violated our new hygiene test regarding the use of "may", "isAlso", "isA" and similar phrases, including 'mayBeTradedIn', which was eliminated in favor of the appropriate properties of listings in SEC, 'mayBeSubordinatedTo', which was renamed 'isSubordinatedTo', and 'hasPartialSovereigntyOver', which has an embedded 'also' that triggered the test.  In the case of the latter, because it was very similar to 'hasSharedSovereigntyOver' and sparsely used, we replaced 'hasPartialSovereigntyOver' with shared sovereignty and eliminated the challenge with 'also'.

Note that there a quite a few similar issues in provisional, which will be addressed as time permits and when other issues with those ontologies are addressed.

Fixes: #1327 / FBC-271


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


