### PR TITLE
Fix to hygiene test 1292

### DIFF
--- a/etc/testing/hygiene/testHygiene1292.sparql
+++ b/etc/testing/hygiene/testHygiene1292.sparql
@@ -5,7 +5,7 @@ prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 ##
 # banner Classes should not refer to multiple concepts.
 
-SELECT DISTINCT ?warning ?resource
+SELECT DISTINCT ?error ?resource
 WHERE
 {
     ?resource ?property owl:Class .
@@ -13,5 +13,5 @@ WHERE
     FILTER (REGEX(str(?resource), "/[^/]+(And|Or)[A-Z0-9][^/]+$") )
     FILTER (!CONTAINS(str(?resource), "InvestmentOrDepositAccount"))
     FILTER (!CONTAINS(str(?resource), "LoanOrCreditAccount"))  
-    BIND (concat ("PRODERROR: Resource ", str(?resource), " may refer to multiple concepts.") AS ?warning)
+    BIND (concat ("PRODERROR: Resource ", str(?resource), " may refer to multiple concepts.") AS ?error)
 }


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This replaces 'warning' with 'error' in hygiene test 1292.

Fixes: #1548 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


