### PR TITLE
Implement Canadian Business Numbers and Tax Accounts, Closes #1504

### DIFF
--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -13,6 +13,7 @@
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
 	<!ENTITY fibo-fbc-fct-usfsind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/">
+	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
@@ -43,6 +44,7 @@
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
 	xmlns:fibo-fbc-fct-usfsind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"
+	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
@@ -125,9 +127,9 @@
 		<fibo-fnd-rel-rel:hasLegalName>Banque du Canada</fibo-fnd-rel-rel:hasLegalName>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bankofcanada.ca/wp-content/uploads/2010/11/regulation_canadian_financial.pdf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The Bank of Canada&apos;s overall goal is to promote a stable and efficient financial system in Canada. The focus on the financial system as a whole parallels the
-Bank&apos;s approach to monetary policy, which focuses on the entire economy.
-
-The Bank provides liquidity to the financial system, gives policy advice to the federal government on the design and development of the system, oversees major clearing and settlement systems, and provides banking services to these systems and their participants.</fibo-fnd-utl-av:explanatoryNote>
+         Bank&apos;s approach to monetary policy, which focuses on the entire economy.
+         
+         The Bank provides liquidity to the financial system, gives policy advice to the federal government on the design and development of the system, oversees major clearing and settlement systems, and provides banking services to these systems and their participants.</fibo-fnd-utl-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 	</owl:NamedIndividual>
 	
@@ -156,6 +158,82 @@ The Bank provides liquidity to the financial system, gives policy advice to the 
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
 	</owl:NamedIndividual>
 	
+	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;BusinessNumber">
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/TaxIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/appliesIn"/>
+				<owl:hasValue rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumberRegistrationIdentifierScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>business number</rdfs:label>
+		<skos:definition>an unique, 9-digit number and the standard identifier for businesses which is unique to a business or legal entity</skos:definition>
+		<skos:example>000000000</skos:example>
+		<fibo-fnd-utl-av:abbreviation>BN</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/services/taxes/business-number.html</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;BusinessNumberRegistrationIdentifierScheme">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/RegistrationIdentifierScheme"/>
+		<rdfs:label>Canada Revenue Agency business number registration identifier scheme</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>registration identifier scheme for business numbers defined by the Canada Renenue Agency for the registration of a business or legal entity</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;BusinessNumberRegistrationService">
+		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationService"/>
+		<rdfs:label>Canada Revenue Agency business number registration service</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/you-need-a-business-number-a-program-account.html"/>
+		<skos:definition>Canada Revenue Agency service for the registration of business entities</skos:definition>
+		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;BusinessNumberRegistry">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;BusinessRegistry"/>
+		<rdfs:label>Canada Revenue Agency business number entity registry</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>Canada Revenue Agency business number registry</skos:definition>
+		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CanadaRevenueAgency">
+		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
+		<rdfs:label>Canada Revenue Agency</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>individual representing the taxation authority of the Government of Canada</skos:definition>
+		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgencyHeadOfficeAddress"/>
+		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</fibo-fnd-plc-vrt:hasWebsite>
+		<fibo-fnd-rel-rel:hasLegalName>Agence du revenu du Canada</fibo-fnd-rel-rel:hasLegalName>
+		<fibo-fnd-rel-rel:hasLegalName>Canada Revenue Agency</fibo-fnd-rel-rel:hasLegalName>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>This agency administers tax laws for the Canadian Governments and several of the provinces and territories of Canada</fibo-fnd-utl-av:explanatoryNote>
+		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CanadaRevenueAgencyHeadOfficeAddress">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<rdfs:label>Canada Revenue Agency head office address</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>individual representing the head office address for the Canada Revenue Agency</skos:definition>
+		<fibo-fnd-plc-adr:hasAddressLine1>555 Mackenzie Avenue</fibo-fnd-plc-adr:hasAddressLine1>
+		<fibo-fnd-plc-adr:hasPostalCode>K1A 0L5</fibo-fnd-plc-adr:hasPostalCode>
+		<fibo-fnd-plc-loc:hasCountry rdf:resource="&lcc-3166-1;Canada"/>
+		<fibo-fnd-plc-loc:hasMunicipality rdf:resource="&fibo-fbc-fct-bci;Ottawa"/>
+		<fibo-fnd-plc-loc:hasSubdivision rdf:resource="&lcc-3166-2-ca;Ontario"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CanadianBankingRegulatoryAgencyAndCentralBank">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;CentralBank"/>
 		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationAuthority"/>
@@ -165,6 +243,314 @@ The Bank provides liquidity to the financial system, gives policy advice to the 
 		<skos:definition>individual representing the regulatory agency, registration authority and central banking role of the Bank of Canada</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-cajrga;BankOfCanada"/>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bankofcanada.ca/</fibo-fnd-utl-av:adaptedFrom>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;CorporationIncomeTaxNumber">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumber"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/LedgerAccount"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/TaxIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/appliesIn"/>
+				<owl:hasValue rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-cajrga;CorporationIncomeTaxNumberIdentifierScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>corporation income tax number</rdfs:label>
+		<skos:definition>a concatenation of an entitiy&apos;s business number, the &apos;RC&apos; program string and a 4-digit subaccount number used for reporting corporate income tax</skos:definition>
+		<skos:example>000000000RC0001</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/corporation-income-tax-program-account.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one tax account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CorporationIncomeTaxNumberIdentifierScheme">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/RegistrationIdentifierScheme"/>
+		<rdfs:label>Canada Revenue Agency corporation income tax number identifier scheme</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>registration identifier scheme for corporation income tax numbers defined by the Canada Renenue Agency for the registration of a business or legal entity</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CorporationIncomeTaxNumberRegistrationService">
+		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationService"/>
+		<rdfs:label>Canada Revenue Agency corporation income tax number registration service</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html"/>
+		<skos:definition>Canada Revenue Agency service for the registration of corporation income tax accounts</skos:definition>
+		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CorporationIncomeTaxNumberRegistry">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;BusinessRegistry"/>
+		<rdfs:label>Canada Revenue Agency corporation income tax number registry</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>Canada Revenue Agency corporation income tax number registry</skos:definition>
+		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;GSTHSTRegistrationIdentifierScheme">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/RegistrationIdentifierScheme"/>
+		<rdfs:label>Canada Revenue Agency GST/HST registation number identifier scheme</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>registration identifier scheme for GST/HST accounts defined by the Canada Renenue Agency for the registration of a business or legal entity</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;GSTHSTRegistrationNumber">
+		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;ValueAddedTaxIdentificationNumber"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumber"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/LedgerAccount"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/TaxIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/appliesIn"/>
+				<owl:hasValue rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-cajrga;GSTHSTRegistrationIdentifierScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>GST/HST registration number</rdfs:label>
+		<skos:definition>a concatenation of an entitiy&apos;s business number, the &apos;RT&apos; program string and a 4-digit subaccount number used for reporting GST/HST</skos:definition>
+		<skos:example>000000000RT0001</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one GST/HST account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;GSTHSTRegistrationRegistry">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;BusinessRegistry"/>
+		<rdfs:label>Canada Revenue Agency GSTHST number registry</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/e-services/e-services-businesses/confirming-a-gst-hst-account-number/terms-conditions-use.html"/>
+		<skos:definition>Canada Revenue Agency GSTHST number registry</skos:definition>
+		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-utl-av:explanatoryNote>Limited public access.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;GSTHSTRegistrationService">
+		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationService"/>
+		<rdfs:label>Canada Revenue Agency GST/HST number registration service</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html"/>
+		<skos:definition>Canada Revenue Agency service for the registration of GST/HST accounts</skos:definition>
+		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;ImportExportProgramNumber">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumber"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/LedgerAccount"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/TaxIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/appliesIn"/>
+				<owl:hasValue rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-cajrga;ImportExportProgramNumberIdentifierScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>import export program number</rdfs:label>
+		<skos:definition>a concatenation of an entitiy&apos;s business number, the &apos;RM&apos; program string and a 4-digit subaccount number used for reporting payroll deductions</skos:definition>
+		<skos:example>000000000RM0001</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/import-export-program-account.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one import-exports account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;ImportExportProgramNumberIdentifierScheme">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/RegistrationIdentifierScheme"/>
+		<rdfs:label>Canada Revenue Agency import export program number identifier scheme</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>registration identifier scheme for import export program number defined by the Canada Renenue Agency for the registration of a business or legal entity</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;ImportExportProgramNumberRegistrationService">
+		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationService"/>
+		<rdfs:label>Canada Revenue Agency import export program number registration service</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/register.html"/>
+		<skos:definition>Canada Revenue Agency service for the registration of import export program number accounts</skos:definition>
+		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;ImportExportProgramNumberRegistry">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;BusinessRegistry"/>
+		<rdfs:label>Canada Revenue Agency import export program number registry</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>Canada Revenue Agency import export program number registry</skos:definition>
+		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;InformationReturnsIdentifierScheme">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/RegistrationIdentifierScheme"/>
+		<rdfs:label>Canada Revenue Agency information return program number identifier scheme</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>registration identifier scheme for information return program numbers defined by the Canada Renenue Agency for the registration of a business or legal entity</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;InformationReturnsProgramNumber">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumber"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/TaxIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/appliesIn"/>
+				<owl:hasValue rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-cajrga;InformationReturnsIdentifierScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>information return program number</rdfs:label>
+		<skos:definition>a concatenation of an entitiy&apos;s business number, the &apos;RZ&apos; program string and a 4-digit subaccount number used for information returns</skos:definition>
+		<skos:example>000000000RZ0001</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/completing-slips-summaries/financial-slips-summaries/information-returns-program-account.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one information returns program number through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration. As opposed to other program numbers, this number is used for filing information returns and not as an account.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;InformationReturnsProgramNumberRegistrationService">
+		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationService"/>
+		<rdfs:label>Canada Revenue Agency information return program number registration service</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/register.html"/>
+		<skos:definition>Canada Revenue Agency service for the registration of an information return program number accounts</skos:definition>
+		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;InformationReturnsProgramNumberRegistry">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;BusinessRegistry"/>
+		<rdfs:label>Canada Revenue Agency import information return program number registry</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>Canada Revenue Agency information return program number registry</skos:definition>
+		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;PayrollDeductionsProgramIdentifierRegistrationService">
+		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationService"/>
+		<rdfs:label>Canada Revenue Agency payroll deduction program number registration service</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/How-open-payroll-account.html"/>
+		<skos:definition>Canada Revenue Agency service for the registration of payroll deduction program number accounts</skos:definition>
+		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;PayrollDeductionsProgramIdentifierScheme">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/RegistrationIdentifierScheme"/>
+		<rdfs:label>Canada Revenue Agency payroll deduction program number identifier scheme</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>registration identifier scheme for payroll deduction program number defined by the Canada Renenue Agency for the registration of a business or legal entity</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;PayrollDeductionsProgramNumber">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumber"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/LedgerAccount"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/TaxIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/appliesIn"/>
+				<owl:hasValue rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-cajrga;PayrollDeductionsProgramIdentifierRegistrationService"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>payroll deduction program number</rdfs:label>
+		<skos:definition>a concatenation of an entitiy&apos;s business number, the &apos;RP&apos; program string and a 4-digit subaccount number used for reporting payroll deductions</skos:definition>
+		<skos:example>000000000RP0001</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/what-payroll-account.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one deduction account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;PayrollDeductionsProgramNumberRegistry">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;BusinessRegistry"/>
+		<rdfs:label>Canada Revenue Agency payroll deduction program number registry</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>Canada Revenue Agency payroll deduction program registry</skos:definition>
+		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;RegisterdCharityProgramNumber">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumber"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/LedgerAccount"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/TaxIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/appliesIn"/>
+				<owl:hasValue rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-cajrga;RegisterdCharityProgramNumberIdentifierScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>registered charity program number</rdfs:label>
+		<skos:definition>a concatenation of an entitiy&apos;s business number, the &apos;RR&apos; program string and a 4-digit subaccount number used for registered charity contribution</skos:definition>
+		<skos:example>000000000RR0001</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/charities-giving/charities/operating-a-registered-charity/registration-number.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one registered charity account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;RegisterdCharityProgramNumberIdentifierScheme">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/RegistrationIdentifierScheme"/>
+		<rdfs:label>Canada Revenue Agency registered charity program number identifier scheme</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<skos:definition>registration identifier scheme for registered charity program numbers defined by the Canada Renenue Agency for the registration of a business or legal entity</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;RegisterdCharityProgramNumberRegistrationService">
+		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationService"/>
+		<rdfs:label>Canada Revenue Agency registered charity program number registration service</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/register.html"/>
+		<skos:definition>Canada Revenue Agency service for the registration of a registered charity program number accounts</skos:definition>
+		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;RegisterdCharityProgramNumberRegistry">
+		<rdf:type rdf:resource="&fibo-fbc-fct-breg;BusinessRegistry"/>
+		<rdfs:label>Canada Revenue Agency import registered charity program number registry</rdfs:label>
+		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<rdfs:seeAlso rdf:resource="https://apps.cra-arc.gc.ca/ebci/hacc/srch/pub/dsplyBscSrch?request_locale=en"/>
+		<skos:definition>Canada Revenue Agency registered charity program number registry</skos:definition>
+		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
+		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
+		<fibo-fnd-utl-av:explanatoryNote>Full public access.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 
 </rdf:RDF>


### PR DESCRIPTION
Signed-off-by: Rob Warren <warren@myraanalytics.ca>

## Description

This PR implements entities for the taxation authority of the Government of Canada, the Canada Revenue Agency and a definition for Business Numbers (BN).  Definitions for Corporate, HST (VAT), Import/Export and Payroll Tax accounts, whose numbering scheme is derived from the Business Number. Note that the RZ program is not an account.


Fixes: #1504 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


