### PR TITLE
All hygiene tests not lower than PRODERROR level

### DIFF
--- a/etc/testing/hygiene/testHygiene0004.sparql
+++ b/etc/testing/hygiene/testHygiene0004.sparql
@@ -35,5 +35,5 @@ WHERE {
     ?e rdfs:label | fibo-fnd-utl-av:abbreviation ?l  ;
           skos:definition ?def .
   }
-  BIND (concat ("WARN: ", xsd:string(?e), " has to have label and definition.") AS ?error)
+  BIND (concat ("PRODERROR: ", xsd:string(?e), " has to have label and definition.") AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene0268.sparql
+++ b/etc/testing/hygiene/testHygiene0268.sparql
@@ -30,6 +30,6 @@ WHERE {
   FILTER (REGEX (xsd:string (?s), "edmcouncil")) 
   FILTER (?p != owl:someValuesFrom)
   BIND (afn:localname (?p) AS ?prop)
-  BIND (concat ("PRODERROR:", xsd:string (?s), " has an explicit reference to owl:Thing (", ?prop, ").")
+  BIND (concat ("PRODERROR: ", xsd:string (?s), " has an explicit reference to owl:Thing (", ?prop, ").")
 	  AS ?error)
  } 

--- a/etc/testing/hygiene/testHygiene1068.sparql
+++ b/etc/testing/hygiene/testHygiene1068.sparql
@@ -15,7 +15,7 @@ WHERE {
   FILTER (CONTAINS(str(?s), "edmcouncil"))
 
   BIND (
-    concat ("WARN: Definition of ", str(?s), " is immediately circular ")
+    concat ("PRODERROR: Definition of ", str(?s), " is immediately circular ")
       AS ?error
     )
 }

--- a/etc/testing/hygiene/testHygiene1078.sparql
+++ b/etc/testing/hygiene/testHygiene1078.sparql
@@ -20,5 +20,5 @@ FILTER (?p1 != ?p2)
 FILTER (CONTAINS(str(?p), "edmcouncil"))
 FILTER (CONTAINS(str(?p1), "edmcouncil"))
 FILTER (CONTAINS(str(?p2), "edmcouncil"))
-BIND (concat ("WARN: object property whose iri is ", str(?p), " has more than one inverse object property") AS ?error)
+BIND (concat ("PRODERROR: object property whose iri is ", str(?p), " has more than one inverse object property") AS ?error)
 } 

--- a/etc/testing/hygiene/testHygiene1079.sparql
+++ b/etc/testing/hygiene/testHygiene1079.sparql
@@ -8,5 +8,5 @@ WHERE
 {
   ?s rdfs:comment ?o 
   FILTER (CONTAINS(str(?s), "edmcouncil"))
-  BIND (concat ("WARN: ", str(?s), " has an rdfs:comment annotation: ", str(?o)) AS ?error)
+  BIND (concat ("PRODERROR: ", str(?s), " has an rdfs:comment annotation: ", str(?o)) AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1103.sparql
+++ b/etc/testing/hygiene/testHygiene1103.sparql
@@ -13,5 +13,5 @@ WHERE {
   FILTER (REGEX(str(?class2), "edmcouncil"))
   FILTER NOT EXISTS {?class2 owl:deprecated "true"^^xsd:boolean}
   ?class1 owl:equivalentClass ?class2 .
-  BIND (concat ("WARN: Class ", str(?class1), " is modeled as equivalent to ", str(?class2), " - this may indicate polysemy management that is not complient with FIBO.") AS ?error)
+  BIND (concat ("PRODERROR: Class ", str(?class1), " is modeled as equivalent to ", str(?class2), " - this may indicate polysemy management that is not complient with FIBO.") AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1198_dev.sparql
+++ b/etc/testing/hygiene/testHygiene1198_dev.sparql
@@ -14,5 +14,5 @@ WHERE
     ?resource rdf:type ?resourceType .
     FILTER (CONTAINS(str(?resource), "edmcouncil"))
     FILTER (CONTAINS(STRAFTER(str(?resource),"https://spec.edmcouncil.org/fibo/ontology/"), "."))
-    BIND (concat ("WARN: Resource ", str(?resource), " has the dot in its local name. ") AS ?warning) 
+    BIND (concat ("PRODERROR: Resource ", str(?resource), " has the dot in its local name. ") AS ?warning) 
 }

--- a/etc/testing/hygiene/testHygiene1292.sparql
+++ b/etc/testing/hygiene/testHygiene1292.sparql
@@ -13,5 +13,5 @@ WHERE
     FILTER (REGEX(str(?resource), "/[^/]+(And|Or)[A-Z0-9][^/]+$") )
     FILTER (!CONTAINS(str(?resource), "InvestmentOrDepositAccount"))
     FILTER (!CONTAINS(str(?resource), "LoanOrCreditAccount"))  
-    BIND (concat ("WARN:Resource ", str(?resource), " may refer to multiple concepts.") AS ?warning)
+    BIND (concat ("PRODERROR: Resource ", str(?resource), " may refer to multiple concepts.") AS ?warning)
 }


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This PR increases all hygiene test at the WARN level to the PRODERROR level.

Fixes: #1451


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


