### PR TITLE
FND-332 - Circular definition for hasOperand

### DIFF
--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -79,7 +79,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20201101/Utilities/Analytics/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Utilities/Analytics/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20140501/Utilities/Analytics.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Utilities/Analytics.rdf version of this ontology was modified to address issue FIBOFND11-20, which added the definition of Calculation and corrected a reasoning issue related to the use of a custom datatype.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/Utilities/Analytics.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
@@ -91,7 +91,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, add a domain/range to characterizes/isCharacterizedBy, and eliminate duplicate properties that were not used anywhere.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Utilities/Analytics.rdf version of this ontology was modified to augment the definition of ratio with a synonym of rate and eliminate the circularity in the definition of standard deviation.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Utilities/Analytics.rdf version of this ontology was modified to make statistical program a subclass of program and revised restrictions on statistical program to better reflect its intent.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201101/Utilities/Analytics.rdf version of this ontology was modified to eliminate the redundant &apos;calculation formula&apos; concept.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201101/Utilities/Analytics.rdf version of this ontology was modified to eliminate the redundant &apos;calculation formula&apos; concept and eliminate the property hasOperand, which is not used anywhere and whose definition is circular.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -599,7 +599,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
 		<rdfs:label>total</rdfs:label>
 		<skos:definition>sum of the values for some characteristic of all units</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://wiki.edmcouncil.org/display/IND/Specifying+Statistical+Quantities</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-utl-alx;Variable">
@@ -718,14 +717,6 @@ For certain indices, one of the most common weighting factor is by market capita
 		<rdfs:range rdf:resource="&fibo-fnd-arr-arr;StructuredCollection"/>
 		<skos:definition>specifies a collection of values over which some analysis is performed</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>For certain calculations, such as certain measures of dispersion, date value pairs are expected as input, in other words, a dated structured collection.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasOperand">
-		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
-		<rdfs:label>has operand</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
-		<rdfs:range rdf:resource="&fibo-fnd-rel-rel;Referent"/>
-		<skos:definition>indicates the operand of a mathematical argument, parameter or other similar concept</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasPeriodicity">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminate the property hasOperand, which is not used anywhere and whose definition is circular

Fixes: #69 / FND-332


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


