### PR TITLE
Correct hygiene issues related to diacritical markings in various government and jurisdiction ontologies

### DIFF
--- a/BE/GovernmentEntities/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions.rdf
@@ -33,9 +33,9 @@
 		<rdfs:label>Eastern Europe Government Entities and Jurisdictions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides government entities and jurisdictions for countries that are defined as being part of Eastern Europe in the U.N. M49 codes, primarily those that are considered independent countries in ISO 3166, or are important from a banking perspective.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2010-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2010-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
@@ -47,14 +47,17 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200801/GovernmentEntities/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions/"/>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200801/GovernmentEntities/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to address hygiene issues with diacritical marks that are language-specific.</skos:changeNote>
 		<skos:scopeNote>The initial version of this ontology reflects the national level only.</skos:scopeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;BelarusianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Belarusian entity</rdfs:label>
+		<rdfs:label xml:lang="en">Belarusian entity</rdfs:label>
+		<rdfs:label xml:lang="be">Беларускае ўтварэнне</rdfs:label>
+		<rdfs:label xml:lang="ru">Белорусское предприятие</rdfs:label>
 		<skos:definition>sovereign state and polity that is Belarus</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Belarus"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfBelarus"/>
@@ -62,7 +65,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;BulgarianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Bulgarian entity</rdfs:label>
+		<rdfs:label xml:lang="en">Bulgarian entity</rdfs:label>
+		<rdfs:label xml:lang="bg">Българско образувание</rdfs:label>
 		<skos:definition>sovereign state and polity that is Bulgaria</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Bulgaria"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfBulgaria"/>
@@ -70,7 +74,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;CzechEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Czech entity</rdfs:label>
+		<rdfs:label xml:lang="en">Czech entity</rdfs:label>
+		<rdfs:label xml:lang="cs">Český subjekt</rdfs:label>
 		<skos:definition>sovereign state and polity that is Czechia</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Czechia"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheCzechRepublic"/>
@@ -79,6 +84,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfHungary">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Hungary</rdfs:label>
+		<rdfs:label xml:lang="hu">Magyarország kormánya</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.kormany.hu/en/"/>
 		<skos:definition>unitary, dominant-party, parliamentary republic, bordering Slovakia to the north, Ukraine to the northeast, Romania to the east and southeast, Serbia to the south, Croatia and Slovenia to the southwest, and Austria to the west</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfHungary"/>
@@ -88,6 +94,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfRomania">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Romania</rdfs:label>
+		<rdfs:label xml:lang="ro">Guvernul României</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.gov.ro/en/"/>
 		<skos:definition>unitary, semi-presidential republic at the crossroads of Central, Eastern, and Southeastern Europe, bordering Bulgaria to the south, Ukraine to the north, Hungary to the west, Serbia to the southwest, and Moldova to the east</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfRomania"/>
@@ -97,6 +104,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfTheCzechRepublic">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Czech Republic</rdfs:label>
+		<rdfs:label xml:lang="cs">Vláda České republiky</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.vlada.cz/en/"/>
 		<skos:definition>unitary, parliamentary, constitutional republic and multi-party, representative democracy, with the president as head of state and prime minister as head of government, that is a landlocked country in Central Europe bordered by Austria to the south, Germany to the west, Poland to the northeast and Slovakia to the southeast</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfCzechia"/>
@@ -106,6 +114,8 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfBelarus">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Belarus</rdfs:label>
+		<rdfs:label xml:lang="ru">Правительство Республики Беларусь</rdfs:label>
+		<rdfs:label xml:lang="be">Урад Рэспублікі Беларусь</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.bundeskanzleramt.gv.at/en.html"/>
 		<skos:definition>unitary presidential republic, a landlocked country in Eastern Europe bordered by Russia to the northeast, Ukraine to the south, Poland to the west, and Lithuania and Latvia to the northwest</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfBelarus"/>
@@ -115,6 +125,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfBulgaria">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Bulgaria</rdfs:label>
+		<rdfs:label xml:lang="bg">Правителство на Република България</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://gov.bg/"/>
 		<skos:definition>unitary parliamentary democracy where the prime minister is the head of government, located in Southeastern Europe bordered by Romania to the north, Serbia and North Macedonia to the west, Greece and Turkey to the south, and the Black Sea to the east</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfBulgaria"/>
@@ -124,6 +135,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfMoldova">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Moldova</rdfs:label>
+		<rdfs:label xml:lang="ro">Guvernul Republicii Moldova</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://gov.md/en/"/>
 		<skos:definition>unitary parliamentary constitutional republic that is a landlocked country in Eastern Europe, bordered by Romania to the west and Ukraine to the north, east, and south</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfMoldova"/>
@@ -133,6 +145,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfPoland">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Poland</rdfs:label>
+		<rdfs:label xml:lang="pl">Rząd Rzeczpospolita Polska</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://poland.pl/politics/"/>
 		<skos:definition>unitary, semi-presidential, constitutional, and representative democratic republic located in Central Europe and bordered by the Baltic Sea, Lithuania, and Russia&apos;s Kaliningrad Oblast to the north, Belarus and Ukraine to the east, Slovakia and the Czech Republic to the south, and Germany to the west</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfPoland"/>
@@ -142,6 +155,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfTheRussianFederation">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;FederalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Russian Federation</rdfs:label>
+		<rdfs:label xml:lang="ru">Правительство Российской Федерации</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://government.ru/en/"/>
 		<skos:definition>federal, dominant-party and semi-presidential constitutional republic located in Eastern Europe and Northern Asia</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfRussianFederation"/>
@@ -151,6 +165,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfTheSlovakRepublic">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Slovak Republic</rdfs:label>
+		<rdfs:label xml:lang="sk">Vláda Slovenskej republiky</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.vlada.gov.sk/government-of-the-slovak-republic/"/>
 		<skos:definition>unitary, parliamentary democratic republic that is a landlocked country in Central Europe, bordered by Poland to the north, Ukraine to the east, Hungary to the south, Austria to the southwest, and Czech Republic to the northwest</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfSlovakia"/>
@@ -160,6 +175,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;GovernmentOfUkraine">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Ukraine</rdfs:label>
+		<rdfs:label xml:lang="uk">Уряд України</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.president.gov.ua/en/"/>
 		<skos:definition>unitary, mixed semi-parliamentary and semi-presidential, constitutional republic located in Eastern Europe, bordered by Russia to the north-east; Belarus to the north; Poland, Slovakia and Hungary to the west; and Romania, Moldova, and the Black Sea to the south</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-eeuj;JurisdictionOfUkraine"/>
@@ -168,7 +184,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;HungarianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Hungarian entity</rdfs:label>
+		<rdfs:label xml:lang="en">Hungarian entity</rdfs:label>
+		<rdfs:label xml:lang="hu">Magyar entitás</rdfs:label>
 		<skos:definition>sovereign state and polity that is Hungary</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Hungary"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfHungary"/>
@@ -176,7 +193,9 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfBelarus">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Belarus</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Belarus</rdfs:label>
+		<rdfs:label xml:lang="en">юрисдикция Беларуси</rdfs:label>
+		<rdfs:label xml:lang="be">юрысдыкцыя Беларусі</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Belarus, consisting of the Supreme Court and specialized courts such as the Constitutional Court, which deals with specific issues related to constitutional and business law</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfBelarus"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Belarus"/>
@@ -184,7 +203,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfBulgaria">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Bulgaria</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Bulgaria</rdfs:label>
+		<rdfs:label xml:lang="bg">юрисдикция на България</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Bulgaria, a civil law legal system under the Ministry of Justice, including the Supreme Administrative Court and the Supreme Court of Cassation, which are the highest courts of appeal and oversee the application of laws in subordinate courts</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfBulgaria"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Bulgaria"/>
@@ -192,7 +212,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfCzechia">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Czechia</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Czechia</rdfs:label>
+		<rdfs:label xml:lang="cs">jurisdikce česka</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of the Czech Republic, a civil law system grounded in the Constitution of the Czech Republic, including the Constitutional Court, Supreme Court, and Supreme Administrative Court, as well as district and county courts that are divided into civil, criminal, and administrative branches</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheCzechRepublic"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Czechia"/>
@@ -200,15 +221,17 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfHungary">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Hungary</rdfs:label>
-		<skos:definition>jurisdiction of the judiciary of Hungary, a civil law system based primarily on German that is divided between courts with regular civil and criminal jurisdiction and administrative courts, including local courts (járásbíróság), regional appellate courts (ítélőtábla), and the supreme court (Kúria)</skos:definition>
+		<rdfs:label xml:lang="hu">Magyarország joghatósága</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Hungary</rdfs:label>
+		<skos:definition>jurisdiction of the judiciary of Hungary, a civil law system based primarily on German that is divided between courts with regular civil and criminal jurisdiction and administrative courts, including local courts, regional appellate courts, and the supreme court</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfHungary"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Hungary"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfMoldova">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Moldova</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Moldova</rdfs:label>
+		<rdfs:label xml:lang="ro">jurisdicția Moldovei</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Moldova, which is the system of courts that interprets and applies the law in Moldova, including an independent Constitutional Court</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfMoldova"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Moldova"/>
@@ -216,15 +239,17 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfPoland">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Poland</rdfs:label>
-		<skos:definition>jurisdiction of the judiciary of Poland, a four-tier court system composed of the Supreme Court (Sąd Najwyższy), the Supreme Administrative Court (Naczelny Sąd Administracyjny), Common Courts (District, Regional, Appellate) and the Military Court</skos:definition>
+		<rdfs:label xml:lang="en">jurisdiction of Poland</rdfs:label>
+		<rdfs:label xml:lang="pl">jurysdykcji polskiej</rdfs:label>
+		<skos:definition>jurisdiction of the judiciary of Poland, a four-tier court system composed of the Supreme Court, the Supreme Administrative Court, Common Courts (District, Regional, Appellate) and the Military Court</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfPoland"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Poland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfRomania">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Romania</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Romania</rdfs:label>
+		<rdfs:label xml:lang="ro">jurisdicția României</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Romania, a civil law system influenced by the French system that is a hierarchical system of courts with the High Court of Cassation and Justice being the supreme court of Romania, and includes courts of appeal, county courts and local courts</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfRomania"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Romania"/>
@@ -232,7 +257,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfRussianFederation">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Russian Federation</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Russian Federation</rdfs:label>
+		<rdfs:label xml:lang="ru">юрисдикция Российской Федерации</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Russian Federation, which is the system of courts that interprets and applies the law in the Russian Federation, including Constitutional Court, Supreme Court and lower federal courts, whose judges are appointed by the Federation Council on the recommendation of the President</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRussianFederation"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;RussianFederation"/>
@@ -240,23 +266,26 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfSlovakia">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Slovakia</rdfs:label>
-		<skos:definition>jurisdiction of the judiciary of the Slovak Republic, which is the system of courts that interprets and applies the law in Slovakia, whose highest judicial body is the Constitutional Court of Slovakia (Ústavný súd), which rules on constitutional issues</skos:definition>
+		<rdfs:label xml:lang="en">jurisdiction of Slovakia</rdfs:label>
+		<rdfs:label xml:lang="sk">jurisdikcia Slovenska</rdfs:label>
+		<skos:definition>jurisdiction of the judiciary of the Slovak Republic, which is the system of courts that interprets and applies the law in Slovakia, whose highest judicial body is the Constitutional Court of Slovakia, which rules on constitutional issues</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheSlovakRepublic"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Slovakia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfUkraine">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Ukraine</rdfs:label>
-		<skos:definition>jurisdiction of the judiciary of Ukraine, which is the system of courts that interprets and applies the law in Ukraine, including the Supreme Court of Ukraine (Верховний Суд України, Verkhovny Sud Ukrayiny)), which is the highest judicial body in the system of courts of general jurisdiction in Ukraine</skos:definition>
+		<rdfs:label xml:lang="en">jurisdiction of Ukraine</rdfs:label>
+		<rdfs:label xml:lang="uk">юрисдикція України</rdfs:label>
+		<skos:definition>jurisdiction of the judiciary of Ukraine, which is the system of courts that interprets and applies the law in Ukraine, including the Supreme Court of Ukraine, which is the highest judicial body in the system of courts of general jurisdiction in Ukraine</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfUkraine"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Ukraine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;MoldovanEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Moldovan entity</rdfs:label>
+		<rdfs:label xml:lang="ro">Entitate moldovenească</rdfs:label>
+		<rdfs:label xml:lang="en">Moldovan entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Moldova</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Moldova"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfMoldova"/>
@@ -264,7 +293,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;PolishEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Polish entity</rdfs:label>
+		<rdfs:label xml:lang="pl">Podmiot polski</rdfs:label>
+		<rdfs:label xml:lang="en">Polish entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Poland</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Poland"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfPoland"/>
@@ -272,7 +302,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;RomanianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Romanian entity</rdfs:label>
+		<rdfs:label xml:lang="ro">Entitate românească</rdfs:label>
+		<rdfs:label xml:lang="en">Romanian entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Romania</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Romania"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfRomania"/>
@@ -280,7 +311,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;RussianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;FederatedSovereignty"/>
-		<rdfs:label>Russian entity</rdfs:label>
+		<rdfs:label xml:lang="en">Russian entity</rdfs:label>
+		<rdfs:label xml:lang="ru">Российское предприятие</rdfs:label>
 		<skos:definition>federated sovereignty and polity that is the Russian Federation</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;RussianFederation"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRussianFederation"/>
@@ -288,7 +320,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;SlovakEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Slovak entity</rdfs:label>
+		<rdfs:label xml:lang="en">Slovak entity</rdfs:label>
+		<rdfs:label xml:lang="sk">Slovenský subjekt</rdfs:label>
 		<skos:definition>sovereign state and polity that is Slovakia</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Slovakia"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheSlovakRepublic"/>
@@ -296,7 +329,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;UkranianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Ukrainian entity</rdfs:label>
+		<rdfs:label xml:lang="en">Ukrainian entity</rdfs:label>
+		<rdfs:label xml:lang="uk">Українське утворення</rdfs:label>
 		<skos:definition>sovereign state and polity that is Ukraine</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Ukraine"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-eeuj;GovernmentOfUkraine"/>

--- a/BE/GovernmentEntities/EuropeanJurisdiction/NorthernEuropeGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/NorthernEuropeGovernmentEntitiesAndJurisdictions.rdf
@@ -301,8 +301,8 @@
 		<rdfs:label xml:lang="en">jurisdiction of Norway</rdfs:label>
 		<rdfs:label xml:lang="no">jurisdiksjon av Norge</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.domstol.no/en/"/>
-		<skos:definition>jurisdiction of the judiciary system in Sweden, a civil law system where laws are created and amended in parliament and the system regulated through the Courts of Justice of Norway</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheKingdomOfSweden"/>
+		<skos:definition>jurisdiction of the judiciary system in Norway, a civil law system where laws are created and amended in parliament and the system regulated through the Courts of Justice of Norway</skos:definition>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheKingdomOfNorway"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Sweden"/>
 	</owl:NamedIndividual>
 	

--- a/BE/GovernmentEntities/EuropeanJurisdiction/NorthernEuropeGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/NorthernEuropeGovernmentEntitiesAndJurisdictions.rdf
@@ -33,9 +33,9 @@
 		<rdfs:label>Northern Europe Government Entities and Jurisdictions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides government entities and jurisdictions for countries that are defined as being part of Northern Europe in the U.N. M49 codes, primarily those that are considered independent countries in ISO 3166, or are important from a banking perspective.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2010-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2010-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
@@ -46,31 +46,38 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200801/GovernmentEntities/EuropeanJurisdiction/NorthernEuropeGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/EuropeanJurisdiction/NorthernEuropeGovernmentEntitiesAndJurisdictions/"/>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200801/GovernmentEntities/EuropeanJurisdiction/NorthernEuropeGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to address hygiene issues with diacritical marks that are language-specific.</skos:changeNote>
 		<skos:scopeNote>The initial version of this ontology reflects the national level only.</skos:scopeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
-	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;AlandEntity">
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;AlandIslandsJurisdiction">
+		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+		<rdfs:label xml:lang="fi">Ahvenanmaan lainkäyttöalue</rdfs:label>
+		<rdfs:label xml:lang="en">Aland Islands jurisdiction</rdfs:label>
+		<rdfs:label xml:lang="sv">Ålandöarnas jurisdiktion</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.lexadin.nl/wlg/courts/nofr/eur/lxctfin.htm/"/>
+		<skos:definition>jurisdiction of the Aland District Court, which deals with criminal cases, civil cases and petitionary matters in first instance, with escalation to the appellate level in Finland as needed</skos:definition>
+		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfAland"/>
+		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;AlandIslands"/>
+		<fibo-fnd-utl-av:synonym xml:lang="fi">Ålands tingsrätt</fibo-fnd-utl-av:synonym>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;AlandicEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;RegionalSovereignty"/>
-		<rdfs:label>Åland entity</rdfs:label>
-		<skos:definition>regional sovereignty and polity that is Åland</skos:definition>
+		<rdfs:label xml:lang="fi">Ahvenanmaan kokonaisuus</rdfs:label>
+		<rdfs:label xml:lang="en">Alandic entity</rdfs:label>
+		<rdfs:label xml:lang="sv">Ålandisk enhet</rdfs:label>
+		<skos:definition>regional sovereignty and polity that is Aland</skos:definition>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;AlandIslands"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-neuj;GovernmentOfAland"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;AlandIslandsJurisdiction">
-		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>Åland Islands jurisdiction</rdfs:label>
-		<rdfs:seeAlso rdf:resource="https://www.lexadin.nl/wlg/courts/nofr/eur/lxctfin.htm/"/>
-		<skos:definition>jurisdiction of the Åland District Court, which deals with criminal cases, civil cases and petitionary matters in first instance, with escalation to the appellate level in Finland as needed</skos:definition>
-		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfAland"/>
-		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;AlandIslands"/>
-	</owl:NamedIndividual>
-	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;DanishEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Danish entity</rdfs:label>
+		<rdfs:label xml:lang="en">Danish entity</rdfs:label>
+		<rdfs:label xml:lang="da">Dansk enhed</rdfs:label>
 		<skos:definition>sovereign state and polity that is Denmark</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Denmark"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;FaroeIslands"/>
@@ -80,7 +87,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;EstonianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Estonian entity</rdfs:label>
+		<rdfs:label xml:lang="et">Eesti üksus</rdfs:label>
+		<rdfs:label xml:lang="en">Estonian entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Estonia</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Estonia"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfEstonia"/>
@@ -88,7 +96,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;FinnishEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Finnish entity</rdfs:label>
+		<rdfs:label xml:lang="en">Finnish entity</rdfs:label>
+		<rdfs:label xml:lang="fi">Suomen entiteetti</rdfs:label>
 		<skos:definition>sovereign state and polity that is Finland</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Finland"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-1;AlandIslands"/>
@@ -97,17 +106,20 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfAland">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;RegionalGovernment"/>
-		<rdfs:label>Government of Åland</rdfs:label>
+		<rdfs:label xml:lang="fi">Ahvenanmaan hallitus</rdfs:label>
+		<rdfs:label xml:lang="en">Government of Aland</rdfs:label>
+		<rdfs:label xml:lang="sv">Ålands regering</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/%C3%85land_Islands/"/>
-		<skos:definition>regional government of the Åland Islands, an archipelago province at the entrance to the Gulf of Bothnia in the Baltic Sea belonging to Finland</skos:definition>
+		<skos:definition>regional government of the Aland Islands, an archipelago province at the entrance to the Gulf of Bothnia in the Baltic Sea belonging to Finland</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-neuj;AlandIslandsJurisdiction"/>
 		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;AlandIslands"/>
-		<fibo-fnd-utl-av:explanatoryNote>The Åland Islands are governed according to the Act on the Autonomy of Åland and international treaties. These laws guarantee the islands&apos; autonomy from Finland, which has ultimate sovereignty over them, as well as a demilitarised status. The Government of Åland, or Landskapsregering, answers to the Parliament of Åland, or Lagting, in accordance with the principles of parliamentarism.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>The Aland Islands are governed according to the Act on the Autonomy of Aland and international treaties. These laws guarantee the islands&apos; autonomy from Finland, which has ultimate sovereignty over them, as well as a demilitarised status. The Government of Aland answers to the Parliament of Aland, in accordance with the principles of parliamentarism.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfIceland">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of Iceland</rdfs:label>
+		<rdfs:label xml:lang="is">Ríkisstjórn Íslands</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.government.is/"/>
 		<skos:definition>unitary parliamentary republic and representative democracy, that is a Nordic island country in the North Atlantic</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-neuj;JurisdictionOfIceland"/>
@@ -117,6 +129,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfTheKingdomOfDenmark">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Kingdom of Denmark</rdfs:label>
+		<rdfs:label xml:lang="da">Kongeriget Danmarks regering</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://denmark.dk/society-and-business/government-and-politics/"/>
 		<skos:definition>unitary constitutional monarchy and parliamentary democracy, with the monarch as the official head of government, that includes the southernmost of the Scandinavian countries, consisting of a peninsula, Jutland, and an archipelago of 443 named islands</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-neuj;JurisdictionOfDenmark"/>
@@ -127,7 +140,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfTheKingdomOfNorway">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Kingdom of Norway</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Kingdom of Norway</rdfs:label>
+		<rdfs:label xml:lang="no">Kongeriket Norges regjering</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.regjeringen.no/en/the-government/id443314/"/>
 		<skos:definition>unitary constitutional monarchy and parliamentary democracy, wherein the monarch is the head of state and the prime minister is the head of government, whose mainland comprises the western and northernmost portion of the Scandinavian Peninsula and includes the remote island of Jan Mayen as well as the archipelago of Svalbard</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-neuj;JurisdictionOfNorway"/>
@@ -136,7 +150,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfTheKingdomOfSweden">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Kingdom of Sweden</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Kingdom of Sweden</rdfs:label>
+		<rdfs:label xml:lang="sv">Konungariket Sveriges regering</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.government.se/government-of-sweden/"/>
 		<skos:definition>constitutional monarchy and parliamentary democracy, with a largely ceremonial and representative monarch as head of state, located in Scandinavia between the North Atlantic, the Baltic Sea and Eurasian Russia</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-neuj;JurisdictionOfSweden"/>
@@ -145,6 +160,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfEstonia">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
+		<rdfs:label xml:lang="et">Eesti Vabariigi valitsus</rdfs:label>
 		<rdfs:label xml:lang="en">Government of the Republic of Estonia</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.valitsus.ee/en/"/>
 		<skos:definition>democratic unitary parliamentary republic divided into fifteen counties, located on the eastern coast of the Baltic Sea in Northern Europe</skos:definition>
@@ -155,6 +171,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfFinland">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Finland</rdfs:label>
+		<rdfs:label xml:lang="fi">Suomen tasavallan hallitus</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://valtioneuvosto.fi/en/government"/>
 		<skos:definition>parliamentary republic within the framework of a representative democracy comprised of 19 regions and 310 municipalities, located in the Nordic region of Europe</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-neuj;JurisdictionOfFinland"/>
@@ -164,7 +181,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfIreland">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Ireland</rdfs:label>
-		<rdfs:label xml:lang="ga">Rialtas na hÉireann</rdfs:label>
+		<rdfs:label xml:lang="ga">Rialtas Phoblacht na hÉireann</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.gov.ie/"/>
 		<skos:definition>parliamentary, representative democratic republic, based on the British model, that is an independent state and member of the European Union, which covers five-sixths of the island of Ireland in the North Atlantic</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-neuj;JurisdictionOfIreland"/>
@@ -174,6 +191,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfLatvia">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Latvia</rdfs:label>
+		<rdfs:label xml:lang="lv">Latvijas Republikas valdība</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.mk.gov.lv/en"/>
 		<skos:definition>unitary, parliamentary, constitutional republic located in the Baltic region of Northern Europe</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-neuj;JurisdictionOfLatvia"/>
@@ -183,6 +201,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfLithuania">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="en">Government of the Republic of Lithuania</rdfs:label>
+		<rdfs:label xml:lang="lt">Lietuvos Respublikos Vyriausybė</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://lrv.lt/en/"/>
 		<skos:definition>unitary semi-presidential republic situated along the southeastern shore of the Baltic Sea, to the southeast of Sweden and Denmark</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-neuj;JurisdictionOfLithuania"/>
@@ -191,7 +210,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;IcelandicEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Icelandic entity</rdfs:label>
+		<rdfs:label xml:lang="en">Icelandic entity</rdfs:label>
+		<rdfs:label xml:lang="is">Íslensk eining</rdfs:label>
 		<skos:definition>sovereign state and polity that is Iceland</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Iceland"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-neuj;GovernmentOfIceland"/>
@@ -199,7 +219,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;IrishEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Irish entity</rdfs:label>
+		<rdfs:label xml:lang="ga">Aonán Éireannach</rdfs:label>
+		<rdfs:label xml:lang="en">Irish entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Ireland</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Ireland"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfIreland"/>
@@ -207,7 +228,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;JurisdictionOfDenmark">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Denmark</rdfs:label>
+		<rdfs:label xml:lang="da">Danmarks jurisdiktion</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Denmark</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Courts_of_Denmark/"/>
 		<skos:definition>jurisdiction of the judiciary of Denmark, a civil law system with some references to Germanic law that was substantially reformed in 2007</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheKingdomOfDenmark"/>
@@ -216,7 +238,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;JurisdictionOfEstonia">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Estonia</rdfs:label>
+		<rdfs:label xml:lang="et">Eesti jurisdiktsioon</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Estonia</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.kohus.ee/en/estonian-courts/estonian-court-system"/>
 		<skos:definition>jurisdiction of the judiciary of Estonia, a civil law legal system based on the Germanic legal model, whose Supreme Court is the court of cassation, which also conducts constitutional review</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfEstonia"/>
@@ -225,7 +248,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;JurisdictionOfFinland">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Finland</rdfs:label>
+		<rdfs:label xml:lang="fi">Suomen lainkäyttövaltaan</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Finland</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Judicial_system_of_Finland"/>
 		<skos:definition>jurisdiction of the judiciary of Finland, a civil law system divided between courts with regular civil and criminal jurisdiction and administrative courts with jurisdiction over litigation between individuals and the public administration</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfFinland"/>
@@ -234,7 +258,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;JurisdictionOfIceland">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Iceland</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Iceland</rdfs:label>
+		<rdfs:label xml:lang="is">lögsögu Íslands</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.government.is/topics/law-and-order/the-judicial-system-in-iceland/"/>
 		<skos:definition>jurisdiction of the judiciary of Finland, a three-tier civil law system whose highest court is the Supreme Court of Iceland</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfIceland"/>
@@ -243,7 +268,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;JurisdictionOfIreland">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Ireland</rdfs:label>
+		<rdfs:label xml:lang="ga">dlínse na hÉireann</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Ireland</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.citizensinformation.ie/en/justice/courts_system/"/>
 		<skos:definition>jurisdiction of the judiciary of Ireland, which is the system of courts that interprets and applies the law in Ireland</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfIreland"/>
@@ -252,6 +278,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;JurisdictionOfLatvia">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+		<rdfs:label xml:lang="lv">Latvijas jurisdikcija</rdfs:label>
 		<rdfs:label xml:lang="en">jurisdiction of Latvia</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.satv.tiesa.gov.lv/"/>
 		<skos:definition>jurisdiction of the judiciary of Latvia, which is the system of courts that interprets and applies the law in Latvia</skos:definition>
@@ -261,6 +288,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;JurisdictionOfLithuania">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+		<rdfs:label xml:lang="lt">Lietuvos jurisdikcija</rdfs:label>
 		<rdfs:label xml:lang="en">jurisdiction of Lithuania</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.teismai.lt/en/courts/judicial-system/650"/>
 		<skos:definition>jurisdiction of the judiciary of Lithuania, whose highest court is the Constitutional Court (Konstitucinis Teismas), but the general jurisdiction dealing with civil and criminal cases includes the Supreme Court of Lithuania, the Court of Appeal of Lithuania, regional courts, and district courts</skos:definition>
@@ -270,7 +298,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;JurisdictionOfNorway">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Norway</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Norway</rdfs:label>
+		<rdfs:label xml:lang="no">jurisdiksjon av Norge</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.domstol.no/en/"/>
 		<skos:definition>jurisdiction of the judiciary system in Sweden, a civil law system where laws are created and amended in parliament and the system regulated through the Courts of Justice of Norway</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheKingdomOfSweden"/>
@@ -279,7 +308,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;JurisdictionOfSweden">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Sweden</rdfs:label>
+		<rdfs:label xml:lang="sv">Sveriges jurisdiktion</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Sweden</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.government.se/information-material/2019/03/organisation-and-responsibilities-of-the-ministry-of-justice/"/>
 		<skos:definition>jurisdiction of the judiciary system in Sweden, which is part of the Ministry of Justice, whose courts are divided into two parallel and separate systems - general courts (allmänna domstolar) for criminal and civil cases, and general administrative courts (allmänna förvaltningsdomstolar) for cases relating to disputes between private persons and the authorities</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheKingdomOfSweden"/>
@@ -288,7 +318,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;LatvianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Latvian entity</rdfs:label>
+		<rdfs:label xml:lang="en">Latvian entity</rdfs:label>
+		<rdfs:label xml:lang="lv">Latvijas vienība</rdfs:label>
 		<skos:definition>sovereign state and polity that is Latvia</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Latvia"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfLatvia"/>
@@ -296,7 +327,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;LithuanianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Lithuanian entity</rdfs:label>
+		<rdfs:label xml:lang="lt">Lietuvos subjektas</rdfs:label>
+		<rdfs:label xml:lang="en">Lithuanian entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Lithuania</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Lithuania"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheRepublicOfLithuania"/>
@@ -304,7 +336,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;NorwegianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Norwegian entity</rdfs:label>
+		<rdfs:label xml:lang="no">Norsk enhet</rdfs:label>
+		<rdfs:label xml:lang="en">Norwegian entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Norway</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;BouvetIsland"/>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Norway"/>
@@ -314,7 +347,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-neuj;SwedishEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Swedish entity</rdfs:label>
+		<rdfs:label xml:lang="sv">Svensk enhet</rdfs:label>
+		<rdfs:label xml:lang="en">Swedish entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Sweden</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Sweden"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-neuj;GovernmentOfTheKingdomOfSweden"/>

--- a/BE/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions.rdf
@@ -140,7 +140,6 @@
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
 		<rdfs:label xml:lang="es">Gobierno del Reino de España</rdfs:label>
 		<rdfs:label xml:lang="en">Government of the Kingdom of Spain</rdfs:label>
-		<rdfs:label>Government of the Kingdom of Spain</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.lamoncloa.gob.es/lang/en/Paginas/index.aspx"/>
 		<skos:definition>unitary parliamentary constitutional monarchy, whose monarch is the head of state and prime minister is the head of government, located in Southwestern Europe with some pockets of territory across the Strait of Gibraltar and the Atlantic Ocean</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfSpain"/>
@@ -199,7 +198,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfMalta">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Republic of Malta</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Republic of Malta</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.gov.mt/"/>
 		<skos:definition>unitary parliamentary constitutional republic modelled on the Westminster system that is a Southern European island country consisting of an archipelago in the Mediterranean Sea</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfMalta"/>
@@ -208,7 +207,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfNorthMacedonia">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Republic of North Macedonia</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Republic of North Macedonia</rdfs:label>
+		<rdfs:label xml:lang="mk">Влада на Република Северна Македонија</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://vlada.mk/"/>
 		<skos:definition>unitary parliamentary, constitutional, democratic republic, located in the Balkan Peninsula in Southeast Europe</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfNorthMacedonia"/>
@@ -217,7 +217,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSanMarino">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Republic of San Marino</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Republic of San Marino</rdfs:label>
+		<rdfs:label xml:lang="it">Governo della Repubblica di San Marino</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.sanmarino.sm/on-line/en/home.html"/>
 		<skos:definition>unitary parliamentary, diarchic, directorial republic that is a microstate in Southern Europe, completely surrounded by Italy, located on the northeastern side of the Apennine Mountains</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfSanMarino"/>
@@ -226,7 +227,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSerbia">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Republic of Serbia</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Republic of Serbia</rdfs:label>
+		<rdfs:label xml:lang="sr">Влада Републике Србије</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.srbija.gov.rs/"/>
 		<skos:definition>unitary, dominant-party, parliamentary constitutional republic that is situated at the crossroads of Central and Southeast Europe in the southern Pannonian Plain and the central Balkans</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfSerbia"/>
@@ -235,7 +237,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSlovenia">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Republic of Slovenia</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Republic of Slovenia</rdfs:label>
+		<rdfs:label xml:lang="sl">Vlada Republike Slovenije</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.gov.si/"/>
 		<skos:definition>unitary, parliamentary constitutional republic bordered by Italy to the west, Austria to the north, Hungary to the northeast, Croatia to the southeast, and the Adriatic Sea to the southwest</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfSlovenia"/>
@@ -244,7 +247,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GreekEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Greek entity</rdfs:label>
+		<rdfs:label xml:lang="en">Greek entity</rdfs:label>
+		<rdfs:label xml:lang="el">Ελληνική οντότητα</rdfs:label>
 		<skos:definition>sovereign state and polity that is Greece</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Greece"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheHellenicRepublic"/>
@@ -252,7 +256,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;HolySeeEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Holy See entity</rdfs:label>
+		<rdfs:label xml:lang="it">Entità della Santa Sede</rdfs:label>
+		<rdfs:label xml:lang="en">Holy See entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is the Holy See</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;HolySee"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheHolySee"/>
@@ -260,7 +265,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;ItalianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Italian entity</rdfs:label>
+		<rdfs:label xml:lang="it">Ente italiano</rdfs:label>
+		<rdfs:label xml:lang="en">Italian entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Italy</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Italy"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfItaly"/>
@@ -268,16 +274,18 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfAlbania">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Albania</rdfs:label>
+		<rdfs:label xml:lang="sq">juridiksioni i Shqipërisë</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Albania</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Supreme_Court_of_Albania"/>
-		<skos:definition>jurisdiction of the judiciary of Albania, a system of courts that includes the supreme court, constitutional court, appeal court and administrative court, and whose Supreme Court of the Republic of Albania (Gjykata e Lartë e Republikës së Shqipërisë) is the highest court and is the final court of appeal</skos:definition>
+		<skos:definition>jurisdiction of the judiciary of Albania, a system of courts that includes the supreme court, constitutional court, appeal court and administrative court, and whose Supreme Court of the Republic of Albania is the highest court and is the final court of appeal</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfAlbania"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Albania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfAndorra">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Andorra</rdfs:label>
+		<rdfs:label xml:lang="ca">jurisdicció d’Andorra</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Andorra</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Andorra, composed of the Magistrates Court, the Criminal Law Court, the High Court of Andorra, and the Constitutional Court</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfThePrincipalityOfAndorra"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Andorra"/>
@@ -285,7 +293,10 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfBosniaAndHerzegovina">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Bosnia and Herzegovina</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Bosnia and Herzegovina</rdfs:label>
+		<rdfs:label xml:lang="bs">nadležnost Bosne i Hercegovine</rdfs:label>
+		<rdfs:label xml:lang="hr">nadležnost Bosne i Hercegovine</rdfs:label>
+		<rdfs:label xml:lang="sr">надлежност Босне и Херцеговине</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.mpr.gov.ba/organizacija_nadleznosti/pravosudje/Default.aspx"/>
 		<skos:definition>jurisdiction of the judiciary of Bosnia and Herzegovina, whose Constitutional Court of Bosnia and Herzegovina is the supreme, final arbiter of legal matters</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheFederationOfBosniaAndHerzegovina"/>
@@ -294,7 +305,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfCroatia">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Croatia</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Croatia</rdfs:label>
+		<rdfs:label xml:lang="hr">nadležnost Hrvatske</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.usud.hr/"/>
 		<skos:definition>jurisdiction of the judiciary of Croatia, a civil law legal system in which law arises primarily from written statutes, influenced by German and Austrian legal systems, whose national courts include the Constitutional Court, which oversees violations of the Constitution, and the Supreme Court, which is the highest court of appeal</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfCroatia"/>
@@ -303,16 +315,18 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfGreece">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Greece</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Greece</rdfs:label>
+		<rdfs:label xml:lang="el">δικαιοδοσία της Ελλάδας</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.mfa.gr/missionsabroad/en/about-greece/government-and-politics/judicial-power.html"/>
-		<skos:definition>jurisdiction of the judiciary of the Hellenic Republic, whose supreme courts include the Court of Cassation (Άρειος Πάγος), the Council of State (Συμβούλιο της Επικρατείας) and the Court of Auditors (Ελεγκτικό Συνέδριο)</skos:definition>
+		<skos:definition>jurisdiction of the judiciary of the Hellenic Republic, whose supreme courts include the Court of Cassation, the Council of State and the Court of Auditors</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheHellenicRepublic"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Greece"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfItaly">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Italy</rdfs:label>
+		<rdfs:label xml:lang="it">giurisdizione dell&apos;Italia</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Italy</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Italy, a system of courts that is based on Roman law modified by the Napoleonic code and later statutes, comprising the Supreme Court of Cassation, the highest court in Italy for both criminal and civil appeal cases, and the Constitutional Court of Italy (Corte Costituzionale)</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfItaly"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Italy"/>
@@ -320,7 +334,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfMalta">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Malta</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Malta</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://justice.gov.mt/en/justice/Pages/The-Judiciary-in-Malta.aspx"/>
 		<skos:definition>jurisdiction of the judiciary of Malta, which is based partially on English law and partly on Continental law, that interprets and applies the laws of Malta to ensure equal justice under law, and to provide a mechanism for dispute resolution</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfMalta"/>
@@ -329,7 +343,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfMontenegro">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Montenegro</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Montenegro</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Montenegro, that interprets and applies the laws of Montenegro, and has been working with the European Union over the last several years to increase judicial independence and accountability</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfMontenegro"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Montenegro"/>
@@ -337,7 +351,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfNorthMacedonia">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of North Macedonia</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of North Macedonia</rdfs:label>
+		<rdfs:label xml:lang="mk">јурисдикција на Северна Македонија</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.sobranie.mk/the-constitution-of-the-republic-of-macedonia-ns_article-constitution-of-the-republic-of-north-macedonia.nspx"/>
 		<skos:definition>jurisdiction of the judiciary of North Macedonia, an independent judicial branch that includes a constitutional court</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfNorthMacedonia"/>
@@ -346,7 +361,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfPortugal">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Portugal</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Portugal</rdfs:label>
+		<rdfs:label xml:lang="pt">jurisdição de portugal</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Judiciary_of_Portugal"/>
 		<skos:definition>jurisdiction of the judiciary of Portugal, a system of courts that together constitute one of the four organs of Sovereignty as defined by the Portuguese Constitution</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfThePortugueseRepublic"/>
@@ -355,7 +371,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfSanMarino">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of San Marino</rdfs:label>
+		<rdfs:label xml:lang="it">giurisdizione di San Marino</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of San Marino</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of San Marino, including the Council of Twelve, which forms the judicial branch during the period of legislature of the Council</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSanMarino"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;SanMarino"/>
@@ -363,7 +380,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfSerbia">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Serbia</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Serbia</rdfs:label>
+		<rdfs:label xml:lang="sr">надлежност Србије</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Serbia, a three-tiered judicial system that includes the Supreme Court of Cassation as the court of the last resort, Courts of Appeal as the appellate instance, and Basic and High courts as the general jurisdictions at first instance</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSerbia"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Serbia"/>
@@ -371,7 +389,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfSlovenia">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Slovenia</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Slovenia</rdfs:label>
+		<rdfs:label xml:lang="sl">pristojnost Slovenije</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.sodisce.si/"/>
 		<skos:definition>jurisdiction of the judiciary of Slovenia, a system of courts with general responsibilities and specialised courts that deal with matters relating to specific legal areas, including a Constitutional Court at the highest level</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSlovenia"/>
@@ -380,16 +399,19 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfSpain">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of Spain</rdfs:label>
+		<rdfs:label xml:lang="es">jurisdicción de España</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of Spain</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.poderjudicial.es/cgpj/es/Poder_Judicial"/>
-		<skos:definition>jurisdiction of judiciary of Spain, a system of courts that senior judges - the President and judges of the Constitutional Court (the highest tribunal in the Kingdom)</skos:definition>
+		<skos:definition>jurisdiction of judiciary of Spain, a system of courts that includes senior judges - the President and judges of the Constitutional Court (the highest tribunal in the Kingdom) - that interprets and applies the law in Spain</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheKingdomOfSpain"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfTheHolySee">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label>jurisdiction of the Holy See</rdfs:label>
+		<rdfs:label xml:lang="it">giurisdizione della Santa Sede</rdfs:label>
+		<rdfs:label xml:lang="la">ius proprium Sanctae Sedis</rdfs:label>
+		<rdfs:label xml:lang="en">jurisdiction of the Holy See</rdfs:label>
 		<skos:definition>jurisdiction of the Bishop of Rome, known as the pope, which includes the apostolic episcopal see of the Diocese of Rome with universal ecclesiastical jurisdiction of the worldwide Catholic Church, as well as a sovereign entity of international law, governing the Vatican City</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheHolySee"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;HolySee"/>
@@ -397,7 +419,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;MalteseEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Maltese entity</rdfs:label>
+		<rdfs:label xml:lang="en">Maltese entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Malta</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Malta"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfMalta"/>
@@ -405,7 +427,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;MontenegrinEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Montenegrin entity</rdfs:label>
+		<rdfs:label xml:lang="en">Montenegrin entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Montenegro</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Montenegro"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfMontenegro"/>
@@ -413,7 +435,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;NorthMacedonianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>North Macedonian entity</rdfs:label>
+		<rdfs:label xml:lang="en">North Macedonian entity</rdfs:label>
+		<rdfs:label xml:lang="mk">Северномакедонски субјект</rdfs:label>
 		<skos:definition>sovereign state and polity that is North Macedonia</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Macedonia"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfNorthMacedonia"/>
@@ -421,7 +444,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;PortugueseEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Portuguese entity</rdfs:label>
+		<rdfs:label xml:lang="pt">Entidade portuguesa</rdfs:label>
+		<rdfs:label xml:lang="en">Portuguese entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Portugal</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Portugal"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfThePortugueseRepublic"/>
@@ -429,7 +453,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;SammarineseEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Sammarinese entity</rdfs:label>
+		<rdfs:label xml:lang="it">Ente sammarinese</rdfs:label>
+		<rdfs:label xml:lang="en">Sammarinese entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is San Marino</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;SanMarino"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSanMarino"/>
@@ -437,7 +462,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;SerbianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Serbian entity</rdfs:label>
+		<rdfs:label xml:lang="en">Serbian entity</rdfs:label>
+		<rdfs:label xml:lang="sr">Српски ентитет</rdfs:label>
 		<skos:definition>sovereign state and polity that is Serbia</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Serbia"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSerbia"/>
@@ -445,7 +471,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;SloveneEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Slovene entity</rdfs:label>
+		<rdfs:label xml:lang="en">Slovene entity</rdfs:label>
+		<rdfs:label xml:lang="sl">Slovenska entiteta</rdfs:label>
 		<skos:definition>sovereign state and polity that is Slovenia</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Slovenia"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSlovenia"/>
@@ -453,7 +480,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;SpanishEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Spanish entity</rdfs:label>
+		<rdfs:label xml:lang="es">Entidad española</rdfs:label>
+		<rdfs:label xml:lang="en">Spanish entity</rdfs:label>
 		<skos:definition>sovereign state and polity that is Spain</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Spain"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheKingdomOfSpain"/>

--- a/BE/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions.rdf
@@ -35,9 +35,9 @@
 		<rdfs:label>Southern Europe Government Entities and Jurisdictions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides government entities and jurisdictions for countries that are defined as being part of Southern Europe in the U.N. M49 codes, primarily those that are considered independent countries in ISO 3166, or are important from a banking perspective.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2010-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2010-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
@@ -49,14 +49,16 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200801/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions/"/>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200801/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to address hygiene issues with diacritical marks that are language-specific.</skos:changeNote>
 		<skos:scopeNote>The initial version of this ontology reflects the national level only.</skos:scopeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;AlbanianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Albanian entity</rdfs:label>
+		<rdfs:label xml:lang="en">Albanian entity</rdfs:label>
+		<rdfs:label xml:lang="sq">Entiteti shqiptar</rdfs:label>
 		<skos:definition>sovereign state and polity that is Albania</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Albania"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfAlbania"/>
@@ -64,7 +66,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;AndorranEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Andorran entity</rdfs:label>
+		<rdfs:label xml:lang="en">Andorran entity</rdfs:label>
+		<rdfs:label xml:lang="ca">Entitat andorrana</rdfs:label>
 		<skos:definition>sovereign state and polity that is Andorra</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Andorra"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfThePrincipalityOfAndorra"/>
@@ -72,7 +75,10 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;BosnianAndHerzegovinianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;FederatedSovereignty"/>
-		<rdfs:label>Bosnian and Herzegovinian entity</rdfs:label>
+		<rdfs:label xml:lang="bs">Bosanskohercegovački entitet</rdfs:label>
+		<rdfs:label xml:lang="hr">Bosanskohercegovački entitet</rdfs:label>
+		<rdfs:label xml:lang="en">Bosnian and Herzegovinian entity</rdfs:label>
+		<rdfs:label xml:lang="sr">Босанскохерцеговачки ентитет</rdfs:label>
 		<skos:definition>federal sovereignty state and polity that is Bosnia and Herzegovina</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;BosniaAndHerzegovina"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheFederationOfBosniaAndHerzegovina"/>
@@ -80,7 +86,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;CroatianEntity">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-		<rdfs:label>Croatian entity</rdfs:label>
+		<rdfs:label xml:lang="en">Croatian entity</rdfs:label>
+		<rdfs:label xml:lang="hr">Hrvatski entitet</rdfs:label>
 		<skos:definition>sovereign state and polity that is Croatia</skos:definition>
 		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Croatia"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfCroatia"/>
@@ -88,7 +95,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfMontenegro">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of Montenegro</rdfs:label>
+		<rdfs:label xml:lang="en">Government of Montenegro</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.gov.me/en/homepage/"/>
 		<skos:definition>unitary, dominant-party, parliamentary constitutional republic that is located in South and Southeast Europe on the coast of the Balkans</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfMontenegro"/>
@@ -97,7 +104,10 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheFederationOfBosniaAndHerzegovina">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;FederalGovernment"/>
-		<rdfs:label>Government of the Federation of Bosnia and Herzegovina</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Federation of Bosnia and Herzegovina</rdfs:label>
+		<rdfs:label xml:lang="bs">Vlada Federacije Bosne i Hercegovine</rdfs:label>
+		<rdfs:label xml:lang="hr">Vlada Federacije Bosne i Hercegovine</rdfs:label>
+		<rdfs:label xml:lang="sr">Влада Федерације Босне и Херцеговине</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://fbihvlada.gov.ba/english/"/>
 		<skos:definition>federal parliamentary constitutional republic that is a representative democracy, located in South and Southeast Europe, within the Balkans</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfBosniaAndHerzegovina"/>
@@ -106,7 +116,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheHellenicRepublic">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Hellenic Republic</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Hellenic Republic</rdfs:label>
+		<rdfs:label xml:lang="el">Κυβέρνηση της Ελληνικής Δημοκρατίας</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.mfa.gr/missionsabroad/en/about-greece/government-and-politics/"/>
 		<skos:definition>unitary parliamentary republic, located on the Balkan Peninsula in Southeast Europe</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfGreece"/>
@@ -115,7 +126,9 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheHolySee">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Holy See</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Holy See</rdfs:label>
+		<rdfs:label xml:lang="it">Governo della Santa Sede</rdfs:label>
+		<rdfs:label xml:lang="la">Imperium in Consiliis Sanctae Sedis</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.vatican.va/content/vatican/en.html"/>
 		<skos:definition>unitary Christian absolute monarchy (under an ecclesiastical and elective theocracy), headquartered in, operates from, and exercises &apos;exclusive dominion&apos; over the independent Vatican City State enclave in Rome, of which the pope is sovereign, administered by the Roman Curia</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfTheHolySee"/>
@@ -125,6 +138,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheKingdomOfSpain">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
+		<rdfs:label xml:lang="es">Gobierno del Reino de España</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Kingdom of Spain</rdfs:label>
 		<rdfs:label>Government of the Kingdom of Spain</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.lamoncloa.gob.es/lang/en/Paginas/index.aspx"/>
 		<skos:definition>unitary parliamentary constitutional monarchy, whose monarch is the head of state and prime minister is the head of government, located in Southwestern Europe with some pockets of territory across the Strait of Gibraltar and the Atlantic Ocean</skos:definition>
@@ -134,7 +149,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfThePortugueseRepublic">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Portuguese Republic</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Portuguese Republic</rdfs:label>
+		<rdfs:label xml:lang="pt">Governo da República Portuguesa</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.portugal.gov.pt/en/gc21"/>
 		<skos:definition>unitary, semi-presidential, constitutional, representative democratic republic, located mostly on the Iberian Peninsula, in southwestern Europe</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfPortugal"/>
@@ -143,7 +159,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfThePrincipalityOfAndorra">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Principality of Andorra</rdfs:label>
+		<rdfs:label xml:lang="ca">Govern del Principat d’Andorra</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Principality of Andorra</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.govern.ad/"/>
 		<skos:definition>unitary parliamentary semi-elective diarchy, a sovereign landlocked microstate on the Iberian Peninsula, in the eastern Pyrenees, bordered by France to the north and Spain to the south</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfAndorra"/>
@@ -152,7 +169,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfAlbania">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Republic of Albania</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Republic of Albania</rdfs:label>
+		<rdfs:label xml:lang="sq">Qeveria e Republikës së Shqipërisë</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://parlament.al/"/>
 		<skos:definition>unitary parliamentary constitutional republic, located in Southeast Europe on the Adriatic and Ionian Sea within the Mediterranean Sea</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfAlbania"/>
@@ -161,7 +179,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfCroatia">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Republic of Croatia</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Republic of Croatia</rdfs:label>
+		<rdfs:label xml:lang="hr">Vlada Republike Hrvatske</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://vlada.gov.hr/"/>
 		<skos:definition>unitary parliamentary constitutional republic, located in Southeast Europe, bordering Slovenia to the northwest, Hungary to the northeast, Serbia to the east, Bosnia and Herzegovina, and Montenegro to the southeast, sharing a maritime border with Italy</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfCroatia"/>
@@ -170,7 +189,8 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfItaly">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-		<rdfs:label>Government of the Republic of Italy</rdfs:label>
+		<rdfs:label xml:lang="en">Government of the Republic of Italy</rdfs:label>
+		<rdfs:label xml:lang="it">Governo della Repubblica Italiana</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.governo.it/"/>
 		<skos:definition>unitary parliamentary, constitutional, democratic republic, consisting of a peninsula bordering the Alps and surrounded by several islands, located in south-central Europe</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfItaly"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminates language-specific diacritical markings in definitions of governments and jurisdictions for the EU; adds language-specific labels to government entities, governments and jurisdictions using the languages suggested as administrative for that country by the U.N.

Fixes: #1333 / BE-224


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


