### PR TITLE
BE-233 - hasNominalCapital should be a subproperty of hasMonetaryAmount in Corporations

### DIFF
--- a/BE/Corporations/Corporations.rdf
+++ b/BE/Corporations/Corporations.rdf
@@ -66,7 +66,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/Corporations/Corporations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210301/Corporations/Corporations/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/Corporations/Corporations.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/Corporations/Corporations.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180901/Corporations/Corporations.rdf version of this ontology was modified per the FIBO 2.0 RFC to generalize certain unions where they were no longer required.</skos:changeNote>
@@ -74,7 +74,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190401/Corporations/Corporations.rdf version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190701/Corporations/Corporations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/Corporations/Corporations.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/Corporations/Corporations.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve and eliminate circular and ambiguous definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/Corporations/Corporations.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, eliminate circular and ambiguous definitions and make hasNominalCapital a subproperty of hasMonetaryAmount and incorporation date and registration date explicit dates.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -162,16 +162,16 @@
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-corp-corp;hasDateOfIncorporation">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label>has date of incorporation</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>indicates the formal date of incorporation as stated in filing documents</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-corp-corp;hasDateOfRegistration">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label>has date of registration</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>indicates the date on which the corporation has registered in some jurisdiction for regulatory and / or for tax purposes</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -186,11 +186,11 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-corp-corp;hasNominalCapital">
-		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 		<rdfs:label>has nominal capital</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition>indicates the aggregate value of all shares that have been authorized by a board of directors, including shares held by investors, shares held internally by the company and any unissued shares</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Nominal capital is an alternate term for authorized share capital. The maximum value of securities that a company can legally issue. This number is specified in the memorandum of association (or articles of incorporation in the US) when a company is incorporated, but can be changed later with shareholders approval.  Authorized share capital may be divided into (1) Issued capital - par value of the shares actually issued, (2) Paid up capital - money received from the shareholders in exchange for shares, and (3) Uncalled capital - money remaining unpaid by the shareholders for the shares they have bought.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Nominal capital is initially specified in the memorandum of association (or articles of incorporation in the US) when a company is incorporated, but can be changed later with shareholders approval.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>has authorized capital</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>has authorized stock</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>has nominal share capital</fibo-fnd-utl-av:synonym>
@@ -201,7 +201,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-corp-corp;hasDateOfRegistration"/>
-				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;Date"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -222,7 +222,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-corp-corp;hasDateOfIncorporation"/>
-				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;Date"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/BE/Corporations/Corporations.rdf
+++ b/BE/Corporations/Corporations.rdf
@@ -185,6 +185,14 @@
 		<fibo-fnd-utl-av:synonym>has subscribed share capital</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
+	<owl:DatatypeProperty rdf:about="&fibo-be-corp-corp;hasSharesAuthorized">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
+		<rdfs:label xml:lang="en">has shares authorized</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition xml:lang="en">indicates the maximum number of shares that are permitted to be issued, as established by the board of directors</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An initial number of authorized shares is typically established at the time of incorporation, and is documented in articles of incorporation.  The number of shares authorized may be extended from time to time by the board of directors as needed, and articles of incorporation and other legal documentation will be amended accordingly.  It includes shares that are available, but not yet issued, for sale to generate capital, and shares available for distribution to insiders as part of their compensation packages.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:DatatypeProperty>
+	
 	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
 		<rdfs:subClassOf>
 			<owl:Restriction>

--- a/BE/Corporations/Corporations.rdf
+++ b/BE/Corporations/Corporations.rdf
@@ -74,7 +74,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190401/Corporations/Corporations.rdf version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190701/Corporations/Corporations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/Corporations/Corporations.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/Corporations/Corporations.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, eliminate circular and ambiguous definitions and make hasNominalCapital a subproperty of hasMonetaryAmount and incorporation date and registration date explicit dates.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/Corporations/Corporations.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, eliminate circular and ambiguous definitions and make incorporation date and registration date explicit dates.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -176,25 +176,13 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-corp-corp;hasIssuedCapital">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-corp-corp;hasNominalCapital"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 		<rdfs:label>has issued capital</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition>indicates the aggregate value of all shares held by shareholders</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>A corporation can, at any time, issue new shares up to the full amount of authorized share capital.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>has subscribed capital</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>has subscribed share capital</fibo-fnd-utl-av:synonym>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-corp-corp;hasNominalCapital">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
-		<rdfs:label>has nominal capital</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition>indicates the aggregate value of all shares that have been authorized by a board of directors, including shares held by investors, shares held internally by the company and any unissued shares</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Nominal capital is initially specified in the memorandum of association (or articles of incorporation in the US) when a company is incorporated, but can be changed later with shareholders approval.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>has authorized capital</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>has authorized stock</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>has nominal share capital</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>has registered capital</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
@@ -208,13 +196,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-corp-corp;hasIssuedCapital"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-corp-corp;hasNominalCapital"/>
 				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/BE/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf
+++ b/BE/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf
@@ -58,9 +58,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20201201/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210301/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200701/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to update the LEI format to use the form published by the GLEIF at data.world.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to make incorporation and registration dates explicit dates.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -132,7 +133,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;AlphabetIncIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Alphabet Inc. incorporation date</rdfs:label>
 		<skos:definition>date that Alphabet Inc. was first registered as a corporation in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>2015-07-23</fibo-fnd-dt-fd:hasDateValue>
@@ -159,7 +160,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;AppleIncIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Apple Inc. incorporation date</rdfs:label>
 		<skos:definition>date that Apple Inc. was first registered as a corporation in the State of California</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1977-01-03</fibo-fnd-dt-fd:hasDateValue>
@@ -185,7 +186,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;InternationalBusinessMachinesCorporationIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>International Business Machines Corporation incorporation date</rdfs:label>
 		<skos:definition>date that International Business Machines Corporation was first registered as a corporation in the State of New York</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1911-06-16</fibo-fnd-dt-fd:hasDateValue>
@@ -211,7 +212,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheCoca-ColaCompanyIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>The Coca-Cola Company incorporation date</rdfs:label>
 		<skos:definition>date that The Coca-Cola Company was first registered as a corporation in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1919-09-05</fibo-fnd-dt-fd:hasDateValue>
@@ -237,7 +238,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheHomeDepotIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>The Home Depot, Inc. incorporation date</rdfs:label>
 		<skos:definition>date that The Home Depot, Inc. was first registered as a corporation in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1978-06-29</fibo-fnd-dt-fd:hasDateValue>
@@ -263,7 +264,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheProctorAndGambleCompanyIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>The Proctor &amp; Gamble Company incorporation date</rdfs:label>
 		<skos:definition>date that The Proctor &amp; Gamble Company was first registered as a corporation in the State of Ohio</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1905-05-05</fibo-fnd-dt-fd:hasDateValue>

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -8,7 +8,7 @@
 	<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/">
 	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
-	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/">
+	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
@@ -35,7 +35,7 @@
 	xmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"
 	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
-	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"
+	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
@@ -75,7 +75,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
@@ -86,7 +86,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210101/OwnershipAndControl/Executives/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210301/OwnershipAndControl/Executives/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/Executives.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160801/OwnershipAndControl/Executives.rdf version of this ontology was modified per the FIBO 2.0 RFC to fix reasoning issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/Executives.rdf version of this ontology was modified to clarify the definition of responsible party.</skos:changeNote>
@@ -95,7 +95,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/Executives.rdf version of this ontology was modified to integrate concepts related to authorization, including board membership and the concept of a signatory (moved from legal persons) to improve semantics; simplify the ontology, and normalize definitions to be ISO 704 compliant.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/Executives.rdf version of this ontology was modified to correct the label on hasAuthorizedParty.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200701/OwnershipAndControl/Executives.rdf version of this ontology was modified to add PrincipalParty as the parent of CEO and others.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/Executives.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/Executives.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, add the concept of corporate bylaws and restriction on authorized shares (moved from SEC).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -407,6 +407,19 @@
 		<fibo-fnd-utl-av:synonym>corporate secretary</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-be-oac-exec;CorporateBylaws">
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;Bylaws"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-oac-exec;hasSharesAuthorized"/>
+				<owl:someValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>corporate bylaws</rdfs:label>
+		<skos:definition>written rules for conduct of a corporation, adopted by the board of directors</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Corporate bylaws may contain any provision, not inconsistent with law or with the certificate of incorporation, relating to the business of the corporation, the conduct of its affairs, and its rights or powers or the rights or powers of its stockholders, directors, officers or employees. Changes to the bylaws of a corporation require a board-level resolution and may require a vote of the shareholders.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-be-oac-exec;CorporateOfficer">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;Signatory"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
@@ -608,6 +621,14 @@
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;ResponsibleParty"/>
 		<skos:definition>identifies a party that has some assignment, commitment or obligation with respect to the formal organization</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-be-oac-exec;hasSharesAuthorized">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
+		<rdfs:label xml:lang="en">has shares authorized</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition xml:lang="en">indicates the maximum number of shares that are permitted to be issued, as established by the board of directors</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An initial number of authorized shares is typically established at the time of incorporation, and is documented in articles of incorporation.  The number of shares authorized may be extended from time to time by the board of directors as needed, and articles of incorporation and other legal documentation will be amended accordingly.  It includes shares that are available, but not yet issued, for sale to generate capital, and shares available for distribution to insiders as part of their compensation packages.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasSigningAuthorityFor">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-exec;isAuthorizedBy"/>

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -411,7 +411,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;Bylaws"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oac-exec;hasSharesAuthorized"/>
+				<owl:onProperty rdf:resource="&fibo-be-corp-corp;hasSharesAuthorized"/>
 				<owl:someValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -621,14 +621,6 @@
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;ResponsibleParty"/>
 		<skos:definition>identifies a party that has some assignment, commitment or obligation with respect to the formal organization</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-be-oac-exec;hasSharesAuthorized">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
-		<rdfs:label xml:lang="en">has shares authorized</rdfs:label>
-		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
-		<skos:definition xml:lang="en">indicates the maximum number of shares that are permitted to be issued, as established by the board of directors</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An initial number of authorized shares is typically established at the time of incorporation, and is documented in articles of incorporation.  The number of shares authorized may be extended from time to time by the board of directors as needed, and articles of incorporation and other legal documentation will be amended accordingly.  It includes shares that are available, but not yet issued, for sale to generate capital, and shares available for distribution to insiders as part of their compensation packages.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasSigningAuthorityFor">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-exec;isAuthorizedBy"/>

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -96,7 +96,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to change the restriction on financial instrument identifier from some values to min 0, to allow for cases when an instrument identifier identifies a listing, eliminate duplication of concepts in LCC, and simplify addresses.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to move redemption provision from debt to financial instruments, given that it is a broader concept needed for equities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to add a property indicating the currency that an instrument is issued in, simplify the contract party hierarchy and add properties relating financial instruments to shareholders.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to incorporate a hasMaturityDate property given that it can apply to debt instruments and preferred shares, as well as to other financial instruments, eliminated the redundant hasScheduledMaturityDate property, cleaned up circular definitions, and eliminated the property &apos;mayBeTradedIn&apos;, which was only used in one place and was redundant with the concept of a ListedSecurity / Listing in SEC, and added a synonym and additional explanatory note to packaged financial product.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to incorporate a hasMaturityDate property given that it can apply to debt instruments and preferred shares, as well as to other financial instruments, eliminated the redundant hasScheduledMaturityDate property, cleaned up circular definitions, eliminated the property &apos;mayBeTradedIn&apos;, which was only used in one place and was redundant with the concept of a ListedSecurity / Listing in SEC, added a synonym and additional explanatory note to packaged financial product and added hasNominalValue, which was a gap.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -171,6 +171,13 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;FinancialInstrumentIdentifier"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasNominalValue"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -402,6 +409,15 @@
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>indicates the date on which the principal amount of an instrument is due to be repaid to the investor and interest or coupon payments stop, and/or the date on which the instrument may be redeemed</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Maturity dates typically apply to debt instruments, such as notes, drafts, bonds, and other loans, but may also apply to preferred shares and other financial instruments.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;hasNominalValue">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
+		<rdfs:label>has nominal value</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+		<skos:definition>indicates the face value of something</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Nominal value of a security is its redemption price and will vary from its market value. A preferred stock&apos;s nominal (par) value is important in that it is used to calculate its dividend while the nominal value of common stock is an arbitrary value assigned for balance sheet purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>face value</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;hasPrincipalExecutiveOfficeAddress">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -98,8 +98,8 @@
 		<dct:abstract>This ontology includes example individuals for US national banks, state chartered banks, and other institutions, as well as details related to some of the larger corporations that issue stock and are represented in the Dow Jones Industrial Average and S&amp;P 500.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-fbc-fct-usind</sm:fileAbbreviation>
 		<sm:filename>USExampleIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
@@ -140,13 +140,14 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level and entity ownership relations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified to add information about the example corporations included in FIBO use cases for securities instrument data and various indices such as the DJIA, update LEI records generally, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to make incorporation and registration dates explicit.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -578,7 +579,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;BankOfNewYorkMellonCorporationIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Bank of New York Mellon Corporation incorporation date</rdfs:label>
 		<skos:definition>the date that the Bank of New York Mellon Corporation was first incorporated in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>2007-02-09</fibo-fnd-dt-fd:hasDateValue>
@@ -661,7 +662,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CitiCardsSouthDakotaAcceptanceCorpIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Citi Cards South Dakota Acceptance Corp. incorporation date</rdfs:label>
 		<skos:definition>date that Citi Cards South Dakota Acceptance Corp. was first incorporated in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>2003-07-28</fibo-fnd-dt-fd:hasDateValue>
@@ -759,7 +760,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CitibankNAIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Citibank, N.A. incorporation date</rdfs:label>
 		<skos:definition>date that Citibank, N.A. (National Association) was first incorporated in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1982-09-10</fibo-fnd-dt-fd:hasDateValue>
@@ -881,7 +882,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CiticorpLLCRegistrationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Citicorp LLC registration date</rdfs:label>
 		<skos:definition>date that Citicorp LLC was first registered as a limited liability company in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>2005-01-13</fibo-fnd-dt-fd:hasDateValue>
@@ -935,7 +936,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CitigroupIncIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Citigroup Inc. incorporation date</rdfs:label>
 		<skos:definition>date that Citigroup Inc. was first registered as a corporation in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1988-03-08</fibo-fnd-dt-fd:hasDateValue>
@@ -1158,7 +1159,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseAndCoIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. incorporation date</rdfs:label>
 		<skos:definition>date that JPMorgan Chase &amp; Co. was first registered as a corporation in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1968-10-28</fibo-fnd-dt-fd:hasDateValue>
@@ -1315,7 +1316,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationRegistrationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association registration date</rdfs:label>
 		<skos:definition>date that JPMorgan Chase Bank, National Association was first registered as a corporation in the State of Ohio</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>2012-06-28</fibo-fnd-dt-fd:hasDateValue>
@@ -1373,7 +1374,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;PinnacleBankDateOfRegistration">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Pinnacle Bank date of registration</rdfs:label>
 		<skos:definition>date that Pinnacle Bank was first registered as a stock corporation in the State of California</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>2006-03-20</fibo-fnd-dt-fd:hasDateValue>
@@ -1545,7 +1546,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyRegistrationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>State Street Bank and Trust Company registration date</rdfs:label>
 		<skos:definition>date that State Street Bank and Trust Company was first registered as a trust company in the State of Massachusetts</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1891-04-14</fibo-fnd-dt-fd:hasDateValue>
@@ -1596,7 +1597,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;StateStreetCorporationIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>State Street Corporation incorporation date</rdfs:label>
 		<skos:definition>date that State Street Corporation was first registered as a corporation in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1969-10-16</fibo-fnd-dt-fd:hasDateValue>
@@ -1805,7 +1806,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WFCHoldingsLLCIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>WFC Holdings, LLC incorporation date</rdfs:label>
 		<skos:definition>date that WFC Holdings, LLC was first registered as a corporation in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1998-09-09</fibo-fnd-dt-fd:hasDateValue>
@@ -1881,7 +1882,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WellsFargoAndCompanyIncorporationDate">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Wells Fargo &amp; Company incorporation date</rdfs:label>
 		<skos:definition>date that Wells Fargo &amp; Company was first registered as a corporation in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1966-03-02</fibo-fnd-dt-fd:hasDateValue>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
@@ -88,8 +88,8 @@
 		<dct:abstract>This ontology extends the financial services entities ontology in FBC with individual American entities that provide broad based services required by other FIBO domains, such as market data providers, instrument identifier issuers, organizations that provide exchanges in multiple countries, and so forth.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2017-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2017-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
@@ -131,12 +131,13 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to normalize a few labels and definitions, revise GLEIF LEI registration data, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to make incorporation and registration dates explicit.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -232,7 +233,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;BloombergDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Bloomberg date established</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>date that Bloomberg L.P. was established</skos:definition>
@@ -250,7 +251,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;BloombergFinanceDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Bloomberg Finance L.P. date established</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>date that Bloomberg Finance L.P. was established</skos:definition>
@@ -609,7 +610,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;IntercontinentalExchangeDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Intercontinental Exchange date established</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>date that Intercontinental Exchange was established</skos:definition>
@@ -617,7 +618,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;IntercontinentalExchangeDateRegistered">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Intercontinental Exchange date registered</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>date that Intercontinental Exchange, Inc. was registered as a legal entity with the Delaware Division of Corporations</skos:definition>
@@ -681,7 +682,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;SPGlobalDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>S&amp;P Global date established</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>date that S&amp;P Global was established</skos:definition>
@@ -750,7 +751,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;ThomsonReutersDateEstablished">
-		<rdf:type rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>Thomson Reuters date established</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>date that Thomson Reuters was established</skos:definition>

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -74,8 +74,8 @@
 		<dct:abstract>This ontology provides basic concepts such as account, account holder, account provider, relationship manager that are commonly used by financial services providers to describe customers and to determine counterparty identities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -110,7 +110,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/ClientsAndAccounts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised per the FIBO 2.0 RFC with respect to the definitions for accounts and account identifiers, such as BBAN and IBAN identifiers, including but not limited to bank accounts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to support the addition of maturity-related properties to financial instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181101/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
@@ -119,6 +119,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for balance, fee, general ledger, ledger account, income and related properties, revise definitions to be ISO 704 compliant, and eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for transaction records, which are needed to represent statements of various sorts, to add the concept of an account statement, and to clean up and augment definitions related to accounts, account holders, etc. as required for the purpose of representing credit card accounts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to generalize the definition of customer account and eliminate ambiguity in others.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to change a property on CertificateOfDeposit from has notional amount to has nominal value for the sake of consistency.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -448,7 +449,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasNotionalAmount"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasNominalValue"/>
 				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -113,7 +113,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/FinancialProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified by the FIBO 2.0 RFC, including, but not limited to, the addition of lifecycle events, concepts related to trade settlement, and the definition of a unique transaction identifier (UTI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified as a part of organizational hierarchy simplification and to correct a logical inconsistency with respect to the representation of baskets.</skos:changeNote>
@@ -122,7 +122,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to add the notion of a weighted basket, whose consituents are weighted.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191101/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate duplication with concepts in LCC and eliminated a redundant superclass on FinancialServiceProvider.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to replace the property &apos;characterizes&apos; with &apos;describes&apos; with respect to restrictions on catalogs, and to correct the label on terminated trade.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve and eliminate circular and ambiguous definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, eliminate circular and ambiguous definitions, and revise definitions that referenced &apos;face value&apos; improperly.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -1032,7 +1032,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label>has nominal number of units</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;integer"/>
-		<skos:definition>indicates the base (face value) number of units of something associated with some offering</skos:definition>
+		<skos:definition>indicates the base number of units of something associated with some offering</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;hasOffering">
@@ -1047,7 +1047,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasNotionalAmount"/>
 		<rdfs:label>has offering amount</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition>indicates the notional monetary amount (face value), determined based on reference data, market rates or some other agreed method associated with some offering</skos:definition>
+		<skos:definition>indicates the notional monetary amount, determined based on reference data, market rates or some other agreed method associated with some offering</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;hasOfferingPrice">

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
+	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
 	<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -41,6 +42,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
+	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
 	xmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -95,6 +97,7 @@
 		<sm:fileAbbreviation>fibo-sec-eq-eq</sm:fileAbbreviation>
 		<sm:filename>EquityInstruments.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -130,7 +133,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments, including features specific to preferred shares.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, clean up ambiguous definitions, and eliminate redundant restrictions related to security form.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add concepts covering additional features of preferred shares, move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology, add a property for the number of authorized shares, rename EquityIssuer to ShareIssuer to be clearer about the intent, and add the concept of a price per share.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add concepts covering additional features of preferred shares, move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology, rename EquityIssuer to ShareIssuer to be clearer about the intent, and add the concept of a price per share.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -966,14 +969,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;issues"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+				<owl:onProperty rdf:resource="&fibo-be-oac-exec;hasSharesAuthorized"/>
+				<owl:someValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharesAuthorized"/>
-				<owl:someValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;issues"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>share issuer</rdfs:label>
@@ -1243,15 +1246,6 @@
 		<rdfs:range rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
 		<skos:definition xml:lang="en">indicates the payment status for shares issued</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasSharesAuthorized">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
-		<rdfs:label xml:lang="en">has shares authorized</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
-		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
-		<skos:definition xml:lang="en">indicates the maximum number of shares that are permitted to be issued, as established by the board of directors</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An initial number of authorized shares is typically established at the time of incorporation, and is documented in articles of incorporation.  The number of shares authorized may be extended from time to time by the board of directors as needed, and articles of incorporation and other legal documentation will be amended accordingly.  It includes shares that are available, but not yet issued, for sale to generate capital, and shares available for distribution to insiders as part of their compensation packages.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasSharesIssued">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
-	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
 	<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -41,8 +41,8 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
-	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
 	xmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -96,8 +96,8 @@
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-sec-eq-eq</sm:fileAbbreviation>
 		<sm:filename>EquityInstruments.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -969,7 +969,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oac-exec;hasSharesAuthorized"/>
+				<owl:onProperty rdf:resource="&fibo-be-corp-corp;hasSharesAuthorized"/>
 				<owl:someValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Made hasNominalCapital a subproperty of hasMonetaryAmount and cleaned up the explanatory note.  Also made  incorporation and registration dates explicit dates rather than simple dates.

Fixes: #1471 / BE-233


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


