### PR TITLE
DER-105 - Definitions in the commodities ontology need additional work in preparation for release

### DIFF
--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -94,6 +94,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->		
 		
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
@@ -264,7 +265,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20210601/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20210901/AboutFIBOProd/"/>
   </owl:Ontology>
 
 </rdf:RDF>

--- a/DER/AllDER.rdf
+++ b/DER/AllDER.rdf
@@ -3,6 +3,8 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-all "https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-der-drc-comm "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/">
+	<!ENTITY fibo-der-drc-cur "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/">
 	<!ENTITY fibo-der-drc-ff "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/">
 	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
@@ -22,6 +24,8 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-all="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-der-drc-comm="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"
+	xmlns:fibo-der-drc-cur="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"
 	xmlns:fibo-der-drc-ff="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"
 	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
@@ -77,6 +81,7 @@
 		<sm:keyword>options, futures, rights instruments, swaps</sm:keyword>
 		<sm:moduleAbbreviation>fibo-der</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
@@ -88,7 +93,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210701/AllDER/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210901/AllDER/"/>
 		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for DER is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), Securities (SEC), and Derivatives (DER) domains, excluding individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/DER/DerivativesContracts/CommoditiesContracts.rdf
+++ b/DER/DerivativesContracts/CommoditiesContracts.rdf
@@ -96,7 +96,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">cash-settled forward contract</rdfs:label>
-		<skos:definition xml:lang="en">derivative instrument where, upon expiration or exercise, the seller of the financial instrument does not deliver the actual (physical) underlying asset but instead transfers the associated cash position</skos:definition>
+		<skos:definition xml:lang="en">derivative instrument where, upon expiration or exercise, the associated cash position is transferred to the appropriate party rather than delivery of the actual (physical) underlying asset</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;CommodityDerivative">
@@ -130,16 +130,15 @@
 		<skos:definition xml:lang="en">futures contract to buy or sell a predetermined amount of a commodity at a specific price on a specific date in the future</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">CFTC glossary</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A commodity future is an agreement to purchase or sell a commodity for delivery in the future: (1) at a price that is determined at initiation of the contract; (2) that obligates each party to the contract to fulfill the contract at the specified price; (3) that is used to assume or shift price risk; and (4) that may be satisfied by delivery or offset. A futures contract has standardized terms and is traded on an exchange, where prices are settled on a daily basis until the end of the contract.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A commodity future is an agreement to purchase or sell a commodity for delivery in the future: (1) at a price that is determined at initiation of the contract; (2) that obligates each party to the contract to fulfill the contract at the specified price; (3) that is used to assume or shift price risk; and (4) that may be satisfied by delivery or offset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;CommodityOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;CommodityDerivative"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:label xml:lang="en">commodity option</rdfs:label>
-		<skos:definition xml:lang="en">option where the option buyer has the right to buy or sell specified commodities assets at a fixed price or formula, on or before a specified date</skos:definition>
+		<skos:definition xml:lang="en">option where the option buyer has the right to buy or sell specified commodities or commodity related index at a fixed price or formula, on or before a specified date</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Commodity assets may include at least one commodity, commodity index, and/or commodity-specific contract.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;CommodityReturnLeg">

--- a/DER/DerivativesContracts/CommoditiesContracts.rdf
+++ b/DER/DerivativesContracts/CommoditiesContracts.rdf
@@ -47,10 +47,15 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/">
 		<rdfs:label xml:lang="en">Commodities Contracts Ontology</rdfs:label>
-		<dct:abstract>This ontology specifies core concepts for commodities-based derivatives and spot contracts, including their underliers.</dct:abstract>
+		<dct:abstract>This ontology specifies core concepts for commodities-based derivatives and spot contracts, including the definitions of the most common categories of underlying negotiable commodities, corresponding to those outlined in the ISO 10962 CFI standard. Note that the ontology does not include any specific units of measure for these commodities. The intent is that FIBO users would select one of the many available units ontologies to use in specifying the details of individual contracts.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
 		<sm:fileAbbreviation>fibo-der-drc-comm</sm:fileAbbreviation>
@@ -68,8 +73,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210901/DerivativesContracts/CommoditiesContracts/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;AgriculturalResource">

--- a/DER/DerivativesContracts/CommoditiesContracts.rdf
+++ b/DER/DerivativesContracts/CommoditiesContracts.rdf
@@ -84,7 +84,7 @@
 		<rdfs:label xml:lang="en">base metal</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-pas-pas;PreciousMetal"/>
 		<skos:definition xml:lang="en">common metal that tarnishes, oxidizes, or corrodes relatively quickly when exposed to air or moisture, that is widely used in commercial and industrial applications, such as construction and manufacturing</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Base metals or alloys include metals other than precious metals, such as copper, lead, zinc, tin, or brass. Note that iron and steel are included under metal and metal products in some classification schemes - see https://fred.stlouisfed.org/series/WPU101 for example.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Base metals or alloys include metals other than precious metals, such as copper, lead, zinc, tin, iron, steel, or brass. Note that iron and steel are included under metal and metal products in some classification schemes - see https://fred.stlouisfed.org/series/WPU101 for example.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;BasketOfCommodities">
@@ -104,7 +104,7 @@
 	<owl:Class rdf:about="&fibo-der-drc-comm;Bullion">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;PreciousMetal"/>
 		<rdfs:label xml:lang="en">bullion</rdfs:label>
-		<skos:definition xml:lang="en">physical precious metal that is officially recognized as being at least 99.5 percent pure, in the form of bars, ingots, or coins</skos:definition>
+		<skos:definition xml:lang="en">physical precious metal that is officially recognized as being at least 99.5 percent pure</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;CommodityBasketConstituent">

--- a/DER/DerivativesContracts/CommoditiesContracts.rdf
+++ b/DER/DerivativesContracts/CommoditiesContracts.rdf
@@ -7,8 +7,10 @@
 	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -28,8 +30,10 @@
 	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -56,8 +60,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -81,10 +87,36 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Base metals or alloys include metals other than precious metals, such as copper, lead, zinc, tin, or brass. Note that iron and steel are included under metal and metal products in some classification schemes - see https://fred.stlouisfed.org/series/WPU101 for example.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-comm;BasketOfCommodities">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;WeightedBasket"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasConstituent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-comm;CommodityBasketConstituent"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>basket of commodities</rdfs:label>
+		<skos:definition>custom basket whose constituents consist of one or more negotiable commodities</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A commodity basket may contain constituents from one of the potential underlying assets or from multiple underlying assets.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-comm;Bullion">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;PreciousMetal"/>
 		<rdfs:label xml:lang="en">bullion</rdfs:label>
 		<skos:definition xml:lang="en">physical precious metal that is officially recognized as being at least 99.5 percent pure, in the form of bars, ingots, or coins</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-comm;CommodityBasketConstituent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;WeightedBasketConstituent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>commodity basket constituent</rdfs:label>
+		<skos:definition>component of a custom commodity basket whose relative importance with respect to other basket constituents is known</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;CommodityDerivative">
@@ -185,13 +217,6 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The underlying of a commodity swap may include a physical commodity, or the price, or behavior of the price, or any other aspect of a physical commodity.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-comm;ElectricityCommodity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;EnergyResource"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;GeneratedResource"/>
-		<rdfs:label xml:lang="en">electricity commodity</rdfs:label>
-		<skos:definition xml:lang="en">electricity as a commodity</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-comm;EnergyResource">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
 		<rdfs:label xml:lang="en">energy resource</rdfs:label>
@@ -202,7 +227,6 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;EnergyTransmissionRights">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;EnergyResource"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;GeneratedResource"/>
 		<rdfs:label xml:lang="en">energy transmission rights</rdfs:label>
 		<skos:definition xml:lang="en">rights to the transmission of power across an electricity distribution network</skos:definition>
 	</owl:Class>
@@ -287,7 +311,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">oil commodity</rdfs:label>
-		<skos:definition xml:lang="en">generated resource that is a viscous liquid derived from petrolium, especially for use as fuel or as a lubricant</skos:definition>
+		<skos:definition xml:lang="en">generated resource that is a viscous liquid derived from petroleum, including for use as fuel, or as a lubricant, and the manufacture of many types of paints, plastics, and other materials</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;OilGrade">

--- a/DER/DerivativesContracts/CommoditiesContracts.rdf
+++ b/DER/DerivativesContracts/CommoditiesContracts.rdf
@@ -321,10 +321,10 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;CommodityDerivative"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:label>weather derivative</rdfs:label>
-		<skos:definition xml:lang="en">derivative instrument whose primary underlying notional item is based something related to the weather, for example, the average temperature in Chicago in January</skos:definition>
+		<skos:definition xml:lang="en">derivative instrument whose primary underlying notional item is based on something related to the weather, for example, the average temperature in Chicago in January</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">CFTC glossary, https://www.cftc.gov/LearnAndProtect/EducationCenter/CFTCGlossary/glossary_wxyz.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the CFI standard, weather is classified as an environmental resource.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such a derivative can be used to hedge risks related to the demand for heating fuel or electricity.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such a derivative can be used to hedge risks related to the demand for heating fuel or electricity. The underlying &apos;asset&apos; is not a negotiable commodity per se, but because the weather can impact the prices and other things related to other commodities, weather derivatives are treated as commodity derivatives for regulatory purposes.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-comm;hasGrade">

--- a/DER/DerivativesContracts/CommoditiesContracts.rdf
+++ b/DER/DerivativesContracts/CommoditiesContracts.rdf
@@ -87,29 +87,18 @@
 		<skos:definition xml:lang="en">physical precious metal that is officially recognized as being at least 99.5 percent pure, in the form of bars, ingots, or coins</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-comm;CashSettledForwardContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;CommodityForward"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasCalculationAgent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;CalculationAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash-settled forward contract</rdfs:label>
-		<skos:definition xml:lang="en">derivative instrument where, upon expiration or exercise, the associated cash position is transferred to the appropriate party rather than delivery of the actual (physical) underlying asset</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-comm;CommodityDerivative">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;CommodityInstrument"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-comm;CommodityUnderlyingAsset"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-comm;CommodityUnderlyingAsset"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>commodity derivative</rdfs:label>
-		<skos:definition xml:lang="en">derivative instrument whose primary underlying notional item is a physical commodity, or the price, or behavior of the price, or any other aspect related to a physical commodity</skos:definition>
+		<skos:definition xml:lang="en">derivative instrument whose primary underlying notional item is a physical commodity, or the price, or related index, or any other aspect related to a physical commodity</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;CommodityForward">
@@ -221,7 +210,7 @@
 	<owl:Class rdf:about="&fibo-der-drc-comm;EnvironmentalResource">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
 		<rdfs:label xml:lang="en">environmental resource</rdfs:label>
-		<skos:definition xml:lang="en">negotiable commodity including carbon-related, emission reduction, and weather</skos:definition>
+		<skos:definition xml:lang="en">negotiable commodity including offset credits</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
@@ -326,6 +315,16 @@
 		<rdfs:label xml:lang="en">service resource</rdfs:label>
 		<skos:definition xml:lang="en">negotiable commodity involving services such as transportation, communications, and trade</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-comm;WeatherDerivative">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;CommodityDerivative"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
+		<rdfs:label>weather derivative</rdfs:label>
+		<skos:definition xml:lang="en">derivative instrument whose primary underlying notional item is based something related to the weather, for example, the average temperature in Chicago in January</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">CFTC glossary, https://www.cftc.gov/LearnAndProtect/EducationCenter/CFTCGlossary/glossary_wxyz.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the CFI standard, weather is classified as an environmental resource.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such a derivative can be used to hedge risks related to the demand for heating fuel or electricity.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-comm;hasGrade">

--- a/DER/DerivativesContracts/CommoditiesContracts.rdf
+++ b/DER/DerivativesContracts/CommoditiesContracts.rdf
@@ -73,11 +73,12 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-comm;BaseIndustrialMetal">
+	<owl:Class rdf:about="&fibo-der-drc-comm;BaseMetal">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;Metal"/>
-		<rdfs:label xml:lang="en">base industrial metal</rdfs:label>
+		<rdfs:label xml:lang="en">base metal</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-pas-pas;PreciousMetal"/>
-		<skos:definition xml:lang="en">metal or alloy, other than a precious metal or noble metal, such as copper, lead, zinc, tin, or brass</skos:definition>
+		<skos:definition xml:lang="en">common metal that tarnishes, oxidizes, or corrodes relatively quickly when exposed to air or moisture, that is widely used in commercial and industrial applications, such as construction and manufacturing</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Base metals or alloys include metals other than precious metals, such as copper, lead, zinc, tin, or brass. Note that iron and steel are included under metal and metal products in some classification schemes - see https://fred.stlouisfed.org/series/WPU101 for example.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;Bullion">
@@ -136,7 +137,9 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;CommodityDerivative"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:label xml:lang="en">commodity option</rdfs:label>
-		<skos:definition xml:lang="en">option whose underlying asset is at least one commodity, commodity index, and/or commodity-specific contract</skos:definition>
+		<skos:definition xml:lang="en">option where the option buyer has the right to buy or sell specified commodities assets at a fixed price or formula, on or before a specified date</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Commodity assets may include at least one commodity, commodity index, and/or commodity-specific contract.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;CommodityReturnLeg">
@@ -281,7 +284,10 @@
 	<owl:Class rdf:about="&fibo-der-drc-comm;Metal">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;ExtractionResource"/>
 		<rdfs:label xml:lang="en">metal</rdfs:label>
-		<skos:definition xml:lang="en">chemical resource with high electrical conductivity, luster, and malleability that readily loses electrons to form ions (cations)</skos:definition>
+		<skos:definition xml:lang="en">material that, when freshly prepared, polished, or fractured, shows a lustrous appearance, and conducts electricity and heat relatively well</skos:definition>
+		<skos:example xml:lang="en">Examples include precious or industrial metal, such as aluminium, copper, gold, lead, nickel, platinum, silver, tin, zinc.</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">https://en.wikipedia.org/wiki/Metal</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;OilCommodity">

--- a/IND/MarketIndices/BasketIndices.rdf
+++ b/IND/MarketIndices/BasketIndices.rdf
@@ -15,7 +15,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
 	<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
 	<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/">
@@ -44,7 +43,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
 	xmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"
@@ -66,7 +64,6 @@
 		<sm:copyright>Copyright (c) 2014-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-ind-mkt-bas</sm:fileAbbreviation>
@@ -85,14 +82,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210401/MarketIndices/BasketIndices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210801/MarketIndices/BasketIndices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200901/MarketIndices/BasketIndices.rdf version of this ontology was revised to add the details needed to calculate market cap for a capitalization-based weighting function.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/MarketIndices/BasketIndices.rdf version of this ontology was revised to to eliminate the restriction on reference index that it has an index value - the restriction should be on the quantity value such that the value refers to the indicator it represents.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/MarketIndices/BasketIndices.rdf version of this ontology was revised to eliminate the restriction on reference index that it has an index value - the restriction should be on the quantity value such that the value refers to the indicator it represents.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210401/MarketIndices/BasketIndices.rdf version of this ontology was revised to loosen the restriction on a reference index to simply reference any weighted basket so that one could include commodity indices, for example.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -279,18 +276,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isBasedOn"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-ind-mkt-bas;BasketOfCreditRisks">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-bsk;BasketOfIndices">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-bsk;BasketOfSecurities">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;WeightedBasket"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">reference index</rdfs:label>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised several definitions based on discussion in the DER FCT on 17 Aug 2021, including (1) the definition of BaseIndustrialMetal, which we renamed BaseMetal, (2) the definition of commodity option, which we aligned with the CFI standard, and (3) the more general definition of Metal.  Other changes include (4) the addition of WeatherDerivative, (5) addition of BasketOfCommodities and CommodityBasketConstituent - consisting of negotiable commodities, in support of the references to such baskets in the CFI standard, and (6) relaxation of a restriction on reference index to allow it to reflect any sort of weighted basket, thus enabling us to represent commodity indices.

Fixes: #1572 / DER-105


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


