### PR TITLE
FBC-279 - Cardholder should be a subclass of CustomerAccountHolder

### DIFF
--- a/FBC/ProductsAndServices/CardAccounts.rdf
+++ b/FBC/ProductsAndServices/CardAccounts.rdf
@@ -269,7 +269,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;Cardholder">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;CustomerAccountHolder"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
@@ -299,7 +299,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>cardholder</rdfs:label>
-		<skos:definition>account holder to whom a payment card is issued or other individual authorized to use the payment card</skos:definition>
+		<skos:definition>account holder to whom a payment card is issued</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised subclass relationship in card accounts to make a cardholder a subclass of customer account holder rather than of a "vanilla" account holder

Fixes: #1505 / FBC-279


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


