### PR TITLE
FND-337 - Need to be able to identify a person's place of residence

### DIFF
--- a/FND/AgentsAndPeople/People.rdf
+++ b/FND/AgentsAndPeople/People.rdf
@@ -598,8 +598,8 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 		<rdfs:label>has primary residence</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-aap-ppl;Person"/>
 		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
-		<skos:definition>identifies the dwelling where an individual resides the majority of the year</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>For tax purposes, in cases when an individual owns more than one home, their primary residence is the home in which they reside most of the time, and for which they can provide evidence to that effect.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>identifies a dwelling where an individual resides the majority of the year</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>For tax purposes, in cases when an individual owns more than one home, their primary residence is the home in which they reside most of the time, and for which they can provide evidence to that effect. Having said this, there are cases, such as for individuals that have dual citizenship, where they may have multiple primary residences, one in each country in which they maintain a home.  There may also be subtle issues related to &apos;rent control&apos; that may impact the statements an individual makes about their primary residence. In other words, one cannot necessarily infer a person&apos;s identity from their primary place of residence.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-aap-ppl;hasResidence">

--- a/FND/AgentsAndPeople/People.rdf
+++ b/FND/AgentsAndPeople/People.rdf
@@ -46,8 +46,8 @@
 		<dct:abstract>This ontology defines concepts for people and human related terms, for use in other FIBO ontology elements. People as defined here are human persons only. This ontology sets out a number of basic properties which are held by people or are definitive of a small number of specific types of people such as minors or adults. Primary use cases for determining the set of personal information definitions included are the common elements required to (1) open a bank account, (2) identify a sophisticated investor, and (3) establish foreign account ownership for money laundering purposes.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/</sm:dependsOn>
@@ -71,7 +71,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20201201/AgentsAndPeople/People/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210301/AgentsAndPeople/People/"/>
 		<skos:changeNote>The http://spec.edmcouncil.org/fibo/ontology/FND/20130801/AgentsAndPeople/People.rdf version of the ontology was was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/. It was further revised in the FTF in advance of the Long Beach meeting, resulting in https://spec.edmcouncil.org/fibo/ontology/FND/20141101/AgentsAndPeople/People/.</skos:changeNote>
 		<skos:changeNote>The http://spec.edmcouncil.org/fibo/ontology/FND/20141101/AgentsAndPeople/People.rdf version of the ontology was was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report, primarily to use the hasAddress property in addresses, and change PostalAddress to PhysicalAddress in a restriction on Person. Also revised the identifiesAddress property in favor of verifiesAddress, and revised hasDateofBirth with respect to an identity document to be verifiesDateOfBirth, which was determined to be more appropriate by the RTF.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20160201/AgentsAndPeople/People.rdf version of the ontology was was modified per the FIBO 2.0 RFC, including integration of LCC.</skos:changeNote>
@@ -88,6 +88,7 @@
 		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20190501/AgentsAndPeople/People.rdf version of the ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20190901/AgentsAndPeople/People.rdf version of the ontology was modified to eliminate duplication with concepts in LCC and correct a bug in a restriction on identity document.</skos:changeNote>
 		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20200201/AgentsAndPeople/People.rdf version of the ontology was modified to add explicit DateOfBirth and DateOfDeath, added DeathCertificate and related concepts, streamlined related properties and restrictions.</skos:changeNote>
+		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20201201/AgentsAndPeople/People.rdf version of the ontology was modified to add hasResidence, hasMailingAddress, and hasPrimaryResidence properties and a restriction on person with respect to residence accordingly.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -429,8 +430,8 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddress"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-aap-ppl;hasResidence"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -560,6 +561,14 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 		<skos:definition>the patronymic or family name which a person was born with and which predates any changes of name due to marriage</skos:definition>
 	</owl:DatatypeProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-aap-ppl;hasMailingAddress">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-plc-adr;hasAddress"/>
+		<rdfs:label>has mailing address</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-aap-ppl;Person"/>
+		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<skos:definition>identifies a physical address where an individual can receive communications, including letters and packages</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasMiddleNameOrInitial">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasPersonName"/>
 		<rdfs:label>has middle name or initial</rdfs:label>
@@ -582,6 +591,23 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 		<rdfs:domain rdf:resource="&fibo-fnd-aap-ppl;Person"/>
 		<rdfs:range rdf:resource="&fibo-fnd-aap-ppl;PlaceOfBirth"/>
 		<skos:definition>identifies the location where an individual was born</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-aap-ppl;hasPrimaryResidence">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasResidence"/>
+		<rdfs:label>has primary residence</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-aap-ppl;Person"/>
+		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<skos:definition>identifies the dwelling where an individual resides the majority of the year</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>For tax purposes, in cases when an individual owns more than one home, their primary residence is the home in which they reside most of the time, and for which they can provide evidence to that effect.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-aap-ppl;hasResidence">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-plc-adr;hasAddress"/>
+		<rdfs:label>has residence</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-aap-ppl;Person"/>
+		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<skos:definition>identifies a dwelling where an individual lives</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasSurname">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added 3 properties to the People ontology, hasResidence, hasPrimaryResidence, and hasMailingAddress, and revised the restriction on person that used hasAddress to be hasResidence (still min 0)

Fixes: #1444 / FND-337


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


