### PR TITLE
FBC-274 - Eliminate remaining circular definitions and naming related hygiene issues in FBC

### DIFF
--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -89,12 +89,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210101/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210201/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away, to support collateral agreements such as deeds of trust, UCC filings and the like, to add the concept of a rate reset time of day, to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/DebtAndEquities/Debt/ version of this ontology was modified to make redemption provision a child of contractual commitment and move it to financial instruments, as such provisions apply to preferred shares and other instruments in addition to debt.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/DebtAndEquities/Debt/ version of this ontology was modified to move the concept of an extension provision from Debt to Contracts to support representation of preferred shares and other extendable contracts.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/DebtAndEquities/Debt/ version of this ontology was modified to move the concept of an extension provision from Debt to Contracts to support representation of preferred shares and other extendable contracts, and eliminate remaining circular definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -741,7 +741,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasRecurrenceInterval"/>
 		<rdfs:label>has compounding frequency</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RecurrenceInterval"/>
-		<skos:definition>the frequency at which interest is compounded</skos:definition>
+		<skos:definition>the frequency at which interest is added to the principal of the debt over the course of the agreement</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasDebtAmount">
@@ -902,7 +902,7 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;Creditor"/>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;Debt"/>
-		<skos:definition>links a creditor to a debt that is owed to them</skos:definition>
+		<skos:definition>links a creditor to a debt that is outstanding and payable to them</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;isOwedBy">
@@ -919,14 +919,14 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;Debt"/>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;Creditor"/>
-		<skos:definition>links a debt to the party to which it is owed</skos:definition>
+		<skos:definition>links a debt to the party to which it is payable</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;isPrincipalOf">
 		<rdfs:label>is principal of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;Principal"/>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>links the value of a debt, excluding any interest or other costs of using credit to the debt that it applies to</skos:definition>
+		<skos:definition>links the value of a debt, excluding any interest or other costs of using credit, to the debt that it applies to</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;owes">

--- a/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf
@@ -31,9 +31,9 @@
 		<rdfs:label>European Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with additional kinds of entities that that provide services in Europe, across national boundaries, such as European market data providers, organizations that provide exchanges in multiple countries, organizations that support the European Union, and so forth.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2018 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2017-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2017-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
@@ -47,6 +47,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf version of this ontology was revised to adjust the name of the CreditInstitutionOrInvestmentFirm classification to eliminate the &apos;or&apos; in the name to address hygiene issues.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -60,17 +61,17 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;CreditInstitution">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionOrInvestmentFirm"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionInvestmentFirm"/>
 		<rdfs:label>credit institution</rdfs:label>
 		<skos:definition>an undertaking the business of which is to take deposits or other repayable funds from the public and to grant credits for its own account, and to which authorisation has been granted to operate within the European Union and European Economic Area countries (EEA)</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32013R0575&amp;from=EN#page=18</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-fct-eufse;CreditInstitutionOrInvestmentFirm">
+	<owl:Class rdf:about="&fibo-fbc-fct-eufse;CreditInstitutionInvestmentFirm">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
-		<rdfs:label>credit institution or investment firm</rdfs:label>
-		<skos:definition>a European financial institution that is a credit institution or an investment firm as defined by the European Banking Authority (EBA)</skos:definition>
+		<rdfs:label>credit institution / investment firm</rdfs:label>
+		<skos:definition>classification specific to European financial institutions that designates them as credit institutions / investment firms as defined by the European Banking Authority (EBA)</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32013R0575&amp;from=EN#page=18</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
@@ -84,7 +85,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;InvestmentFirm">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionOrInvestmentFirm"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionInvestmentFirm"/>
 		<rdfs:subClassOf>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
@@ -107,7 +108,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;LocalFirm">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionOrInvestmentFirm"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionInvestmentFirm"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;BrokerageFirm"/>
 		<rdfs:label>local firm</rdfs:label>
 		<skos:definition>a firm dealing for its own account on markets in financial futures or options or other derivatives and on cash markets for the sole purpose of hedging positions on derivatives markets, or dealing for the accounts of other members of those markets and being guaranteed by clearing members of the same markets, where responsibility for ensuring the performance of contracts entered into by such a firm is assumed by clearing members of the same markets</skos:definition>
@@ -123,7 +124,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;PaymentInstitution">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionOrInvestmentFirm"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionInvestmentFirm"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminated remaining hygiene issues in FBC, including circular definitions in properties in Debt and renaming the CreditInstitutionOrInvestmentFirm class to eliminate the 'or' in European functional entities, adjusting its label and definition accordingly

Fixes: #1351 / FBC-274


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


