### PR TITLE
BE-224 - Typo in ontology prefix: fibo-ge-ge-cbj

### DIFF
--- a/BE/AllBE-NorthAmerica.rdf
+++ b/BE/AllBE-NorthAmerica.rdf
@@ -2,11 +2,11 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-caj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/">
+	<!ENTITY fibo-be-ge-cbj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-be-ge-mxj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-be-ge-usj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-bena-all "https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-NorthAmerica/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-ge-ge-cbj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY lcc-3166-2 "https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/">
 	<!ENTITY lcc-3166-2-ag "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-AG/">
 	<!ENTITY lcc-3166-2-as "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-AS/">
@@ -54,11 +54,11 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-NorthAmerica/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-caj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"
+	xmlns:fibo-be-ge-cbj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-be-ge-mxj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-be-ge-usj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-bena-all="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-NorthAmerica/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-ge-ge-cbj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/"
 	xmlns:lcc-3166-2="https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/"
 	xmlns:lcc-3166-2-ag="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-AG/"
 	xmlns:lcc-3166-2-as="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-AS/"

--- a/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf
@@ -240,6 +240,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfHaiti">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
+		<rdfs:label xml:lang="fr">Gouvernement de la République d&apos;Haïti</rdfs:label>
 		<rdfs:label xml:lang="en">Government of the Republic of Haiti</rdfs:label>
 		<skos:definition>unitary semi-presidential republic located on the island of Hispaniola in the Greater Antilles archipelago</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfHaiti"/>
@@ -329,8 +330,9 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfHaiti">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Haiti</rdfs:label>
-		<skos:definition>the jurisdiction of the judiciary of République d&apos;Haïti, whose highest court is the Cour de Cassation, assisted by local and civil courts at a communal level</skos:definition>
+		<rdfs:label xml:lang="fr">juridiction de la République d&apos;Haïti</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Haiti</rdfs:label>
+		<skos:definition>jurisdiction of the judiciary of Haiti, whose highest court is the Cour de Cassation, assisted by local and civil courts at a communal level</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfHaiti"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Haiti"/>
 	</owl:NamedIndividual>

--- a/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-ge-cbj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -8,7 +9,6 @@
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-ge-ge-cbj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -20,6 +20,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-ge-cbj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -27,7 +28,6 @@
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-ge-ge-cbj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -41,9 +41,9 @@
 		<rdfs:label>Caribbean Government Entities and Jurisdictions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the set of basic government-level entities and jurisdictions for independent countries and British Commonwealth regional sovereignties identified as part of the Caribbean in the U.N. M49 classification.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2020-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
@@ -60,371 +60,375 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200701/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/"/>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200701/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to correct the ontology prefix and address language-specific diacritical marks.</skos:changeNote>
 		<skos:scopeNote>The initial version of this ontology reflects the highest national or regional level (for British Commonwealth members) only.</skos:scopeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;AntiguaAndBarbudaEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;AntiguaAndBarbudaEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Antigua and Barbuda entity</rdfs:label>
 		<skos:definition>sovereign state and polity that consists of two major islands, Antigua and Barbuda (separated by 39 miles), and a number of smaller islands in the middle of the Leeward Islands, that is part of the Lesser Antilles</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;AntiguaAndBarbuda"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfAntiguaAndBarbuda"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfAntiguaAndBarbuda"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;BahamianEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;BahamianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Bahamian entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is The Bahamas</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;Bahamas"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheCommonwealthOfTheBahamas"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheCommonwealthOfTheBahamas"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;BarbadianEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;BarbadianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Barbadian entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Barbados</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;Barbados"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfBarbados"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfBarbados"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;BermudanEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;BermudanEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;RegionalSovereignty"/>
 		<rdfs:label>Bermudan entity</rdfs:label>
 		<skos:definition>regional sovereignty and polity that is Bermuda</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;Bermuda"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfBermuda"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfBermuda"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;CaymanIslandsEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;CaymanIslandsEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;RegionalSovereignty"/>
 		<rdfs:label>Cayman Islands entity</rdfs:label>
 		<skos:definition>regional sovereignty and polity that is the Cayman Islands</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;CaymanIslands"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheCaymanIslands"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheCaymanIslands"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;CubanEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;CubanEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Cuban entity</rdfs:label>
 		<skos:definition>soverign state and polity that is Cuba</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Cuba"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheRepublicOfCuba"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfCuba"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;DominicaEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;DominicaEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Dominica entity</rdfs:label>
 		<skos:definition>soverign state and polity that is Dominica</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Dominica"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheCommonwealthOfDominica"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheCommonwealthOfDominica"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;DominicanRepublicEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;DominicanRepublicEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Dominican Republic entity</rdfs:label>
 		<skos:definition>soverign state and polity that is the Dominican Republic</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;DominicanRepublic"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheDominicanRepublic"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheDominicanRepublic"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfAntiguaAndBarbuda">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfAntiguaAndBarbuda">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Antigua and Barbuda</rdfs:label>
 		<skos:definition>unitary parliamentary constitutional monarchy, with the queen (Elizabeth II) as head of state represented locally by a governor-general</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfAntiguaAndBarbuda"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfAntiguaAndBarbuda"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;AntiguaAndBarbuda"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfBarbados">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfBarbados">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Barbados</rdfs:label>
 		<skos:definition>unitary parliamentary constitutional monarchy, modeled on the British Westminster system, with the Queen of Barbados (Elizabeth II) as head of state, represented locally by a governor-general</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfBarbados"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfBarbados"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Barbados"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfBermuda">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfBermuda">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;RegionalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Bermuda</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.gov.bm/"/>
 		<skos:definition>parliamentary representative democratic dependency and a British island territory in the North Atlantic Ocean</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfBermuda"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfBermuda"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Bermuda"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfGrenada">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfGrenada">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Grenada</rdfs:label>
 		<skos:definition>unitary two-party parliamentary constitutional monarchy that is a Commonwealth realm with Queen Elizabeth II as head of state, represented locally by a governor-general, located in the West Indies in the Caribbean Sea at the southern end of the Grenadines island chain</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfGrenada"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfGrenada"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Grenada"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfJamaica">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfJamaica">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Jamaica</rdfs:label>
 		<skos:definition>parliamentary constitutional monarchy with legislative power vested in the bicameral Parliament of Jamaica, consisting of an appointed Senate and a directly elected House of Representatives, and an independent member of the British Commonwealth, situated in the Caribbean Sea</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfJamaica"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfJamaica"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Jamaica"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfSaintLucia">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfSaintLucia">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Saint Lucia</rdfs:label>
 		<skos:definition>unitary parliamentary constitutional monarchy that is a Commonwealth realm with Queen Elizabeth II as head of state, represented locally by a governor-general, located in the West Indies in the eastern Caribbean Sea on the boundary with the Atlantic Ocean</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfSaintLucia"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfSaintLucia"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;SaintLucia"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfSaintVincentAndTheGrenadines">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfSaintVincentAndTheGrenadines">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Saint Vincent and the Grenadines</rdfs:label>
 		<skos:definition>unitary parliamentary constitutional monarchy, with the Queen of Saint Vincent and the Grenadines (Elizabeth II) as head of state represented locally by a governor-general, an Anglo-Caribbean country of several islands in the Lesser Antilles island arc, in the southeast Windward Islands, which lies in the West Indies at the southern end of the eastern border of the Caribbean Sea where the latter meets the Atlantic Ocean</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfSaintVincentAndTheGrenadines"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfSaintVincentAndTheGrenadines"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;SaintVincentAndTheGrenadines"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfTheCaymanIslands">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfTheCaymanIslands">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;RegionalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Cayman Islands</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.gov.ky/"/>
 		<skos:definition>parliamentary democracy with judicial, executive and legislative branches, and a British Overseas Territory, encompassing 3 islands in the western Caribbean Sea</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfTheCaymanIslands"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfTheCaymanIslands"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;CaymanIslands"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfTheCommonwealthOfDominica">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfTheCommonwealthOfDominica">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Commonwealth of Dominica</rdfs:label>
 		<skos:definition>unitary parliamentary democracy that is an independent republic and member of the Commonwealth of Nations, one of few republics in the Caribbean</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfDominica"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfDominica"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Dominica"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfTheCommonwealthOfTheBahamas">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfTheCommonwealthOfTheBahamas">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Commonwealth of the Bahamas</rdfs:label>
 		<skos:definition>parliamentary constitutional monarchy, with the queen of the Bahamas (Elizabeth II) as head of state represented locally by a governor-general</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfTheCommonwealthOfTheBahamas"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfTheCommonwealthOfTheBahamas"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Bahamas"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfTheDominicanRepublic">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfTheDominicanRepublic">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the the Dominican Republic</rdfs:label>
 		<skos:definition>unitary presidential republic that occupies the eastern five-eighths of the island of Hispaniola in the Greater Antilles archipelago, which it shares with Haiti</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfTheDominicanRepublic"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfTheDominicanRepublic"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;DominicanRepublic"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfTheFederationOfSaintChristopherAndNevis">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfTheFederationOfSaintChristopherAndNevis">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Federation of Saint Christopher and Nevis</rdfs:label>
 		<skos:definition>federal parliamentary constitutional monarchy that is a Commonwealth realm with the Queen of Saint Christopher and Nevis (Queen Elizabeth II) as head of state, represented locally by a governor-general, located in the Leeward Islands chain of the Lesser Antilles</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfTheFederationOfSaintChristopherAndNevis"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfTheFederationOfSaintChristopherAndNevis"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;SaintKittsAndNevis"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfTheRepublicOfCuba">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfCuba">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
+		<rdfs:label xml:lang="es">Gobierno de la República de Cuba</rdfs:label>
 		<rdfs:label xml:lang="en">Government of the Republic of Cuba</rdfs:label>
-		<skos:definition>government of República de Cuba, which is a unitary Marxist–Leninist one-party socialist republic that includes the island of Cuba as well as Isla de la Juventud and several minor archipelagos</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfCuba"/>
+		<rdfs:seeAlso rdf:resource="https://www.presidencia.gob.cu/en/government/"/>
+		<skos:definition>unitary Marxist–Leninist one-party socialist republic that includes the island of Cuba as well as Isla de la Juventud and several minor archipelagos</skos:definition>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfCuba"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Cuba"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfTheRepublicOfHaiti">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfHaiti">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Haiti</rdfs:label>
 		<skos:definition>unitary semi-presidential republic located on the island of Hispaniola in the Greater Antilles archipelago</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfHaiti"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfHaiti"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Haiti"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GovernmentOfTheRepublicOfTrinidadAndTobago">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfTrinidadAndTobago">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Trinidad and Tobago</rdfs:label>
 		<skos:definition>unitary parliamentary constitutional republic with a two-party system and a bicameral parliamentary system based on the Westminster System, that is the southernmost island country in the Caribbean</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-ge-ge-cbj;JurisdictionOfTheRepublicOfTrinidadAndTobago"/>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfTheRepublicOfTrinidadAndTobago"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;TrinidadAndTobago"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;GrenadianEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;GrenadianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Grenadian entity</rdfs:label>
 		<skos:definition>soverign state and polity that is Grenada</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;Grenada"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfGrenada"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfGrenada"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;HaitianEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;HaitianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Haitian entity</rdfs:label>
 		<skos:definition>soverign state and polity that is Haiti</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Haiti"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheRepublicOfHaiti"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfHaiti"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JamaicanEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JamaicanEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Jamaican entity</rdfs:label>
 		<skos:definition>soverign state and polity that is Jamaica</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;Jamaica"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfJamaica"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfJamaica"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfAntiguaAndBarbuda">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfAntiguaAndBarbuda">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of Antigua and Barbuda</rdfs:label>
 		<skos:definition>jurisdiction of the Eastern Caribbean Supreme Court (based in Saint Lucia; one judge of the Supreme Court is a resident of the islands and presides over the High Court of Justice, including the Judicial Committee of the Privy Council (JCPC), which is the highest court of appeal for certain British territories, some Commonwealth countries and a few UK bodies</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfAntiguaAndBarbuda"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfAntiguaAndBarbuda"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;AntiguaAndBarbuda"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfBarbados">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfBarbados">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of Barbados</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Barbados, an independent branch of the Barbadian government, subject only to the Barbadian Constitution, including the Magistrates&apos; Court, Supreme Court, and Caribbean Court of Justice</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfBarbados"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfBarbados"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Barbados"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfBermuda">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfBermuda">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of Bermuda</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Bermuda, including the Magistrates&apos; Court, Supreme Court, Court of Appeal, and Judicial Committee of the Privy Council (JCPC), which is the highest court of appeal for certain British territories, some Commonwealth countries and a few UK bodies</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfBermuda"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfBermuda"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Bermuda"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfCuba">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfCuba">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Cuba</rdfs:label>
-		<skos:definition>jurisdiction of the judiciary of República de Cuba</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheRepublicOfCuba"/>
+		<rdfs:label xml:lang="es">jurisdicción de la República de Cuba</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Cuba</rdfs:label>
+		<skos:definition>jurisdiction of the judiciary of the Republic of Cuba, including the system of courts that interprets and applies the law in Cuba</skos:definition>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfCuba"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Cuba"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfDominica">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfDominica">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of Dominica</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of the Commonwealth of Dominica, which is a member of the International Criminal Court, with a Bilateral Immunity Agreement of protection with the US military, as covered under Article 98</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheCommonwealthOfDominica"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheCommonwealthOfDominica"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Dominica"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfGrenada">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfGrenada">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of Grenada</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Grenada, which is part of the Eastern Caribbean States Supreme Court with an associate judge residing in Grenada</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfGrenada"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfGrenada"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Grenada"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfHaiti">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfHaiti">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of Haiti</rdfs:label>
 		<skos:definition>the jurisdiction of the judiciary of République d&apos;Haïti, whose highest court is the Cour de Cassation, assisted by local and civil courts at a communal level</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheRepublicOfHaiti"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfHaiti"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Haiti"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfJamaica">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfJamaica">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of Jamaica</rdfs:label>
 		<skos:definition>the jurisdiction of the judiciary of Jamaica, a system based on English common law and local statutes, including the Judicial Committee of the Privy Council (JCPC), which is the highest court of appeal for certain British territories, some Commonwealth countries and a few UK bodies</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfJamaica"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfJamaica"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Jamaica"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfSaintLucia">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfSaintLucia">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of the Saint Lucia</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Saint Lucia, a mixed judicial system based on on both the civil law and English common law</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfSaintLucia"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfSaintLucia"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;SaintLucia"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfSaintVincentAndTheGrenadines">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfSaintVincentAndTheGrenadines">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of the Federation of Saint Vincent and the Grenadines</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Saint Vincent and the Grenadines, which is divided into district courts, the Eastern Caribbean Supreme Court and the Privy Council in London being the court of last resort</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfSaintVincentAndTheGrenadines"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfSaintVincentAndTheGrenadines"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;SaintVincentAndTheGrenadines"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfTheCaymanIslands">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfTheCaymanIslands">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of the Cayman Islands</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of the Cayman Islands, a four-tiered judicial system is based on English common law, colonial and local statutes, including the Judicial Committee of the Privy Council (JCPC), which is the highest court of appeal for certain British territories, some Commonwealth countries and a few UK bodies</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheCaymanIslands"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheCaymanIslands"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;CaymanIslands"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfTheCommonwealthOfTheBahamas">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfTheCommonwealthOfTheBahamas">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of the Commonwealth of the Bahamas</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of the Bahamas, a judicial system based on English common law and local statutes, including the Judicial Committee of the Privy Council (JCPC), which is the highest court of appeal for certain British territories, some Commonwealth countries and a few UK bodies, and which considered a safe jurisdiction as an International Financial Center (IFC), with a legal framework that is in compliance with the standards set by Organization for Economic Cooperation and Development (OECD)</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheCommonwealthOfTheBahamas"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheCommonwealthOfTheBahamas"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Bahamas"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfTheDominicanRepublic">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfTheDominicanRepublic">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of the Dominican Republic</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of the Dominican Republic, whose highest court is the Supreme Court of Justice, composed of 16 judges appointed by the National Council of Magistrates, an entity created by the constitutional reform of 1994 to ensure the independence of the Judicial Branch</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheDominicanRepublic"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheDominicanRepublic"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;DominicanRepublic"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfTheFederationOfSaintChristopherAndNevis">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfTheFederationOfSaintChristopherAndNevis">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of the Federation of Saint Christopher and Nevis</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Saint Kitts and Nevis, a mixed judicial system based on on both the civil law and English common law</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheFederationOfSaintChristopherAndNevis"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheFederationOfSaintChristopherAndNevis"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;SaintKittsAndNevis"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;JurisdictionOfTheRepublicOfTrinidadAndTobago">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;JurisdictionOfTheRepublicOfTrinidadAndTobago">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label>jurisdiction of the Republic of Trinidad and Tobago</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Trinidad and Tobago, a hierarchical system comprising a Supreme Court of Judicature, a Magistracy and a Family Court, with final appeal on some matters decided by the Judicial Committee of the Privy Council (JCPC)</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheRepublicOfTrinidadAndTobago"/>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfTrinidadAndTobago"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;TrinidadAndTobago"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;SaintKittsAndNevisEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;SaintKittsAndNevisEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Saint Kitts and Nevis entity</rdfs:label>
 		<skos:definition>soverign state and polity that is the Federation of Saint Christopher and Nevis</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;SaintKittsAndNevis"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheFederationOfSaintChristopherAndNevis"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheFederationOfSaintChristopherAndNevis"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;SaintLucianEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;SaintLucianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Saint Lucian entity</rdfs:label>
 		<skos:definition>soverign state and polity that is Saint Lucia</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;SaintLucia"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfSaintLucia"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfSaintLucia"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;SaintVincentianEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;SaintVincentianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Saint Vincentian entity</rdfs:label>
 		<skos:definition>soverign state and polity that is Saint Vincent and the Grenadines (or simply Saint Vincent)</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;SaintVincentAndTheGrenadines"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfSaintVincentAndTheGrenadines"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfSaintVincentAndTheGrenadines"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ge-ge-cbj;TrinidadianAndTobagonianEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-cbj;TrinidadianAndTobagonianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>Trinidadian and Tobagonian entity</rdfs:label>
 		<skos:definition>soverign state and polity that is the Republic of Trinidad and Tobago</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;TrinidadAndTobago"/>
-		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-ge-ge-cbj;GovernmentOfTheRepublicOfTrinidadAndTobago"/>
+		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-cbj;GovernmentOfTheRepublicOfTrinidadAndTobago"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf
@@ -233,7 +233,7 @@
 		<rdfs:label xml:lang="es">Gobierno de la República de Cuba</rdfs:label>
 		<rdfs:label xml:lang="en">Government of the Republic of Cuba</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.presidencia.gob.cu/en/government/"/>
-		<skos:definition>unitary Marxist–Leninist one-party socialist republic that includes the island of Cuba as well as Isla de la Juventud and several minor archipelagos</skos:definition>
+		<skos:definition>unitary Marxist-Leninist, one party socialist republic that includes the island of Cuba as well as Isla de la Juventud and several minor archipelagos</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-cbj;JurisdictionOfCuba"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Cuba"/>
 	</owl:NamedIndividual>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised the prefix for the Caribbean government entities to conform with our naming conventions and addressed issues with diacritical language symbols

Fixes: #1314 / BE-224


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


