### PR TITLE
SEC-68 - The definition of bill of exchange needs clarification

### DIFF
--- a/SEC/Debt/TradedShortTermDebt.rdf
+++ b/SEC/Debt/TradedShortTermDebt.rdf
@@ -71,12 +71,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Debt/TradedShortTermDebt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210901/Debt/TradedShortTermDebt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Debt/TradedShortTermDebt.rdf version of this ontology was modified to eliminate a circular definition.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Debt/TradedShortTermDebt.rdf version of this ontology was modified to clarify the definition of bill of exchange.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;BankersAcceptance">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;FixedIncomeSecurity"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-tstd;BillOfExchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -97,12 +99,19 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bankers&apos; acceptance</rdfs:label>
-		<skos:definition xml:lang="en">a short-term debt instrument issued by a company that is guaranteed by a commercial bank</skos:definition>
+		<skos:definition xml:lang="en">short-term debt instrument issued by a company that is guaranteed by a commercial bank</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Considered negotiable instruments with features of a time draft, bankers&apos; acceptances are created by the drawer and provide the bearer with the right to the amount noted on the face of the acceptance on the specified date. Unlike traditional checks, bankers&apos; acceptances function based on the creditworthiness of the banking institution instead of the individual or business acting as the drawer. Additionally, the drawer must provide the funds necessary to support the bankers&apos; acceptance, eliminating the risk associated with insufficient funds on the part of the drawer.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;BillOfExchange">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;FixedIncomeSecurity"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-pty;hasPartyInRole"/>
@@ -124,6 +133,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bill of exchange</rdfs:label>
 		<skos:definition xml:lang="en">short-term negotiable financial instrument consisting of an order in writing addressed by one person (the seller of goods) to another (the buyer), requiring the latter to pay a fixed amount of money on demand (a sight draft) or on a predetermined date (a time draft)</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A bill of exchange is a written agreement between two parties - the buyer and the seller - used primarily in international trade. The buyer or seller typically employs a bank to issue the bill of exchange due to the risks involved with international transactions. Bills of exchange can be transferred by endorsement, much like a check. They can also require the buyer to pay a third party - a bank - in the event that the buyer fails to make good on his agreement with the seller.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">bank draft</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym xml:lang="en">draft</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	

--- a/SEC/Debt/TradedShortTermDebt.rdf
+++ b/SEC/Debt/TradedShortTermDebt.rdf
@@ -99,7 +99,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bankers&apos; acceptance</rdfs:label>
-		<skos:definition xml:lang="en">short-term debt instrument issued by a company that is guaranteed by a commercial bank</skos:definition>
+		<skos:definition xml:lang="en">short-term debt instrument that is guaranteed by a commercial bank and used as a relatively safe form of payment for large transactions</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Considered negotiable instruments with features of a time draft, bankers&apos; acceptances are created by the drawer and provide the bearer with the right to the amount noted on the face of the acceptance on the specified date. Unlike traditional checks, bankers&apos; acceptances function based on the creditworthiness of the banking institution instead of the individual or business acting as the drawer. Additionally, the drawer must provide the funds necessary to support the bankers&apos; acceptance, eliminating the risk associated with insufficient funds on the part of the drawer.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/SEC/Debt/TradedShortTermDebt.rdf
+++ b/SEC/Debt/TradedShortTermDebt.rdf
@@ -95,11 +95,11 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-gty;hasGuarantor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;CommercialBank"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;Bank"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bankers&apos; acceptance</rdfs:label>
-		<skos:definition xml:lang="en">short-term debt instrument that is guaranteed by a commercial bank and used as a relatively safe form of payment for large transactions</skos:definition>
+		<skos:definition xml:lang="en">short-term debt instrument that is guaranteed and paid by a bank and used as a relatively safe form of payment for large transactions</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Considered negotiable instruments with features of a time draft, bankers&apos; acceptances are created by the drawer and provide the bearer with the right to the amount noted on the face of the acceptance on the specified date. Unlike traditional checks, bankers&apos; acceptances function based on the creditworthiness of the banking institution instead of the individual or business acting as the drawer. Additionally, the drawer must provide the funds necessary to support the bankers&apos; acceptance, eliminating the risk associated with insufficient funds on the part of the drawer.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Clarified the definition of a bill of exchange, including (1) moving it up the hierarchy to a subclass of tradable debt instrument, adding an explanatory note and a synonym of 'bank draft', and (2) revising the definition of bankers' acceptance to say that it is both a bill of exchange and a fixed income security, which a bill of exchange may or may not be

Fixes: #1582 / SEC-68


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


