### PR TITLE
DER-103 - Clean up and release the currency contracts ontology

### DIFF
--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -24,7 +24,7 @@
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/">
   		<rdfs:label>About FIBO Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users.  It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release.  Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2021-06-28T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2021-09-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2021 EDM Council, Inc.</sm:copyright>
@@ -94,6 +94,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->		
 		
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>

--- a/DER/AllDER.rdf
+++ b/DER/AllDER.rdf
@@ -40,7 +40,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/">
 		<rdfs:label>Derivatives Domain</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2021-06-28T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2021-09-30T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain</dct:title>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
@@ -77,6 +77,7 @@
 		<sm:keyword>options, futures, rights instruments, swaps</sm:keyword>
 		<sm:moduleAbbreviation>fibo-der</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
@@ -87,7 +88,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210601/AllDER/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210701/AllDER/"/>
 		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for DER is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), Securities (SEC), and Derivatives (DER) domains, excluding individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/DER/DerivativesContracts/CurrencyContracts.rdf
+++ b/DER/DerivativesContracts/CurrencyContracts.rdf
@@ -45,11 +45,11 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/">
 		<rdfs:label xml:lang="en">Currency Contracts Ontology</rdfs:label>
-		<dct:abstract>This ontology defines concepts common to foreign exchange derivatives (spots, forwards, options and swaps).</dct:abstract>
+		<dct:abstract>This ontology defines concepts common to currency spot contracts and foreign exchange derivatives (forwards, options and swaps).</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
@@ -67,8 +67,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/CurrencyContracts/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-drc-cur;CurrencyDerivative">
@@ -241,5 +241,9 @@
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;ExchangeRate"/>
 		<skos:definition xml:lang="en">rate of exchange between two currencies as specified in a spot contract</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&fibo-der-drc-ff;CurrencyFuture">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-cur;CurrencyDerivative"/>
+	</owl:Class>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/FuturesAndForwards.rdf
+++ b/DER/DerivativesContracts/FuturesAndForwards.rdf
@@ -104,7 +104,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/FuturesAndForwards/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to eliminate references to hasContractSize, clean up unnecessary restrictions on Future and Forward, and eliminate the redundant listing class.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210601/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to move designated contract market to the markets ontology in FBC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210601/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to move designated contract market to the markets ontology in FBC and revise the definition of a CurrencyFuture to eliminate an unnecessary superclass and restriction due to the release of CurrencyContracts.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -135,13 +135,6 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-ff;CurrencyFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;CurrencyInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">currency future</rdfs:label>
 		<skos:definition xml:lang="en">futures contract whose underlying asset is an agreement to exchange a specified amount of one currency for another at some point in the future based on pricing stated in the contract</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Description

Revised CurrencyFuture to eliminate redundant subclass and restriction axioms given that CurrencyContracts adds more appropriate restrictions; added the relationship with CurrencyFutures in CurrencyContracts; released CurrencyContracts

Fixes: #1559 / DER-103


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


