### PR TITLE
Hygiene tests ignore owl:deprecated resources - hot fix

### DIFF
--- a/etc/testing/hygiene/testHygiene0001.sparql
+++ b/etc/testing/hygiene/testHygiene0001.sparql
@@ -14,11 +14,7 @@ prefix lcc-cr: <https://www.omg.org/spec/LCC/Countries/CountryRepresentation/>
 SELECT DISTINCT ?error
 WHERE {
   ?s ?p ?o .
-  OPTIONAL
-    {
-       ?o owl:deprecated ?deprecated .
-       FILTER (str(?deprecated) != "true")
-    }
+  FILTER NOT EXISTS {?o owl:deprecated "true"^^xsd:boolean} .
   FILTER (ISIRI (?o))
   FILTER (REGEX (xsd:string (?o), "edmcouncil"))
   FILTER NOT EXISTS {?o a []}

--- a/etc/testing/hygiene/testHygiene0002.sparql
+++ b/etc/testing/hygiene/testHygiene0002.sparql
@@ -24,17 +24,8 @@ WHERE {
   ?p1 rdfs:subPropertyOf ?p2 .
   ?p2 rdfs:domain ?D2 .
   ?D2 rdfs:subClassOf + ?D1 .
-  OPTIONAL
-     {
-         ?p1 owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
-  OPTIONAL
-     {
-         ?p2 owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
-
+  FILTER NOT EXISTS {?p1 owl:deprecated "true"^^xsd:boolean} .
+  FILTER NOT EXISTS {?p2 owl:deprecated "true"^^xsd:boolean} .
   BIND (
     concat ("PRODERROR: Crossed domains. ", afn:localname(?p1), " < ", afn:localname (?p2), " but the domain ", afn:localname (?D1), " is a superclass of ", afn:localname (?D2)) AS ?error
   )

--- a/etc/testing/hygiene/testHygiene0003.sparql
+++ b/etc/testing/hygiene/testHygiene0003.sparql
@@ -23,15 +23,7 @@ WHERE {
   ?p1 rdfs:subPropertyOf ?p2 .
   ?p2 rdfs:range ?D2 .
   ?D2 rdfs:subClassOf+ ?D1 .
-  OPTIONAL
-     {
-         ?p1 owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
-  OPTIONAL
-     {
-         ?p2 owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?p1 owl:deprecated "true"^^xsd:boolean} .
+  FILTER NOT EXISTS {?p2 owl:deprecated "true"^^xsd:boolean} .
    BIND (concat ("PRODERROR: Crossed ranges. ", afn:localname(?p1), " < ", afn:localname (?p2), " but the range ", afn:localname (?D1), " is a superclass of ", afn:localname (?D2)) AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene0004.sparql
+++ b/etc/testing/hygiene/testHygiene0004.sparql
@@ -13,15 +13,9 @@ prefix fibo-fnd-utl-av:  <https://spec.edmcouncil.org/fibo/ontology/FND/Utilitie
 SELECT DISTINCT ?error
 WHERE {
   ?e a ?c .
-  OPTIONAL
-     {
-         ?e owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?e owl:deprecated "true"^^xsd:boolean} .
   FILTER (REGEX (xsd:string (?e), "edmcouncil"))
-  FILTER NOT EXISTS {
-    ?e owl:deprecated "true"^^xsd:boolean
-  }
+  FILTER NOT EXISTS {?e owl:deprecated "true"^^xsd:boolean} .
   FILTER (?c in (owl:Class,
           owl:ObjectProperty,
           owl:AnnotationProperty,

--- a/etc/testing/hygiene/testHygiene0005.sparql
+++ b/etc/testing/hygiene/testHygiene0005.sparql
@@ -23,11 +23,7 @@ prefix fibo-fnd-utl-av: <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities
 SELECT DISTINCT ?error
 WHERE {
   ?ont a owl:Ontology .
-  OPTIONAL
-     {
-         ?ont owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?ont owl:deprecated "true"^^xsd:boolean} .
   FILTER (REGEX (xsd:string (?ont), "edmcouncil"))	
   FILTER NOT EXISTS {
 	?ont rdfs:label ?l  ;

--- a/etc/testing/hygiene/testHygiene0114.sparql
+++ b/etc/testing/hygiene/testHygiene0114.sparql
@@ -10,11 +10,7 @@ prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 SELECT ?error
 WHERE {
   ?s ?p ?o .
-  OPTIONAL
-     {
-         ?s owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?o owl:deprecated "true"^^xsd:boolean} .
   FILTER (DATATYPE(?o)=xsd:string)
   FILTER (REGEX (xsd:string (?s), "edmcouncil")) 
   BIND (afn:localname (?p) AS ?prop)

--- a/etc/testing/hygiene/testHygiene0268.sparql
+++ b/etc/testing/hygiene/testHygiene0268.sparql
@@ -27,11 +27,7 @@ WHERE {
   UNION
   {?s rdfs:subClassOf|owl:equivalentClass [?p owl:Thing]}
   }
-  OPTIONAL
-     {
-         ?s owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?s owl:deprecated "true"^^xsd:boolean} .
   FILTER (REGEX (xsd:string (?s), "edmcouncil")) 
   FILTER (?p != owl:someValuesFrom)
   BIND (afn:localname (?p) AS ?prop)

--- a/etc/testing/hygiene/testHygiene1067.sparql
+++ b/etc/testing/hygiene/testHygiene1067.sparql
@@ -1,5 +1,6 @@
 PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl:   <http://www.w3.org/2002/07/owl#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Labels should be unique across FIBO for classes and properties.
@@ -13,11 +14,7 @@ WHERE
         { 
 			?s  rdfs:label  ?label .
 			{?s a owl:Class} UNION {?s a owl:ObjectProperty} UNION {?s a owl:DatatypeProperty}.
-			OPTIONAL
-			{
-			?s owl:deprecated ?deprecated .
-			FILTER (str(?deprecated) != "true")
-			}
+			FILTER NOT EXISTS {?s owl:deprecated "true"^^xsd:boolean} .
 			FILTER regex(str(?s), "edmcouncil")
         }
 		GROUP BY ?label

--- a/etc/testing/hygiene/testHygiene1068.sparql
+++ b/etc/testing/hygiene/testHygiene1068.sparql
@@ -2,6 +2,7 @@ prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Definitions shouldn't be circular - this finds direct circularities therein.
@@ -9,11 +10,7 @@ prefix skos: <http://www.w3.org/2004/02/skos/core#>
 SELECT DISTINCT ?error ?definition ?label
 WHERE {
   ?s rdfs:label ?label .
-  OPTIONAL
-     {
-         ?s owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?s owl:deprecated "true"^^xsd:boolean} .
   ?s skos:definition ?definition .
   FILTER NOT EXISTS {?s a owl:NamedIndividual} .
   FILTER (REGEX(?definition, "\\W"+?label+"\\W"))

--- a/etc/testing/hygiene/testHygiene1078.sparql
+++ b/etc/testing/hygiene/testHygiene1078.sparql
@@ -1,4 +1,5 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Object properties shouldn't have more than one inverse.
@@ -17,11 +18,7 @@ UNION
 ?p2 owl:inverseOf ?p. 
 FILTER (?p1 != ?p2) 
 }
-OPTIONAL
-     {
-         ?p owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+FILTER NOT EXISTS {?p owl:deprecated "true"^^xsd:boolean} .
 FILTER (CONTAINS(str(?p), "edmcouncil"))
 FILTER (CONTAINS(str(?p1), "edmcouncil"))
 FILTER (CONTAINS(str(?p2), "edmcouncil"))

--- a/etc/testing/hygiene/testHygiene1079.sparql
+++ b/etc/testing/hygiene/testHygiene1079.sparql
@@ -1,5 +1,6 @@
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner rdfs:comment shouldn't be used for FIBO annotation.
@@ -8,11 +9,7 @@ SELECT DISTINCT ?error
 WHERE 
 {
   ?s rdfs:comment ?o .
-  OPTIONAL
-     {
-         ?s owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?s owl:deprecated "true"^^xsd:boolean} .
   FILTER (CONTAINS(str(?s), "edmcouncil"))
   BIND (concat ("PRODERROR: ", str(?s), " has an rdfs:comment annotation: ", str(?o)) AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1103.sparql
+++ b/etc/testing/hygiene/testHygiene1103.sparql
@@ -13,15 +13,7 @@ WHERE {
   FILTER (REGEX(str(?class2), "edmcouncil"))
   FILTER NOT EXISTS {?class2 owl:deprecated "true"^^xsd:boolean}
   ?class1 owl:equivalentClass ?class2 .
-  OPTIONAL
-     {
-         ?class1 owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
-  OPTIONAL
-     {
-         ?class2 owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?class1 owl:deprecated "true"^^xsd:boolean} .
+  FILTER NOT EXISTS {?class2 owl:deprecated "true"^^xsd:boolean} .
   BIND (concat ("PRODERROR: Class ", str(?class1), " is modeled as equivalent to ", str(?class2), " - this may indicate polysemy management that is not complient with FIBO.") AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1177.sparql
+++ b/etc/testing/hygiene/testHygiene1177.sparql
@@ -1,5 +1,5 @@
-PREFIX owl:   <http://www.w3.org/2002/07/owl#>
-
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner No ontology may import itself.
@@ -8,11 +8,7 @@ SELECT DISTINCT ?error ?ontology
 WHERE
 {
     ?ontology owl:imports ?ontology.
-    OPTIONAL
-     {
-         ?ontology owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+    FILTER NOT EXISTS {?ontology owl:deprecated "true"^^xsd:boolean} .
     FILTER (CONTAINS(str(?ontology), "edmcouncil"))
     BIND (concat ("PRODERROR: ", str(?ontology), " imports itself.") AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1190.sparql
+++ b/etc/testing/hygiene/testHygiene1190.sparql
@@ -1,5 +1,6 @@
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Class subClassOf hierarchy shouldn't be circular.
@@ -9,11 +10,7 @@ WHERE
 {
   FILTER (CONTAINS(str(?class), "edmcouncil"))
   ?class rdfs:subClassOf+ ?class .
-  OPTIONAL
-     {
-         ?class owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?class owl:deprecated "true"^^xsd:boolean} .
 
   BIND (concat ("PRODERROR: There is a hierarchy cycle around class ", str(?class)) AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1190_properties.sparql
+++ b/etc/testing/hygiene/testHygiene1190_properties.sparql
@@ -1,6 +1,6 @@
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 prefix owl:   <http://www.w3.org/2002/07/owl#>
-
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Property subPropertyOf hierarchy shouldn't be circular.
@@ -10,11 +10,7 @@ WHERE
 {
   FILTER (CONTAINS(str(?property), "edmcouncil"))
   ?property rdfs:subPropertyOf+ ?property .
-  OPTIONAL
-     {
-         ?property owl:deprecated ?deprecated .
-         FILTER (str(?deprecated) != "true")
-     }
+  FILTER NOT EXISTS {?property owl:deprecated "true"^^xsd:boolean} .
 
   BIND (concat ("PRODERROR: There is a hierarchy cycle around property ", str(?property)) AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1198.sparql
+++ b/etc/testing/hygiene/testHygiene1198.sparql
@@ -1,6 +1,7 @@
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Local names of classes and properties shouldn't contain dots.
@@ -12,11 +13,7 @@ WHERE
     UNION
     {?resource rdf:type/rdfs:subClassOf* rdfs:Class .}
     ?resource rdf:type ?resourceType .
-    OPTIONAL
-       {
-           ?resource owl:deprecated ?deprecated .
-           FILTER (str(?deprecated) != "true")
-       }
+    FILTER NOT EXISTS {?resource owl:deprecated "true"^^xsd:boolean} .
     FILTER (CONTAINS(str(?resource), "edmcouncil"))
     FILTER (CONTAINS(STRAFTER(str(?resource),"https://spec.edmcouncil.org/fibo/ontology/"), "."))
     BIND (concat ("PRODERROR: Resource ", str(?resource), " has the dot in its local name. ") AS ?error) 

--- a/etc/testing/hygiene/testHygiene1289.sparql
+++ b/etc/testing/hygiene/testHygiene1289.sparql
@@ -1,6 +1,7 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Object properties should not play the role of the isA relationship.
@@ -9,11 +10,7 @@ SELECT ?error ?resource
 WHERE
 {
     ?resource rdf:type owl:ObjectProperty.
-    OPTIONAL
-       {
-           ?resource owl:deprecated ?deprecated .
-           FILTER (str(?deprecated) != "true")
-       }
+    FILTER NOT EXISTS {?resource owl:deprecated "true"^^xsd:boolean} .
     FILTER regex(str(?resource), "edmcouncil")
     FILTER (REGEX(LCASE(str(?resource)), "/isa$") || REGEX(LCASE(str(?resource)), "/may[^/]*$") || REGEX(LCASE(str(?resource)), "/[^/]*(become|also)[^/]*$") )
     BIND (concat ("PRODERROR: Property ", str(?resource), " may be an isA impostor.") AS ?error)

--- a/etc/testing/hygiene/testHygiene1290.sparql
+++ b/etc/testing/hygiene/testHygiene1290.sparql
@@ -1,6 +1,7 @@
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner All classes should be rooted in FND, LCC or FBC domain.
@@ -9,11 +10,7 @@ SELECT DISTINCT ?error ?class ?domainIdentifier
 WHERE 
 {
     ?class a owl:Class .
-    OPTIONAL
-       {
-           ?class owl:deprecated ?deprecated .
-           FILTER (str(?deprecated) != "true")
-       }
+    FILTER NOT EXISTS {?class owl:deprecated "true"^^xsd:boolean} .
     FILTER NOT EXISTS {?class rdfs:subClassOf ?classParent}
     FILTER (CONTAINS(str(?class), "edmcouncil"))
     BIND (STRBEFORE(STRAFTER(str(?class),"https://spec.edmcouncil.org/fibo/ontology/"),"/") As ?domainIdentifier)

--- a/etc/testing/hygiene/testHygiene1292.sparql
+++ b/etc/testing/hygiene/testHygiene1292.sparql
@@ -1,6 +1,7 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Classes should not refer to multiple concepts.
@@ -9,11 +10,7 @@ SELECT DISTINCT ?error ?resource
 WHERE
 {
     ?resource ?property owl:Class .
-    OPTIONAL
-       {
-           ?resource owl:deprecated ?deprecated .
-           FILTER (str(?deprecated) != "true")
-       }
+    FILTER NOT EXISTS {?resource owl:deprecated "true"^^xsd:boolean} .
     FILTER regex(str(?resource), "edmcouncil")
     FILTER (REGEX(str(?resource), "/[^/]+(And|Or)[A-Z0-9][^/]+$") )
     FILTER (!CONTAINS(str(?resource), "InvestmentOrDepositAccount"))

--- a/etc/testing/hygiene/testHygiene1293.sparql
+++ b/etc/testing/hygiene/testHygiene1293.sparql
@@ -1,6 +1,7 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner "min 1" cardinality restrictions should be avoided because of performance considerations.
@@ -10,11 +11,7 @@ WHERE {
   ?restriction  rdf:type owl:Restriction.
   {{?restriction owl:minQualifiedCardinality ?cardinality} UNION {?restriction owl:minCardinality ?cardinality}}.
   ?class rdfs:subClassOf ?restriction .
-  OPTIONAL
-       {
-           ?class owl:deprecated ?deprecated .
-           FILTER (str(?deprecated) != "true")
-       }
+  FILTER NOT EXISTS {?class owl:deprecated "true"^^xsd:boolean} .
   FILTER (CONTAINS(str(?class), "edmcouncil"))
   FILTER (?cardinality = 1)
   BIND (concat ("ERROR: OWL class", str(?class), " is a subclass of a restriction of type owl:minCardinality or owl:minQualifiedCardinality equal to 1") AS ?error)

--- a/etc/testing/hygiene/testHygiene1610.sparql
+++ b/etc/testing/hygiene/testHygiene1610.sparql
@@ -1,4 +1,5 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Deprecated resources should be monitored and removed if possible.


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

This is to hotfix https://github.com/edmcouncil/fibo/pull/1613.

Fixes: #1610


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


