### PR TITLE
Three hygiene tests can be promoted to prod errors

### DIFF
--- a/etc/testing/hygiene/testHygiene0114.sparql
+++ b/etc/testing/hygiene/testHygiene0114.sparql
@@ -17,6 +17,6 @@ WHERE {
   BIND (REPLACE (xsd:string (?o), ?reg, "")  AS ?bads)
 #  FILTER (!REGEX (?o, (CONCAT ("^", ?reg, "*$"))))
   FILTER (?bads != "")
-  BIND (concat ("WARN:", xsd:string(?o), " has a bad character |", ?bads, "|")
+  BIND (concat ("PRODERROR:", xsd:string(?o), " has a bad character |", ?bads, "|")
 	  AS ?error)
  } 

--- a/etc/testing/hygiene/testHygiene1289.sparql
+++ b/etc/testing/hygiene/testHygiene1289.sparql
@@ -5,11 +5,11 @@ prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 ##
 # banner Object properties should not play the role of the isA relationship.
 
-SELECT ?warning ?resource
+SELECT ?error ?resource
 WHERE
 {
     ?resource rdf:type owl:ObjectProperty.
     FILTER regex(str(?resource), "edmcouncil")
     FILTER (REGEX(LCASE(str(?resource)), "/isa$") || REGEX(LCASE(str(?resource)), "/may[^/]*$") || REGEX(LCASE(str(?resource)), "/[^/]*(become|also)[^/]*$") )
-    BIND (concat ("WARN:Property ", str(?resource), " may be an isA impostor.") AS ?warning)
+    BIND (concat ("PRODERROR:Property ", str(?resource), " may be an isA impostor.") AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1290.sparql
+++ b/etc/testing/hygiene/testHygiene1290.sparql
@@ -5,7 +5,7 @@ prefix owl:   <http://www.w3.org/2002/07/owl#>
 ##
 # banner All classes should be rooted in FND, LCC or FBC domain.
 
-SELECT DISTINCT ?warning ?class ?domainIdentifier
+SELECT DISTINCT ?error ?class ?domainIdentifier
 WHERE 
 {
     ?class a owl:Class .
@@ -13,6 +13,6 @@ WHERE
     FILTER (CONTAINS(str(?class), "edmcouncil"))
     BIND (STRBEFORE(STRAFTER(str(?class),"https://spec.edmcouncil.org/fibo/ontology/"),"/") As ?domainIdentifier)
     FILTER (?domainIdentifier NOT IN ('FND', 'LCC', 'FBC'))
-    BIND (concat ("WARN: Class ", str(?class), " is a top-level class outside FIBO foundations.") AS ?warning)
+    BIND (concat ("PRODERROR: Class ", str(?class), " is a top-level class outside FIBO foundations.") AS ?error)
 }
 ORDER BY ?domainIdentifier


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

Three hygiene tests can be promoted to prod errors.

Fixes: #1342 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


