### PR TITLE
SEC-163 - Restructure ABS such that a cash structured finance instrument is a subclass of debt instrument rather than bond

### DIFF
--- a/BP/SecuritiesIssuance/AgencyMBSIssuance.rdf
+++ b/BP/SecuritiesIssuance/AgencyMBSIssuance.rdf
@@ -278,7 +278,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughMBSFinalProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDealProspectus"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOfferingProspectus"/>
 		<rdfs:label xml:lang="en">pass through m b s final prospectus</rdfs:label>
 		<skos:definition xml:lang="en">Term origin:MBS PoC Reviews</skos:definition>
 	</owl:Class>

--- a/MD/DebtTemporal/DebtPricingYields.rdf
+++ b/MD/DebtTemporal/DebtPricingYields.rdf
@@ -962,7 +962,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasWac">
 		<rdfs:label xml:lang="en">has wac</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
 		<rdfs:range rdf:resource="&fibo-md-dbtx-py;WeightedAverageCoupon"/>
 	</owl:ObjectProperty>
 	
@@ -1083,7 +1083,7 @@
 		</rdfs:subClassOf>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument">
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasWac"/>

--- a/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities.rdf
@@ -11,7 +11,8 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
-	<!ENTITY fibo-loan-typ-prod "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/LoanProducts/">
+	<!ENTITY fibo-loan-typ-cr "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/CreditProducts/">
+	<!ENTITY fibo-loan-typ-gen "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/GeneralLoans/">
 	<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities/">
 	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
@@ -37,7 +38,8 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
-	xmlns:fibo-loan-typ-prod="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/LoanProducts/"
+	xmlns:fibo-loan-typ-cr="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/CreditProducts/"
+	xmlns:fibo-loan-typ-gen="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/GeneralLoans/"
 	xmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities/"
 	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
@@ -66,7 +68,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/LoanProducts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/CreditProducts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/GeneralLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
@@ -76,28 +79,34 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;ABSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
-		<rdfs:label xml:lang="en">a b s deal</rdfs:label>
-		<skos:definition xml:lang="en">The issue of a series of Cash Asset Backed Security certificates.</skos:definition>
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AssetBackedSecuritiesOffering">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesOffering"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">asset-backed securities offering</rdfs:label>
+		<skos:definition xml:lang="en">offering involving the issue of a series of cash asset-backed security certificates</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;ABSDealProspectus">
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AssetBackedSecuritiesOfferingProspectus">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedDealProspectus"/>
-		<rdfs:label xml:lang="en">a b s deal prospectus</rdfs:label>
+		<rdfs:label xml:lang="en">asset-backed securities offering prospectus</rdfs:label>
 		<skos:definition xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the asset backed security issue.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AutoLoanABS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AutoLoanAssetBackedSecurity">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPool"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">auto loan a b s</rdfs:label>
-		<skos:definition xml:lang="en">ABS issued by auto finance companies and are backed by underlying pools of auto-related loans or leases.</skos:definition>
+		<rdfs:label xml:lang="en">auto loan asset-backed security</rdfs:label>
+		<skos:definition xml:lang="en">asset-backed security issued by an auto finance company that is backed by an underlying pool of auto-related loans or leases</skos:definition>
 		<skos:editorialNote xml:lang="en">Leases not shown at present. Added during later review.</skos:editorialNote>
 	</owl:Class>
 	
@@ -106,31 +115,19 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPoolConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;poolHasLoanType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-prod;AutoLoanPurpose"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-gen;AutoLoan"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">auto loan pool</rdfs:label>
 		<skos:definition xml:lang="en">A loan pool covering automobile-related loans.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AutoLoanPoolConstituent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-		<rdfs:label xml:lang="en">auto loan pool constituent</rdfs:label>
-		<skos:definition xml:lang="en">An auto loan defined as a constituent of an Auto Loan Pool.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument">
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;isSubordinatedTo"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+				<owl:onClass rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -151,7 +148,7 @@
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash asset backed security instrument</rdfs:label>
+		<rdfs:label xml:lang="en">cash asset-backed security</rdfs:label>
 		<skos:definition xml:lang="en">An asset-backed security is a type of bond or note that is based on pools of assets, or collateralized by the cash flows from a specified pool of underlying assets. Assets are pooled to make otherwise minor and uneconomical investments worthwhile, while also reducing risk by diversifying the underlying assets.</skos:definition>
 		<skos:editorialNote xml:lang="en">Definition of ABS is one with any kind of asset underlying which is not a mortgage, e.g. a loan, credit card etc. Asset Backed Securities, for example home equity loans (HEL), credit cards, etc. These are securities backed by receivables [payments] that are either secured (HEL) or unsecured (credit card), tranched on the basis of prepayment and default risks. Action: Determine where mobile home and second mortgage based securities fit in, and add to the relevant definition. Outcome: these would be specialised kinds of pools of loans and are therefore reflected by specific typs of Cash ABS, in the same way as Auto Loan ABS are defined. Note also that an issue of ABS certificates (contracts) may have different tranches which relate to these different kinds of loan, and other as yet undefined types of loan. These are capable of extension into indefinite numbers of loan types / pool types, so it would not be practical to include all the possibilities in the standard terms other than as selectable types of loan in the loan type selection data range.</skos:editorialNote>
 		<skos:editorialNote xml:lang="en">The issuer of the (Cash) Asset Backed Security. This is generally a Special Purpose Vehicle set up by a corporation. Further details from riskglossary.com: To create an ABS, a corporation creates a special purpose vehicle to which it sells the assets. While is is common to speak of the corporation as the issuer of the ABS, legally, it is the trust or special purpose vehicle that is the issuer. It sells securities to investors. To protect investors from possible bankruptcy of the corporation, there are three legal safeguards: - Transfer of assets from the corporation is a non-recourse, true sale. - Investors receive a perfected interest in the assets&apos; cash flows. - A non-consolidation legal opinion is obtained certifying that assets of the trust or special purpose vehicle cannot be consolidated with the corporation&apos;s assets in the event of bankruptcy. These same safeguards allow the corporation to remove the assets from its balance sheet. The corporation generally continues to service the assets - collecting interest and principal payments, pursuing delinquencies, etc. It is paid out of asset cash flows for providing these ongoing services.</skos:editorialNote>
@@ -177,35 +174,40 @@
 		<skos:definition>method of providing investors with a relatively predictable repayment schedule, even though the underlying assets are nonamortizing</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CreditCardABS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CreditCardAssetBackedSecurity">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;CreditCardPool"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit card a b s</rdfs:label>
-		<skos:definition xml:lang="en">These are generally issued by a bank and backed by largely unsecured obligations owed by individuals to the issuer of the card. Definition origin:CESR</skos:definition>
+		<rdfs:label xml:lang="en">credit card asset-backed security</rdfs:label>
+		<skos:definition xml:lang="en">asset-backed security based on credit card receivables</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">Federal Deposit Insurance Corporation (FDIC) Credit Card Securitization Manual, available at https://www.fdic.gov/regulations/examinations/credit_card_securitization/ch2.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Credit card securitizations currently represent the primary funding vehicle for unsecured revolving consumer credit. Similar to mortgage and other asset securitizations, the financial institution that originates the credit card receivables sells a group of these receivables to a trust. The trust then creates and sells certificates backed by the credit card receivables to investors, which are predominately institutional investors. Very few credit card ABS are marketed to retail customers, primarily due to the complex nature of the transactions and the need to continually monitor various performance indices on the underlying receivables. The underlying credit card receivables generate income to support the interest payments on the certificates.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CreditCardPool">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;DebtPool"/>
 		<rdfs:label xml:lang="en">credit card pool</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+		<skos:definition xml:lang="en">pool of outstanding balances on designated accounts</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">Federal Deposit Insurance Corporation (FDIC) Credit Card Securitization Manual, available at https://www.fdic.gov/regulations/examinations/credit_card_securitization/ch2.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In a credit card securitization transaction only the receivables are sold, not the accounts that generate the receivables. The financial institution retains legal ownership of the credit card accounts and can continue to change the terms on the accounts. Accounts corresponding to securitized loans are typically referred to as the designated accounts (or sometimes trust accounts). The initial outstanding balances on the designated accounts are sold to the trust as are the rights to any new charges on the designated accounts. Subsequently, as cardholder purchase activity generates more receivables on the designated accounts, these new receivables are purchased by the trust from the originating institution/seller/transferor. The trust uses the monthly principal payments received from the cardholders to acquire these new charges or receivables. When the securitization is initially set up, the originating institution/seller adds sufficient receivables to support the principal balance of the certificates plus an additional amount (seller&apos;s interest) that serves to absorb fluctuations in the outstanding balance of the receivables. The originating institution/seller will make subsequent additions to the trust in order to keep the seller&apos;s interest at the required level.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;EsotericABS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;EsotericAssetBackedSecurity">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingCashflow"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">esoteric a b s</rdfs:label>
-		<skos:definition xml:lang="en">An asset backed security based on some underlying promised future cashflow.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">New example from Goldman Sachs hearing April 2010: Exotic ABS bsaed on box office takings for movies.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label xml:lang="en">esoteric asset-backed security</rdfs:label>
+		<skos:definition xml:lang="en">asset-backed security based on some underlying promised future cashflow</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Esoteric asset-backed securities have been built based on cash flows from movie revenues, royalty payments, aircraft landing slots, toll roads, and solar photovoltaics.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;FullyAmortizingBond">
@@ -222,16 +224,10 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPoolConstituent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cr;HomeEquityLineOfCredit"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">home equity line of credit pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPoolConstituent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-		<rdfs:label xml:lang="en">home equity line of credit pool constituent</rdfs:label>
-		<skos:definition xml:lang="en">A line of credit defined as a constituent of a Home Equity Line Of Credit Pool.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;IndexAmortizingBond">
@@ -430,16 +426,9 @@
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-abs;description">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">a textual description of the cash flow used as an asset.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets">
 		<rdfs:label xml:lang="en">has underlying assets</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity"/>
 		<rdfs:range>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
@@ -458,24 +447,9 @@
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasUnderlyingCashflow">
 		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
 		<rdfs:label xml:lang="en">has underlying cashflow</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;EsotericABS"/>
+		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;EsotericAssetBackedSecurity"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset"/>
 	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;poolHasLoanType">
-		<rdfs:label xml:lang="en">pool has loan type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-prod;LoanPurpose"/>
-		<skos:definition xml:lang="en">The type of loans that make up the pool.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-abs;revolving">
-		<rdfs:label xml:lang="en">revolving</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CreditCardPool"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Feature whereby the principal can go up or down. This means that the loan could pay down principal or add principal to it.</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;specifiesIndexParameter">
 		<rdfs:label>specifies index parameter</rdfs:label>
@@ -486,7 +460,7 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-abs;tranche">
 		<rdfs:label xml:lang="en">tranche</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition xml:lang="en">Security Tranche that this ABS security forms part of.</skos:definition>
 	</owl:DatatypeProperty>

--- a/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities.rdf
@@ -54,9 +54,23 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities/">
-		<rdfs:label xml:lang="en">AssetBackedSecurities</rdfs:label>
+		<rdfs:label xml:lang="en">Asset-backed Securities Ontology</rdfs:label>
 		<dct:abstract>Debt securities backed by a pool of assets, including loans of various kinds, credit card pools and home equity lines of credit, as well as esoteric assets.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/LOAN/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-sec-dbt-ab-abs</sm:fileAbbreviation>
+		<sm:filename>AssetBackedSecurities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -149,9 +163,11 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">cash asset-backed security</rdfs:label>
-		<skos:definition xml:lang="en">An asset-backed security is a type of bond or note that is based on pools of assets, or collateralized by the cash flows from a specified pool of underlying assets. Assets are pooled to make otherwise minor and uneconomical investments worthwhile, while also reducing risk by diversifying the underlying assets.</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition of ABS is one with any kind of asset underlying which is not a mortgage, e.g. a loan, credit card etc. Asset Backed Securities, for example home equity loans (HEL), credit cards, etc. These are securities backed by receivables [payments] that are either secured (HEL) or unsecured (credit card), tranched on the basis of prepayment and default risks. Action: Determine where mobile home and second mortgage based securities fit in, and add to the relevant definition. Outcome: these would be specialised kinds of pools of loans and are therefore reflected by specific typs of Cash ABS, in the same way as Auto Loan ABS are defined. Note also that an issue of ABS certificates (contracts) may have different tranches which relate to these different kinds of loan, and other as yet undefined types of loan. These are capable of extension into indefinite numbers of loan types / pool types, so it would not be practical to include all the possibilities in the standard terms other than as selectable types of loan in the loan type selection data range.</skos:editorialNote>
+		<skos:definition xml:lang="en">debt instrument backed by receivables other than those arising out of real estate, loans or mortgages</skos:definition>
+		<skos:editorialNote xml:lang="en">Asset Backed Securities, for example home equity loans (HEL), credit cards, etc. These are securities backed by receivables [payments] that are either secured (HEL) or unsecured (credit card), tranched on the basis of prepayment and default risks. Action: Determine where mobile home and second mortgage based securities fit in, and add to the relevant definition. Outcome: these would be specialised kinds of pools of loans and are therefore reflected by specific typs of Cash ABS, in the same way as Auto Loan ABS are defined. Note also that an issue of ABS certificates (contracts) may have different tranches which relate to these different kinds of loan, and other as yet undefined types of loan. These are capable of extension into indefinite numbers of loan types / pool types, so it would not be practical to include all the possibilities in the standard terms other than as selectable types of loan in the loan type selection data range.</skos:editorialNote>
 		<skos:editorialNote xml:lang="en">The issuer of the (Cash) Asset Backed Security. This is generally a Special Purpose Vehicle set up by a corporation. Further details from riskglossary.com: To create an ABS, a corporation creates a special purpose vehicle to which it sells the assets. While is is common to speak of the corporation as the issuer of the ABS, legally, it is the trust or special purpose vehicle that is the issuer. It sells securities to investors. To protect investors from possible bankruptcy of the corporation, there are three legal safeguards: - Transfer of assets from the corporation is a non-recourse, true sale. - Investors receive a perfected interest in the assets&apos; cash flows. - A non-consolidation legal opinion is obtained certifying that assets of the trust or special purpose vehicle cannot be consolidated with the corporation&apos;s assets in the event of bankruptcy. These same safeguards allow the corporation to remove the assets from its balance sheet. The corporation generally continues to service the assets - collecting interest and principal payments, pursuing delinquencies, etc. It is paid out of asset cash flows for providing these ongoing services.</skos:editorialNote>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">ABS</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;ControlledAmortizationBond">

--- a/SEC/Debt/AssetBackedSecurities/CDOs.rdf
+++ b/SEC/Debt/AssetBackedSecurities/CDOs.rdf
@@ -250,12 +250,6 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;overseenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioTrustee"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">c d o portfolio</rdfs:label>
 		<skos:definition xml:lang="en">A portfolio in which the reference assets of the CDO are held.</skos:definition>
 	</owl:Class>
@@ -270,11 +264,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">c d o portfolio manager</rdfs:label>
 		<skos:definition xml:lang="en">The portfolio manager for a managed CDO or arbitrage CDO (also called an asset manager). This assumes that the role is the same in both cases.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOPortfolioTrustee">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;Trustee"/>
-		<rdfs:label xml:lang="en">c d o portfolio trustee</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOReferenceObligation">
@@ -697,12 +686,6 @@
 		<rdfs:label xml:lang="en">has origination objective</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;overseenBy">
-		<rdfs:label xml:lang="en">overseen by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioTrustee"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;ratedAtIssue">

--- a/SEC/Debt/AssetBackedSecurities/CDOs.rdf
+++ b/SEC/Debt/AssetBackedSecurities/CDOs.rdf
@@ -157,7 +157,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDODeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationOffering"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasConstituent"/>
@@ -392,7 +392,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CollateralizedLoanObligationOffering">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationOffering"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>

--- a/SEC/Debt/AssetBackedSecurities/CDOs.rdf
+++ b/SEC/Debt/AssetBackedSecurities/CDOs.rdf
@@ -157,7 +157,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDODeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasConstituent"/>
@@ -351,7 +351,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">cash c d o tranche</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity"/>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
 	</owl:Class>
 	
@@ -387,31 +387,21 @@
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cdo;CollateralizedLoanObligation"/>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
 		<skos:definition xml:lang="en">structured debt security that has investment-grade bonds as its underlying assets backed by the receivables on high-yield or junk bonds</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">CBO</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A multitranche debt structure similar in some respects to a collateralized mortgage obligation (CMO) structure. Typically low-rated bonds rather than mortgages serve as the collateral. The organization creating and promoting the structure usually holds the underlying equity and may also collect a fee. Junk bonds are typically not investment grade, but because they pool several types of credit quality bonds together, they offer enough diversification to be &quot;investment grade.&quot; For example high yield [emerging market] CBO which consists of a portfolio of different high yield [emerging market] bonds. Investopedia: Similar in structure to a collateralized mortgage obligation (CMO), but different in that CBOs represent different levels of credit risk, not different maturities. Defoinition Origin:Investopedia</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CollateralizedBondObligationDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
-		<rdfs:label xml:lang="en">collateralized bond obligation deal</rdfs:label>
-		<skos:definition xml:lang="en">An issue of Collateralized Bond Obligation notes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CollateralizedLoanObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationInstrument"/>
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CollateralizedLoanObligationOffering">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">collateralized loan obligation</rdfs:label>
+		<rdfs:label xml:lang="en">collateralized loan obligation offering</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CollateralizedLoanObligationDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
-		<rdfs:label xml:lang="en">collateralized loan obligation deal</rdfs:label>
-		<skos:definition xml:lang="en">An issue of Collateralized Loan Obligations.</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">CLO offering</fibo-fnd-utl-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;Creditworthiness">

--- a/SEC/Debt/AssetBackedSecurities/CDOs.rdf
+++ b/SEC/Debt/AssetBackedSecurities/CDOs.rdf
@@ -384,7 +384,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">collateralized bond obligation</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cdo;CollateralizedLoanObligation"/>
+		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cdo;CollateralizedLoanObligationOffering"/>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
 		<skos:definition xml:lang="en">structured debt security that has investment-grade bonds as its underlying assets backed by the receivables on high-yield or junk bonds</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">CBO</fibo-fnd-utl-av:abbreviation>

--- a/SEC/Debt/AssetBackedSecurities/CMOs.rdf
+++ b/SEC/Debt/AssetBackedSecurities/CMOs.rdf
@@ -41,7 +41,7 @@
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyCMO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;hasUnderlyingPool"/>
@@ -120,7 +120,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;CMODeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligation"/>
 		<rdfs:label xml:lang="en">c m o deal</rdfs:label>
 		<skos:definition xml:lang="en">An issue of Collateralized mortgaged Obligations.</skos:definition>
 	</owl:Class>

--- a/SEC/Debt/AssetBackedSecurities/CMOs.rdf
+++ b/SEC/Debt/AssetBackedSecurities/CMOs.rdf
@@ -41,7 +41,7 @@
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyCMO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationOffering"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;hasUnderlyingPool"/>
@@ -120,7 +120,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;CMODeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationOffering"/>
 		<rdfs:label xml:lang="en">c m o deal</rdfs:label>
 		<skos:definition xml:lang="en">An issue of Collateralized mortgaged Obligations.</skos:definition>
 	</owl:Class>

--- a/SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities.rdf
@@ -17,6 +17,7 @@
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/MortgageLoans/">
 	<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/">
 	<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities/">
 	<!ENTITY fibo-sec-dbt-ab-cmo "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/CMOs/">
@@ -51,6 +52,7 @@
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/MortgageLoans/"
 	xmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"
 	xmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities/"
 	xmlns:fibo-sec-dbt-ab-cmo="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/CMOs/"
@@ -68,9 +70,26 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities/">
-		<rdfs:label xml:lang="en">MortgageBackedSecurities</rdfs:label>
+		<rdfs:label xml:lang="en">Mortgage-backed Securities Ontology</rdfs:label>
 		<dct:abstract>Mortgage backed securities are like asset backed securities except that the underlying loan pool is a pool of mortgage loans.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BP/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/LOAN/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/MD/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/CMOs/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-sec-dbt-ab-mbs</sm:fileAbbreviation>
+		<sm:filename>MortgageBackedSecurities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/"/>
@@ -87,9 +106,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/MortgageLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/CDOs/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/CMOs/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
@@ -115,7 +134,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;AgencyMBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOffering"/>
 		<rdfs:label xml:lang="en">agency m b s deal</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal"/>
 		<skos:definition xml:lang="en">An issue of securities backed by pools of mortgages held by government agencies.</skos:definition>
@@ -237,24 +256,6 @@
 		<skos:definition xml:lang="en">A non agency mortgage pool which has been securitized as part of a tranched Mortgage Backed Security.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesOffering"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;SecuritizedMortgagePool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">m b s deal</rdfs:label>
-		<skos:definition xml:lang="en">The issue of a series of Mortgage Backed Security certificates.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSDealProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedDealProspectus"/>
-		<rdfs:label xml:lang="en">m b s deal prospectus</rdfs:label>
-		<skos:definition xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the mortgage backed security issue. Term origin:SMER</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSIssuer">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
 		<rdfs:subClassOf>
@@ -303,12 +304,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageDebt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isCharacterizedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity"/>
 			</owl:Restriction>
@@ -319,19 +314,35 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MBSIssuer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage backed security instrument</rdfs:label>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">mortgage-backed security</rdfs:label>
+		<skos:definition xml:lang="en">debt obligations that represent claims to the cash flows from pools of mortgage loans, most commonly on residential property</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">MBS</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>Mortgage loans are purchased from banks, mortgage companies and other originators, and then assembled into pools by a governmental, quasigovernmental or private entity. The entity then issues securities that represent claims on the principal and interest payments made by borrowers on the loans in the pool, a process known as securitization.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageCollateral">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
-		<rdfs:label xml:lang="en">mortgage collateral</rdfs:label>
-		<skos:definition xml:lang="en">Mortgage Debt Assets pledged to a lender until a loan is repaid. Further notes: This provides one means by which some extension of finance (such as a loan, debt or equity issue) is under-written.</skos:definition>
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOffering">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesOffering"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;SecuritizedMortgagePool"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">mortgage-backed security offering</rdfs:label>
+		<skos:definition xml:lang="en">The issue of a series of Mortgage Backed Security certificates.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageDebt">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedDebt"/>
-		<rdfs:label xml:lang="en">mortgage debt</rdfs:label>
-		<skos:definition xml:lang="en">Mortgage debt issued under a Mortgage Backed Security.</skos:definition>
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOfferingProspectus">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedDealProspectus"/>
+		<rdfs:label xml:lang="en">mortgage-backed security offering prospectus</rdfs:label>
+		<skos:definition xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the mortgage backed security issue. Term origin:SMER</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgagePool">
@@ -339,11 +350,11 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePoolConstituent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;Mortgage"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">mortgage pool</rdfs:label>
-		<skos:definition xml:lang="en">A number of mortgages combined into a single pool and used as an asset.</skos:definition>
+		<skos:definition xml:lang="en">loan pool consisting of mortgages that are held in trust as collateral for the issuance of a mortgage-backed security</skos:definition>
 		<skos:editorialNote xml:lang="en">Analytics review session notes: Dated facts (for non agency mortgage pools): Aggregate of : Scheduled payments (% and $) Payments Prepayments (% and $ notional) Default amounts (statistics: Prepayments: (start at 0 and ramp up and then level off (why?)) SMM basic measure monthly Basis CPR C? Prepayment Rate based on SMM annualised PSA based on CPR takes the COR and applies a curve to the rate of prepayments on the model. (%) e.g. 100% PSA is applied to model. 200% PSA implies x%CPR per month Tries to reflect how prepayments in a pool will accelerate and then burn out. This reflects the nature of a mortgage pool, elgl why people will prepay, refinance, address selection and so on i.e. local economy facts. so those will drop out of the pool and you are left with those who will not. that&apos;s why it levels off. So who originates these figures? Is it measured ongoing?: No . Used to determine a pricing speed when marketing the security to investors. So this is part of the primary market / issuance where there is marketing. These are the estimated figures as they will be at issue. PSA may also be used as triggers. 100 - 400% PSA band - if you go outside that band, may change payment behaviour of those classes. Defaults: measures or rate of default CDR conditional default rate (annual) MDR Monhtly default rate - like CPR = Rate over time. - both defined as Rates. (%) Figures are originated by the servicer of the debt pool. Each serviceer will have their own formats but will do info on prepayments, llosses, detauls on specific loans and so on.</skos:editorialNote>
 		<skos:editorialNote xml:lang="en">The class Mortgage Pool originally had a property &apos;pool type&apos; referring to a selection list of textual stylings of pool types. Those are now replaced with actual sub types of mortgage pool. Here are the original notes and definition that went with the enumerated list of pool types: 
 
@@ -365,12 +376,6 @@ Under Agency mortgages, basically you have various types of pools under the vari
 As far as definitions:The simple definition is that each of these pool types represents pools of mortgages that have conformed to certain standards (that change periodically) that make them &quot;conforming&quot; -- such as mortgage balance under a certain threshold, creditworthiness, loan-to-value, etc. Also, GNMA is explicitly backed by the US government, while FNMA and FHLMC are only implicitly backed by the US government. Perhaps there needs to be some research done on the parameters for what makes a loan conforming or not. 
 
 Consensus:Review.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgagePoolConstituent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-		<rdfs:label xml:lang="en">mortgage pool constituent</rdfs:label>
-		<skos:definition xml:lang="en">Amortgage defined as a constituent of a Mortgage Pool.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyIOTranche">
@@ -457,7 +462,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOffering"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;isAlso"/>
@@ -471,7 +476,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSDealProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDealProspectus"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOfferingProspectus"/>
 		<rdfs:label xml:lang="en">pass through m b s deal prospectus</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
 		<skos:definition xml:lang="en">The written prospectus for an agency, pass through issue of Mortgage Backed Securities</skos:definition>
@@ -513,7 +518,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOffering"/>
 		<rdfs:label xml:lang="en">private label m b s deal</rdfs:label>
 	</owl:Class>
 	
@@ -554,8 +559,9 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SecuritizedMortgagePool">
-		<rdfs:label xml:lang="en">securitized mortgage pool</rdfs:label>
-		<skos:definition xml:lang="en">A mortgage pool which is securitized as part of the issue of some mortgage backed security.</skos:definition>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
+		<skos:definition xml:lang="en">mortgage pool that is securitized as part of the issue of some mortgage backed security</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a logical union of a non agency mortgage pool which is securitized and an agency mortgage pool which has been securitized.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -607,7 +613,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOffering"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;isAlso.1"/>
@@ -618,7 +624,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDealProspectus"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOfferingProspectus"/>
 		<rdfs:label xml:lang="en">tranched m b s deal prospectus</rdfs:label>
 	</owl:Class>
 	
@@ -714,8 +720,8 @@ Consensus:Review.</skos:editorialNote>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough">
 		<rdfs:label xml:lang="en">pass through</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
+		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityOffering"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether the cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
 	</owl:DatatypeProperty>

--- a/SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities.rdf
@@ -100,14 +100,14 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument">
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurity">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;hasTrancheType"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheType"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool">
@@ -144,7 +144,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;CommercialMBS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
 		<rdfs:label xml:lang="en">commercial m b s</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;ResidentialMBS"/>
 	</owl:Class>
@@ -238,7 +238,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesOffering"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
@@ -299,7 +299,7 @@
 		<skos:definition xml:lang="en">Specific kinds of tranche are modeled for example and investigation only and have been removed from the diagrams. These will be removed from the final model.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument">
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -478,7 +478,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;hasNote"/>
@@ -535,7 +535,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;ResidentialMBS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
 		<rdfs:label xml:lang="en">residential m b s</rdfs:label>
 		<skos:definition xml:lang="en">Residential Mortgage-Backed Securities, which are trust certificates (bonds) backed by a pool of residential mortgage loans.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notes from CESR: They are issued by banks and backed by an underlying pool of residential mortgages. There can be some distinctions between prime RMBS and sub-prime/non-conforming RMBS although there is no consensus about what constitutes a sub-prime/non-conforming mortgage in Europe.</fibo-fnd-utl-av:explanatoryNote>
@@ -623,7 +623,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;cashflowPrecedence"/>
@@ -682,7 +682,7 @@ Consensus:Review.</skos:editorialNote>
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;hasNote">
 		<rdfs:subPropertyOf rdf:resource="&lcc-cr;hasPart"/>
 		<rdfs:label xml:lang="en">has note</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;SecurityNote"/>
 	</owl:ObjectProperty>
 	
@@ -708,14 +708,14 @@ Consensus:Review.</skos:editorialNote>
 		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isPartOf"/>
 		<rdfs:label xml:lang="en">is slice of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;SecurityNote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
 		<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-mbs;hasNote"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough">
 		<rdfs:label xml:lang="en">pass through</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurity"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether the cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
 	</owl:DatatypeProperty>

--- a/SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities.rdf
@@ -657,13 +657,6 @@ Consensus:Review.</skos:editorialNote>
 		<skos:definition xml:lang="en">The party which agrees to buy any certificates that are not bought by investors Term origin:MBS PoC Reviews</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;Trustee">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">trustee</rdfs:label>
-		<skos:definition xml:lang="en">A party which has some role in relation to some financial investment (portfolio, issue etc.) which is formally defined as being a &quot;Trustee&quot; in that context.</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition is a bit self referential at present. Working definition for this class (added April 2010 as making CDO Portfolio Trusttee a direct child of &quot;Party&quot; seemed too simplistic). Action: Other types of Trustee need to be added to this class.</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;cashflowPrecedence">
 		<rdfs:label xml:lang="en">cashflow precedence</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>

--- a/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities.rdf
@@ -42,10 +42,20 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities/">
-		<rdfs:label xml:lang="en">PoolBackedSecurities</rdfs:label>
+		<rdfs:label xml:lang="en">Pool-backed Securities Ontology</rdfs:label>
 		<dct:abstract>Concepts common to asset backed and mortgage backed securities, including pools, instruments, prospectuses and deals common concepts. 
 		Note that in common industry parlance, the term &apos;asset backed security&apos; is used to refer to securities which specifically do not have a mortgage loan pool as their underlying asset. For this reason, this ontology provides a common parent to both asset backed and mortgage backed securities, which is effectively an asset backed security in the broader sense. This has been labeled as &apos;pool backed security instrument&apos; as there is no common industry name for this common parent class, other than &apos;asset backed security&apos;.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-sec-dbt-ab-pbs</sm:fileAbbreviation>
+		<sm:filename>PoolBackedSecurities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>

--- a/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities/">
@@ -25,6 +26,7 @@
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/PoolBackedSecurities/"
@@ -48,6 +50,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
@@ -60,7 +63,6 @@
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
@@ -73,7 +75,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrumentPool">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrumentPool"/>
-		<rdfs:label xml:lang="en">cash structured finance instrument pool</rdfs:label>
+		<rdfs:label xml:lang="en">cash-structured finance instrument pool</rdfs:label>
 		<skos:definition xml:lang="en">A pool investment consisting of a collection of cash structured finance instruments.</skos:definition>
 	</owl:Class>
 	
@@ -89,15 +91,9 @@
 		<skos:definition xml:lang="en">Debt issued under some Security, with some Collateral.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal">
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CollateralizedObligationOffering">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;DebtOffering"/>
-		<rdfs:label xml:lang="en">collateralized obligation deal</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CollateralizedObligationInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
-		<rdfs:label xml:lang="en">collateralized obligation instrument</rdfs:label>
+		<rdfs:label xml:lang="en">collateralized obligation</rdfs:label>
 		<skos:definition xml:lang="en">Pending further investigation. At present: CDO = issued against pool of securities MBS = issued against pool of individual debts (base loans) Action: identify if this is the case. Option 1: Model as it was; Option 2: Add a level of detail in between, whereby there is a pool of pools or some other such thing Option 3: this is a terminological thing only in that CDOs are never referred to as a parent of CMO for purely teerminological reasons as per ABS v MBS in which case we would add in a terminological layer.</skos:definition>
 	</owl:Class>
 	
@@ -107,21 +103,27 @@
 		<skos:definition xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the pool backed security issue. Term origin:SMER</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal">
+	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesOffering">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;DebtOffering"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool backed securities deal</rdfs:label>
+		<rdfs:label xml:lang="en">pool-backed securities offering</rdfs:label>
 		<skos:definition xml:lang="en">The issue of a series of Pool Backed Security certificates. These are (at least in this context) securities issued backed by a pool of individual loans, mortgages or other individual loan products.</skos:definition>
 		<skos:editorialNote xml:lang="en">This term makes the distinction, perhaps artificial, between deals backed by pools of individual debt (this term), and deals backed by pools of securities (collateralized deals). This structure of relations between kinds of deals may prove to be a little artificial, but it reflects the structure of relations between kinds of securities, arrived at in earlier SME reviews. That is, Pool Backed Security (which breaks down into ABS and MBS) has a pool of individual loan products (a sub type of which is mortgage loans). The terms reflect the fact that in common parlance the term &quot;ABS&quot; is taken to mean something which is explicitly NOT a MBS but can be any other type of loan or credit based security, hence the creation of the non standard term &quot;Pool Backed Security&quot;. The naming of deals simply attempts to reflect that. Terms to be included in Deal (per PoC conversations): Underwriters Issuer Deal Number Series number Deal Value Different collateral pools that support the deal. Review existing terms and make sure all covered.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
@@ -135,17 +137,16 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">pool-backed security</rdfs:label>
-		<skos:definition xml:lang="en">A type of bond or note which derives its cashflow from some underlying pool of debt in which loans or mortgage advanced to borrowers are pooled together for the purposes of creating this type of security. Further notes: This is distinguished from CDO instruments which have an underlying pool of debt securities, as distinct from an underlying pool of loan products such as mortgages, credit cards or loans.</skos:definition>
+		<skos:definition xml:lang="en">bond or note that derives its cashflow from some underlying pool of debt in which loans or mortgage advanced to borrowers are pooled together for the purposes of creating this type of security</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;DebtPool"/>
 		<rdfs:label xml:lang="en">securitized debt pool</rdfs:label>
-		<skos:definition xml:lang="en">pool of individual debt instruments (such as loans or mortgages) which is securitized as part of the issue of some security</skos:definition>
+		<skos:definition xml:lang="en">pool of individual debt instruments (such as loans or mortgages) that is securitized as part of the issue of some security</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;NonNegotiableSecurity"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 		<rdfs:label xml:lang="en">structured finance instrument</rdfs:label>
 		<skos:definition xml:lang="en">debt instrument that has periodic principal payments with the amount of principal that is paid being dictated by a published factor</skos:definition>
@@ -154,8 +155,15 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrumentPool">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;InstrumentPool"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasConstituent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">structured finance instrument pool</rdfs:label>
-		<skos:definition xml:lang="en">A pool investment consisting of a collection of structured finance instruments.</skos:definition>
+		<skos:definition xml:lang="en">pool consisting of a collection of structured finance instruments</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;backs">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Preliminary restructuring of asset-backed securities and some renaming to replace abbrevations with full names based on discussion in the SEC FCT

Fixes: #1570 / SEC-163


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


