### PR TITLE
SEC-118 - Eliminate remaining circular definitions and other hygiene violations in the SEC ontologies

### DIFF
--- a/SEC/Debt/Bonds.rdf
+++ b/SEC/Debt/Bonds.rdf
@@ -89,9 +89,9 @@
 		<rdfs:label>Bonds Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the basic concept of a bond and a number of bond variants including convertible and callable bonds. Medium term notes (MTNs) and debentures are also defined.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -140,10 +140,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200901/Debt/Bonds/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Debt/Bonds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/Debt/Bonds.rdf version of this ontology was revised to reflect the refactored definition of a listing and improve the definition of corporate bond.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and eliminate a redundant superclass from RegularCouponSchedule.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate a duplicate &apos;isBasedOn&apos; property and replace it with the property of the same name in the debt ontology, to revise the inheritance hierarchy for bond conversion terms to reflect changes in the representation of redemption more generally, to reflect the move of redemption provision from debt to financial instruments, and eliminate circular and ambiguous definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200901/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate false positives in hygiene tests due to concept names containing words, such as &apos;and&apos;, which might indicate that the concept actually reflects more than one thing.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -488,15 +489,16 @@
 		<fibo-fnd-utl-av:explanatoryNote>The adjustments to the interest rate (coupon) are made periodically, usually on a quarterly or monthly basis, and are tied to a certain money-market index. Also known as a &quot;floater&quot;. For example six months USD LIBOR + 0.20%.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-bnd;FullFaithAndCreditBond">
+	<owl:Class rdf:about="&fibo-sec-dbt-bnd;FullFaithCreditBond">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;UnsecuredBond"/>
-		<rdfs:label>full faith and credit bond</rdfs:label>
+		<rdfs:label>full faith credit bond</rdfs:label>
 		<skos:definition>bond secured by an unconditional promise to pay by another entity</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Full faith and credit bonds are typically backed by a government entity and are considered low risk.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>full faith and credit bond</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;GeneralObligationMunicipalBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;FullFaithAndCreditBond"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;FullFaithCreditBond"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:label>general obligation municipal bond</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;RevenueBond"/>
@@ -536,11 +538,12 @@
 		<fibo-fnd-utl-av:explanatoryNote>These bonds are typically asset-linked and backed by the issuer&apos;s balance sheet.  Green bonds finance projects aimed at energy efficiency, pollution prevention, sustainable agriculture, fishery and forestry, the protection of aquatic and terrestrial ecosystems, clean transportation, sustainable water management and the cultivation of environmentally friendly technologies, and often include incentives such as tax exemption.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-bnd;ImplicitFullFaithAndCreditBond">
+	<owl:Class rdf:about="&fibo-sec-dbt-bnd;ImplicitFullFaithCreditBond">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;UnsecuredBond"/>
-		<rdfs:label>implicit full faith and credit bond</rdfs:label>
+		<rdfs:label>implicit full faith credit bond</rdfs:label>
 		<skos:definition>bond issued by a government sponsored agency or corporation rather than by the government directly</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>It doesn&apos;t carry an explicit full faith and credit guarantee but the market believes the government wouldn&apos;t let it default or fail.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>implicit full faith and credit bond</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;IndexLinkedSecurity">

--- a/SEC/Debt/DebtInstruments.rdf
+++ b/SEC/Debt/DebtInstruments.rdf
@@ -83,13 +83,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210101/Debt/DebtInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Debt/DebtInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Debt/DebtInstruments.rdf version of this ontology was modified to reflect use of actualExpression as an annotation rather than datatype property, to deprecate maturity-related properties which have been moved to financial instruments more generally, and to simplify restrictions on tradable debt instrument.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to support integration of the bonds ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Debt/DebtInstruments.rdf version of this ontology was modified to correct the declaration of the property &apos;has estate or death put feature&apos; to remove an erroneous subproperty relationship and integrate the instrument pricing ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Debt/DebtInstruments.rdf version of this ontology was modified to reflect a change to make redemption provision a child of contractual commitment and move it to financial instruments, as such provisions apply to preferred shares and other instruments in addition to debt, and eliminate non-tradable and tradable debt instrument redemption provisions, which are synonymous, and adjust the hierarchy for call feature, notification provision, and put feature accordingly.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, hasMaturityDate, to Financial Instruments, since a maturity date can apply to a preferred share in addition to a debt instrument or offering and rename &apos;mayBeSubordinatedTo&apos;, which violates the policy related to masquerading properties.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, hasMaturityDate, to Financial Instruments, since a maturity date can apply to a preferred share in addition to a debt instrument or offering rename &apos;mayBeSubordinatedTo&apos;, which violates the policy related to masquerading properties, and eliminate a circular definition and unnecessary references to external sources.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -145,8 +145,6 @@
 		<rdf:type rdf:resource="&fibo-sec-dbt-dbti;RelativePrice"/>
 		<rdfs:label>at a discount</rdfs:label>
 		<skos:definition>a selling price that is less than the face or nominal value</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/a/at-a-discount.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>below par</fibo-fnd-utl-av:synonym>
 	</owl:NamedIndividual>
 	
@@ -154,8 +152,6 @@
 		<rdf:type rdf:resource="&fibo-sec-dbt-dbti;RelativePrice"/>
 		<rdfs:label>at a premium</rdfs:label>
 		<skos:definition>a selling price significantly above the stated face or redemption value due to high demand or timing of redemption</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/a/at-a-premium.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>above par</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>premium</fibo-fnd-utl-av:synonym>
 	</owl:NamedIndividual>
@@ -183,7 +179,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>call feature</rdfs:label>
 		<skos:definition>redemption provision defining the rights of the issuer to buy back a security at a call price after a call protection period</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council / Quarule</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Most corporate and municipal bonds have ten-year call features (termed call protection by holders); government securities typically have none.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>call provision</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -204,7 +199,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<rdfs:label>call premium</rdfs:label>
 		<skos:definition>the price over par paid by an issuer to redeem securities when exercising a call provision</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council / Quarule</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;CallPrice">
@@ -212,7 +206,6 @@
 		<rdfs:label>call price</rdfs:label>
 		<skos:definition>price at which an asset is redeemed in the event of a call</skos:definition>
 		<fibo-fnd-utl-alx:actualExpression>par value + call premium</fibo-fnd-utl-alx:actualExpression>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council / Quarule</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>redemption price</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -241,7 +234,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>call schedule</rdfs:label>
 		<skos:definition>a schedule of call prices and when they are in effect</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council / Quarule</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;CallWindow">
@@ -321,7 +313,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;CallFeature"/>
 		<rdfs:label>make whole feature</rdfs:label>
 		<skos:definition>a call provision allowing the issuer to pay off remaining debt early</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/m/make-wholecall.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The issuer typically has to make a lump sum payment to the investor derived from a formula based on the net present value (NPV) of future interest or coupon payments that will not be paid incrementally because of the call combined with the principal payment the investor would have received at maturity.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>make whole provision</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -359,7 +350,6 @@
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 		<skos:definition>a debt instrument that may not be bought or sold</skos:definition>
 		<skos:example>Low-risk instruments such as savings bonds are examples of nonnegotiable debt instruments.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>Non-Tradeable. (n.d.) Farlex Financial Dictionary. (2009). Retrieved December 16 2016 from http://financial-dictionary.thefreedictionary.com/Non-Tradeable</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Generally, a nonnegotiable instrument may be redeemed by the issuer, but this is often subject to some limitations.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -379,8 +369,6 @@
 		<rdf:type rdf:resource="&fibo-sec-dbt-dbti;RelativePrice"/>
 		<rdfs:label>par value</rdfs:label>
 		<skos:definition>the stated value of a negotiable instrument, stock, or bond, as compared with the value that instrument might receive when sold</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/p/par.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>face value</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>nominal value</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>par</fibo-fnd-utl-av:synonym>
@@ -436,7 +424,6 @@
 		<rdfs:label>put feature</rdfs:label>
 		<skos:definition>redemption provision giving the holder the right, but not the obligation, to sell a specified amount of the debt instrument (i.e., redeem it), prior to maturity</skos:definition>
 		<skos:editorialNote>FIBIM has term &quot;Putable Date&quot; which (by implication, and comparing with definition for &quot;Next Call Date&quot;) is presumably a single calendar date in the future, at a given point in time. That does not cover the definition of formal terms defining when and how the issue may be put, which is what is modeled here.</skos:editorialNote>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>put provision</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -456,15 +443,12 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<rdfs:label>put premium</rdfs:label>
 		<skos:definition>an amount over par that a debt instrument holder must pay to sell the security early</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/p/put.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PutPrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:label>put price</rdfs:label>
 		<skos:definition>price at which a debt instrument with a put feature may be sold by the holder</skos:definition>
-		<skos:editorialNote>needs review - should the expression be exercise value vs. par value?</skos:editorialNote>
 		<fibo-fnd-utl-alx:actualExpression>par value + put premium</fibo-fnd-utl-alx:actualExpression>
 	</owl:Class>
 	
@@ -493,8 +477,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>put schedule</rdfs:label>
 		<skos:definition>a schedule that defines the events associated with the put feature of a debt instrument, i.e, the dates on which the debt instrument may be sold at what price by the holder</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/p/put.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PutWindow">
@@ -512,9 +494,7 @@
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;RelativePrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:label>relative price</rdfs:label>
-		<skos:definition>a relative price with respect to either a stated or market value for a debt instrument at some point in time, defined as par, premium, or discount</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/m/market-price.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/p/par.asp</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>security price specified in comparison with either a stated or market value for a debt instrument at some point in time</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;Strip">

--- a/SEC/Debt/TradedShortTermDebt.rdf
+++ b/SEC/Debt/TradedShortTermDebt.rdf
@@ -49,8 +49,9 @@
 		<rdfs:label xml:lang="en">Traded Short-Term Debt Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a number of basic, traded short-term debt instruments, many of which are considered money market instruments that may be freely traded.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2019 EDM Council, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
@@ -70,7 +71,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Debt/TradedShortTermDebt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Debt/TradedShortTermDebt/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Debt/TradedShortTermDebt.rdf version of this ontology was modified to eliminate a circular definition.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -158,7 +160,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>drawee</rdfs:label>
-		<skos:definition>a party that is required to pay the amount stated on the bill of exchange to the payee</skos:definition>
+		<skos:definition>party that is required to pay the amount stated on the bill of exchange to the payee</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;Drawer">
@@ -175,14 +177,14 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>drawer</rdfs:label>
-		<skos:definition>a party that requires the drawee to pay a third party (or the drawer can be paid by the drawee)</skos:definition>
+		<skos:definition>party that requires a drawee to pay either a third party or themselves with respect to a bill of exchange</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;EurodollarDeposit">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;CertificateOfDeposit"/>
 		<rdfs:label xml:lang="en">eurodollar deposit</rdfs:label>
 		<skos:definition xml:lang="en">a certificate of deposit with a fixed interest rate issued in U.S. dollars outside the jurisdiction of the Federal Reserve, held at banks outside of the United States, including branches of U.S. banks located outside of the U.S.</skos:definition>
-		<skos:editorialNote xml:lang="en">From riskglossary.com (part of Money Market Deposit article): The Eurodollar market has become global, so its name is a bit of a misnomer. A bank in Japan or Singapore may accept dollar deposits, but these are still called Eurodollar deposits. The market also includes other currencies, so there are Eurosterling, Euroyen, Euroswiss, etc. To confuse matters, in 1999, the European Union embraced the euro as its new currency, so you can now hear of Euroeuro. Eurocurrency is the general term for any currency deposited in bank branches outside countries where it is the national currency. Comment: Should this not rather be labeled as Eurocurrency Deposit, corresponding with the above definition? Eurodollar deposit would be a dollar-denominated sub type of this.</skos:editorialNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A bank in Japan or Singapore may accept dollar deposits, but these are still called Eurodollar deposits. The market also includes other currencies, so there are Eurosterling, Euroyen, Euroswiss, etc. Eurocurrency is the general term for any currency deposited in bank branches outside countries where it is the national currency.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;MoneyMarketInstrument">

--- a/SEC/Securities/ParametricSchedules.rdf
+++ b/SEC/Securities/ParametricSchedules.rdf
@@ -33,9 +33,9 @@
 		<rdfs:label>Parametric Schedules Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts related to parametric schedules, including how to represent individual schedules as well as related date periods, explicit dates, and other concepts needed for parametric schedule representation.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2019 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2019 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-sec-sec-sch</sm:fileAbbreviation>
 		<sm:filename>ParametricSchedules.rdf</sm:filename>
@@ -44,8 +44,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/ParametricSchedules/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/ParametricSchedules/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/ParametricSchedules.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/ParametricSchedules.rdf version of this ontology was modified to eliminate circular definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -79,8 +80,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>calculation period</rdfs:label>
-		<skos:definition>a date period defined as the number of days from the start of the calculation period to the scheduled end date of the period</skos:definition>
-		<skos:editorialNote>This need not be the same as the length given by the Calculation Period Length (Frequency in FpML) in the parametric schedule.</skos:editorialNote>
+		<skos:definition>date period defined as the number of days from the start to the scheduled end of the computation window</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationPeriodLength">
@@ -125,14 +125,12 @@
 		<rdfs:label>floating-rate note date</rdfs:label>
 		<skos:definition>a calculated date associated with a floating-rate note, also known as a floater or FRN, which is a debt instrument with a variable interest rate</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>FRN date</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/f/frn.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;FloatingRateNoteDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-bd;BusinessDayAdjustment"/>
 		<rdfs:label>floating-rate note date rule</rdfs:label>
 		<skos:definition>a business day adjustment rule applied to floating-rate note instruments</skos:definition>
-		<skos:editorialNote>FpML definition: &quot;Per 2000 ISDA Definitions, Section 4.11, FRN Convention, Eurodollar Convention.&quot; The above definition is from FpML and does not give the meaning or nature of this rule. FpML notes that this is not strictly a Date Roll Rule (but it may be selected in place of one). On inspection of the ISDA 2000 definition text, this may be because the FRN rule contains within it a specification of the Modified Following date roll rule (Date following rule modified by Modification rule). This rule appears in FpML both in the BusinessDayConventionEnum and the RollConventionEnum (for date roll rules and for scheduled event dates respectively). From FpML definition for BusinessDayConventionEnum: &quot;... Note that FRN is included here as a type of business day convention although it does not strictly fall within ISDA&apos;s definition of a Business Day Convention and does not conform to the simple definition given above.&quot; Note that this FRN rule is also included in the FpML enumeration for &quot;RollConventionEnum&quot;. This is the enumeration of possible Calculation Period End Dates and uses the word &quot;Roll&quot; in a completely different sense (the date that the application of some calculation to some amount is rolled over from one rate to the next). Full definition from ISDA 2000 Section 4.11: Section 4.11. FRN Convention; Eurodollar Convention. &quot;FRN Convention&quot; or &quot;Eurodollar Convention&quot; means, in respect of either Payment Dates or Period End Dates for a Swap Transaction and a party, that the Payment Dates or Period End Dates of that party will be each day during the Term of the Swap Transaction that numerically corresponds to the preceding applicable Payment Date or Period End Date, as the case may be, of that party in the calendar month that is the specified number of months after the month in which the preceding applicable Payment Date or Period End Date occurred (or, in the case of the first applicable Payment Date or the Period End Date, the day that numerically corresponds to the Effective Date in the calendar month that is the specified number of months after the month in which the Effective Date occurred), except that (a) if there is not any such numerically corresponding day in the calendar month in which a Payment Date or Period End Date, as the case may be, of that party should occur, then the Payment Date or Period End Date will be the last day that is a Business Day in that month, (b) if a Payment Date or Period End Date, as the case may be, of the party would otherwise fall on a day that is not a Business Day, then the Payment Date or Period End Date will be the first following day that is a Business Day unless that day falls in the next calendar month, in which case the Payment Date or Period End Date will be the first preceding day that is a Business Day and (c) if the preceding applicable Payment Date or Period End Date, as the case may be, of that party occurred on the last day in a calendar month that was a Business Day, then all subsequent applicable Payment Dates or Period End Dates, as the case may be, of that party prior to the Termination Date will be the last day that is a Business Day in the month that is the specified number of months after the month in which the preceding applicable Payment Date or Period End Date occurred.</skos:editorialNote>
 		<fibo-fnd-utl-av:abbreviation>FRN date rule</fibo-fnd-utl-av:abbreviation>
 	</owl:Class>
 	
@@ -170,7 +168,6 @@
 		<rdfs:label>International Money Market (IMM) settlement date rule</rdfs:label>
 		<skos:definition>a settlement date rule as defined in the International Money Market (IMM) settlement dates calendar</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>IMM settlement date rule</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/i/imm.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The International Money Market (IMM) is a division of the Chicago Mercantile Exchange (CME) that deals with the trading of currency and interest rate futures and options.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -55,9 +55,9 @@
 		<rdfs:label>Securities Listings Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for listing securities, such as registered, listed, and exchange-traded security, the notion of a securities exchange, and related services.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
@@ -82,7 +82,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesListings/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/SecuritiesListings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesListings.rdf version of this ontology was revised to reuse the composite date value datatype and add disjointness between registered security and exempt security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate an extraneous subclass axiom.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesListings.rdf version of this ontology was revised to rename isIssuedIn to isIssuedOn, which is more natural to most securities SMEs, generalized certain references to securities exchanges, and eliminate deprecated elements.</skos:changeNote>
@@ -90,6 +90,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and to eliminate the redundancy between hasIssue and lists.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesListings.rdf version of this ontology was revised to incorporate the form of registration and loosen the restriction on the number of possible registration authorities for a registered security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues), adjust definitions to eliminate ambiguity, add a property for lot size on listing, and eliminate the now redundant and confusing registered security form class.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate a false positive hygiene testing issue due to a concept whose name included &apos;and&apos; but that actually was a singular concept.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -97,36 +98,9 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;ExchangeAndListingService"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;ListingService"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-sec-lst;ExchangeAndListingService">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;isProvisionedBy"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-				<owl:onClass rdf:resource="&fibo-sec-sec-lst;Listing"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>exchange and listing service</rdfs:label>
-		<skos:definition>trading and (optionally) listing service for the purposes of securities trading</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;ListedSecurity">
@@ -216,6 +190,33 @@
 		<rdfs:label xml:lang="en">listing</rdfs:label>
 		<skos:definition>registry entry for a security that is managed by an exchange and that documents that the security meets the requirements for making that security available for trading on that exchange</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en">market listing</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-sec-lst;ListingService">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;isProvisionedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onClass rdf:resource="&fibo-sec-sec-lst;Listing"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>listing service</rdfs:label>
+		<skos:definition>service provided by an exchange to facilitate securities trading</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This resolution corrects circular definitions in debt instruments, parametric schedules and traded short-term debt.  It also eliminates false positive hygiene results for several classes in SEC (in bonds and securities listings) whose names included 'and' but that, in fact, defined singular concepts.

Note that there is one class remaining in the Bonds ontology that actually needs to be split into multiple concepts and that still includes 'and' in its name, which should be addressed in a separate resolution.

Fixes: #1340 / SEC-118


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


