### PR TITLE
FND-349 - Use of equivalence in custom datatypes causes reasoning issues

### DIFF
--- a/FND/AgentsAndPeople/Agents.rdf
+++ b/FND/AgentsAndPeople/Agents.rdf
@@ -36,12 +36,13 @@
 		<sm:filename>Agents.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210601/AgentsAndPeople/Agents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210901/AgentsAndPeople/Agents/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20130801/AgentsAndPeople/Agents.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/AgentsAndPeople/Agents.rdf version of this ontology was modified to support the FIBO 2.0 RFC, primarily with respect to equivalence relationships to LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/AgentsAndPeople/Agents.rdf version of this ontology was modified to loosen the range restriction on hasName to rdfs:Literal, facilitating multi-lingual name representation.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190301/AgentsAndPeople/Agents.rdf version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/AgentsAndPeople/Agents.rdf version of this ontology was modified to add a custom datatype for text values (which might be either xsd:string or rdf:langString) and use that in the restriction on hasName on autonomous agent.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210601/AgentsAndPeople/Agents.rdf version of this ontology was modified to add notes on the custom Text datatype indicating that it is outside the RL profile and that if someone wants to use this ontology with OWL 2 RL rules they might want to comment this out / eliminate it where it is used.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/Foundations/20130601/AgentsAndPeople/Agents.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIs (also called 303 URIs, vs. hash style) as required to support server side processing 
    (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -55,6 +56,7 @@
 		<rdfs:label>langString</rdfs:label>
 		<skos:definition>literal with a non-empty language tag that is well-formed according to section 2.2.9 of [BCP47]</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>This declaration is included in order to support language-tagged strings in FIBO.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting this and its usage out in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 	</rdfs:Datatype>
 	
 	<owl:Class rdf:about="&fibo-fnd-aap-agt;AutomatedSystem">
@@ -95,6 +97,7 @@ Whether or not you restrict your view of agents to the software variety, most ag
 
 (3) Adaptive - an agent is capable of responding to other agents and/or its environment. Agents can react to messages and events and then respond appropriately.  Agents can be designed to make difficult decisions and even modify their behavior based on their experiences.  They can learn and evolve.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Note that this does not necessarily imply that an agent is free to act as it sees fit, without constraint. Rather, an autonomous thing in the sense meant here is something which may or may not be subject to controls and constraints but is self-actualizing in its behavior in response to any such constraints. Autonomous things may include human beings, organizations, software agents, robots and animals.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting out the restriction on hasTextValue altogether or change the data range to rdfs:Literal in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-aap-agt;Name">
@@ -108,6 +111,7 @@ Whether or not you restrict your view of agents to the software variety, most ag
 		<rdfs:label>name</rdfs:label>
 		<skos:definition>designation by which someone, some place, or something is known</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 1087-1 Terminology work - Vocabulary - Theory and Application, First edition, 2000-10-15</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting out the restriction on hasTextValue altogether or change the data range to rdfs:Literal in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
 	<rdfs:Datatype rdf:about="&fibo-fnd-aap-agt;Text">
@@ -124,6 +128,7 @@ Whether or not you restrict your view of agents to the software variety, most ag
 		</owl:equivalentClass>
 		<skos:definition>datatype that maps to both base types for string-valued data properties and annotations</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>There are cases where the representation of certain features of something, such as a name, which might be multilingual or might not, defaults to rdfs:Literal when left unspecified, although it should be limited to plain strings or language-typed strings (i.e., exclude numbers, binary types, and so forth). There is no combined option in RDF or OWL, however, which is the role that this datatype is intended to fulfill.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting this and its usage here, and in the People, Organizations, and other ontologies out, or replacing it with rdfs:Literal out in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 		<fibo-fnd-utl-av:usageNote>This composite datatype should be used in cases where a standard representation using one of the options in the union for string values does not work. Note that certain tools may not support rdf:langString, including, but not limited to some versions of Protege.</fibo-fnd-utl-av:usageNote>
 	</rdfs:Datatype>
 	

--- a/FND/DatesAndTimes/FinancialDates.rdf
+++ b/FND/DatesAndTimes/FinancialDates.rdf
@@ -40,7 +40,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210601/DatesAndTimes/FinancialDates/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20210901/DatesAndTimes/FinancialDates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/DatesAndTimes/FinancialDates/ version of this ontology was revised by the FIBO FND 1.2 RTF in order to introduce the definition of a time interval, which is a location, to ground some of the concepts such as a date period, and duration as well as to support the definition of business recurrence intervals for use in parametric schedules for securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20170201/DatesAndTimes/FinancialDates/ version of this ontology was revised by the FIBO 2.0 RFC in order to introduce the definition of a time instant, to eliminate a reasoning issue with relative dates, and remove a circular dependency inadvertently incorporated in the ontology with a FIBO FND 1.2 modification.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/DatesAndTimes/FinancialDates/ version of this ontology was revised to introduce a composite date datatype to allow for cases whereby the representation of a date for certain purposes, such as GLEIF LEI data, is inconsistent, and to facilitate mapping FIBO to multiple data sources in user environments.</skos:changeNote>
@@ -49,6 +49,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/DatesAndTimes/FinancialDates/ version of this ontology was revised to move dated collection and dated collection constituent as well as hasObservedDateTime and hasAcquisitionDate to financial dates in order to improve usability, simplify reasoning, made definitions ISO 704 compliant, and eliminate redundant restrictions on ad hoc schedule entry.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/DatesAndTimes/FinancialDates/ version of this ontology was revised to add hasOpeningDateTime and hasClosingDateTime for use in defining trading days and sessions and eliminated the functional property declaration on hasExplicitDate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201201/DatesAndTimes/FinancialDates/ version of this ontology was revised to add the concept of age and a corresponding property that supports its use.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210601/DatesAndTimes/FinancialDates.rdf version of this ontology was modified to add notes on the custom CombinedDateTime datatype indicating that it is outside the RL profile and that if someone wants to use this ontology with OWL 2 RL rules they might want to comment this out / eliminate it where it is used.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the December 2014 Long Beach meeting in support of the SEC specification.  It is also needed to provide temporal relationships for Ownership and Control.
 
 These three ontologies are designed for use together:
@@ -193,6 +194,7 @@ Similar points apply to other kinds of calendar periods, such as calendar week, 
 		</owl:equivalentClass>
 		<skos:definition>datatype that maps to several base types for dates and times</skos:definition>
 		<skos:scopeNote>There are many cases where the representation of a date may or may not include a time, and where the underlying data representation varies.  This composite datatype should only be used in cases where a standard representation using one of the options in the union for date or date and time value specification does not work.</skos:scopeNote>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting this and its usage here, and in other ontologies out, or replacing it with rdfs:Literal out in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 		<fibo-fnd-utl-av:usageNote>Valid values must use the ISO 8601 representation for a date, or the corresponding XML Schema Datatypes representation for a date and time, or date and time including the time zone.</fibo-fnd-utl-av:usageNote>
 	</rdfs:Datatype>
 	
@@ -279,6 +281,7 @@ Similar points apply to other kinds of calendar periods, such as calendar week, 
 		<rdfs:label>dated collection constituent</rdfs:label>
 		<skos:definition>element of a collection that is associated with a date and time</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Note that the use of several options for the representation of a date and time stamp enables extensions for milliseconds, nanoseconds using an xsd:string that has the format of an xsd:dateTime datatype but extends the level of granularity consistently.  An example of where this is required is to represent prices that change multiple times in a given day.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting out the restriction on hasObservedDateTime altogether or change the data range to rdfs:Literal in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-fd;DatedStructuredCollection">
@@ -629,6 +632,7 @@ The recurrence start date can also be relative to the starting Date of the overa
 		<rdfs:label>has acquisition date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition>links an asset or owner/controller/controllee to the date or date and time of purchase</skos:definition>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting out the range restriction or change the range to rdfs:Literal in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-dt-fd;hasAge">
@@ -657,6 +661,7 @@ The recurrence start date can also be relative to the starting Date of the overa
 		<rdfs:label xml:lang="en">has closing date time</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition xml:lang="en">the day and time at which something closes</skos:definition>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting out the range restriction or change the range to rdfs:Literal in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-dt-fd;hasCount">
@@ -791,6 +796,7 @@ The recurrence start date can also be relative to the starting Date of the overa
 		<rdfs:label>has observed date and time</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition>indicates a date and time for an event, measurement, or other observation</skos:definition>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting out the range restriction or change the range to rdfs:Literal in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-dt-fd;hasOpeningDateTime">
@@ -798,6 +804,7 @@ The recurrence start date can also be relative to the starting Date of the overa
 		<rdfs:label xml:lang="en">has opening date time</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition xml:lang="en">the day and time at which something opens</skos:definition>
+		<fibo-fnd-utl-av:usageNote>The use of custom datatypes is outside the OWL 2 RL profile and so users should consider commenting out the range restriction or change the range to rdfs:Literal in applications that are constrained to OWL 2 RL.</fibo-fnd-utl-av:usageNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-dt-fd;hasOrdinalNumber">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added usage notes to the agents and dates and times ontologies advising users that if they are using FIBO in the OWL 2 RL profile that the custom datatypes are not supported and suggesting that they comment them out and / or use rdfs:Literal where they are used in range declarations and data range restrictions

Fixes: #1591 / FND-349


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


