### PR TITLE
IND-107 - The definition of 'market rate' should not incorporate the concept of a market trend

### DIFF
--- a/IND/Indicators/Indicators.rdf
+++ b/IND/Indicators/Indicators.rdf
@@ -65,7 +65,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190901/Indicators/Indicators.rdf version of this ontology was modified to eliminate a redundant superclass declaration on MarketSpread, introduced by refactoring of FND analytics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200401/Indicators/Indicators.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200701/Indicators/Indicators.rdf version of this ontology was modified to add definitions for historical and implied volatility, and differentiate price volatility accordingly.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/Indicators/Indicators.rdf version of this ontology was modified to a restriction on isValueOf to MarketRate and eliminate its dependence on PublishedFinancialInformation, and to revise the definition of market rate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/Indicators/Indicators.rdf version of this ontology was modified to a restriction on isValueOf to MarketRate and eliminate its dependence on PublishedFinancialInformation, and to revise the definition of market rate, daily average market rate, and end of day market rate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -79,7 +79,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>daily average market rate</rdfs:label>
-		<skos:definition>a measure of the overall price level of a given rate, calculated as the sum of all values of the rates for a particular reference rate, foreign exchange rate, lending rate, or other market rate divided by the total number of rates collected over the course of a twenty-four (24) hour period for a specific date</skos:definition>
+		<skos:definition>overall level of a given rate, calculated as the sum of some selected observed values of the rates for a particular reference rate, foreign exchange rate, lending rate, or other market rate divided by the number of samples collected over the course of a twenty-four (24) hour period for a specific date</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/m/marketaverage.asp</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
@@ -93,7 +93,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>end-of-day market rate</rdfs:label>
-		<skos:definition>a measure of the price level (value) of a given market rate of the end of the business day for a specific date</skos:definition>
+		<skos:definition>value of a given market rate of the end of the business day for a specific date</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;FinancialInformationPublisher">
@@ -168,7 +168,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>market rate</rdfs:label>
-		<skos:definition>rate that represents a ratio value established in the marketplace for a set of instruments (S&amp;P500, NASDAQ composite, 30 day CD) or that describes the economic climate for an industry (Dow Jones Industrial Average (DJIA), H&amp;Q Growth Technologies) and/or political region (LIBOR, Prime)</skos:definition>
+		<skos:definition>value of a rate established in the marketplace for a set of instruments or that describes the economic climate for an industry and/or political region (e.g., SOFR, Prime)</skos:definition>
 		<skos:example>Financial market rates include, but are not limited to reference rates, foreign exchange rates, lending rates, bankers&apos; acceptance rates, and so forth.</skos:example>
 		<skos:scopeNote>Market rates include but may not be limited to the following:
 (1) Index: Statistical composite that measures changes in the economy or in financial markets, often expressed in percentage changes from a base year or from the previous month
@@ -180,7 +180,6 @@
 (7) Prime                        
 (8) Time Deposit Rate: Benchmark reflecting market fluctuations of Deposit/Redeposit issued instruments</skos:scopeNote>
 		<skos:scopeNote>known collectively (in the CFI Standard) as referential instruments</skos:scopeNote>
-		<fibo-fnd-utl-av:synonym>benchmark</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;MarketSpread">

--- a/IND/Indicators/Indicators.rdf
+++ b/IND/Indicators/Indicators.rdf
@@ -57,7 +57,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210401/Indicators/Indicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210501/Indicators/Indicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/Indicators/Indicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/Indicators/Indicators.rdf version of this ontology was modified per the FIBO 2.0 RFC, namely, to integrate concepts recently added to the FND domain including Rate, ExchangeRate, InterestRate and StructuredCollection and revise definitions of TermStructure and Volatility to better support concepts such as yield curves and analysis of market rates generally.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/Indicators/Indicators.rdf version of this ontology was modified to integrate the composite date value and reflect migration of statistical measures to Analytics.</skos:changeNote>
@@ -65,7 +65,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190901/Indicators/Indicators.rdf version of this ontology was modified to eliminate a redundant superclass declaration on MarketSpread, introduced by refactoring of FND analytics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200401/Indicators/Indicators.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200701/Indicators/Indicators.rdf version of this ontology was modified to add definitions for historical and implied volatility, and differentiate price volatility accordingly.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/Indicators/Indicators.rdf version of this ontology was modified to a restriction on isValueOf to MarketRate and eliminate its dependence on PublishedFinancialInformation.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/Indicators/Indicators.rdf version of this ontology was modified to a restriction on isValueOf to MarketRate and eliminate its dependence on PublishedFinancialInformation, and to revise the definition of market rate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -168,7 +168,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>market rate</rdfs:label>
-		<skos:definition>rate that measures market trends for a set of instruments (S&amp;P500, NASDAQ composite, 30 day CD) or that describes the economic climate for an industry (Dow Jones Industrial Average (DJIA), H&amp;Q Growth Technologies) and/or political region (LIBOR, Prime)</skos:definition>
+		<skos:definition>rate that represents a ratio value established in the marketplace for a set of instruments (S&amp;P500, NASDAQ composite, 30 day CD) or that describes the economic climate for an industry (Dow Jones Industrial Average (DJIA), H&amp;Q Growth Technologies) and/or political region (LIBOR, Prime)</skos:definition>
 		<skos:example>Financial market rates include, but are not limited to reference rates, foreign exchange rates, lending rates, bankers&apos; acceptance rates, and so forth.</skos:example>
 		<skos:scopeNote>Market rates include but may not be limited to the following:
 (1) Index: Statistical composite that measures changes in the economy or in financial markets, often expressed in percentage changes from a base year or from the previous month

--- a/IND/MarketIndices/EquityIndexExampleIndividuals.rdf
+++ b/IND/MarketIndices/EquityIndexExampleIndividuals.rdf
@@ -112,7 +112,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210401/MarketIndices/EquityIndexExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210501/MarketIndices/EquityIndexExampleIndividuals/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -222,7 +222,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-mkt-eqind;DowJonesIndustrialAverageValue-2020-03-06T120514-0500">
-		<rdf:type rdf:resource="&fibo-ind-ind-ind;MarketRate"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-alx;NumericIndexValue"/>
 		<rdfs:label>Dow Jones Industrial Average value as of Mar 6, 2020</rdfs:label>
 		<skos:definition>individual representing the value of the DJIA on 6 Mar 2020 at 12:05:14 pm in NYC</skos:definition>
 		<fibo-fnd-acc-cur:hasRateValue rdf:datatype="&xsd;decimal">25523.20</fibo-fnd-acc-cur:hasRateValue>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised the definition of market rate to read 'rate that represents a ratio value established in the marketplace for' ... per FCT discussion

Fixes: #1515 / IND-107


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


