### PR TITLE
FND-346 - Need the definition of a structured name and definition of a new datatype for the combination of xsd:string and rdf:langString

### DIFF
--- a/BE/LegalEntities/LEIEntities.rdf
+++ b/BE/LegalEntities/LEIEntities.rdf
@@ -156,6 +156,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasName"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&fibo-fnd-aap-agt;Text"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-law-jur;appliesIn"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 			</owl:Restriction>
@@ -170,12 +177,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasName"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;Text"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>entity legal form</rdfs:label>
@@ -397,7 +398,6 @@
 	<owl:DatatypeProperty rdf:about="&fibo-be-le-lei;hasLegalFormAbbreviation">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:label>has legal form abbreviation</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>the precise abbreviation for the entity legal form as defined in the jurisdiction in which it is registered, for example LLC, LLP, Ltd, PLC, Corp.</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -412,7 +412,6 @@
 	<owl:DatatypeProperty rdf:about="&fibo-be-le-lei;hasTransliteratedLegalFormAbbreviation">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:label>has transliterated legal form abbreviation</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>a transliterated (i.e., in Latin or Romanized ASCII) representation of the abbreviation for the entity legal form</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -420,7 +419,6 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>has transliterated name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>a transliterated (i.e., in Latin or Romanized ASCII) representation of a name for the entity</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
 	</owl:DatatypeProperty>

--- a/FND/AgentsAndPeople/Agents.rdf
+++ b/FND/AgentsAndPeople/Agents.rdf
@@ -51,6 +51,12 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
+	<rdfs:Datatype rdf:about="&rdf;langString">
+		<rdfs:label>langString</rdfs:label>
+		<skos:definition>literal with a non-empty language tag that is well-formed according to section 2.2.9 of [BCP47]</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>This declaration is included in order to support language-tagged strings in FIBO.</fibo-fnd-utl-av:explanatoryNote>
+	</rdfs:Datatype>
+	
 	<owl:Class rdf:about="&fibo-fnd-aap-agt;AutomatedSystem">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
 		<rdfs:label>automated system</rdfs:label>
@@ -95,7 +101,8 @@ Whether or not you restrict your view of agents to the software variety, most ag
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;Text"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&fibo-fnd-aap-agt;Text"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>name</rdfs:label>
@@ -130,8 +137,7 @@ Whether or not you restrict your view of agents to the software variety, most ag
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-agt;hasTextValue">
 		<rdfs:label>has text value</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
-		<skos:definition>provides a custom string value for something, with or without a language tag</skos:definition>
+		<skos:definition>provides a string value for something, with or without a language tag</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-aap-agt;isStructuredNameOf">

--- a/FND/AgentsAndPeople/People.rdf
+++ b/FND/AgentsAndPeople/People.rdf
@@ -553,7 +553,6 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasFamilyName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasPersonName"/>
 		<rdfs:label>has family name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<owl:equivalentProperty rdf:resource="&fibo-fnd-aap-ppl;hasLastName"/>
 		<owl:equivalentProperty rdf:resource="&fibo-fnd-aap-ppl;hasSurname"/>
 		<skos:definition>indicates the name shared in common to identify the members of a family, as distinguished from each member&apos;s given name</skos:definition>
@@ -563,7 +562,6 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasFirstName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasPersonName"/>
 		<rdfs:label>has first name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<owl:equivalentProperty rdf:resource="&fibo-fnd-aap-ppl;hasGivenName"/>
 		<skos:definition>indicates the given name or first name of a person, that is, the name chosen for them at birth or changed by them subsequently from the name given at birth</skos:definition>
 	</owl:DatatypeProperty>
@@ -572,7 +570,6 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasPersonName"/>
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasLegalName"/>
 		<rdfs:label>has full legal name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates the complete name of a person, typically used in formal situations including those of a legal or contractual nature</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -587,14 +584,12 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasGivenName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasPersonName"/>
 		<rdfs:label>has given name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates the given name or first name of a person, that is, the name chosen for them at birth or changed by them subsequently from the name given at birth</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasLastName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasPersonName"/>
 		<rdfs:label>has last name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<owl:equivalentProperty rdf:resource="&fibo-fnd-aap-ppl;hasSurname"/>
 		<skos:definition>indicates the name shared in common to identify the members of a family, as distinguished from each member&apos;s given name</skos:definition>
 	</owl:DatatypeProperty>
@@ -602,28 +597,24 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasMaidenName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasPersonName"/>
 		<rdfs:label>has maiden name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates the name shared in common to identify the members of a family, that predates any changes of name due to marriage</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasMiddleNameOrInitial">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasPersonName"/>
 		<rdfs:label>has middle name or initial</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>one or more additional names or initial letters for names that occur between a person&apos;s first and last name</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasNamePrefix">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:label>has name prefix</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates a character or sequence of characters, preceding a person&apos;s name, that provides additional information about the person, such as a form of address representing a title, honorific, or military rank</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasNameSuffix">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:label>has name suffix</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates a character or sequence of characters, following a person&apos;s name, that provides additional information about the person, such as their position, educational degree, accreditation, office, or honor</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -631,7 +622,6 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>has person name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>links a name to an individual</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Note that the concept of a person name may include symbology as long as the symbols are properly encoded.  Because person name is a class, other iconography or symbology that cannot be encoded in UTF-8 can, alternatively, be linked or attached as a separate image or in another form.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:DatatypeProperty>
@@ -664,7 +654,6 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-aap-ppl;hasSurname">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-ppl;hasPersonName"/>
 		<rdfs:label>has surname</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates the name shared in common to identify the members of a family, as distinguished from each member&apos;s given name</skos:definition>
 	</owl:DatatypeProperty>
 

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -65,7 +65,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions, to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name, to loosen domain restrictions on some properties which were too narrowly specified, and to add two new properties, describes and isDescribedBy, which are more appropriate for certain cases where we were using characterizes and isCharacterizedBy.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Relations/Relations.rdf version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201201/Relations/Relations.rdf version of this ontology was modified to clean up references to external dictionaries that don&apos;t meet FIBO policies, eliminate ambiguity where possible, eliminate the superproperties of produces and is produced by, whose semantics are different from their parent properties, and improve ISO 704 compliance of definitions.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Relations/Relations.rdf version of this ontology was modified to add Reference as a superclass of Name and use the combined text data type as the range of certain data properties.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Relations/Relations.rdf version of this ontology was modified to add Reference as a superclass of Name and use the hasTextValue property as the superproperty of certain data properties.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -167,7 +167,6 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>has alias</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates an alternate name of by which something is known</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -175,7 +174,6 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>has common name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates a name by which something is frequently referred, without reference to any formal usage or structure</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -195,7 +193,6 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>has formal name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates a name by which something is known for some official purpose or context, or which is structured in some way such as to always follow the same format regardless of usage</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -209,7 +206,6 @@
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasLegalName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasFormalName"/>
 		<rdfs:label>has legal name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>specifies the name used to refer to a party in legal communications</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -406,7 +402,6 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;hasTextValue"/>
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>was formerly known as</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;Text"/>
 		<skos:definition>indicates a name by which something was known in the past</skos:definition>
 	</owl:DatatypeProperty>
 	


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Simplified property declarations that used the new Text datatype to avoid issues with Protege and Pellet, but retained the concept for use in applications that support RDF 1.1 and rdf:langString.


Fixes: #1533 / FND-346


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


