### PR TITLE
DER-94 - Add 'has round lot size' as a subproperty of hasLotSize, and 'has unit of trading' as a synonym

### DIFF
--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -85,10 +85,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210201/FinancialInstruments/InstrumentPricing/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/InstrumentPricing/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, to add adjusted price and to create a more general hasLotSize property that can be used in various contexts.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, and add a restriction on SecurityPrice to point to the security.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize as .</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -604,6 +604,16 @@
 		<rdfs:range rdf:resource="&fibo-fbc-fi-ip;RateOfReturn"/>
 		<skos:definition xml:lang="en">indicates the retrospective rate of return for a given financial instrument over some period of time</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-fi-ip;hasRoundLotSize">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-fi-ip;hasLotSize"/>
+		<rdfs:label xml:lang="en">has round lot size</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;positiveInteger"/>
+		<skos:definition xml:lang="en">standard number of securities traded on an exchange</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In stocks, a round lot is considered 100 shares or a larger number that can be evenly divided by 100. In bonds, a round lot is usually $100,000 worth. Odd lots and smaller lots have become increasingly common due to technology advances and small investor demand.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">normal trading unit</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">unit of trading</fibo-fnd-utl-av:synonym>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-ip;hasTradingDateTime">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDateTime"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added a property for hasRoundLotSize, with a synonym of 'has unit of trading' and 'normal trading unit' to Instrument Pricing, as a subproperty of hasLotSize, for use in derivatives valuation and pricing

Fixes: #1434 / DER-94


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


