### PR TITLE
DER-101 - Finalize the Options ontology for release

### DIFF
--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -96,6 +96,7 @@
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/SwapsIndividuals/"/>
 		

--- a/DER/AllDER.rdf
+++ b/DER/AllDER.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY fibo-der-all "https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-ff "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
+	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-der-rtd-irswp "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/">
 	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/">
@@ -22,6 +23,7 @@
 	xmlns:fibo-der-all="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-ff="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
+	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-der-rtd-irswp="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"
 	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"
@@ -77,6 +79,7 @@
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>

--- a/DER/CommoditiesDerivatives/CommoditiesContracts.rdf
+++ b/DER/CommoditiesDerivatives/CommoditiesContracts.rdf
@@ -2,9 +2,9 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-ff "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
+	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -24,9 +24,9 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-ff="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
+	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -133,7 +133,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-com-ctr;CommodityOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivative"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;VanillaOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:label xml:lang="en">commodity option</rdfs:label>
 		<skos:definition xml:lang="en">option whose underlying asset is at least one commodity, commodity index, and/or commodity-specific contract</skos:definition>
 	</owl:Class>

--- a/DER/DerivativesContracts/CurrencyContracts.rdf
+++ b/DER/DerivativesContracts/CurrencyContracts.rdf
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-der-sp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Spots/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-cur "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/">
 	<!ENTITY fibo-der-drc-ff "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
+	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -24,11 +24,11 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-der-sp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Spots/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-cur="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"
 	xmlns:fibo-der-drc-ff="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
+	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -142,7 +142,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-cur;CurrencyOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-cur;CurrencyDerivative"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;VanillaOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -152,7 +152,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasStrikeRate"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasStrikeRate"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;ExchangeRate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -83,7 +83,7 @@
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-der-exo;AsianOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;ExoticOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ex;hasExerciseDate"/>
@@ -154,7 +154,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-exo;ChooserOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;ExoticOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-exo;hasOptionTypeElectionDate"/>
@@ -191,14 +191,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPayoutCommitment"/>
 		<rdfs:label xml:lang="en">defined conditions payout commitment</rdfs:label>
 		<skos:definition xml:lang="en">A commitment which is only made when certain defined conditions are met. Further notes: Like all contractual commitments, the details of the commitment (and in this case, the conditions) are defined in the corresponding Contractual Terms. These set out what the commitment is and what the conditions are under which it is to be met. Term introduced in order to support digital and other exotic options. Note this is similar to but distinct from commitments where the specific nature of the commitment (typically a cashflow) is defined by resolving some mathematical formula i.e. where the commitment to do something is not conditional but the precise monetary amounts (payment, settlement) are.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-exo;ExoticOption">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:label xml:lang="en">exotic option</rdfs:label>
-		<skos:definition xml:lang="en">option that has a non-standard payout structure or other feature</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">Commodity Futures Trading Commission (CFTC) glossary, https://www.cftc.gov/LearnAndProtect/EducationCenter/CFTCGlossary/glossary_e.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Exotic options include Asian options and lookback options, and are mostly traded in the over-the-counter market.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-exo;FixedLookbackStrikeFormula">
@@ -571,7 +563,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	
 	<owl:Class rdf:about="&fibo-der-der-exo;Swaption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OverTheCounterInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;ExoticOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -2,8 +2,8 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-der-exo "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
@@ -28,8 +28,8 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-der-exo="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
@@ -83,7 +83,7 @@
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-der-exo;AsianOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ExoticOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ex;hasExerciseDate"/>
@@ -154,7 +154,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-exo;ChooserOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ExoticOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-exo;hasOptionTypeElectionDate"/>
@@ -167,9 +167,9 @@
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-der-opt;CallOption">
+							<rdf:Description rdf:about="&fibo-der-drc-opt;CallOption">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-der-opt;PutOption">
+							<rdf:Description rdf:about="&fibo-der-drc-opt;PutOption">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -244,7 +244,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;StrikePrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-opt;StrikePrice"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fixed strike terms</rdfs:label>
@@ -474,7 +474,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-exo;enteredIntoBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option payout commitment</rdfs:label>
@@ -563,7 +563,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	
 	<owl:Class rdf:about="&fibo-der-der-exo;Swaption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OverTheCounterInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ExoticOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -583,7 +583,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;enteredIntoBy">
 		<rdfs:label xml:lang="en">entered into by</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-exo;OptionPayoutCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-exo;fixedStrikeAmount">
@@ -609,7 +609,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;hasPremiumType">
 		<rdfs:label xml:lang="en">has premium type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-opt;OptionPremium"/>
 		<rdfs:range rdf:resource="&fibo-der-der-exo;OptionPremiumPaymentArrangement"/>
 		<skos:definition xml:lang="en">The type of premium payment. FpML: &apos;Premium type for a forward starting equity option.&apos;</skos:definition>
 	</owl:ObjectProperty>
@@ -655,7 +655,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<skos:definition xml:lang="en">The price or other variable (as a number) which has to be met for the event to be deemed to have occurred.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremium">
+	<owl:Class rdf:about="&fibo-der-drc-opt;OptionPremium">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasFormula"/>

--- a/DER/DerivativesContracts/FuturesAndForwards.rdf
+++ b/DER/DerivativesContracts/FuturesAndForwards.rdf
@@ -100,7 +100,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210601/DerivativesContracts/FuturesAndForwards/"/>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to eliminate references to hasContractSize and clean up unnecessary restrictions on Future and Forward.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to eliminate references to hasContractSize, clean up unnecessary restrictions on Future and Forward, and eliminate the redundant listing class.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -242,19 +242,6 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ff;FuturesListing">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;Listing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;lists"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Future"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures listing</rdfs:label>
-		<skos:definition xml:lang="en">listing of a futures instrument on a derivatives exchange</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ff;IndexFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
 		<rdfs:subClassOf>
@@ -325,7 +312,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ff;FuturesListing"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;Listing"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">standardized futures listing terms</rdfs:label>

--- a/DER/DerivativesContracts/FuturesAndForwards.rdf
+++ b/DER/DerivativesContracts/FuturesAndForwards.rdf
@@ -12,9 +12,7 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -46,9 +44,7 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -91,9 +87,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -105,8 +99,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210501/DerivativesContracts/FuturesAndForwards/"/>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to eliminate references to hasContractSize.</skos:changeNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210601/DerivativesContracts/FuturesAndForwards/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to eliminate references to hasContractSize and clean up unnecessary restrictions on Future and Forward.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -202,18 +196,6 @@
 	<owl:Class rdf:about="&fibo-der-drc-ff;Forward">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OverTheCounterInstrument"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">forward</rdfs:label>
 		<skos:definition xml:lang="en">derivative instrument that is privately negotiated between parties to buy the underlier at a specified future date at the price specified in the contract</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
@@ -392,18 +374,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasLotSize"/>
 				<owl:someValuesFrom rdf:resource="&xsd;decimal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;PayingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;ReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A futures contract obligates the buyer to pay the seller a predetermined price based on the market value of the underlier, unless the contract is sold before settlement date which may happen if a trader waits to take a profit or cut a loss. This contrasts with options trading in which the option buyer may choose whether or not to exercise the option. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearing houses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check.</fibo-fnd-utl-av:explanatoryNote>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -2,12 +2,10 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
-	<!ENTITY fibo-fbc-dae-gty "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
-	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
@@ -16,7 +14,6 @@
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
@@ -38,12 +35,10 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
-	xmlns:fibo-fbc-dae-gty="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
-	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
@@ -52,7 +47,6 @@
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
@@ -73,26 +67,26 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 		<rdfs:label xml:lang="en">Options Ontology</rdfs:label>
-		<dct:abstract>Concepts common to all option contracts and their corresponding transactions. An option gives one party (the holder) the right to purchase or sell the underlying commodity at a given time or times in the future (as determined by the exercise convention), if they choose to do so. Includes option features, these being definitions of how the option comes into or ceases being in force when a given event occurs along with a range of other variations.</dct:abstract>
+		<dct:abstract>Concepts common to all option contracts. An option gives one party (the holder) the right to purchase or sell the underlying commodity at a given time or times in the future (as determined by the exercise convention), if they choose to do so.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/"/>
 		<sm:dependsOn rdf:resource="https://www.omg.org/spec/LCC/"/>
-		<sm:fileAbbreviation>fibo-der-der-opt</sm:fileAbbreviation>
+		<sm:fileAbbreviation>fibo-der-drc-opt</sm:fileAbbreviation>
 		<sm:filename>Options.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -101,7 +95,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -111,24 +104,24 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210601/DerivativesContracts/Options/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;DerivativesClearingOrganization">
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For options, the derivatives clearing organization is responsible for clearing transactions for put and call options on common stocks and other equity issues, stock indexes, foreign currencies, interest rate composites and single-stock futures.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-der-der-opt;AtTheMoney">
-		<rdf:type rdf:resource="&fibo-der-der-opt;Moneyness"/>
+	<owl:NamedIndividual rdf:about="&fibo-der-drc-opt;AtTheMoney">
+		<rdf:type rdf:resource="&fibo-der-drc-opt;Moneyness"/>
 		<rdfs:label xml:lang="en">at-the-money</rdfs:label>
 		<skos:definition xml:lang="en">moneyness classifier that refers to an option whose value in terms of its strike price is the same or close to the current market price of the underlying security</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">ATM</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An ATM option has a delta of ±0.50, positive if it is a call, negative for a put.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;BasketOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;VanillaOption"/>
+	<owl:Class rdf:about="&fibo-der-drc-opt;BasketOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -139,8 +132,8 @@
 		<skos:definition xml:lang="en">option whose underlying asset is a group, or basket, of commodities, securities, indices, or currencies</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;BondOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;FixedIncomeOption"/>
+	<owl:Class rdf:about="&fibo-der-drc-opt;BondOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;FixedIncomeOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -151,7 +144,7 @@
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to buy or sell (depending on whether it is a call or a put) a bond at a certain price on or before a specified date</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;CallOption">
+	<owl:Class rdf:about="&fibo-der-drc-opt;CallOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:label xml:lang="en">call option</rdfs:label>
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to buy the assets specified at a fixed price or formula, on or before a specified date</skos:definition>
@@ -159,12 +152,12 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller (issuer) of the call option assumes the obligation of delivering the assets specified should the buyer exercise the option. The buyer has the option, but not the obligation, to purchase the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;EquityOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;VanillaOption"/>
+	<owl:Class rdf:about="&fibo-der-drc-opt;EquityOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExerciseStyle"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasExerciseStyle"/>
 				<owl:hasValue rdf:resource="&fibo-sec-dbt-ex;AmericanExerciseConvention"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -174,7 +167,7 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For an Equity Option, one contract represents 100 shares of stock.  Equity options settle in &apos;American style&apos;.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;ExoticOption">
+	<owl:Class rdf:about="&fibo-der-drc-opt;ExoticOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:label xml:lang="en">exotic option</rdfs:label>
 		<skos:definition xml:lang="en">option that has a non-standard payout structure or other feature</skos:definition>
@@ -182,16 +175,16 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Exotic options include Asian options and lookback options, and are mostly traded in the over-the-counter market.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;ExtrinsicValue">
+	<owl:Class rdf:about="&fibo-der-drc-opt;ExtrinsicValue">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryMeasure"/>
 		<rdfs:label xml:lang="en">extrinsic value</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;IntrinsicValue"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-opt;IntrinsicValue"/>
 		<skos:definition xml:lang="en">measure of the difference between the market price of an option, called the premium, and its intrinsic value</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Extrinsic value is also the portion of the worth that has been assigned to an option by factors other than the underlying asset&apos;s price. The opposite of extrinsic value is intrinsic value, which is the inherent worth of an option.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;FixedIncomeOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;VanillaOption"/>
+	<owl:Class rdf:about="&fibo-der-drc-opt;FixedIncomeOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;DebtInstrumentDerivative"/>
 		<rdfs:label xml:lang="en">fixed income option</rdfs:label>
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to buy (via a call option) or sell (via a put option) the underlying fixed income assets specified at a pre-determined price (i.e., the strike price, fixed or calculated), on or before a specified date (the expiration date)</skos:definition>
@@ -199,16 +192,16 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Fixed income options, or debt options, are derivatives contracts that use bonds or other fixed-income securities as their underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-der-der-opt;InTheMoney">
-		<rdf:type rdf:resource="&fibo-der-der-opt;Moneyness"/>
+	<owl:NamedIndividual rdf:about="&fibo-der-drc-opt;InTheMoney">
+		<rdf:type rdf:resource="&fibo-der-drc-opt;Moneyness"/>
 		<rdfs:label xml:lang="en">in-the-money</rdfs:label>
 		<skos:definition xml:lang="en">moneyness classifier that refers to an option that has value in a strike price that is favorable in comparison to the prevailing market price of the underlying asset</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">ITM</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An in-the-money call option means the option holder has the opportunity to buy the security below its current market price. An in-the-money put option means the option holder can sell the security above its current market price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;InterestRateOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionOnFuture"/>
+	<owl:Class rdf:about="&fibo-der-drc-opt;InterestRateOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionOnFuture"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -220,15 +213,15 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the option is exercised, delivery is in the form of the corresponding interest rate future.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;IntrinsicValue">
+	<owl:Class rdf:about="&fibo-der-drc-opt;IntrinsicValue">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryMeasure"/>
 		<rdfs:label xml:lang="en">intrinsic value</rdfs:label>
 		<skos:definition xml:lang="en">measure of what an asset is worth, i.e. with respect to its current price</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This measure is arrived at by means of an objective calculation or complex financial model. In financial analysis this term is used in conjunction with the work of identifying, as nearly as possible, the underlying value of a company and its cash flow. In options pricing it refers to the difference between the strike price of the option and the current price of the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;LongTermEquityAnticipationSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;EquityOption"/>
+	<owl:Class rdf:about="&fibo-der-drc-opt;LongTermEquityAnticipationSecurity">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;EquityOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractDuration"/>
@@ -241,7 +234,7 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">By providing opportunities to control and manage risk or even to speculate, LEAPS are virtually identical to regular options. Expiration dates on LEAPs can range from nine months to three years, which is longer than the holding period for a traditional call or put option. Although they are not available on all stocks, LEAPS are available on most widely held issues.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;Moneyness">
+	<owl:Class rdf:about="&fibo-der-drc-opt;Moneyness">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -254,7 +247,7 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Moneyness describes the intrinsic value of an option in its current state. The term moneyness is most commonly used with put and call options and is an indicator as to whether the option would make money if it were exercised immediately. Moneyness can be measured with respect to the underlying stock or other asset&apos;s current/spot price or its future price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionHolder">
+	<owl:Class rdf:about="&fibo-der-drc-opt;OptionHolder">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Owner"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -267,7 +260,7 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In a call, the option holder has the right, but not the obligation, to buy the underlying asset, while, in a put, the option holder has the right to sell the underlying asset. An option holder may sell the option contract itself, at which point the buyer becomes the option holder. The holder has an obligation to inform the seller by a certain time if they wish to exercise. Once the instrument is exercised there are typically additional, relevant obligations with regard to settlement.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionIssuer">
+	<owl:Class rdf:about="&fibo-der-drc-opt;OptionIssuer">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -284,7 +277,7 @@
 		<skos:definition xml:lang="en">issuer granting the rights defined in the option in exchange for some consideration</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionListing">
+	<owl:Class rdf:about="&fibo-der-drc-opt;OptionListing">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;Listing"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -297,8 +290,8 @@
 		<skos:definition xml:lang="en">listing of an option contract on a derivatives exchange</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionOnFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;VanillaOption"/>
+	<owl:Class rdf:about="&fibo-der-drc-opt;OptionOnFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -316,7 +309,7 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremium">
+	<owl:Class rdf:about="&fibo-der-drc-opt;OptionPremium">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -334,7 +327,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasRelativePaymentDate"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasRelativePaymentDate"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -343,7 +336,7 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The option premium is the income received by the seller (writer) of an option contract to another party. In-the-money option premiums are composed of two factors: intrinsic and extrinsic value. Out-of-the-money options&apos; premiums consist solely of extrinsic value. For stock options, the premium is quoted as a dollar amount per share, and most contracts represent the commitment of 100 shares.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionTradingStrategy">
+	<owl:Class rdf:about="&fibo-der-drc-opt;OptionTradingStrategy">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;TradingStrategy"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -356,15 +349,15 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Simple combinations include option spread trades such as vertical spreads, calendar (or horizontal) spreads, and diagonal spreads. More involved combinations include trades such as Condor or Butterfly spreads which are actually combinations of two vertical spreads.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-der-der-opt;OutOfTheMoney">
-		<rdf:type rdf:resource="&fibo-der-der-opt;Moneyness"/>
+	<owl:NamedIndividual rdf:about="&fibo-der-drc-opt;OutOfTheMoney">
+		<rdf:type rdf:resource="&fibo-der-drc-opt;Moneyness"/>
 		<rdfs:label xml:lang="en">out-of-the-money</rdfs:label>
 		<skos:definition xml:lang="en">moneyness classifier that refers to an option whose value in terms of its strike price is not favorable in comparison to the prevailing market price of the underlying asset</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">OTM</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An OTM call option will have a strike price that is higher than the market price of the underlying asset. Alternatively, an OTM put option has a strike price that is lower than the market price of the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;PutOption">
+	<owl:Class rdf:about="&fibo-der-drc-opt;PutOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:label xml:lang="en">put option</rdfs:label>
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to to sell the assets specified at a fixed price or formula, on or before a specified date</skos:definition>
@@ -372,8 +365,8 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller of the put option assumes the obligation of buying the assets specified should the buyer exercise the option.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;SingleStockOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;EquityOption"/>
+	<owl:Class rdf:about="&fibo-der-drc-opt;SingleStockOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;EquityOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -389,7 +382,7 @@
 		<skos:definition xml:lang="en">equity option whose underlier is a specific equity instrument</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;StandardizedOptionsTerms">
+	<owl:Class rdf:about="&fibo-der-drc-opt;StandardizedOptionsTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;StandardizedTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -415,7 +408,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;VanillaOption"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">standardized options terms</rdfs:label>
@@ -424,14 +417,14 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such terms may relate to the underlying instruments, exercise price, expiration date, and contract size, for example.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;StrikePrice">
+	<owl:Class rdf:about="&fibo-der-drc-opt;StrikePrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<rdfs:label xml:lang="en">strike price</rdfs:label>
 		<skos:definition xml:lang="en">price at which an underlying asset may be bought or sold when the contract is exercised</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For call options, the strike price is the price at which the security may be purchased by the option holder; for put options, the strike price is the price at which the security may be sold.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;VanillaOption">
+	<owl:Class rdf:about="&fibo-der-drc-opt;VanillaOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -450,24 +443,24 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Vanilla options include call or put options that have no special or unusual features, and are typically exchange traded.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasCalculatedMarketValue">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasCalculatedMarketValue">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
 		<rdfs:label xml:lang="en">has calculated market value</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionPremium"/>
 		<skos:definition xml:lang="en">indicates a calculated price as of some relative date considered the market value of the option at that point in time</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en">has premium</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExercisePrice">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasExercisePrice">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
 		<rdfs:label xml:lang="en">has exercise price</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;StrikePrice"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-opt;StrikePrice"/>
 		<skos:definition xml:lang="en">specifies a predetermined price at which the holder commits to buy or sell an underlying asset</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en">has strike price</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExerciseSchedule">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasExerciseSchedule">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
 		<rdfs:label xml:lang="en">has exercise schedule</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
@@ -476,7 +469,7 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An exercise schedule may be as simple as a single date or date period. However, in more complex cases, it may be an ad hoc schedule of individual dates, or a regular schedule of periodic exercise dates.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExerciseStyle">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasExerciseStyle">
 		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isClassifiedBy"/>
 		<rdfs:label>has exercise style</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
@@ -484,24 +477,24 @@
 		<skos:definition>indicates the exercise convention specified for the option</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionHolder">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasOptionHolder">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
 		<rdfs:label>has option holder</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionHolder"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionHolder"/>
 		<skos:definition>indicates the owner of the option</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionWriter">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasOptionWriter">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
 		<rdfs:label>has option writer</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
 		<skos:definition>indicates the original issuer of the option</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically, the option writer collects the premium when the option is initially sold.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasRelativePaymentDate">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasRelativePaymentDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
 		<rdfs:label xml:lang="en">has relative payment date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
@@ -509,7 +502,7 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can be expressed as either an adjustable or relative date. FpML: &apos;The payment date, which can be expressed as either an adjustable or relative date.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasStrikeRate">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasStrikeRate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasQuantityValue"/>
 		<rdfs:label xml:lang="en">has strike rate</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;ExchangeRate"/>
@@ -519,40 +512,40 @@
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Option">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionHolder"/>
-				<owl:onClass rdf:resource="&fibo-der-der-opt;OptionHolder"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasOptionHolder"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;OptionHolder"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasCalculatedMarketValue"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasCalculatedMarketValue"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-opt;OptionPremium"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExercisePrice"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;StrikePrice"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasExercisePrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-opt;StrikePrice"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExerciseSchedule"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasExerciseSchedule"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExerciseStyle"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasExerciseStyle"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ex;ExerciseConvention"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionWriter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasOptionWriter"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -277,19 +277,6 @@
 		<skos:definition xml:lang="en">issuer granting the rights defined in the option in exchange for some consideration</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-opt;OptionListing">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;Listing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;lists"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Option"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option listing</rdfs:label>
-		<skos:definition xml:lang="en">listing of an option contract on a derivatives exchange</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-opt;OptionOnFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:subClassOf>
@@ -325,12 +312,6 @@
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasRelativePaymentDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option premium</rdfs:label>
 		<skos:definition xml:lang="en">current market price of an option contract</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The option premium is the income received by the seller (writer) of an option contract to another party. In-the-money option premiums are composed of two factors: intrinsic and extrinsic value. Out-of-the-money options&apos; premiums consist solely of extrinsic value. For stock options, the premium is quoted as a dollar amount per share, and most contracts represent the commitment of 100 shares.</fibo-fnd-utl-av:explanatoryNote>
@@ -341,7 +322,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
-				<owl:hasValue rdf:resource="&fibo-fbc-fi-fi;Option"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option trading strategy</rdfs:label>
@@ -475,14 +456,6 @@
 		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
 		<skos:definition>indicates the issuer of the option</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically, the option writer collects the premium when the option is initially sold.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasRelativePaymentDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
-		<rdfs:label xml:lang="en">has relative payment date</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
-		<skos:definition xml:lang="en">The payment date for the Option Premium.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can be expressed as either an adjustable or relative date. FpML: &apos;The payment date, which can be expressed as either an adjustable or relative date.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasStrikeRate">

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -67,7 +67,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 		<rdfs:label xml:lang="en">Options Ontology</rdfs:label>
-		<dct:abstract>Concepts common to all option contracts. An option gives one party (the holder) the right to purchase or sell the underlying commodity at a given time or times in the future (as determined by the exercise convention), if they choose to do so.</dct:abstract>
+		<dct:abstract>Concepts common to all option contracts. An option gives one party (the holder) the right to purchase or sell the underlying instrument at a given time or times in the future (as determined by the exercise convention), if they choose to do so.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
@@ -149,7 +149,7 @@
 		<rdfs:label xml:lang="en">call option</rdfs:label>
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to buy the assets specified at a fixed price or formula, on or before a specified date</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller (issuer) of the call option assumes the obligation of delivering the assets specified should the buyer exercise the option. The buyer has the option, but not the obligation, to purchase the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller (issuer) of the call option assumes the obligation of delivering the assets specified should the buyer exercise the option.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;EquityOption">
@@ -244,7 +244,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">moneyness</rdfs:label>
 		<skos:definition xml:lang="en">classifier for a derivative relating its strike price to the price of its underlying asset</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Moneyness describes the intrinsic value of an option in its current state. The term moneyness is most commonly used with put and call options and is an indicator as to whether the option would make money if it were exercised immediately. Moneyness can be measured with respect to the underlying stock or other asset&apos;s current/spot price or its future price.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Moneyness describes the intrinsic value of an option in its current state. The term moneyness is most commonly used with put and call options and is an indicator as to the comparative value of the option with respect to its exercise/strike price. Moneyness can be measured with respect to the underlying stock or other asset&apos;s current/spot price or its future price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;OptionHolder">
@@ -257,7 +257,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option holder</rdfs:label>
 		<skos:definition xml:lang="en">party that owns an option</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In a call, the option holder has the right, but not the obligation, to buy the underlying asset, while, in a put, the option holder has the right to sell the underlying asset. An option holder may sell the option contract itself, at which point the buyer becomes the option holder. The holder has an obligation to inform the seller by a certain time if they wish to exercise. Once the instrument is exercised there are typically additional, relevant obligations with regard to settlement.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In a call, the option holder has the right, but not the obligation, to buy the underlying asset, while, in a put, the option holder has the right to sell the underlying asset. An option holder may sell the option contract itself, at which point the buyer becomes the option holder. Once the instrument is exercised there are typically additional, relevant obligations with regard to settlement.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;OptionIssuer">
@@ -360,26 +360,9 @@
 	<owl:Class rdf:about="&fibo-der-drc-opt;PutOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:label xml:lang="en">put option</rdfs:label>
-		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to to sell the assets specified at a fixed price or formula, on or before a specified date</skos:definition>
+		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to sell the assets specified at a fixed price or formula, on or before a specified date</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller of the put option assumes the obligation of buying the assets specified should the buyer exercise the option.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-opt;SingleStockOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;EquityOption"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-						<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">single stock option</rdfs:label>
-		<skos:definition xml:lang="en">equity option whose underlier is a specific equity instrument</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;StandardizedOptionsTerms">
@@ -420,7 +403,7 @@
 	<owl:Class rdf:about="&fibo-der-drc-opt;StrikePrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<rdfs:label xml:lang="en">strike price</rdfs:label>
-		<skos:definition xml:lang="en">price at which an underlying asset may be bought or sold when the contract is exercised</skos:definition>
+		<skos:definition xml:lang="en">price at which a lot of the underlying asset may be bought or sold when the contract is exercised</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For call options, the strike price is the price at which the security may be purchased by the option holder; for put options, the strike price is the price at which the security may be sold.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -490,7 +473,7 @@
 		<rdfs:label>has option writer</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
-		<skos:definition>indicates the original issuer of the option</skos:definition>
+		<skos:definition>indicates the issuer of the option</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically, the option writer collects the premium when the option is initially sold.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -10,6 +10,7 @@
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
+	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
@@ -45,6 +46,7 @@
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
+	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
@@ -91,6 +93,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
@@ -186,13 +189,6 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller (issuer) of the call option assumes the obligation of delivering the assets specified should the buyer exercise the option. The buyer has the option, but not the obligation, to purchase the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;CombinationOption">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:label xml:lang="en">combination option</rdfs:label>
-		<skos:definition xml:lang="en">option constructed from more than one option type, strike price, or expiration date on the same underlying asset</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Simple combinations include option spread trades such as vertical spreads, calendar (or horizontal) spreads, and diagonal spreads. More involved combinations include trades such as Condor or Butterfly spreads which are actually combinations of two vertical spreads.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-opt;EquityOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;VanillaOption"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
@@ -206,6 +202,14 @@
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to buy (via a call option) or sell (via a put option) the underlying equity assets specified at a pre-determined price (i.e., the strike price, fixed or calculated), on or before a specified date (the expiration date)</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For an Equity Option, one contract represents 100 shares of stock.  Equity options settle in &apos;American style&apos;.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-der-opt;ExoticOption">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
+		<rdfs:label xml:lang="en">exotic option</rdfs:label>
+		<skos:definition xml:lang="en">option that has a non-standard payout structure or other feature</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">Commodity Futures Trading Commission (CFTC) glossary, https://www.cftc.gov/LearnAndProtect/EducationCenter/CFTCGlossary/glossary_e.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Exotic options include Asian options and lookback options, and are mostly traded in the over-the-counter market.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;ExtrinsicValue">
@@ -280,28 +284,6 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Moneyness describes the intrinsic value of an option in its current state. The term moneyness is most commonly used with put and call options and is an indicator as to whether the option would make money if it were exercised immediately. Moneyness can be measured with respect to the underlying stock or other asset&apos;s current/spot price or its future price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionGuarantor">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-gty;Guarantor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-drc-bsc;DesignatedContractMarket">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-drc-bsc;DerivativesClearingOrganization">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option guarantor</rdfs:label>
-		<skos:definition xml:lang="en">guarantor that is an options exchange or clearinghouse that guarantees fulfillment of the terms of the option</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In other words, the exchange or clearinghouse guarantees the trade with respect to any losses incurred by the holder in the event of a default by the issuer, not the value of the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionHolder">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Owner"/>
 		<rdfs:subClassOf>
@@ -333,7 +315,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionOnFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;CombinationOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;VanillaOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
@@ -376,6 +358,19 @@
 		<rdfs:label xml:lang="en">option premium</rdfs:label>
 		<skos:definition xml:lang="en">current market price of an option contract</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The option premium is the income received by the seller (writer) of an option contract to another party. In-the-money option premiums are composed of two factors: intrinsic and extrinsic value. Out-of-the-money options&apos; premiums consist solely of extrinsic value. For stock options, the premium is quoted as a dollar amount per share, and most contracts represent the commitment of 100 shares.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-der-opt;OptionTradingStrategy">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;TradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
+				<owl:hasValue rdf:resource="&fibo-fbc-fi-fi;Option"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">option trading strategy</rdfs:label>
+		<skos:definition xml:lang="en">trading tactic involving more than one option type, strike price, or expiration date on the same underlying asset</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Simple combinations include option spread trades such as vertical spreads, calendar (or horizontal) spreads, and diagonal spreads. More involved combinations include trades such as Condor or Butterfly spreads which are actually combinations of two vertical spreads.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-der-der-opt;OutOfTheMoney">
@@ -441,19 +436,6 @@
 		<skos:definition xml:lang="en">equity option whose underlier is a specific equity instrument</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-opt;StandardizedExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StandardizedOptionsTerms"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized exercise terms</rdfs:label>
-		<skos:definition xml:lang="en">Standard exercise terms for an option contract, determined in advance by the exchange. These will become exercise terms of an individual option contract. These may be varied or overridden for individual contracts.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-opt;StandardizedOptionsTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;StandardizedTerms"/>
 		<rdfs:subClassOf>
@@ -492,44 +474,12 @@
 	<owl:Class rdf:about="&fibo-der-der-opt;StrikePrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<rdfs:label xml:lang="en">strike price</rdfs:label>
-		<skos:definition xml:lang="en">The strike price for the option is the agreed price for the transaction if this takes place. Applies to all options types. Action: Make sure that&apos;s there for all Options types.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;TradedOptionPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;ExchangeParticipant"/>
-		<rdfs:label xml:lang="en">traded option principal</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;TradedOptionsCounterparty"/>
-		<skos:definition xml:lang="en">The principal to the Traded Option contract. THis is the party which gives the other party the right to take up the obligation, and which is obliged to honor that transaction if that option is taken up.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;TradedOptionsCounterparty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionHolder"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;ExchangeParticipant"/>
-		<rdfs:label xml:lang="en">traded options counterparty</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;UnderlyingAssetBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
-		<rdfs:label xml:lang="en">underlying asset buyer</rdfs:label>
-		<skos:definition xml:lang="en">buyer of the underlying asset in an option-related transaction</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the party which buys the underlying in the event that the transaction goes ahead.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;UnderlyingAssetSeller">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Seller"/>
-		<rdfs:label xml:lang="en">underlying asset seller</rdfs:label>
-		<skos:definition xml:lang="en">seller of the underlying asset in an option transaction</skos:definition>
+		<skos:definition xml:lang="en">price at which an underlying asset may be bought or sold when the contract is exercised</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For call options, the strike price is the price at which the security may be purchased by the option holder; for put options, the strike price is the price at which the security may be sold.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;VanillaOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-gty;hasGuarantor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionGuarantor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasPriceDeterminationMethod"/>
@@ -545,7 +495,16 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;TradedOptionsCounterparty"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-der-der-opt;OptionHolder">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-fct-mkt;ExchangeParticipant">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -580,7 +539,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExercisePrice">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
 		<rdfs:label xml:lang="en">has exercise price</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+		<rdfs:range rdf:resource="&fibo-der-der-opt;StrikePrice"/>
 		<skos:definition xml:lang="en">specifies a predetermined price at which the holder commits to buy or sell an underlying asset</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en">has strike price</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
@@ -628,7 +587,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExercisePrice"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;StrikePrice"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -647,18 +606,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasLotSize"/>
 				<owl:someValuesFrom rdf:resource="&xsd;decimal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Seller"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -153,36 +153,6 @@
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;CallOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-der-opt;OptionHolder">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-drc-bsc;PayingParty">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-der-opt;OptionIssuer">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-drc-bsc;ReceivingParty">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">call option</rdfs:label>
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to buy the assets specified at a fixed price or formula, on or before a specified date</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
@@ -314,6 +284,19 @@
 		<skos:definition xml:lang="en">issuer granting the rights defined in the option in exchange for some consideration</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-der-opt;OptionListing">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;Listing"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;lists"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Option"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">option listing</rdfs:label>
+		<skos:definition xml:lang="en">listing of an option contract on a derivatives exchange</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-der-opt;OptionOnFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;VanillaOption"/>
 		<rdfs:subClassOf>
@@ -383,36 +366,6 @@
 	
 	<owl:Class rdf:about="&fibo-der-der-opt;PutOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-der-opt;OptionHolder">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-drc-bsc;ReceivingParty">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-der-opt;OptionIssuer">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-drc-bsc;PayingParty">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">put option</rdfs:label>
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to to sell the assets specified at a fixed price or formula, on or before a specified date</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
@@ -492,36 +445,6 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDuration"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-der-opt;OptionHolder">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fbc-fct-mkt;ExchangeParticipant">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-der-opt;OptionIssuer">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fbc-fct-mkt;ExchangeParticipant">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">vanilla option</rdfs:label>
 		<skos:definition xml:lang="en">common option giving the buyer (holder) the right, but not the obligation, to buy (via a call option) or sell (via a put option) the underlying assets specified at a pre-determined price (i.e., the strike price, fixed or calculated), on or before a specified date (the expiration date)</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Vanilla options include call or put options that have no special or unusual features, and are typically exchange traded.</fibo-fnd-utl-av:explanatoryNote>
@@ -561,6 +484,23 @@
 		<skos:definition>indicates the exercise convention specified for the option</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionHolder">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
+		<rdfs:label>has option holder</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionHolder"/>
+		<skos:definition>indicates the owner of the option</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionWriter">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
+		<rdfs:label>has option writer</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
+		<skos:definition>indicates the original issuer of the option</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically, the option writer collects the premium when the option is initially sold.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasRelativePaymentDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
 		<rdfs:label xml:lang="en">has relative payment date</rdfs:label>
@@ -577,6 +517,13 @@
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Option">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionHolder"/>
+				<owl:onClass rdf:resource="&fibo-der-der-opt;OptionHolder"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasCalculatedMarketValue"/>
@@ -600,6 +547,12 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExerciseStyle"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ex;ExerciseConvention"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionWriter"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionIssuer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/DER/RateDerivatives/IROptions.rdf
+++ b/DER/RateDerivatives/IROptions.rdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
+	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-rat-iro "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IROptions/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
@@ -17,7 +17,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IROptions/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
+	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-rat-iro="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IROptions/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
@@ -73,7 +73,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rat-iro;InterestRateCapOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;InterestRateOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;InterestRateOption"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
 		<rdfs:label xml:lang="en">interest rate cap option</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-der-rat-iro;InterestRateFloorOption"/>
@@ -83,7 +83,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rat-iro;InterestRateFloorOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;InterestRateOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;InterestRateOption"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
 		<rdfs:label xml:lang="en">interest rate floor option</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-der-rat-iro;InterestRateCapOption"/>

--- a/DER/SecurityBasedDerivatives/EquityOptions.rdf
+++ b/DER/SecurityBasedDerivatives/EquityOptions.rdf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-sbd-eqo "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquityOptions/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -19,8 +19,8 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquityOptions/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-sbd-eqo="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquityOptions/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -59,8 +59,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqo;EquityBasketOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;BasketOption"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;EquityOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;BasketOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;EquityOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-sbd-eqo;hasAnnex"/>
@@ -82,7 +82,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqo;EquityIndexOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;EquityOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;EquityOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -126,7 +126,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191101/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate duplication with concepts in LCC and eliminated a redundant superclass on FinancialServiceProvider.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to replace the property &apos;characterizes&apos; with &apos;describes&apos; with respect to restrictions on catalogs, and to correct the label on terminated trade.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, eliminate circular and ambiguous definitions, and revise definitions that referenced &apos;face value&apos; improperly.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to rename ownership related properties for consistent alignment with the ownership situational pattern and to add a definition for trading strategy.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to rename ownership related properties for consistent alignment with the ownership situational pattern, add a definition for trading strategy, and loosen the constraint on offeree for offering to be optional.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -418,7 +418,8 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-pty;hasPartyInRole"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;Offeree"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;Offeree"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -440,7 +441,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>offering</rdfs:label>
-		<skos:definition>an expression of interest in providing something to someone that is contigent upon acceptance, forbearance, or some other consideration, as desired by the offeree(s)</skos:definition>
+		<skos:definition>expression of interest in providing something to someone that is contigent upon acceptance, forbearance, or some other consideration, as might be desired by an offeree(s)</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The making of an offer is the first of three steps in the traditional process of forming a valid contract: an offer, an acceptance of the offer, and an exchange of consideration. (Consideration is the act of doing something or promising to do something that a person is not legally required to do, or the forbearance or the promise to forbear from doing something that he or she has the legal right to do.)</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -17,6 +17,7 @@
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
@@ -54,6 +55,7 @@
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
@@ -101,6 +103,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
@@ -113,7 +116,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210401/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210601/ProductsAndServices/FinancialProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified by the FIBO 2.0 RFC, including, but not limited to, the addition of lifecycle events, concepts related to trade settlement, and the definition of a unique transaction identifier (UTI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified as a part of organizational hierarchy simplification and to correct a logical inconsistency with respect to the representation of baskets.</skos:changeNote>
@@ -123,7 +126,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191101/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate duplication with concepts in LCC and eliminated a redundant superclass on FinancialServiceProvider.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to replace the property &apos;characterizes&apos; with &apos;describes&apos; with respect to restrictions on catalogs, and to correct the label on terminated trade.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate references to external dictionary sites that no longer resolve, eliminate circular and ambiguous definitions, and revise definitions that referenced &apos;face value&apos; improperly.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to rename ownership related properties for consistent alignment with the ownership situational pattern.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to rename ownership related properties for consistent alignment with the ownership situational pattern and to add a definition for trading strategy.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -949,6 +952,13 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trader</rdfs:label>
 		<skos:definition>party that engages in the transfer of financial assets in any financial market on behalf of a client or the financial services provider</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradingStrategy">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
+		<rdfs:label>trading strategy</rdfs:label>
+		<skos:definition>approach used for buying and selling in the securities markets</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A trading strategy is a plan whose aim is to make a profit or hedge against risk, based on rules and other criteria used when making trading decisions. A trading strategy may be simple or complex, and involve considerations such as investment style (e.g., value vs. growth), market cap, technical indicators, fundamental analysis, industry sector, level of portfolio diversification, time horizon or holding period, risk tolerance, leverage, tax considerations, and so on.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;UniqueTransactionIdentifier">

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -79,7 +79,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210401/Securities/SecuritiesListings/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210601/Securities/SecuritiesListings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesListings.rdf version of this ontology was revised to reuse the composite date value datatype and add disjointness between registered security and exempt security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate an extraneous subclass axiom.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesListings.rdf version of this ontology was revised to rename isIssuedIn to isIssuedOn, which is more natural to most securities SMEs, generalized certain references to securities exchanges, and eliminate deprecated elements.</skos:changeNote>
@@ -88,7 +88,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesListings.rdf version of this ontology was revised to incorporate the form of registration and loosen the restriction on the number of possible registration authorities for a registered security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues), adjust definitions to eliminate ambiguity, add a property for lot size on listing, and eliminate the now redundant and confusing registered security form class.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate a false positive hygiene testing issue due to a concept whose name included &apos;and&apos; but that actually was a singular concept.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate an unused ontology import and change the range of hasLotSize to xsd:decimal.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate an unused ontology import, changed the range of hasLotSize to xsd:decimal, and modified the definition of listing to point to an offering rather than directly to the instrument that the offering pertains to.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -168,7 +168,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;lists"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Security"/>
+				<owl:onClass rdf:resource="&fibo-sec-sec-iss;SecuritiesOffering"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -186,7 +186,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">listing</rdfs:label>
-		<skos:definition>registry entry for a security that is managed by an exchange and that documents that the security meets the requirements for making that security available for trading on that exchange</skos:definition>
+		<skos:definition>catalog entry for a securities offering managed by an exchange that provides the terms under which that security is made available on that exchange</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en">market listing</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

In preparation for releasing the options ontology, we (1) added TradingStrategy to the financial products and services ontology, (2) moved exotic option back from the exotic options ontology to the main options ontology to fill out the taxonomy, (3) renamed 'combination option' to 'option trading strategy' and made it a subclass of the new trading strategy class, (4) made option on future a subclass of vanilla option, and (5) eliminated several unused classes - option guarantor, standardized exercise terms, traded option principal, traded options counterparty, underlying asset buyer and underlying asset seller.

We have also revised the prefix of the ontology from fibo-der-der-opt to fibo-der-drc-opt so that it corresponds to the other prefixes in the module (for released ontologies).

Fixes: #1542  / DER-101


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


