### PR TITLE
SEC-155 - Equity issuer should be renamed to share issuer, just to be clear

### DIFF
--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -66,8 +66,8 @@
 		<dct:abstract>This ontologyprovides examples of how to represent simple equities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2019-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2019-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2019-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2019-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -101,10 +101,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquitiesExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Equities/EquitiesExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was modified to add CFI codes to the example equity instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to add the share class to some of the examples, replace registered form with book entry (registered) form, and add detail to the common share and listing individuals.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to replace equity issuer with share issuer.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -171,7 +172,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:label>Alphabet Inc. equity issuer</rdfs:label>
 		<skos:definition>Alphabet Inc. functional entity that is an issuer of stock</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-be-le-usee;AlphabetInc-US-CA"/>
@@ -210,7 +211,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AppleIncEquityIssuer">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:label>Apple Inc. common stock issuer</rdfs:label>
 		<skos:definition>Apple Inc. functional entity that is an issuer of common stock</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-be-le-usee;AppleInc-US-CA"/>
@@ -497,7 +498,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;CitigroupIncEquityIssuer">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:label>Citigroup Inc. common stock issuer</rdfs:label>
 		<skos:definition>Citigroup Inc. functional entity that is an issuer of common stock</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usind;CitigroupInc-US-DE"/>
@@ -615,7 +616,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationEquityIssuer">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:label>International Business Machines Corporation common stock issuer</rdfs:label>
 		<skos:definition>IBM functional entity that is an issuer of common stock</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-be-le-usee;InternationalBusinessMachinesCorporation-US-NY"/>
@@ -654,7 +655,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;JPMorganChaseAndCoEquityIssuer">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:label>J.P. Morgan Chase &amp; Co. common stock issuer</rdfs:label>
 		<skos:definition>J.P. Morgan Chase &amp; Co. functional entity that is an issuer of common stock</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCo-US-DE"/>
@@ -700,7 +701,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheCoca-ColaCompanyEquityIssuer">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:label>The Coca-Cola Company common stock issuer</rdfs:label>
 		<skos:definition>The Coca-Cola Company functional entity that is an issuer of common stock</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-be-le-usee;TheCoca-ColaCompany-US-DE"/>
@@ -739,7 +740,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheHomeDepotIncEquityIssuer">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:label>The Home Depot, Inc. common stock issuer</rdfs:label>
 		<skos:definition>Home Depot, Inc. functional entity that is an issuer of common stock</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-be-le-usee;TheHomeDepotInc-US-DE"/>
@@ -777,7 +778,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyEquityIssuer">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:label>The Proctor &amp; Gamble Company common stock issuer</rdfs:label>
 		<skos:definition>The Proctor &amp; Gamble Company functional entity that is an issuer of common stock</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-be-le-usee;TheProctorAndGambleCompany-US-OH"/>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -124,13 +124,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments, including features specific to preferred shares.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, clean up ambiguous definitions, and eliminate redundant restrictions related to security form.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add concepts covering additional features of preferred shares and move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology, and add a property for the number of authorized shares.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add concepts covering additional features of preferred shares and move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology, add a property for the number of authorized shares, and rename EquityIssuer to ShareIssuer to be clearer about the intent.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -321,53 +321,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>equity conversion terms</rdfs:label>
 		<skos:definition>conversion terms specifying the details regarding conversion of shares into other securities</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;EquityIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasFloatingShares"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharesIssued"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharesOutstanding"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasTreasuryShares"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;issues"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharesAuthorized"/>
-				<owl:someValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>equity issuer</rdfs:label>
-		<skos:definition>issuer of shares that represent an ownership interest in something</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This includes shares that represent equity ownership in a corporation, or ownership in a mutual fund, or an interest in a general or limited partnership, or ownership in a structured product, such as a real estate investment trust.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;EquityPosition">
@@ -967,6 +920,53 @@
 		<skos:definition xml:lang="en">financial instrument that signifies a unit of equity ownership in a corporation, or a unit of ownership in a mutual fund, or interest in a general or limited partnership, or a unit of ownership in a structured product, such as a real estate investment trust</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;ShareIssuer">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasFloatingShares"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharesIssued"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharesOutstanding"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasTreasuryShares"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;issues"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharesAuthorized"/>
+				<owl:someValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>share issuer</rdfs:label>
+		<skos:definition>issuer of securities that represent an ownership interest in something</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>This includes shares that represent equity ownership in a corporation, or ownership in a mutual fund, or an interest in a general or limited partnership, or ownership in a structured product, such as a real estate investment trust.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;SharePaymentStatus">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStatus"/>
 		<rdfs:subClassOf>
@@ -1181,7 +1181,7 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasFloatingShares">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">has floating shares</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the number of shares that are available for trading, i.e., the number of shares outstanding less closely held shares (those held by insiders) and restricted shares</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A relatively small float results in higher volatility, as a large purchase or sell order will have significant influence on the value of the stock.</fibo-fnd-utl-av:explanatoryNote>
@@ -1233,7 +1233,7 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasSharesAuthorized">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">has shares authorized</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the maximum number of shares that are permitted to be issued, as established by the board of directors</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An initial number of authorized shares is typically established at the time of incorporation, and is documented in articles of incorporation.  The number of shares authorized may be extended from time to time by the board of directors as needed, and articles of incorporation and other legal documentation will be amended accordingly.  It includes shares that are available, but not yet issued, for sale to generate capital, and shares available for distribution to insiders as part of their compensation packages.</fibo-fnd-utl-av:explanatoryNote>
@@ -1242,7 +1242,7 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasSharesIssued">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">has shares issued</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the actual number of shares held by shareholders (i.e., shares outstanding) and treasury shares</skos:definition>
 	</owl:DatatypeProperty>
@@ -1250,7 +1250,7 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasSharesOutstanding">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">has shares outstanding</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the number of shares currently held by shareholders, including those held by retail investors, institutional investors and insiders, and typically available for trading</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The number of outstanding shares is used in calculating key metrics such as a company&apos;s market capitalization, as well as its earnings per share (EPS) and cash flow per share (CFPS).</fibo-fnd-utl-av:explanatoryNote>
@@ -1259,7 +1259,7 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasTreasuryShares">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">has treasury shares</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;EquityIssuer"/>
+		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the number of shares issued but not outstanding, including those that were available in the market at one time but have been repurchased by the company</skos:definition>
 	</owl:DatatypeProperty>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Changed the name of equity issuer to share issuer for clarification purposes per the SEC FCT.  Some organizations such as LLCs also issue equity, but not shares per se, so we should rename equity issuer to share issuer to be clear about the role it plays.

Fixes: #1418 / SEC-151


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


