### PR TITLE
SEC-157 - For a given equity instrument, we are missing the number of shares issued of a given class of share

### DIFF
--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -127,14 +127,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210401/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210601/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments, including features specific to preferred shares.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, clean up ambiguous definitions, and eliminate redundant restrictions related to security form.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add concepts covering additional features of preferred shares, move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology, rename EquityIssuer to ShareIssuer to be clearer about the intent, and add the concept of a price per share.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Equities/EquityInstruments.rdf version of this ontology was revised to rename ownership related properties for consistent alignment with the ownership situational pattern.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Equities/EquityInstruments.rdf version of this ontology was revised to rename ownership related properties for consistent alignment with the ownership situational pattern and to move properties / restrictions that define how many shares have been issued from the issuer to the share.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -911,37 +911,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;EquityInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasShareClass"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&xsd;string"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersOwnershipOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;ShareholdersEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">share</rdfs:label>
-		<skos:definition xml:lang="en">financial instrument that signifies a unit of equity ownership in a corporation, or a unit of ownership in a mutual fund, or interest in a general or limited partnership, or a unit of ownership in a structured product, such as a real estate investment trust</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;ShareIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasFloatingShares"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
@@ -970,10 +939,41 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasShareClass"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-corp-corp;hasSharesAuthorized"/>
 				<owl:someValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersOwnershipOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;ShareholdersEquity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">share</rdfs:label>
+		<skos:definition xml:lang="en">financial instrument that signifies a unit of equity ownership in a corporation, or a unit of ownership in a mutual fund, or interest in a general or limited partnership, or a unit of ownership in a structured product, such as a real estate investment trust</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;ShareIssuer">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;issues"/>
@@ -1199,7 +1199,6 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasFloatingShares">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">has floating shares</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the number of shares that are available for trading, i.e., the number of shares outstanding less closely held shares (those held by insiders) and restricted shares</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A relatively small float results in higher volatility, as a large purchase or sell order will have significant influence on the value of the stock.</fibo-fnd-utl-av:explanatoryNote>
@@ -1251,7 +1250,6 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasSharesIssued">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">has shares issued</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the actual number of shares held by shareholders (i.e., shares outstanding) and treasury shares</skos:definition>
 	</owl:DatatypeProperty>
@@ -1259,7 +1257,6 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasSharesOutstanding">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">has shares outstanding</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the number of shares currently held by shareholders, including those held by retail investors, institutional investors and insiders, and typically available for trading</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The number of outstanding shares is used in calculating key metrics such as a company&apos;s market capitalization, as well as its earnings per share (EPS) and cash flow per share (CFPS).</fibo-fnd-utl-av:explanatoryNote>
@@ -1268,7 +1265,6 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasTreasuryShares">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">has treasury shares</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareIssuer"/>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the number of shares issued but not outstanding, including those that were available in the market at one time but have been repurchased by the company</skos:definition>
 	</owl:DatatypeProperty>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Moved properties / restrictions that define how many shares have been issued/outstanding/treasury/floating from the issuer to the share

Fixes: #1544 / SEC-157


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


