### PR TITLE
FND-318 -The definition of release date is too narrow

### DIFF
--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -767,7 +767,7 @@ For certain indices, one of the most common weighting factor is by market capita
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;hasReleaseDateTime">
 		<rdfs:label>has release date and time</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
-		<skos:definition>specifies the date and time on which something is published date</skos:definition>
+		<skos:definition>specifies the date and time on which something is published</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasSubtrahend">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Expanded the definition of 'release date' to be more comprehensive, as a release date can apply to any product, document, report or other similar concept, for both the object and data property in question

Fixes: #1601 / FND-318


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


