### PR TITLE
IND-105 - Explanatory note in CA Economic Indicators has wrong datatype

### DIFF
--- a/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf
+++ b/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf
@@ -51,9 +51,9 @@
 		<rdfs:label>Canadian Economic Indicators Ontology</rdfs:label>
 		<dct:abstract>This ontology provides specific parameters which make up the various types of market economic indicators applicable to the Canadian economy.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicatorPublishers/</sm:dependsOn>
@@ -75,11 +75,12 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20200301/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210301/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was added to the IND specification per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was revised per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was revised to reflect the new hasCoverageArea property in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20181101/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was revised to eliminate duplication with concepts in LCC and merge countries with locations in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200301/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was revised to correct a datatype on an explanatory note.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -181,7 +182,7 @@
 		<rdfs:label>Canadian producer price index</rdfs:label>
 		<skos:definition>an economic indicator representing a measure of the change over time in the prices of a fixed-basket of domestic producer goods and services</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www23.statcan.gc.ca/imdb-bmdi/pub/indexth-eng.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;anyURI">Note that Canada does not produce a high level, cross industry PPI per se. Canadian PPIs are published by industry sector. Three of the most important are captured in the union defined herein, which may be expanded over time to integrate others, as needed.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Note that Canada does not produce a high level, cross industry PPI per se. Canadian PPIs are published by industry sector. Three of the most important are captured in the union defined herein, which may be expanded over time to integrate others, as needed.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-caei;CanadianStatisticsPublisher">

--- a/IND/ForeignExchange/ForeignExchange.rdf
+++ b/IND/ForeignExchange/ForeignExchange.rdf
@@ -35,9 +35,9 @@
 		<rdfs:label>Foreign Exchange Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the parameters for foreign exchange rates, covering spot and forward rates, as well as Fx spot rate volatilities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2019 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2019 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2014-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/Indicators/Indicators/</sm:dependsOn>
@@ -50,20 +50,19 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20190901/ForeignExchange/ForeignExchange/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210301/ForeignExchange/ForeignExchange/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/ForeignExchange/ForeignExchange.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/ForeignExchange/ForeignExchange.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 2 report, namely, to take advantage of content added via the FIBO FND 1.1 with respect to higher-level concepts of Rate, ExchangeRate, and InterestRate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/ForeignExchange/ForeignExchange.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/ForeignExchange/ForeignExchange.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190901/ForeignExchange/ForeignExchange.rdf version of this ontology was modified to eliminate unnecessary references, some of which had incorrect datatypes.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;CurrencyConversionService">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;ForeignExchangeService"/>
 		<rdfs:label>currency conversion service</rdfs:label>
-		<skos:definition>a foreign exchange service involving the conversion of currency of one country or group of countries for another, typically, but not always, as a counter transaction</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/currency-exchange.asp</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>foreign exchange service involving the conversion of currency of one country or group of countries for another, typically, but not always, as a counter transaction</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>A currency exchange service may be provided by a stand-alone business or may be part of the services offered by a bank or other financial institution. The currency exchange profits from its services either through adjusting the exchange rate or taking a commission.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -76,40 +75,38 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>currency forward rate</rdfs:label>
-		<skos:definition>a rate of exchange between two currencies for settlement at some future point in time, expressed as a premium on the spot rate</skos:definition>
+		<skos:definition>rate of exchange between two currencies for settlement at some future point in time, expressed as a premium on the spot rate</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;CurrencySpotBuyRate">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;CurrencySpotRate"/>
 		<rdfs:label>currency spot buy rate</rdfs:label>
-		<skos:definition>an indicative spot buying market rate as observed by the reporting source</skos:definition>
+		<skos:definition>indicative spot buying market rate as observed by the reporting source</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;CurrencySpotMidRate">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;CurrencySpotRate"/>
 		<rdfs:label>currency spot mid rate</rdfs:label>
-		<skos:definition>an indicative middle market (mean of spot buying and selling) rate as observed by the reporting source</skos:definition>
+		<skos:definition>indicative middle market (mean of spot buying and selling) rate as observed by the reporting source</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;CurrencySpotRate">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;QuotedExchangeRate"/>
 		<rdfs:label>currency spot rate</rdfs:label>
-		<skos:definition>a rate to exchange one currency for another for immediate delivery</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/s/spotexchangerate.asp</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>rate at which one currency may be exchanged for another for immediate delivery</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Spot rates represent the prices buyers pay in one currency to purchase a second currency. Although the spot exchange rate is for delivery on the earliest value date, the standard settlement date for most spot transactions is two business days after the transaction date.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;CurrencySpotSellRate">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;CurrencySpotRate"/>
 		<rdfs:label>currency spot sell rate</rdfs:label>
-		<skos:definition>an indicative spot selling market rate as observed by the reporting source</skos:definition>
+		<skos:definition>indicative spot selling market rate as observed by the reporting source</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;ForeignExchangeService">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
 		<rdfs:label>foreign exchange service</rdfs:label>
-		<skos:definition>a financial service involving the exchange of one currency for another, conversion of one currency for another, and transfer of money from one country to another whereby currency conversion is required</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>financial service involving the exchange of one currency for another, conversion of one currency for another, and transfer of money from one country to another whereby currency conversion is required</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;FxSpotVolatility">
@@ -121,8 +118,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>FX spot volatility</rdfs:label>
-		<skos:definition>a measure of exchange rate fluctuation</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">OptionsEducation.org</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>measure of exchange rate fluctuation</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Mathematically, volatility is the annualized standard deviation of the daily changes in the exchange rate.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -130,8 +126,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;ElectronicFundsTransferService"/>
 		<rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;ForeignExchangeService"/>
 		<rdfs:label>international electronic funds transfer service</rdfs:label>
-		<skos:definition>an electronic funds transfer (EFT) service involving the transfer of funds across national borders, that may also involve currency conversion</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>electronic funds transfer (EFT) service involving the transfer of funds across national borders, that may also involve currency conversion</skos:definition>
 		<fibo-fnd-utl-av:synonym>international wire transfer</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -146,7 +141,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>quoted exchange rate</rdfs:label>
-		<skos:definition>an exchange rate quoted at a specific point in time, for a given block amount of currency as quoted against another (base) currency</skos:definition>
+		<skos:definition>exchange rate quoted at a specific point in time, for a given block amount of currency as quoted against another (base) currency</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>An exchange rate of R represents a rate of R units of the quoted currency to 1 unit of the base currency.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Corrected wrong datatype in the Canadian Economic Indicators ontology (was on a note), and removed extraneous references from ForeignExchange, one of which was not a true URL but typed as anyURI

Fixes: #1416 / IND-105


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


