### PR TITLE
IND-103 - Need a synonym of 'basket of goods' on fixed basket and address hygiene issue for the name of GoodsOrServicesPopulation

### DIFF
--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -117,7 +117,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20211201/EconomicIndicators/EconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210201/EconomicIndicators/EconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the FIBO 2.0 RFC. Primary changes include the addition of a number of statistical measures (mean, total, etc.) and their use in existing and new indicators, and the addition of several more economic indicators.</skos:changeNote>
@@ -127,7 +127,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190901/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate duplicatation with concepts in LCC and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200301/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to reflect the change in name and definition of numeric index to numeric index value in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200401/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to add definitions for alternative unemployment calculations and correct a circular property definition.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200901/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200901/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, added a synonym to fixed basket and revised the name of the &apos;goods or services population&apos; to &apos;goods population&apos; to eliminate a hygiene issue and reflect the synonym of &apos;basket of goods&apos;.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -713,8 +713,9 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>fixed basket</rdfs:label>
-		<skos:definition>a basket of goods and services whose quantity and quality are held fixed for some period of time</skos:definition>
+		<skos:definition>basket of goods and services whose quantity and quality are held fixed for some period of time</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:synonym>basket of goods</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;FixedBasketConstituent">
@@ -739,7 +740,7 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 		<skos:definition>component of a fixed basket</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-ind-ei-ei;GoodsOrServicesPopulation">
+	<owl:Class rdf:about="&fibo-ind-ei-ei;GoodsPopulation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalUniverse"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -756,9 +757,10 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>goods or services population</rdfs:label>
-		<skos:definition>a statistical universe consisting of specific goods and/or services designed for the purposes of supporting surveys such as those used as the basis for price indices</skos:definition>
+		<rdfs:label>goods population</rdfs:label>
+		<skos:definition>statistical universe consisting of specific goods (and possibly services) designed for the purposes of supporting surveys such as those used as the basis for price indices</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:synonym>goods and services population</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea">
@@ -978,7 +980,7 @@ A household may be located in a housing unit or in a set of collective living qu
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-ind-ei-ei;EstablishmentPopulation">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;GoodsOrServicesPopulation">
+							<rdf:Description rdf:about="&fibo-ind-ei-ei;GoodsPopulation">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -1001,7 +1003,7 @@ A household may be located in a housing unit or in a set of collective living qu
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-ind-ei-ei;EstablishmentPopulation">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;GoodsOrServicesPopulation">
+							<rdf:Description rdf:about="&fibo-ind-ei-ei;GoodsPopulation">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -740,7 +740,7 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 		<skos:definition>component of a fixed basket</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-ind-ei-ei;GoodsPopulation">
+	<owl:Class rdf:about="&fibo-ind-ei-ei;FixedBasketPopulation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalUniverse"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -757,10 +757,11 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>goods population</rdfs:label>
-		<skos:definition>statistical universe consisting of specific goods (and possibly services) designed for the purposes of supporting surveys such as those used as the basis for price indices</skos:definition>
+		<rdfs:label>fixed basket population</rdfs:label>
+		<skos:definition>statistical universe consisting of specific goods and/or services designed for the purposes of supporting surveys such as those used as the basis for price indices</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>goods and services population</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>goods and/or services population</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea">
@@ -980,7 +981,7 @@ A household may be located in a housing unit or in a set of collective living qu
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-ind-ei-ei;EstablishmentPopulation">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;GoodsPopulation">
+							<rdf:Description rdf:about="&fibo-ind-ei-ei;FixedBasketPopulation">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -1003,7 +1004,7 @@ A household may be located in a housing unit or in a set of collective living qu
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-ind-ei-ei;EstablishmentPopulation">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;GoodsPopulation">
+							<rdf:Description rdf:about="&fibo-ind-ei-ei;FixedBasketPopulation">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added a synonym of 'basket of goods' to 'fixed basket'; renamed 'GoodsOrServicesPopulation' to 'FixedBasketPopulation' accordingly, but added a synonym of 'goods and services population' to make it parallel with the basket naming and for clarity, correcting a hygiene issue as well as reflecting the synonym on fixed basket, per the FCT

Fixes: #1376 / IND-103


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


