### PR TITLE
FND-342 - Revise the ownership lattice relations to better align with the situational model

### DIFF
--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -110,7 +110,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210401/ProductsAndServices/ClientsAndAccounts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised per the FIBO 2.0 RFC with respect to the definitions for accounts and account identifiers, such as BBAN and IBAN identifiers, including but not limited to bank accounts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to support the addition of maturity-related properties to financial instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181101/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
@@ -120,6 +120,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for transaction records, which are needed to represent statements of various sorts, to add the concept of an account statement, and to clean up and augment definitions related to accounts, account holders, etc. as required for the purpose of representing credit card accounts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to generalize the definition of customer account and eliminate ambiguity in others.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to change a property on CertificateOfDeposit from has notional amount to has nominal value for the sake of consistency.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to rename ownership related properties for consistent alignment with the ownership situational pattern.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -180,7 +181,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;isOwnedBy"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;isAssetOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -249,7 +250,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;Holding"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedThing"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedAsset"/>
 				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;AccountAsAnAsset"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -113,7 +113,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210401/ProductsAndServices/FinancialProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified by the FIBO 2.0 RFC, including, but not limited to, the addition of lifecycle events, concepts related to trade settlement, and the definition of a unique transaction identifier (UTI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified as a part of organizational hierarchy simplification and to correct a logical inconsistency with respect to the representation of baskets.</skos:changeNote>
@@ -123,6 +123,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191101/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate duplication with concepts in LCC and eliminated a redundant superclass on FinancialServiceProvider.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to replace the property &apos;characterizes&apos; with &apos;describes&apos; with respect to restrictions on catalogs, and to correct the label on terminated trade.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, eliminate circular and ambiguous definitions, and revise definitions that referenced &apos;face value&apos; improperly.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to rename ownership related properties for consistent alignment with the ownership situational pattern.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -350,7 +351,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Ownership"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedThing"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedAsset"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -473,7 +474,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;Holding"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedThing"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedAsset"/>
 				<owl:onClass rdf:resource="&fibo-fnd-oac-own;Asset"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FND/OwnershipAndControl/Ownership.rdf
+++ b/FND/OwnershipAndControl/Ownership.rdf
@@ -35,9 +35,9 @@
 		<rdfs:label>Ownership Ontology</rdfs:label>
 		<dct:abstract>This ontology defines high-level, ownership-related concepts for use in other FIBO ontology elements. These include the concept of owner, asset and ownership along with relationships between them whereby an asset is some thing owned by some owner.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
@@ -50,7 +50,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/OwnershipAndControl/Ownership/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210401/OwnershipAndControl/Ownership/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20130801/OwnershipAndControl/Ownership.rdf version of the ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://www.omg.org/spec/EDMC-FIBO/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20180801/OwnershipAndControl/Ownership.rdf version of the ontology was modified to revise the definition of Asset using the new CombinedDateTime datatype rather than xsd:dateTime to provide increased flexibility.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/OwnershipAndControl/Ownership.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
@@ -62,6 +62,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190401/OwnershipAndControl/Ownership.rdf version of the ontology was modified to add definitions for tangible and intangible asset, etc., as needed for refinement of the concept of collateral and other loan-specific concepts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200101/OwnershipAndControl/Ownership.rdf version of the ontology was modified to integrate the concept of a situation, situational roles, and corresponding relations with the definition of ownership, and eliminate minimum cardinality of 1 in restrictions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200601/OwnershipAndControl/Ownership.rdf version of the ontology was modified to reflect the move of hasAquisitionDate from relations to financial dates and eliminate circular definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/OwnershipAndControl/Ownership.rdf version of the ontology was modified to better align with revisions to the situation lattice.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -82,7 +83,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;isOwnedBy"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;isAssetOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Owner"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -123,7 +124,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;Situation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedThing"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedAsset"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;Undergoer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -144,12 +145,12 @@
 		<fibo-fnd-utl-av:explanatoryNote>Tangible assets include cash, cash equivalents and accounts receivables (AR), inventory, equipment, buildings and real estate, crops, and investments.  Tangible assets such as art, furniture, stamps, gold, wine, toys and books of significant value may be included in an individual or organization&apos;s asset portfolio.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;hasOwnedThing">
+	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;hasOwnedAsset">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;hasUndergoer"/>
-		<rdfs:label>has owned thing</rdfs:label>
+		<rdfs:label>has owned asset</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-oac-own;Ownership"/>
 		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-oac-own;isOwnedThingInRole"/>
+		<owl:inverseOf rdf:resource="&fibo-fnd-oac-own;isOwnedAsset"/>
 		<skos:definition>indicates the asset in an ownership situation</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -158,38 +159,55 @@
 		<rdfs:label>has owning party</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-oac-own;Ownership"/>
 		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Owner"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-oac-own;isOwningPartyInRole"/>
+		<owl:inverseOf rdf:resource="&fibo-fnd-oac-own;isOwningParty"/>
 		<skos:definition>identifies the actor that holds title to the asset in an ownership situation</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;isOwnedBy">
+	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;isAssetOf">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;isAffectedBy"/>
-		<rdfs:label>is owned by</rdfs:label>
+		<rdfs:label>is asset of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-oac-own;Asset"/>
 		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Owner"/>
-		<skos:definition>identifies the party that owns the asset</skos:definition>
+		<skos:definition>identifies the owner of an asset</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;isOwnedThingInRole">
+	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;isOwnedAsset">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;undergoes"/>
-		<rdfs:label>is owned thing in role</rdfs:label>
+		<rdfs:label>is owned asset</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-oac-own;Asset"/>
 		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Ownership"/>
-		<skos:definition>indicates the context of ownership in which the thing plays the role of an asset</skos:definition>
+		<skos:definition>indicates the context of ownership in which something is an asset</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;isOwningPartyInRole">
+	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;isOwnedBy">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;experiencesDirectly"/>
+		<rdfs:label>is owned by</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
+		<skos:definition>indicates something that someone owns</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;isOwningParty">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;actsIn"/>
-		<rdfs:label>is owning party in role</rdfs:label>
+		<rdfs:label>is owning party</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-oac-own;Owner"/>
 		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Ownership"/>
 		<skos:definition>indicates the context of ownership in which the party plays the role of owner</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;owns">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;playsActiveRoleThatDirectlyAffects"/>
 		<rdfs:label>owns</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition>to have (something) as one&apos;s own, possess</skos:definition>
+		<skos:definition>indicates something that a party holds title to and may possess</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-oac-own;ownsAsset">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;actsOn"/>
+		<rdfs:label>is asset owner</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-oac-own;Owner"/>
+		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
+		<owl:inverseOf rdf:resource="&fibo-fnd-oac-own;isAssetOf"/>
+		<skos:definition>identifies an asset that an owner owns</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/FND/OwnershipAndControl/Ownership.rdf
+++ b/FND/OwnershipAndControl/Ownership.rdf
@@ -70,12 +70,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;Undergoer"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-				<owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:cardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasAcquisitionDate"/>
 				<owl:onDataRange rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
@@ -85,6 +79,12 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;isAssetOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Owner"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;isOwnedAsset"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Ownership"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>asset</rdfs:label>
@@ -107,13 +107,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;Actor"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-oac-own;owns"/>
-						<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;isOwningParty"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Ownership"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;ownsAsset"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>owner</rdfs:label>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -127,13 +127,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210401/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments, including features specific to preferred shares.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, clean up ambiguous definitions, and eliminate redundant restrictions related to security form.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add concepts covering additional features of preferred shares, move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology, rename EquityIssuer to ShareIssuer to be clearer about the intent, and add the concept of a price per share.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Equities/EquityInstruments.rdf version of this ontology was revised to rename ownership related properties for consistent alignment with the ownership situational pattern.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -360,7 +361,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedThing"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedAsset"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This resolution involved renaming certain ownership properties to better align with the situational pattern, to improve consistency and clarify usage, including: 
(1) hasOwnedThing --> hasOwnedAsset (name was inconsistent with target range), 
(2) isOwnedThingInRole --> isOwnedAsset (inverse of hasOwnedAsset), 
(3) isOwningPartyInRole --> isOwningParty (name was inconsistent with its inverse), 
(4) isOwnedBy --> isAssetOf (for consistency with the pattern - points from asset to owner), 
(5) added ownsAsset - inverse of isAssetOf (party in role to party in role, was a gap), 
(6) made owns a subproperty of 'plays active role that directly affects', and 
(7) added a new isOwnedBy, subproperty of experiences directly and inverse of owns to complete the pattern (was also a gap) and create a consistent pattern of naming the various roles involved in ownership.

The resulting pattern is shown in the figure attached:  

[OwnershipPattern.pdf](https://github.com/edmcouncil/fibo/files/6322840/OwnershipPattern.pdf)

See this PR in [FIBO Viewer](https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/?version=pr-1484%2Flatest)

Fixes: #1483 / FND-342


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).



