### PR TITLE
IND-106 - Update the FpML reference interest rates per the latest published version

### DIFF
--- a/IND/InterestRates/CommonInterestRates.rdf
+++ b/IND/InterestRates/CommonInterestRates.rdf
@@ -41,9 +41,9 @@
 		<rdfs:label>Common Interest Rates Ontology</rdfs:label>
 		<dct:abstract>This ontology provides reference data for commonly referenced interest rates, specifically those that are referenced in the ISDA FpML codes for floating interest rates. The rates included herein are generated directly from the FpML published reference data.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
@@ -60,10 +60,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20200201/InterestRates/CommonInterestRates/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210301/InterestRates/CommonInterestRates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/InterestRates/InterestRates.rdf version of this ontology was modified to normalize the prefix for the EU individuals ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190101/InterestRates/InterestRates.rdf version of this ontology was revised extensively to restructure the way in which interest rate benchmarks are modeled and eliminate references to the merged interest rate publishers ontology.</skos:changeNote>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/floating-rate-index-2-27.xml</fibo-fnd-utl-av:adaptedFrom>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190101/InterestRates/InterestRates.rdf version of this ontology was revised to reflect the latest FpML rates.</skos:changeNote>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/floating-rate-index-2-32.xml</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -593,7 +594,7 @@
 		<rdfs:label>CHF-SARON-OIS-COMPOUND</rdfs:label>
 		<skos:definition>the FpML floating interest index for the CHF-SARON-OIS-COMPOUND</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-SARON-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>PPer 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 	</owl:NamedIndividual>
 	
@@ -1572,6 +1573,15 @@
 		<skos:definition>the FpML floating interest index for the GBP-SONIA-OIS-4:15-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-OIS-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_Swap_Rate">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>GBP-SONIA Swap Rate</rdfs:label>
+		<skos:definition>the FpML floating interest index for the GBP-SONIA Swap Rate</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>GBP-SONIA Swap Rate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 	</owl:NamedIndividual>
@@ -3107,6 +3117,15 @@
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SORA-COMPOUND">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>SGD-SORA-COMPOUND</rdfs:label>
+		<skos:definition>the FpML floating interest index for the SGD-SORA-COMPOUND</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>SGD-SORA-COMPOUND</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Currency_Basis_Swap_Rate-11_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Currency Basis Swap Rate-11:00-Tullett Prebon</rdfs:label>
@@ -3317,6 +3336,15 @@
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THOR-COMPOUND">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>THB-THOR-COMPOUND</rdfs:label>
+		<skos:definition>the FpML floating interest index for the THB-THOR-COMPOUND</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>THB-THOR-COMPOUND</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-Annual_Swap_Rate-11_15-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-Annual Swap Rate-11:15-BGCANTOR</rdfs:label>
@@ -3346,6 +3374,15 @@
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TLREF-OIS-COMPOUND">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>TRY-TLREF-OIS-COMPOUND</rdfs:label>
+		<skos:definition>the FpML floating interest index for the TRY-TLREF-OIS-COMPOUND</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>TRY-TLREF-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TRYIBOR-Reference_Banks">
@@ -3479,6 +3516,7 @@
 		<skos:definition>the FpML floating interest index for the UK Base Rate</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>UK Base Rate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-3M_LIBOR_SWAP-CME_vs_LCH-ICAP">
@@ -3521,6 +3559,33 @@
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-AMERIBOR</rdfs:label>
+		<skos:definition>the FpML floating interest index for the USD-AMERIBOR</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Average_30D">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-AMERIBOR Average 30D</rdfs:label>
+		<skos:definition>the FpML floating interest index for the USD-AMERIBOR Average 30D</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Average 30D</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Average_90D">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-AMERIBOR Average 90D</rdfs:label>
+		<skos:definition>the FpML floating interest index for the USD-AMERIBOR Average 90D</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Average 90D</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-11_00-BGCANTOR">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revise the FpML reference interest rates to reflect the latest version, published on 2/19/2021 based on individuals published at http://www.fpml.org/coding-scheme/floating-rate-index-2-32.xml and converted to RDF by Pete Rivett

Fixes: #1430 / IND-106


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


