### PR TITLE
FBC-280 - A recent change involving price determination methods inadvertently introduced punning

### DIFF
--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -156,13 +156,12 @@
 		<skos:definition xml:lang="en">cash value of the last transacted price before the market closes</skos:definition>
 	</owl:Class>
 	
-	<rdf:Description rdf:about="&fibo-fbc-fi-ip;ClosingPriceDeterminationMethod">
-		<rdf:type rdf:resource="&owl;Class"/>
-		<rdf:type rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
+	<owl:Class rdf:about="&fibo-fbc-fi-ip;ClosingPriceDeterminationMethod">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
 		<rdfs:label xml:lang="en">closing price determination method</rdfs:label>
 		<skos:definition xml:lang="en">strategy for calculating or otherwise determining an official closing price</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The official closing price is typically the final price at which something trades during regular market hours on an exchange or trading venue.  Because of the evolving nature of online trading in a 24 hour world, every exchange has a method of calculating its official closing price, although that methodology changes from time to time.  They may also publish an adjusted closing price, which reflects changes to the price that reflect corporate actions and after hours trading that occur before the opening of the exchange on the following day. Understanding how the closing price is determined is important to ensure price comparability for a given security across exchanges.</fibo-fnd-utl-av:explanatoryNote>
-	</rdf:Description>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;CollectionOfSecurityPrices">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;DatedStructuredCollection"/>

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -89,7 +89,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, to add adjusted price and to create a more general hasLotSize property that can be used in various contexts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to change both subclasses of price determination method to named individuals and correct the definition of mean price determination.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to change one of the subclasses of price determination method to a named individual and correct the definition of mean price determination. Note that there may be multiple individuals of type &apos;closing price determination method&apos;, depending on the exchange and other factors.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -156,12 +156,13 @@
 		<skos:definition xml:lang="en">cash value of the last transacted price before the market closes</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-ip;ClosingPriceDeterminationMethod">
+	<rdf:Description rdf:about="&fibo-fbc-fi-ip;ClosingPriceDeterminationMethod">
+		<rdf:type rdf:resource="&owl;Class"/>
 		<rdf:type rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
 		<rdfs:label xml:lang="en">closing price determination method</rdfs:label>
 		<skos:definition xml:lang="en">strategy for calculating or otherwise determining an official closing price</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The official closing price is typically the final price at which something trades during regular market hours on an exchange or trading venue.  Because of the evolving nature of online trading in a 24 hour world, every exchange has a method of calculating its official closing price, although that methodology changes from time to time.  They may also publish an adjusted closing price, which reflects changes to the price that reflect corporate actions and after hours trading that occur before the opening of the exchange on the following day. Understanding how the closing price is determined is important to ensure price comparability for a given security across exchanges.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:NamedIndividual>
+	</rdf:Description>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;CollectionOfSecurityPrices">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;DatedStructuredCollection"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Reversed a change that made closing price determination method a named individual rather than a class due to how it is used, and the fact that there may be multiple, distinct methods for determining closing prices depending on the exchange, institution, etc.

Fixes: #1492 / FBC-280


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


