### PR TITLE
SEC-135 - Unclear how Dividend class is meant to be used

### DIFF
--- a/DER/DerivativesContracts/FuturesAndForwards.rdf
+++ b/DER/DerivativesContracts/FuturesAndForwards.rdf
@@ -104,7 +104,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/FuturesAndForwards/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to eliminate references to hasContractSize, clean up unnecessary restrictions on Future and Forward, and eliminate the redundant listing class.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210601/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to move designated contract market to the markets ontology in FBC and revise the definition of a CurrencyFuture to eliminate an unnecessary superclass and restriction due to the release of CurrencyContracts.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210601/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to move designated contract market to the markets ontology in FBC and revise the definition of a CurrencyFuture to eliminate an unnecessary superclass and restriction due to the release of CurrencyContracts and to revise the definition of a dividend future to reference the listed share that it tracks rather than the dividend itself.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -158,10 +158,11 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-ff;DividendFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ff;FinancialFuture"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Dividend"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">dividend future</rdfs:label>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -127,7 +127,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210601/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210701/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
@@ -135,6 +135,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class, streamline the representation of voting rights and payment form, clean up ambiguous definitions, and eliminate redundant restrictions related to security form.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityInstruments.rdf version of this ontology was revised to add concepts covering additional features of preferred shares, move the two exhaustive CFI-specific classes to the Equity CFI individuals ontology, rename EquityIssuer to ShareIssuer to be clearer about the intent, and add the concept of a price per share.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Equities/EquityInstruments.rdf version of this ontology was revised to rename ownership related properties for consistent alignment with the ownership situational pattern and to move properties / restrictions that define how many shares have been issued from the issuer to the share.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210601/Equities/EquityInstruments.rdf version of this ontology was revised to revise the definition of dividend to explicitly state that it reflects the announced commitment of a specific dividend rather than a more general policy.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -258,7 +259,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>dividend</rdfs:label>
-		<skos:definition>commitment to distribute a portion of earnings to shareholders, prorated by class of security</skos:definition>
+		<skos:definition>announced commitment to make a specific distribution of a portion of earnings to shareholders, prorated by class of security</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The amount and timing of payment is set by the board of directors, typically quarterly. Dividends may be paid in the form of money, shares, scrip, or on rare occasion, property.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -701,27 +701,9 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundUnitDistributionPolicy"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasExpectedDividend"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundShareClassUnitDividend"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund share class unit</rdfs:label>
 		<skos:definition xml:lang="en">The legal structure in which you can purchase part of an investment pool, defined by a variety of characteristics like investor type, minimum size of investment, distribution type, fee and currency. A fund unit which gives the holder an equity stake in the fund.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From review sessions: Theoretically you can buy a fraction of a share in a fund. This would depend on the legal structure of the fund, e.g. a minimum investment. There is always a distribution plan.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;FundShareClassUnitDividend">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Dividend"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasPolicyTerms.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundDividendPolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund share class unit dividend</rdfs:label>
-		<skos:definition xml:lang="en">Expected dividend payment from a Fund Unit. REVIEW: Does this apply to the Fund as a whole or to a unit in the fund? This term will be redefined following the Funds model restructuring</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundSubscriptionTerms">
@@ -1349,20 +1331,6 @@
 		<skos:definition xml:lang="en">It is possible to hold shares for which the accrued income is distributed, but then reinvested automatically in additional units/shares allocated to the investor.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;dividendPaymentDate">
-		<rdfs:label xml:lang="en">dividend payment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundDividendPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-bd;DayOfMonth"/>
-		<skos:definition xml:lang="en">Day and month on which the dividends would normally be paid.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;dividendPaymentFrequency">
-		<rdfs:label xml:lang="en">dividend payment frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundDividendPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RecurrenceInterval"/>
-		<skos:definition xml:lang="en">The frequency with which income is allocated (or deemed to be allocated) to investors (eg. six-monthly, yearly, etc).</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;dualFund">
 		<rdfs:label xml:lang="en">dual fund</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundProcessingGeneralTerms"/>
@@ -1382,13 +1350,6 @@
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundCouponPolicy"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-bd;DayOfMonth"/>
 		<skos:definition xml:lang="en">The date at which the coupon is substracted from the NAV</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;exDivDate">
-		<rdfs:label xml:lang="en">ex div date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundDividendPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-bd;DayOfMonth"/>
-		<skos:definition xml:lang="en">The date at which the dividend is substracted from the NAV</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;firstAccountingYearEndDate">
@@ -1533,20 +1494,6 @@
 		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundBondUnitCoupon"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasExpectedDividend">
-		<rdfs:label xml:lang="en">has expected dividend</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundShareClassUnit"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundShareClassUnitDividend"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasFundIdentification">
-		<rdfs:subPropertyOf rdf:resource="&lcc-lr;isIdentifiedBy"/>
-		<rdfs:label xml:lang="en">has fund identification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-fund;CollectiveInvestmentVehicle"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;OrganizationIdentifier"/>
-		<skos:definition xml:lang="en">Identification of the investment fund. Note this relationship has no parent, and is a sibling to the identifiaciton relationship for Incorporated Company. As BEI work progresses, these should both have a parent relationship for all legal entitity identification.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasFundPolicy">
 		<rdfs:label xml:lang="en">has fund policy</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-fund;CollectiveInvestmentVehicle"/>
@@ -1609,13 +1556,6 @@
 		<rdfs:label xml:lang="en">has policy terms</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundBondUnitCoupon"/>
 		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundCouponPolicy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasPolicyTerms.1">
-		<rdfs:label xml:lang="en">has policy terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundShareClassUnitDividend"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundDividendPolicy"/>
-		<skos:definition xml:lang="en">Terms for the expected distributions of dividends.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasPortfolio">
@@ -2362,12 +2302,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasDistributionPolicy.1"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundUnitDistributionMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasFundIdentification"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;OrganizationIdentifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

The resolution to this issue clarifies the definition of dividend to explicitly state that it reflects the announced commitment to pay a dividend rather than being something like a more general policy to do so.  We also cleaned up the definition of DividendFuture to point to the equity rather than the specific dividend, and eliminated redundancy related to dividends in the CIV ontology.

Fixes: #1561 / SEC-135


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


