### PR TITLE
FND-333 - Eliminate remaining circular definitions and naming related hygiene issues in FND

### DIFF
--- a/FND/Arrangements/ClassificationSchemes.rdf
+++ b/FND/Arrangements/ClassificationSchemes.rdf
@@ -31,9 +31,9 @@
 		<rdfs:label>Classification Schemes Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation of classification schemes that themselves are intended to permit the classification of arbitrary concepts into hierarchies (or partial orders) for use in other FIBO ontology elements.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2014-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
@@ -44,10 +44,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Arrangements/ClassificationSchemes/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Arrangements/ClassificationSchemes/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20150501/Arrangements/ClassificationSchemes.rdf version of this ontology was introduced as a part of the initial FIBO FBC RFC and revised due to changes introduced in the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Arrangements/ClassificationSchemes.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Arrangements/ClassificationSchemes.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and change the parent class of Classifier to Aspect in Analytics.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Arrangements/ClassificationSchemes.rdf version of this ontology was revised to eliminate circular definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -60,9 +61,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>classification scheme</rdfs:label>
-		<skos:definition>system for allocating classifiers (elements in a classification scheme) to objects, similar to identifiers in some cases; such classification schemes are intended to permit the classification of arbitrary objects into hierarchies (or partial orders)</skos:definition>
+		<skos:definition>system for allocating classifiers to objects</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO/IEC 11179-3 Information technology - Metadata registries (MDR) - Part 3: Registry metamodel and basic attributes, Third edition, 2013-02-15</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A classification scheme may be a taxonomy, a network, an ontology, or any other terminological system. The classification may also be just a list of controlled vocabulary of property words (or terms). The list might be taken from the &apos;leaf level&apos; of a taxonomy.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>A classification scheme may be a taxonomy, a network, an ontology, or any other terminological system. Such classification schemes are intended to permit the classification of arbitrary objects into hierarchies, or partial orders, as appropriate. The classification may also be just a list of controlled vocabulary of property words (or terms). The list might be taken from the &apos;leaf level&apos; of a taxonomy.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-cls;Classifier">
@@ -93,10 +94,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>industry sector classification scheme</rdfs:label>
-		<rdfs:seeAlso rdf:resource="http://www.investopedia.com/terms/g/gics.asp"/>
 		<skos:definition>system for allocating classifiers to organizations by industry sector</skos:definition>
 		<skos:example>Examples include the North American Industry Classification System (NAICS) and Standardized Industry Classification (SIC) in the U.S. and Canada, and the NACE (Nomenclature Générale des Activités Économiques dans les Communautés Européennes) in the EU, developed by governments to classify industries.  They also include commercial classification schemes, such as the Global Industry Standard Classification (GICS) developed jointly by Morgan Stanley Capital International (MSCI) and Standard and Poor&apos;s, and competing schemes including the Industry Classification Benchmark (ICB) system, maintained by Dow Jones and London&apos;s FTSE Group, among others.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-cls;IndustrySectorClassifier">
@@ -110,7 +109,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>industry sector classifier</rdfs:label>
 		<skos:definition>standardized classification or delineation for an organization, or possibly for a security representing an interest in a given organization, per some scheme for such delineation, by industry</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 
 </rdf:RDF>

--- a/FND/Arrangements/Ratings.rdf
+++ b/FND/Arrangements/Ratings.rdf
@@ -51,9 +51,9 @@
 		<rdfs:label>Ratings Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation of ratings and rating schemes, particularly for ratings describing aspects of business performance, credit worthiness, and investment quality at a high level.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2019-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2019-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2019-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2019-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/</sm:dependsOn>
@@ -83,11 +83,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Arrangements/Ratings/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Arrangements/Ratings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190601/Arrangements/Ratings.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Arrangements/Ratings.rdf version of this ontology was revised to add properties indicating the &apos;best&apos; and &apos;worst&apos; scores on a given scale.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Ratings.rdf version of this ontology was revised to eliminate duplication with LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Ratings.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Arrangements/Ratings.rdf version of this ontology was revised to eliminate circular definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -102,7 +103,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>qualitative rating score</rdfs:label>
-		<skos:definition>rating score that is a qualitative code in some rating scale, such as a triple-A (i.e., AAA) or 5-star rating for something</skos:definition>
+		<skos:definition>rating score that is represented as a qualitative code with respect to some rating scale</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Ratings for the creditworthiness of securities are often qualitative, rather than quantitative, such as a triple-A (i.e., AAA). Many ratings for products and businesses on the Internet are also qualitative, such as 5-star ratings for something.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-rt;QuantitativeRatingScore">
@@ -161,7 +163,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>rating</rdfs:label>
-		<skos:definition>standing of something at a particular time as indicated by one or more rating scores with respect to some scale according to some rating party</skos:definition>
+		<skos:definition>standing of something at a particular time, indicated by at least one scores with respect to some scale, based on an assessment by some party</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-rt;RatingAgency">

--- a/FND/DatesAndTimes/BusinessDates.rdf
+++ b/FND/DatesAndTimes/BusinessDates.rdf
@@ -33,9 +33,9 @@
 		<rdfs:label>Business Dates Ontology</rdfs:label>
 		<dct:abstract>This ontology extends definitions of date and schedule concepts from the FinancialDates ontology with concepts defining dates that may be adjusted when they fall on weekends or holidays as defined in a given business center, for use in other FIBO ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2014-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
@@ -48,10 +48,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/DatesAndTimes/BusinessDates/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/DatesAndTimes/BusinessDates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/DatesAndTimes/BusinessDates/ version of this ontology was revised by the FIBO FND 1.2 RTF in order to add definitions for business recurrence intervals such as the day of the month and week, and to revise the representation of the end of the month to correspond to the way that the other intervals are represented for use in parametric schedules.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/DatesAndTimes/BusinessDates/ version of this ontology was revised to better support definitions related to business day adjustments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180901/DatesAndTimes/BusinessDates/ version of this ontology was revised to loosen domains on properties related to business day and day count (recurrence interval) conventions, eliminate a duplicate individual, normalize definitions to be ISO 704 compliant, eliminate duplication of concepts in LCC, move hasBusinessCenter to locations, where the class BusinessCenter is defined and merge countries with locations.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/DatesAndTimes/BusinessDates/ version of this ontology was revised to eliminate a remaining circular definition.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the December 2014 Long Beach meeting in support of the SEC specification.  It is also needed to provide temporal relationships for Ownership and Control.
 
 These three ontologies are designed for use together:
@@ -140,7 +141,7 @@ They are modularized this way to minimize the ontological committments that are 
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>business recurrence interval</rdfs:label>
-		<skos:definition>recurrence interval that is specified using a business recurrence interval convention</skos:definition>
+		<skos:definition>recurrence interval that is defined per a specific convention that determines how recurring days should be handled</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-bd;BusinessRecurrenceIntervalConvention">
@@ -152,8 +153,6 @@ They are modularized this way to minimize the ontological committments that are 
 	<owl:Class rdf:about="&fibo-fnd-dt-bd;Convention">
 		<rdfs:label>convention</rdfs:label>
 		<skos:definition>widely accepted or established way of doing &apos;something&apos; within some community of practice</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.oxforddictionaries.com/definition/convention</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-bd;DayOfMonth">

--- a/FND/OwnershipAndControl/OwnershipAndControl.rdf
+++ b/FND/OwnershipAndControl/OwnershipAndControl.rdf
@@ -31,9 +31,9 @@
 		<rdfs:label>Ownership and Control Ontology</rdfs:label>
 		<dct:abstract>This ontology brings the concepts of ownership and control together, in cases where the combined semantics are applicable, such as for a wholly owned subsidiary.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2018 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/</sm:dependsOn>
@@ -44,12 +44,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20180801/OwnershipAndControl/OwnershipAndControl/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/OwnershipAndControl/OwnershipAndControl/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/OwnershipAndControl/OwnershipAndControl.rdf version of the ontology was modified to better integrate it with the situation pattern and eliminate circular definitions.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the December 2014 Long Beach meeting in support of the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-oac-oac;OwnershipAndControl">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;Situation"/>
 		<rdfs:label>ownership and control</rdfs:label>
 		<owl:equivalentClass>
 			<owl:Class>
@@ -61,13 +63,13 @@
 				</owl:intersectionOf>
 			</owl:Class>
 		</owl:equivalentClass>
-		<skos:definition>The intersection of ownership and control reflects the unique case where an independent party both owns and controls another independent thing.</skos:definition>
+		<skos:definition>situation in which some party owns and controls something</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-oac;isOwnedAndControlledBy">
 		<rdfs:label>is owned and controlled by</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition>a relationship between some thing and the party that owns, influences, manages and directs it</skos:definition>
+		<skos:definition>relates something to the party that owns, influences, manages and directs it</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-oac;ownsAndControls">

--- a/FND/OwnershipAndControl/OwnershipAndControl.rdf
+++ b/FND/OwnershipAndControl/OwnershipAndControl.rdf
@@ -50,9 +50,9 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-fnd-oac-oac;OwnershipAndControl">
+	<owl:Class rdf:about="&fibo-fnd-oac-oac;OwnershipControlSituation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;Situation"/>
-		<rdfs:label>ownership and control</rdfs:label>
+		<rdfs:label>ownership control situation</rdfs:label>
 		<owl:equivalentClass>
 			<owl:Class>
 				<owl:intersectionOf rdf:parseType="Collection">

--- a/FND/Parties/Roles.rdf
+++ b/FND/Parties/Roles.rdf
@@ -31,9 +31,9 @@
 		<rdfs:label>Roles Ontology</rdfs:label>
 		<dct:abstract>This ontology defines some high-level concepts of roles for use in other FIBO ontology elements. These concepts include the basic property whereby something has some role, along with the high-level concept of an agent in a role. The agent in role concept provides the basis for party in role concepts in the PartyRoles ontology and is framed as some entity defined specifically in respect to some role which it performs in some context..</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
@@ -44,7 +44,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Parties/Roles/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Parties/Roles/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20130801/Parties/Roles.rdf version of the ontology was was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://www.omg.org/spec/EDMC-FIBO/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Roles/Roles.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
@@ -53,7 +53,8 @@
    (4) to use 4-level abbreviations and corresponding namespace prefixes for all FIBO ontologies, reflecting a family/specification/module/ontology structure
    (5) to incorporate changes to the specification metadata to support documentation at the family, specification, module, and ontology level, similar to the abbreviations.
    (6) to combine Parties, Party Roles, and Roles in a single, new, Parties module.</skos:changeNote>
-		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20180801/Parties/Roles.rdf version of the ontology was was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20180801/Parties/Roles.rdf version of the ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20200201/Parties/Roles.rdf version of the ontology was modified to eliminate an unused Role class and hasRole property, which were confusing to users, and to eliminate circularities in remaining definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -66,15 +67,9 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>agent in role</rdfs:label>
-		<skos:definition>An agent-in-role is a relative concept that ties an autonomous agent to a role they are playing in a given situational context.</skos:definition>
+		<rdfs:label>agent-in-role</rdfs:label>
+		<skos:definition>relative concept that ties an agent to a part they play in a given situational context</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>OMG Property and Casualty Information Models, dtc/12-01-04, Annex A, Glossary of Data Model Terms and Definitions</fibo-fnd-utl-av:adaptedFrom>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pty-rl;Role">
-		<rdfs:label>role</rdfs:label>
-		<skos:definition>A role is a set of connected behaviours, rights, obligations, beliefs, and norms as conceptualised by actors in the context of some situation.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://en.wikipedia.org/wiki/Role</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pty-rl;ThingInRole">
@@ -84,23 +79,9 @@
 				<owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:cardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;hasRole"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-rl;Role"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>thing in role</rdfs:label>
-		<skos:definition>a thing-in-role is a relative concept that ties some thing to a role it plays in a given situational context</skos:definition>
+		<rdfs:label>thing-in-role</rdfs:label>
+		<skos:definition>relative concept that ties something to a part it plays in a given situational context</skos:definition>
 	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pty-rl;hasRole">
-		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
-		<rdfs:label>has role</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pty-rl;ThingInRole"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-rl;Role"/>
-		<skos:definition>provides a means for relating a person, organization, group, or other entity to a role that entity plays in some relationship and context</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pty-rl;isPlayedBy">
 		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
@@ -109,13 +90,13 @@
 		<rdfs:domain rdf:resource="&fibo-fnd-pty-rl;ThingInRole"/>
 		<owl:inverseOf rdf:resource="&fibo-fnd-pty-rl;playsRole"/>
 		<skos:definition>indicates the independent thing, typically a person or organization filling a role</skos:definition>
-		<skos:example>a party, counterparty, or third party to a contract is played by an organization or person; an issuer of a financial instrument is typically played by an organization.</skos:example>
+		<skos:example>A party, counterparty, or third party to a contract is played by an organization or person; an issuer of a financial instrument is typically played by an organization.</skos:example>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pty-rl;playsRole">
 		<rdfs:label>plays role</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-pty-rl;ThingInRole"/>
-		<skos:definition>indicates a role that an independent thing, such as a person or organization, plays under some circumstance</skos:definition>
+		<skos:definition>indicates a part that an independent thing, such as a person or organization, plays under some circumstance</skos:definition>
 		<skos:example>an organization in the role of employer, issuer, regulatory agency, bank, custodian, etc.</skos:example>
 	</owl:ObjectProperty>
 

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -37,11 +37,11 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 		<rdfs:label>Addresses Ontology</rdfs:label>
-		<dct:abstract>This ontology provides high level definitions for addresses and address components for use in other FIBO ontology elements.</dct:abstract>
+		<dct:abstract>This ontology provides high level definitions for addresses and address components including elements that are common to addressing standards.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/</sm:dependsOn>
@@ -59,7 +59,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200601/Places/Addresses/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Places/Addresses/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report. Differences from the 1.0 version include the addition of a hasAddress property and PhysicalAddress class as a parent of PostalAddress.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20160201/Places/Addresses.rdf version of this ontology was modified for the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20130801/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/. Primary differences include elimination of data properties in favor of a simple class model,the addition of virtual address, and the addition of addressing scheme.</skos:changeNote>
@@ -67,6 +67,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Places/Addresses.rdf version of this ontology was modified to eliminate duplication of concepts in LCC, simplify address representation and merge countries with locations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/Addresses.rdf version of this ontology was modified to correct a missing imports statement.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200601/Places/Addresses.rdf version of this ontology was modified to eliminate unnecessary unions and max 1 restrictions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Places/Addresses.rdf version of this ontology was modified to revise names of address elements that could be construed as referring to multiple concepts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/Foundations/20130601/Organizations/Addresses.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
    (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -621,7 +622,7 @@
 		<fibo-fnd-utl-av:explanatoryNote>The suffix may provide some insight into the size or length of the street, though not necessarily consistently. In some cities, the suffix differentiates the street from another in the same context, such as 19th Street vs. 19th Avenue in San Francisco.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fnd-plc-adr;StructureOrComplexName">
+	<owl:Class rdf:about="&fibo-fnd-plc-adr;StructureName">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;AddressComponent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -630,8 +631,8 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>structure or complex name</rdfs:label>
-		<skos:definition>identifier for a building, house, office complex, shopping center, or other structure</skos:definition>
+		<rdfs:label>structure name</rdfs:label>
+		<skos:definition>identifier for a building, house, office complex, shopping center, or other structure or group of structures</skos:definition>
 		<skos:example>Examples include &apos;McCoy Center&apos;, which is the name of the office complex where JPMorgan Chase&apos;s Polaris facility is located, &apos;Apple Park&apos;, which is the name of the corporate headquarters of Apple, Inc., and &apos;Howells Bridge Cottage&apos;, which is the name of a very old cottage in Cornwall.</skos:example>
 	</owl:Class>
 	
@@ -647,7 +648,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressIndicatorOrUnit"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressUnit"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -682,7 +683,7 @@
 		<skos:definition>classifier for supplemental address information, such as a highway contract route, rural route, building complex, shopping center, condominium complex, mail box, or other similar designation</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fnd-plc-adr;SupplementalAddressIndicatorOrUnit">
+	<owl:Class rdf:about="&fibo-fnd-plc-adr;SupplementalAddressUnit">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;AddressComponent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -691,7 +692,7 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>supplemental address indicator or unit</rdfs:label>
+		<rdfs:label>supplemental address unit</rdfs:label>
 		<skos:definition>address component that includes a specific route, box, apartment, condominium or other indicator or unit associated with a specific address</skos:definition>
 	</owl:Class>
 	
@@ -844,12 +845,12 @@
 		<skos:definition>specifies an additional qualifier for a street or other delivery location, such as a dwelling located along a waterway</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plc-adr;hasStructureOrComplexName">
+	<owl:ObjectProperty rdf:about="&fibo-fnd-plc-adr;hasStructureName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-		<rdfs:label>has structure or complex name</rdfs:label>
+		<rdfs:label>has structure name</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;StructureOrComplexName"/>
-		<skos:definition>specifies an identifier for a building, house, office complex, shopping center, or other structure</skos:definition>
+		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;StructureName"/>
+		<skos:definition>specifies an identifier for a building, house, office complex, shopping center, or other structure or group of structures</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-plc-adr;hasTransliteratedAddress">

--- a/FND/ProductsAndServices/PaymentsAndSchedules.rdf
+++ b/FND/ProductsAndServices/PaymentsAndSchedules.rdf
@@ -49,9 +49,9 @@
 		<rdfs:label>Payments and Schedules Ontology</rdfs:label>
 		<dct:abstract>This ontology defines basic concepts such as payment, payee, payer, and payment schedule, extending the scheduling concepts from the Dates and Times module, among others.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/</sm:dependsOn>
@@ -80,11 +80,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200201/ProductsAndServices/PaymentsAndSchedules/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/ProductsAndServices/PaymentsAndSchedules/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20150801/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report to replace MoneyAmount with MonetaryAmount.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified per the FIBO 2.0 RFC to make hasPaymentAmount a child of hasMonetaryAmount and move hasObligation and isObligationOf to Agreements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20181001/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified to revise payments to better support loan requirements and eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified to eliminate remaining circular references.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -103,7 +104,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>payee</rdfs:label>
 		<skos:definition>a party to whom a debt should be paid, or to whose order a bill of exchange, note, or check is made payable, or who receives or will receive a payment from a payer in partial or complete fulfillment of an obligation</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-psch;Payer">
@@ -116,7 +116,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>payer</rdfs:label>
 		<skos:definition>a party who pays a bill or fees, or who makes payments to a payee in partial or complete fulfillment of an obligation</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-psch;Payment">
@@ -129,7 +128,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>payment</rdfs:label>
 		<skos:definition>delivery of money in fulfillment of an obligation, such as to satisfy a claim or debt</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-psch;PaymentEvent">
@@ -150,7 +148,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>payment event</rdfs:label>
 		<skos:definition>an event that involves delivery of money in fulfillment of an obligation</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-psch;PaymentObligation">
@@ -171,7 +168,6 @@
 		<rdfs:label>payment obligation</rdfs:label>
 		<skos:definition>a legally enforceable duty to pay a sum of money, or agree to do something (or not to do something), according to the terms stated in a contract</skos:definition>
 		<skos:example>the duty of a borrower to repay a loan, and the legal right of a lender to enforce payment</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-psch;PaymentSchedule">
@@ -183,8 +179,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>payment schedule</rdfs:label>
-		<skos:definition>schedule for delivery of money in fulfillment of an obligation, such as a coupon payment schedule, loan payment schedule, interest payment schedule</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>schedule for delivery of money in fulfillment of an obligation</skos:definition>
+		<skos:example>Examples includ coupon payment, loan payment, and interest payment schedules, among others.</skos:example>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-psch;fulfillsObligation">
@@ -206,7 +202,7 @@
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
 		<rdfs:label>has payment schedule</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
-		<skos:definition>specifies the schedule for payment of an obligation</skos:definition>
+		<skos:definition>specifies the schedule for fulfillment of an obligation</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/FND/Quantities/QuantitiesAndUnits.rdf
+++ b/FND/Quantities/QuantitiesAndUnits.rdf
@@ -31,9 +31,9 @@
 		<rdfs:label>Quantities and Units Ontology</rdfs:label>
 		<dct:abstract>This ontology provides an initial set of concepts supporting the representation of quantities, units, systems of quantities, and systems of units for use in FIBO. It is compatible with and can be mapped directly to the OMG Date Time Vocabulary (DTV) Quantities Ontology, but has been integrated into FND to provide local coverage of quantities and measurements and eliminate the SBVR mark-up.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
@@ -46,12 +46,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Quantities/QuantitiesAndUnits/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Quantities/QuantitiesAndUnits/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Quantities/QuantitiesAndUnits/ was modified to untangle this ontology from analytics, untangle quantity values (measurements) from measures and add refinements from SysML and ISO 11179, including dimensionality.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Quantities/QuantitiesAndUnits/ was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Quantities/QuantitiesAndUnits/ was modified to eliminate deprecated properties.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Quantities/QuantitiesAndUnits/ was modified to allow for dimensionless quantity kinds, including but not limited to percentages, and to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Quantities/QuantitiesAndUnits/ was modified to eliminate the redundant definition of rate, in favor of ratio in Analytics.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Quantities/QuantitiesAndUnits/ was modified to eliminate circular definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -358,7 +359,7 @@
 		<rdfs:label>has dimension</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-qt-qtu;QuantityKind"/>
 		<rdfs:range rdf:resource="&fibo-fnd-qt-qtu;Dimensionality"/>
-		<skos:definition>indicates the dimension associated with a given quantity kind in some system of quantities (which may also be derived and depends on the choice of base quantity)</skos:definition>
+		<skos:definition>indicates a measurable extent associated with a given quantity kind in some system of quantities, which may be derived, depending on the choice of base quantity</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-qt-qtu;hasExponent">
@@ -387,7 +388,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-fnd-qt-qtu;hasQuantityKind">
 		<rdfs:label>has quantity kind</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-qt-qtu;QuantityKind"/>
-		<skos:definition>indicates the quantity kind involved in the definition of a quantity or factor</skos:definition>
+		<skos:definition>indicates the class of mutually comparable quantities involved in the definition of an individual quantity or factor</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-qt-qtu;hasQuantityValue">
@@ -398,7 +399,8 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-qt-qtu;isDerivedFrom">
 		<rdfs:label>is derived from</rdfs:label>
-		<skos:definition>indicates something that the subject is derived from: a derived quantity is derived from a base quantity; a derived unit is derived from a base unit</skos:definition>
+		<skos:definition>indicates something from which the subject is obtained or determined</skos:definition>
+		<skos:example>a derived quantity is derived from a base quantity; a derived unit is derived from a base unit</skos:example>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-qt-qtu;specializes">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Hygiene testing has identified 7 remaining immediately circular definitions and 3 cases where class or property names might indicate that a given element refers to multiple concepts in FND (released ontologies), which should be remedied.  The resolution to this issue adjusted the relevant definitions to eliminate the circularities, renamed 3 classes to eliminate the ambiguity in their names and improved integration of ownership and control concepts with the situation pattern.

Fixes: #1374 / FND-333


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


