### PR TITLE
SEC-140 - CallPrice and PutPrice in DebtInstruments need review

### DIFF
--- a/SEC/Debt/Bonds.rdf
+++ b/SEC/Debt/Bonds.rdf
@@ -140,11 +140,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Debt/Bonds/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Debt/Bonds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/Debt/Bonds.rdf version of this ontology was revised to reflect the refactored definition of a listing and improve the definition of corporate bond.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and eliminate a redundant superclass from RegularCouponSchedule.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate a duplicate &apos;isBasedOn&apos; property and replace it with the property of the same name in the debt ontology, to revise the inheritance hierarchy for bond conversion terms to reflect changes in the representation of redemption more generally, to reflect the move of redemption provision from debt to financial instruments, and eliminate circular and ambiguous definitions.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200901/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate false positives in hygiene tests due to concept names containing words, such as &apos;and&apos;, which might indicate that the concept actually reflects more than one thing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200901/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate false positives in hygiene tests due to concept names containing words, such as &apos;and&apos;, which might indicate that the concept actually reflects more than one thing, and replace the use of call price and put price, which are overly constrained, with monetary price.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -1222,7 +1222,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
 		<rdfs:label>has call price</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;CallFeature"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbti;CallPrice"/>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<skos:definition>indicates the amount of the call on the specified call date, typically the sum of par value and the call premium, as specified in the contract</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>This is the price a bond issuer or preferred stock issuer must pay investors to buy back, or call, all or part of an issue before the maturity date.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>has redemption price</fibo-fnd-utl-av:synonym>
@@ -1280,7 +1280,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bnd;hasCallPrice"/>
 		<rdfs:label>has first call price</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;CallFeature"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbti;CallPrice"/>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<skos:definition>indicates the amount of the call on the first call date as specified in the call schedule</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -1308,7 +1308,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bnd;hasFirstCallPrice"/>
 		<rdfs:label>has first par call price</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;CallFeature"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbti;CallPrice"/>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<skos:definition>specifies the amount of the call on the first par call date as specified in the call schedule</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -1325,7 +1325,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bnd;hasFirstCallPrice"/>
 		<rdfs:label>has first premium call price</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;CallFeature"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbti;CallPrice"/>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<skos:definition>specifies the amount of the call on the first call date on which the bond may be called at a price above par as specified in the call schedule</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -1342,7 +1342,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
 		<rdfs:label>has first put price</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;PutFeature"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbti;PutPrice"/>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<skos:definition>specifies the initial price at which the holder may sell the bond to the issuer prior to maturity</skos:definition>
 	</owl:ObjectProperty>
 	

--- a/SEC/Debt/DebtInstruments.rdf
+++ b/SEC/Debt/DebtInstruments.rdf
@@ -83,13 +83,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Debt/DebtInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Debt/DebtInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Debt/DebtInstruments.rdf version of this ontology was modified to reflect use of actualExpression as an annotation rather than datatype property, to deprecate maturity-related properties which have been moved to financial instruments more generally, and to simplify restrictions on tradable debt instrument.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to support integration of the bonds ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Debt/DebtInstruments.rdf version of this ontology was modified to correct the declaration of the property &apos;has estate or death put feature&apos; to remove an erroneous subproperty relationship and integrate the instrument pricing ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Debt/DebtInstruments.rdf version of this ontology was modified to reflect a change to make redemption provision a child of contractual commitment and move it to financial instruments, as such provisions apply to preferred shares and other instruments in addition to debt, and eliminate non-tradable and tradable debt instrument redemption provisions, which are synonymous, and adjust the hierarchy for call feature, notification provision, and put feature accordingly.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, hasMaturityDate, to Financial Instruments, since a maturity date can apply to a preferred share in addition to a debt instrument or offering rename &apos;mayBeSubordinatedTo&apos;, which violates the policy related to masquerading properties, and eliminate a circular definition and unnecessary references to external sources.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, hasMaturityDate, to Financial Instruments, since a maturity date can apply to a preferred share in addition to a debt instrument or offering rename &apos;mayBeSubordinatedTo&apos;, which violates the policy related to masquerading properties, eliminate a circular definition and unnecessary references to external sources, and eliminate call price and put price, which are overreaching and confusing, in favor of monetary price.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -201,14 +201,6 @@
 		<skos:definition>the price over par paid by an issuer to redeem securities when exercising a call provision</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbti;CallPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
-		<rdfs:label>call price</rdfs:label>
-		<skos:definition>price at which an asset is redeemed in the event of a call</skos:definition>
-		<fibo-fnd-utl-alx:actualExpression>par value + call premium</fibo-fnd-utl-alx:actualExpression>
-		<fibo-fnd-utl-av:synonym>redemption price</fibo-fnd-utl-av:synonym>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;CallSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
 		<rdfs:subClassOf>
@@ -225,7 +217,7 @@
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&fibo-sec-dbt-dbti;CallPremium">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-dbti;CallPrice">
+							<rdf:Description rdf:about="&fibo-fnd-acc-cur;MonetaryPrice">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -445,13 +437,6 @@
 		<skos:definition>an amount over par that a debt instrument holder must pay to sell the security early</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PutPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
-		<rdfs:label>put price</rdfs:label>
-		<skos:definition>price at which a debt instrument with a put feature may be sold by the holder</skos:definition>
-		<fibo-fnd-utl-alx:actualExpression>par value + put premium</fibo-fnd-utl-alx:actualExpression>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PutSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
 		<rdfs:subClassOf>
@@ -468,7 +453,7 @@
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&fibo-sec-dbt-dbti;PutPremium">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-dbti;PutPrice">
+							<rdf:Description rdf:about="&fibo-fnd-acc-cur;MonetaryPrice">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

 Eliminated explicit call price and put price from debt instruments, which were misleading terms and typically used in conjunction with options rather than with bonds, and replaced them with monetary price where they were originally used

Fixes: #1014 / SEC-140


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


