### PR TITLE
FBC-280 - MeanPriceDetermination defined as a named individual - not as a class

### DIFF
--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -85,10 +85,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/InstrumentPricing/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210401/FinancialInstruments/InstrumentPricing/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, to add adjusted price and to create a more general hasLotSize property that can be used in various contexts.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize as .</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to change both subclasses of price determination method to named individuals and correct the definition of mean price determination.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -155,12 +156,12 @@
 		<skos:definition xml:lang="en">cash value of the last transacted price before the market closes</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-fi-ip;ClosingPriceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-ip;ClosingPriceDeterminationMethod">
+		<rdf:type rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
 		<rdfs:label xml:lang="en">closing price determination method</rdfs:label>
 		<skos:definition xml:lang="en">strategy for calculating or otherwise determining an official closing price</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The official closing price is typically the final price at which something trades during regular market hours on an exchange or trading venue.  Because of the evolving nature of online trading in a 24 hour world, every exchange has a method of calculating its official closing price, although that methodology changes from time to time.  They may also publish an adjusted closing price, which reflects changes to the price that reflect corporate actions and after hours trading that occur before the opening of the exchange on the following day. Understanding how the closing price is determined is important to ensure price comparability for a given security across exchanges.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;CollectionOfSecurityPrices">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;DatedStructuredCollection"/>
@@ -262,9 +263,9 @@
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-ip;MeanPriceDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
+		<rdf:type rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
 		<rdfs:label xml:lang="en">mean price determination</rdfs:label>
-		<skos:definition xml:lang="en">method for determining a closing price that represents the arithmetic mean of some set of prices consolidated across sources</skos:definition>
+		<skos:definition xml:lang="en">method for determining a price that represents the arithmetic mean of some set of prices consolidated across sources</skos:definition>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;MidPrice">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Changed both mean price determination and closing price determination method to be named individuals rather than classes and corrected a bug on mean price determination that said it was a subclass of price determination method rather than a type per FCT discussion

Fixes: #1477 / FBC-280


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


