### PR TITLE
DER-96  - Rename the Forwards ontology to Futures and Forwards, and release it

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -131,7 +131,7 @@
 	 
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ParticipationNotes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"/>

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -24,11 +24,11 @@
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/">
   		<rdfs:label>About FIBO Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users.  It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release.  Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2021-03-29T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:submitter>Thematix Partners LLC</sm:submitter>
 		<sm:fileAbbreviation>fibo-prod</sm:fileAbbreviation>
 		<sm:filename>AboutFIBOProd.rdf</sm:filename>		
@@ -91,6 +91,7 @@
      -->		
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/SwapsIndividuals/"/>
 		

--- a/DER/AllDER.rdf
+++ b/DER/AllDER.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-all "https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-der-drc-ff "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-der-rtd-irswp "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/">
 	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/">
@@ -19,6 +20,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-all="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-der-drc-ff="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-der-rtd-irswp="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"
 	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"
@@ -34,7 +36,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/">
 		<rdfs:label>Derivatives Domain</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2021-03-29T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain</dct:title>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
@@ -55,8 +57,8 @@
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
 		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
 		<sm:contributor>Working Ontologist</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
@@ -71,6 +73,7 @@
 		<sm:moduleAbbreviation>fibo-der</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
@@ -78,7 +81,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201201/AllDER/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210301/AllDER/"/>
 		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for DER is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), Securities (SEC), and Derivatives (DER) domains, excluding individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/DER/CommoditiesDerivatives/CommoditiesContracts.rdf
+++ b/DER/CommoditiesDerivatives/CommoditiesContracts.rdf
@@ -3,7 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-drc-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
+	<!ENTITY fibo-der-drc-ff "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -24,7 +24,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-drc-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
+	xmlns:fibo-der-drc-ff="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -52,7 +52,7 @@
 		<sm:fileAbbreviation>fibo-der-com-ctr</sm:fileAbbreviation>
 		<sm:filename>CommoditiesContracts.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -112,7 +112,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-com-ctr;CommodityForward">
 		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivative"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;Forward"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;Forward"/>
 		<rdfs:label xml:lang="en">commodity forward</rdfs:label>
 		<skos:definition xml:lang="en">forward contract involving the sale or purchase of a commodity asset</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
@@ -122,7 +122,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivative"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:label xml:lang="en">commodity future</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<skos:definition xml:lang="en">futures contract tied to the movement in pricing of bulk goods</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This enables contract buyers to buy a specific amount of a commodity at a specific price on a particular date in the future. The price of the contract is determined using the &quot;Open Outcry&quot; system on the floor of a commodity exchange such as the Chicago Board of Trade or the Commodity Exchange in New York. There are commodity futures contracts based on meats such as cattle and pork bellies; grains such as corn, oats, soybeans and wheat; metals such as gold, silver and platinum; and energy products such as heating oil, natural gas and crude oil.</fibo-fnd-utl-av:explanatoryNote>

--- a/DER/DerivativesContracts/FuturesAndForwards.rdf
+++ b/DER/DerivativesContracts/FuturesAndForwards.rdf
@@ -3,7 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-drc-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
+	<!ENTITY fibo-der-drc-ff "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
@@ -32,11 +32,11 @@
 	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-drc-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
+	xmlns:fibo-der-drc-ff="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
@@ -65,19 +65,20 @@
 	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
 		<rdfs:label xml:lang="en">Forwards Ontology</rdfs:label>
-		<dct:abstract>Concepts defining a derivative contract in which one side represents a commitment to sell or purchase the underlier at a defined price at a given time in the future.</dct:abstract>
+		<dct:abstract>This ontology defines concepts for derivative contracts, including forwards and futures, representing a commitment to sell or purchase the underlier at a defined price at a given time in the future.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/"/>
-		<sm:fileAbbreviation>fibo-der-drc-fwd</sm:fileAbbreviation>
-		<sm:filename>Forwards.rdf</sm:filename>
+		<sm:fileAbbreviation>fibo-der-drc-ff</sm:fileAbbreviation>
+		<sm:filename>ForwardsAndFutures.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
@@ -102,12 +103,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;BasketFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;BasketFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -119,8 +120,8 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;BondFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;DebtInstrumentFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;BondFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;DebtInstrumentFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -131,8 +132,8 @@
 		<skos:definition xml:lang="en">futures contract whose underlying asset is at least one bond</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;CurrencyFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;CurrencyFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;CurrencyInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -147,8 +148,8 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">forex future</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;DebtInstrumentFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;DebtInstrumentFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;DebtInstrumentDerivative"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -161,8 +162,8 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;DividendFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;DividendFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -174,8 +175,8 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;EquityFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;EquityFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -188,14 +189,15 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;FinancialFuture">
+	<owl:Class rdf:about="&fibo-der-drc-ff;FinancialFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:label xml:lang="en">financial future</rdfs:label>
 		<skos:definition xml:lang="en">futures contract based on underlying assets excluding commodities</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;Forward">
+	<owl:Class rdf:about="&fibo-der-drc-ff;Forward">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OverTheCounterInstrument"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -210,13 +212,14 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">forward</rdfs:label>
-		<skos:definition xml:lang="en">derivative instrument that is privately negotiated between parties to buy or sell the underlying asset at a specified future date at the price specified at the outset of the contract</skos:definition>
+		<skos:definition xml:lang="en">derivative instrument that is privately negotiated between parties to buy the underlier at a specified future date at the price specified in the contract</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Unlike futures contracts (which are processed through a clearing firm), forward contracts are non-standardized. Further, the two parties must bear each other&apos;s credit risk, which is not the case with a futures contract. Also, since the contracts are not exchange traded, there is no marking to market requirement, which allows a buyer to avoid almost all capital outflow initially (though some counterparties might set collateral requirements). Given the lack of standardization in these contracts, there is very little scope for a secondary market in forwards. The price specified in a forward contract for a specific commodity. The forward price makes the forward contract have no value when the contract is written. However, if the value of the underlying commodity changes, the value of the forward contract becomes positive or negative, depending on the position held. Forwards are priced in a manner similar to futures. Like in the case of a futures contract, the first step in pricing a forward is to add the spot price to the cost of carry (interest forgone, convenience yield, storage costs and interest/dividend received on the underlying). Unlike a futures contract though, the price may also include a premium for counterparty credit risk, and the fact that there is not daily marking to market process to minimize default risk. If there is no allowance for these credit risks, then the forward price will equal the futures price.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Unlike futures contracts (which are processed through a clearing firm), forward contracts are non-standardized. Further, the two parties must bear each other&apos;s credit risk, which is not the case with a futures contract. Also, since the contracts are not exchange traded, there is no mark-to-market requirement, which allows a buyer to avoid almost all capital outflow initially (though some counterparties might set collateral requirements). The forward price makes the forward contract have no value when the contract is written. However, if the value of the underlying commodity changes, the value of the forward contract becomes positive or negative, depending on the position held. Forwards are priced in a manner similar to futures. Like in the case of a futures contract, the first step in pricing a forward is to add the spot price to the cost of carry (interest forgone, convenience yield, storage costs and interest/dividend received on the underlying). Unlike a futures contract though, the price may also include a premium for counterparty credit risk, and the fact that there is not daily marking to market process to minimize default risk. If there is no allowance for these credit risks, then the forward price will equal the futures price.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">forward contract</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;FutureOnFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;FutureOnFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -228,8 +231,8 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;FutureOnOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;FutureOnOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -241,8 +244,8 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;FutureOnSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;FutureOnSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -254,7 +257,7 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;FuturesListing">
+	<owl:Class rdf:about="&fibo-der-drc-ff;FuturesListing">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;Listing"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -267,8 +270,8 @@
 		<skos:definition xml:lang="en">listing of a futures instrument on a derivatives exchange</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;IndexFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;IndexFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -290,8 +293,8 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For each index there may be a different multiple for determining the price of the futures contract.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;InterestRateFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;FinancialFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;InterestRateFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -313,8 +316,8 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Most interest rate futures that trade on American exchanges use U.S. Treasury securities, such as Treasury bills, Treasury bonds, certificates of deposit, Treasury notes, and Ginnie Mae securities, as the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;MoneyMarketFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;DebtInstrumentFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-ff;MoneyMarketFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;DebtInstrumentFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -325,7 +328,7 @@
 		<skos:definition xml:lang="en">futures contract with a money market instrument as the underlying asset</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;StandardizedFuturesListingTerms">
+	<owl:Class rdf:about="&fibo-der-drc-ff;StandardizedFuturesListingTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeTerms"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;StandardizedTerms"/>
 		<rdfs:subClassOf>
@@ -337,7 +340,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-fwd;FuturesListing"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ff;FuturesListing"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">standardized futures listing terms</rdfs:label>
@@ -345,7 +348,7 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Individual listings will take on these standard terms but they are not contractual terms of the futures contract, they are facts about that listing on that exchange.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-fwd;StandardizedFuturesTerms">
+	<owl:Class rdf:about="&fibo-der-drc-ff;StandardizedFuturesTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeTerms"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;StandardizedTerms"/>
 		<rdfs:subClassOf>
@@ -365,18 +368,18 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Standard symbology for the commodities are standardized by the exchanges as part of their standard contracts, for example trading in standard bushels, commonly defined kinds of oil and so on. These give the units in which lot sizes are described and defined.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-fwd;hasConversionFactor">
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ff;hasConversionFactor">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
 		<rdfs:label xml:lang="en">has conversion factor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-fwd;BondFuture"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ff;BondFuture"/>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">indicates the price of the delivered bond/note ($1 par value) to yield a fixed rate. The conversion factor is used to calculate a final delivery price.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-fwd;hasMultiple">
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ff;hasMultiple">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
 		<rdfs:label xml:lang="en">has multiple</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-fwd;IndexFuture"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ff;IndexFuture"/>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">indicates the multiple for determining the price of the futures contract in relation to the underlying index rate</skos:definition>
 	</owl:DatatypeProperty>
@@ -400,7 +403,8 @@
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A futures contract obligates the buyer to purchase the underlying commodity, currency or financial instrument and the seller to sell it unless the contract is sold to another before settlement date which may happen if a trader waits to take a profit or cut a loss. This contrasts with options trading in which the option buyer may choose whether or not to exercise the option by the exercise date. Unlike options, futures convey an obligation to buy. The risk to the holder is unlimited, and because the payoff pattern is symmetrical, the risk to the seller is unlimited as well. Dollars lost and gained by each party on a futures contract are equal and opposite. In other words, futures trading is a zero-sum game. Futures contracts are forward contracts, meaning they represent a pledge to make a certain transaction at a future date. The exchange of assets occurs on the date specified in the contract. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearinghouses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A futures contract obligates the buyer to pay the seller a predetermined price based on the market value of the underlier, unless the contract is sold before settlement date which may happen if a trader waits to take a profit or cut a loss. This contrasts with options trading in which the option buyer may choose whether or not to exercise the option. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearing houses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">futures contract</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/FuturesAndForwards.rdf
+++ b/DER/DerivativesContracts/FuturesAndForwards.rdf
@@ -66,7 +66,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
-		<rdfs:label xml:lang="en">Forwards Ontology</rdfs:label>
+		<rdfs:label xml:lang="en">Futures and Forwards Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts for derivative contracts, including forwards and futures, representing a commitment to sell or purchase the underlier at a defined price at a given time in the future.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
@@ -78,7 +78,7 @@
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/"/>
 		<sm:fileAbbreviation>fibo-der-drc-ff</sm:fileAbbreviation>
-		<sm:filename>ForwardsAndFutures.rdf</sm:filename>
+		<sm:filename>FuturesAndForwards.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
@@ -103,7 +103,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/FuturesAndForwards/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	

--- a/DER/DerivativesContracts/MetadataDERDerivativesContracts.rdf
+++ b/DER/DerivativesContracts/MetadataDERDerivativesContracts.rdf
@@ -24,16 +24,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/MetadataDERDerivativesContracts/">
 		<rdfs:label>Metadata about the EDMC-FIBO Derivatives (DER) Derivatives Contracts Module</rdfs:label>
 		<dct:abstract>The derivatives contracts module includes the contractual components common to all derivatives or to entire classes of derivatives.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-31T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2021-03-29T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/2002/07/owl#</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-drc-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataDERDerivativesContracts.rdf</sm:filename>
 		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201101/DerivativesContracts/MetadataDERDerivativesContracts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/MetadataDERDerivativesContracts/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-der-drc-mod;DerivativesContractsModule">
@@ -42,7 +42,7 @@
 		<dct:abstract>The derivatives contracts module includes the contractual components common to all derivatives or to entire classes of derivatives.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/"/>
-		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ParticipationNotes/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"/>
@@ -56,16 +56,20 @@
 		<sm:contributor>Citigroup</sm:contributor>
 		<sm:contributor>Commodities Futures Trading Commission (CFTC)</sm:contributor>
 		<sm:contributor>Deutsche Bank</sm:contributor>
+		<sm:contributor>Federated Knowledge LLC</sm:contributor>
+		<sm:contributor>John F. Gemski</sm:contributor>
+		<sm:contributor>John F. Tierney</sm:contributor>
+		<sm:contributor>Mizuho Financial Group, Inc.</sm:contributor>
 		<sm:contributor>Nordea Bank AB</sm:contributor>
 		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
 		<sm:contributor>Quarule</sm:contributor>
 		<sm:contributor>State Street Bank and Trust</sm:contributor>
 		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
+		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
 		<sm:contributor>Working Ontologist</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-der-drc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 	</owl:NamedIndividual>

--- a/DER/FxDerivatives/FxContracts.rdf
+++ b/DER/FxDerivatives/FxContracts.rdf
@@ -3,7 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-der-sp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Spots/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-drc-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
+	<!ENTITY fibo-der-drc-ff "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxContracts/">
 	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/">
@@ -28,7 +28,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-der-sp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Spots/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-drc-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
+	xmlns:fibo-der-drc-ff="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxContracts/"
 	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"
@@ -50,11 +50,14 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxContracts/">
-		<rdfs:label xml:lang="en">FxContracts</rdfs:label>
+		<rdfs:label xml:lang="en">Foreign Exchange Contracts Ontology</rdfs:label>
 		<dct:abstract>Concepts common to foreign exchange derivatives (spots, forwards, options and swaps).</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-fx-ctr</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Spots/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
@@ -86,7 +89,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-fx-ctr;ForeignExchangeForward">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;Forward"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;Forward"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivative"/>
 		<rdfs:label xml:lang="en">foreign exchange forward</rdfs:label>
 		<skos:definition xml:lang="en">agreement to deliver and settle a given amount of currency in one currency, in exchange for a given amount in another currency, at an agreed date in the future and at an agreed rate of exchange</skos:definition>

--- a/DER/FxDerivatives/FxOptions.rdf
+++ b/DER/FxDerivatives/FxOptions.rdf
@@ -3,7 +3,6 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-drc-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
 	<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxContracts/">
 	<!ENTITY fibo-der-fx-opt "https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxOptions/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -24,7 +23,6 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-drc-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
 	xmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxContracts/"
 	xmlns:fibo-der-fx-opt="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxOptions/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -49,7 +47,6 @@
 		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-fx-opt</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>

--- a/DER/SecurityBasedDerivatives/EquityForwards.rdf
+++ b/DER/SecurityBasedDerivatives/EquityForwards.rdf
@@ -2,7 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-drc-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
+	<!ENTITY fibo-der-drc-ff "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
 	<!ENTITY fibo-der-sbd-eqf "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquityForwards/">
 	<!ENTITY fibo-der-sbd-eqs "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquitySwaps/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
@@ -23,7 +23,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquityForwards/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-drc-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
+	xmlns:fibo-der-drc-ff="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
 	xmlns:fibo-der-sbd-eqf="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquityForwards/"
 	xmlns:fibo-der-sbd-eqs="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquitySwaps/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
@@ -49,7 +49,7 @@
 		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-sbd-eqf</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquitySwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -80,7 +80,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqf;EquityForwardContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-fwd;Forward"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;Forward"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -84,7 +84,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/SwapsIndividuals/" uri="./DER/DerivativesContracts/SwapsIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/" uri="./DER/DerivativesContracts/RightsAndWarrants.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/" uri="./DER/DerivativesContracts/DerivativesMasterAgreements.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/" uri="./DER/DerivativesContracts/Forwards.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/" uri="./DER/DerivativesContracts/FuturesAndForwards.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/MetadataDERDerivativesContracts/" uri="./DER/DerivativesContracts/MetadataDERDerivativesContracts.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/" uri="./DER/DerivativesContracts/Options.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ParticipationNotes/" uri="./DER/DerivativesContracts/ParticipationNotes.rdf"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Renamed Forwards to FuturesAndForwards, revised metadata and a couple of definitions per FCT discussion and released the Futures and Forwards ontology


Fixes: #1432 / DER-96


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


