### PR TITLE
BE-236 - Elements and jurisdictions should point to the current UN name for countries

### DIFF
--- a/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions.rdf
@@ -41,9 +41,9 @@
 		<rdfs:label>US Government Entities and Jurisdictions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the set of basic federal government, state, and territory level entities and jurisdictions for use in other US-specific FIBO ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
@@ -60,7 +60,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200201/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210301/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions.rdf version of the ontology was modified to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -1758,7 +1759,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
 		<rdfs:seeAlso rdf:resource="https://www.usa.gov/"/>
 		<skos:definition>individual representing the federated sovereignty and polity that is the United States of America</skos:definition>
-		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-us;Alabama"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-us;Alaska"/>
 		<fibo-be-ge-ge:hasSharedSovereigntyOver rdf:resource="&lcc-3166-2-us;AmericanSamoa"/>
@@ -1828,7 +1829,7 @@
 		<rdfs:seeAlso rdf:resource="https://www.usa.gov/branches-of-government"/>
 		<skos:definition>individual representing the federal government of the United States of America</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-usj;UnitedStatesJurisdiction">
@@ -1838,7 +1839,7 @@
 		<rdfs:seeAlso rdf:resource="http://www.uscourts.gov/about-federal-courts"/>
 		<skos:definition>individual representing the federal jurisdiction of the United States of America</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
-		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://en.wikipedia.org/wiki/Federal_jurisdiction_(United_States)</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.uscourts.gov/about-federal-courts</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The United States of America is a federal republic governed by the U.S. Constitution containing fifty states and a federal district which elect the president, and having other territories and possessions in its national jurisdiction. This government is known as the Union, the United States, or the federal government. Federal jurisdiction refers to the legal scope of the government&apos;s powers. Under the Constitution and various treaties, the legal jurisdiction of the United States includes territories and territorial waters.</fibo-fnd-utl-av:explanatoryNote>

--- a/BE/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf
+++ b/BE/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf
@@ -44,8 +44,8 @@
 		<dct:abstract>This ontology includes example entities that are companies in the US that issue stock and that are represented in the Dow Jones Industrial Average (DJIA), to demonstrate how to begin to model those entities in FIBO.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-be-le-usee</sm:fileAbbreviation>
 		<sm:filename>USExampleEntities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
@@ -58,9 +58,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210301/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200701/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to update the LEI format to use the form published by the GLEIF at data.world.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	

--- a/DER/DerivativesContracts/SwapsIndividuals.rdf
+++ b/DER/DerivativesContracts/SwapsIndividuals.rdf
@@ -70,8 +70,8 @@
 		<dct:abstract>This ontology defines indiividuals that represent swaps repositories and intermediaries, including and related schemes, registries, and authorities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -104,9 +104,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20201201/DerivativesContracts/SwapsIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/SwapsIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200301/DerivativesContracts/SwapsIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200701/DerivativesContracts/SwapsIndividuals.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/DerivativesContracts/SwapsIndividuals.rdf version of this ontology was revised to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -172,7 +173,7 @@
 		<skos:definition>individual representing the headquarters address for BSDR LLC</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>731 Lexington Avenue</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10022</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -238,7 +239,7 @@
 		<skos:definition>individual representing the headquarters address for Chicago Mercantile Exchange (CME)</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>20 South Wacker Drive</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>60606</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Illinois"/>
 	</owl:NamedIndividual>
@@ -291,7 +292,7 @@
 		<skos:definition>individual representing the headquarters address for DTCC Data Repository (U.S) LLC</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>55 Water Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10041</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -357,7 +358,7 @@
 		<skos:definition>individual representing the headquarters address for ICE Trade Vault, LLC</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>5660 New Northside Drive</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>30328</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Atlanta"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Georgia"/>
 	</owl:NamedIndividual>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -98,8 +98,8 @@
 		<dct:abstract>This ontology includes example individuals for US national banks, state chartered banks, and other institutions, as well as details related to some of the larger corporations that issue stock and are represented in the Dow Jones Industrial Average and S&amp;P 500.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-fbc-fct-usind</sm:fileAbbreviation>
 		<sm:filename>USExampleIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
@@ -140,13 +140,14 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level and entity ownership relations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified to add information about the example corporations included in FIBO use cases for securities instrument data and various indices such as the DJIA, update LEI records generally, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -364,7 +365,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>1600 Amphitheatre Parkway</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>94043</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Mountain View</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
 	
@@ -388,7 +389,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>One Apple Park WY</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>95014</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Cupertino</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
 	
@@ -438,7 +439,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>500 Grant Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>15258</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Pittsburgh</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
 	</owl:NamedIndividual>
 	
@@ -459,7 +460,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>BNY Mellon, National Association - Business Identifier Code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for BNY Mellon, National Association</skos:definition>
-		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociationBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociationBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
@@ -560,7 +561,7 @@
 		<skos:definition>registration address for The Bank of New York Mellon Corporation</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>225 Liberty Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10286</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -656,7 +657,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>701 East 60th Street North</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>57104-0432</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Sioux Falls</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;SouthDakota"/>
 	</owl:NamedIndividual>
 	
@@ -753,7 +754,7 @@
 		<skos:definition>registration address that is identified as a headquarters address for Citibank N.A.</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>399 Park Avenue</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10022-4617</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -772,7 +773,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>701 East 60th Street North</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>57104-0432</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Sioux Falls</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;SouthDakota"/>
 	</owl:NamedIndividual>
 	
@@ -929,7 +930,7 @@
 		<skos:definition>registration address identified as a headquarters address for Citigroup Inc.</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>388 Greenwich Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10013</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -1006,7 +1007,7 @@
 		<skos:definition>registration address identified as a headquarters address for FMR LLC</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>245 Summer Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>02210</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Boston"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Massachusetts"/>
 	</owl:NamedIndividual>
@@ -1040,7 +1041,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>New Orchard Road</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10504</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Armonk</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
 	
@@ -1048,7 +1049,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>International Business Machines Corporation Business Identifier Code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for International Business Machines Corporation</skos:definition>
-		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;InternationalBusinessMachinesCorporationBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;InternationalBusinessMachinesCorporationBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
@@ -1122,7 +1123,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. Business Identifier Code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for JPMorgan Chase &amp; Co.</skos:definition>
-		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCoBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCoBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
@@ -1152,7 +1153,7 @@
 		<skos:definition>registration address identified as the headquarters address for JPMorgan Chase &amp; Co.</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>270 Park Avenue</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10017-2070</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -1218,7 +1219,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>1111 Polaris Parkway</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>43240</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Columbus</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Ohio"/>
 	</owl:NamedIndividual>
 	
@@ -1238,7 +1239,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association - business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
@@ -1395,7 +1396,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>7597 Monterey Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>95020</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Gilroy</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
 	
@@ -1407,7 +1408,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>18181 Butterfield Blvd. STE 135</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>95037-8101</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Morgan Hill</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
 	
@@ -1468,7 +1469,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>State Street Bank and Trust Company - business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
@@ -1590,7 +1591,7 @@
 		<skos:definition>registration address identified as the headquarters address for State Street Corporation</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>One Lincoln Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>02111</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Boston"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Massachusetts"/>
 	</owl:NamedIndividual>
@@ -1628,7 +1629,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>The Coca-Cola Company business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for The Coca-Cola Company</skos:definition>
-		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;TheCoca-ColaCompanyBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;TheCoca-ColaCompanyBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
@@ -1658,7 +1659,7 @@
 		<skos:definition>registration address for The Coca-Cola Company</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>One Coca-Cola Plaza</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>30313</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Atlanta"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Georgia"/>
 	</owl:NamedIndividual>
@@ -1682,7 +1683,7 @@
 		<skos:definition>registration address for The Home Depot, Inc.</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>2455 Paces Ferry Road</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>30339</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Atlanta"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Georgia"/>
 	</owl:NamedIndividual>
@@ -1704,7 +1705,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>The Proctor &amp; Gamble Company business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
@@ -1735,7 +1736,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>1 Procter &amp; Gamble Plaza</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>45202</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Cincinnati</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Ohio"/>
 	</owl:NamedIndividual>
 	
@@ -1799,7 +1800,7 @@
 		<skos:definition>registration address identified as the headquarters address for WFC Holdings, LLC</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>45 Fremont Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>94105</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;San_Francisco"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
@@ -1875,7 +1876,7 @@
 		<skos:definition>registration address identified as the headquarters address for Wells Fargo &amp; Company</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>420 Montgomery Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>94104</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;San_Francisco"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
@@ -1937,7 +1938,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>Wells Fargo Bank, National Association - business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-rel-rel:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
@@ -1989,7 +1990,7 @@
 		<skos:definition>registration address identified as the headquarters address for Wells Fargo Bank, National Association</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>301 South College Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>28202</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Charlotte"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
 	</owl:NamedIndividual>
@@ -2001,7 +2002,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>101 North Phillips Avenue</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>57104</fibo-fnd-plc-adr:hasPostalCode>
 		<fibo-fnd-plc-loc:hasCityName>Sioux Falls</fibo-fnd-plc-loc:hasCityName>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;SouthDakota"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
@@ -88,8 +88,8 @@
 		<dct:abstract>This ontology extends the financial services entities ontology in FBC with individual American entities that provide broad based services required by other FIBO domains, such as market data providers, instrument identifier issuers, organizations that provide exchanges in multiple countries, and so forth.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2017-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2017-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
@@ -131,12 +131,13 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to normalize a few labels and definitions, revise GLEIF LEI registration data, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -313,7 +314,7 @@
 		<skos:definition>headquarters address for Bloomberg L.P.</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>731 Lexington Avenue</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10022</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -473,7 +474,7 @@
 		<skos:definition>headquarters and legal address for The Depository Trust Company</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>55 Water Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10041</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -632,7 +633,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<fibo-fnd-plc-adr:hasAddressLine1>5660 New Northside Drive NW</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasAddressLine2>3rd Floor</fibo-fnd-plc-adr:hasAddressLine2>
 		<fibo-fnd-plc-adr:hasPostalCode>30328</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Atlanta"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Georgia"/>
 	</owl:NamedIndividual>
@@ -696,7 +697,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<skos:definition>headquarters address for S&amp;P Global, as represented in the New York Division of Corporations repository</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>55 Water Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10041</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -779,7 +780,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<skos:definition>headquarters address for Thomson Reuters Corporation</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>3 Times Square</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10036</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
@@ -79,9 +79,9 @@
 		<rdfs:label>US Markets and Exchanges Individuals</rdfs:label>
 		<dct:abstract>This ontology includes extended individuals (examples that are more complete) for a sampling of markets operating in the US corresponding to the ISO 10383 Codes for exchanges and market identification (MIC).</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-fbc-fct-usmkt</sm:fileAbbreviation>
 		<sm:filename>USMarketsAndExchangesIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
@@ -112,10 +112,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180901/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/ version of this ontology was modified to support revisions of the MIC codes as of 11 January 2019, including the new URI strategy, and to move the registry definitions to a new international financial organizations ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/ version of this ontology was modified to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of this ontology was revised to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -151,7 +152,7 @@
 		<skos:definition>the headquarters address for CBOE Global Markets, Inc.</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>400 South LaSalle Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>60605</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Illinois"/>
 	</owl:NamedIndividual>
@@ -176,7 +177,7 @@
 		<fibo-fbc-fct-fse:hasDateEstablished rdf:resource="&fibo-fbc-fct-usmkt;ChicagoBoardOptionsExchangeDateEstablished"/>
 		<fibo-fbc-fct-mkt:hasExchangeAcronym>CBOE</fibo-fbc-fct-mkt:hasExchangeAcronym>
 		<fibo-fbc-fct-mkt:hasExchangeName>Chicago Board Options Exchange</fibo-fbc-fct-mkt:hasExchangeName>
-		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.cboe.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usmkt;CBOEGlobalMarketsInc-US-DE"/>
@@ -221,7 +222,7 @@
 		<fibo-fbc-fct-fse:hasDateEstablished rdf:resource="&fibo-fbc-fct-usmkt;NYSEAmericanOptionsDateEstablished"/>
 		<fibo-fbc-fct-mkt:hasExchangeAcronym>NYSE</fibo-fbc-fct-mkt:hasExchangeAcronym>
 		<fibo-fbc-fct-mkt:hasExchangeName>NYSE American Options</fibo-fbc-fct-mkt:hasExchangeName>
-		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-arr-arr:isConstituentOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/markets/american-options</fibo-fnd-plc-vrt:hasWebsite>
@@ -276,7 +277,7 @@
 		<fibo-fbc-fct-fse:hasDateEstablished rdf:resource="&fibo-fbc-fct-usmkt;NYSEArcaDateEstablished"/>
 		<fibo-fbc-fct-mkt:hasExchangeAcronym>NYSE</fibo-fbc-fct-mkt:hasExchangeAcronym>
 		<fibo-fbc-fct-mkt:hasExchangeName>NYSE Arca</fibo-fbc-fct-mkt:hasExchangeName>
-		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
 		<fibo-fnd-arr-arr:isConstituentOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
@@ -360,7 +361,7 @@
 		<fibo-fnd-plc-adr:hasAddressLine1>100 South Wacker Drive</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasAddressLine2>Suite 1800</fibo-fnd-plc-adr:hasAddressLine2>
 		<fibo-fnd-plc-adr:hasPostalCode>60606</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;Illinois"/>
 	</owl:NamedIndividual>
@@ -383,7 +384,7 @@
 		<skos:definition>the NYSE Dark functional entity that represents a segment of the NYSE involved in trading of dark pools</skos:definition>
 		<fibo-fbc-fct-mkt:hasExchangeAcronym>NYSEDARK</fibo-fbc-fct-mkt:hasExchangeAcronym>
 		<fibo-fbc-fct-mkt:hasExchangeName>NYSE Dark</fibo-fbc-fct-mkt:hasExchangeName>
-		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-arr-arr:isConstituentOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
@@ -481,7 +482,7 @@
 		<fibo-fbc-fct-fse:hasDateEstablished rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchangeDateEstablished"/>
 		<fibo-fbc-fct-mkt:hasExchangeAcronym>NYSE</fibo-fbc-fct-mkt:hasExchangeAcronym>
 		<fibo-fbc-fct-mkt:hasExchangeName>New York Stock Exchange</fibo-fbc-fct-mkt:hasExchangeName>
-		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchangeLLC-US-NY"/>
@@ -501,7 +502,7 @@
 		<skos:definition>the headquarters address for New York Stock Exchange</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>11 Wall Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10005</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>

--- a/IND/InterestRates/MarketDataProviders.rdf
+++ b/IND/InterestRates/MarketDataProviders.rdf
@@ -76,8 +76,8 @@
 		<dct:abstract>This ontology provides reference data for a number of international market data providers, including, but not limited to, those that publish interest rate benchmarks referenced in the published FpML benchmark reference.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -111,9 +111,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20201201/InterestRates/MarketDataProviders/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210301/InterestRates/MarketDataProviders/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200301/InterestRates/MarketDataProviders.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200701/InterestRates/MarketDataProviders.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20201201/InterestRates/MarketDataProviders.rdf version of this ontology was revised to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -179,7 +180,7 @@
 		<skos:definition>registered address identified as the headquarters address for BGC Partners, Inc.</skos:definition>
 		<fibo-fnd-plc-adr:hasAddressLine1>55 Water Street</fibo-fnd-plc-adr:hasAddressLine1>
 		<fibo-fnd-plc-adr:hasPostalCode>10041</fibo-fnd-plc-adr:hasPostalCode>
-		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStates"/>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Replaced all references to the legacy LCC representation for the United States with United States of America; other countries for which there are multiple names had already been updated in FIBO

Fixes: #1467 / BE-236


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


