### PR TITLE
IND-96 - Certain economic indicators including CPI, CivilianLaborForceParticipationRate and others still have restrictions on hasIndicatorValue and should not

### DIFF
--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -117,7 +117,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210401/EconomicIndicators/EconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210501/EconomicIndicators/EconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the FIBO 2.0 RFC. Primary changes include the addition of a number of statistical measures (mean, total, etc.) and their use in existing and new indicators, and the addition of several more economic indicators.</skos:changeNote>
@@ -128,7 +128,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200301/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to reflect the change in name and definition of numeric index to numeric index value in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200401/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to add definitions for alternative unemployment calculations and correct a circular property definition.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200901/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, added a synonym to fixed basket and eliminated the restriction with respect to date period, which is not the primary concern of a fixed basket, revised the name of the &apos;goods or services population&apos; to &apos;goods population&apos; to eliminate a hygiene issue and reflect the synonym of &apos;basket of goods&apos;, and merged the statistical information publisher class from economic indicator publishers into this ontology.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate the restriction on economic indicator that it has an indicator value - the restriction should be on the quantity value such that the value refers to the indicator it represents.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate the restriction on economic indicator (and its subclasses) that it has an indicator value - the restriction should be on the quantity value such that the value refers to the indicator it represents.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -138,21 +138,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasReferencePeriod"/>
 				<owl:hasValue rdf:resource="&fibo-ind-ei-ei;Daily"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-utl-alx;ArithmeticMean">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-acc-cur;MonetaryAmount">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>average daily earnings</rdfs:label>
@@ -184,21 +169,6 @@
 				<owl:hasValue rdf:resource="&fibo-ind-ei-ei;Hourly"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-utl-alx;ArithmeticMean">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-acc-cur;MonetaryAmount">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>average hourly earnings</rdfs:label>
 		<skos:definition>a measure of the average hourly wage an employee makes over the reporting period</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</fibo-fnd-utl-av:adaptedFrom>
@@ -212,21 +182,6 @@
 				<owl:hasValue rdf:resource="&fibo-ind-ei-ei;Monthly"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-utl-alx;ArithmeticMean">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-acc-cur;MonetaryAmount">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>average monthly earnings</rdfs:label>
 		<skos:definition>a measure of the average monthly wage an employee makes over the reporting period</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</fibo-fnd-utl-av:adaptedFrom>
@@ -238,21 +193,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasReferencePeriod"/>
 				<owl:hasValue rdf:resource="&fibo-ind-ei-ei;Weekly"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-utl-alx;ArithmeticMean">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-acc-cur;MonetaryAmount">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>average weekly earnings</rdfs:label>
@@ -321,12 +261,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;RatioValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>civilian labor force participation rate</rdfs:label>
@@ -403,12 +337,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;FixedBasket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;NumericIndexValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>consumer price index</rdfs:label>
@@ -551,12 +479,6 @@
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;RatioValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>employment-population ratio</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.bls.gov/news.release/pdf/empsit.pdf"/>
 		<skos:definition>an economic indicator representing the ratio of the employed population with respect to the overall civilian non-institutional population of a given economy for some specified period</skos:definition>
@@ -664,12 +586,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EstablishmentPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;Total"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>establishment employment</rdfs:label>
@@ -835,12 +751,6 @@ A household may be located in a housing unit or in a set of collective living qu
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;RatioValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>inflation rate</rdfs:label>
 		<skos:definition>an economic indicator representing a change in prices of goods and services for a specified period, for a given statistical area</skos:definition>
 		<skos:editorialNote>Always either includes or excludes: Energy prices; Food prices. ALL inflation rates cite whether or not they exclude energy and food prices. If nothing stated it is assumed they include them.</skos:editorialNote>
@@ -1002,12 +912,6 @@ A household may be located in a housing unit or in a set of collective living qu
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;NumericIndexValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>producer price index</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;ConsumerPriceIndex"/>
 		<skos:definition>an economic indicator representing a measure of the rate of change over time in the prices of goods and services bought and sold by producers</skos:definition>
@@ -1020,12 +924,6 @@ A household may be located in a housing unit or in a set of collective living qu
 	<owl:Class rdf:about="&fibo-ind-ei-ei;Productivity">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;RatioValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>productivity</rdfs:label>
 		<skos:definition>an economic indicator representing a ratio of a volume measure of output to a volume measure of input use</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=2167</fibo-fnd-utl-av:adaptedFrom>
@@ -1126,12 +1024,6 @@ A household may be located in a housing unit or in a set of collective living qu
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;UnemployedPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasIndicatorValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;RatioValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>unemployment rate</rdfs:label>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminated unnecessary references to an indicator value on the various indices as the values would point back to the thing that they are a value of, rather than the other way around

Fixes: #1522 / IND-96 / IND-108


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


