### PR TITLE
DER-114 - Clean up the Rights and Warrants ontology in preparation for release

### DIFF
--- a/DER/DerivativesContracts/RightsAndWarrants.rdf
+++ b/DER/DerivativesContracts/RightsAndWarrants.rdf
@@ -266,7 +266,7 @@
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;hasConversionRatio">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasFactor"/>
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
-		<rdfs:label xml:lang="en">has securities factor</rdfs:label>
+		<rdfs:label xml:lang="en">has conversion ratio</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">indicates the factor used to determine the number of warrants needed in order to buy or sell a specific number of securities or investment units</skos:definition>

--- a/DER/DerivativesContracts/RightsAndWarrants.rdf
+++ b/DER/DerivativesContracts/RightsAndWarrants.rdf
@@ -108,6 +108,21 @@
 		<skos:definition xml:lang="en">formula used to calculate the number of securities for an allotment right, typically based on the number of these instruments that the holder holds</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-raw;CallAndPutWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;CallWarrant"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;PutWarrant"/>
+		<rdfs:label xml:lang="en">call and put warrant</rdfs:label>
+		<skos:definition xml:lang="en">warrant that either does not specify call or put features, or that explicitly includes both a call and put feature</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-raw;CallWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:label xml:lang="en">call warrant</rdfs:label>
+		<skos:definition xml:lang="en">warrant giving the buyer (holder) the right, but not the obligation, to acquire specific underlying assets during a specified period at a specified price</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-raw;CommodityWarrant">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;CommodityDerivative"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
@@ -160,17 +175,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;ExchangeTradedWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;PublicWarrant"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;isListedVia"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-raw;WarrantListing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exchange traded warrant</rdfs:label>
-		<skos:definition xml:lang="en">A warrant which is traded on a securities exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be any kind of warrant except a (usually) Company Warrant. According to notes on Traditional Wwarrant: Warrants may be privately issued and may not necessarily be traded on an exchange. (Wikipedia)</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label xml:lang="en">exchange-traded warrant</rdfs:label>
+		<skos:definition xml:lang="en">warrant that is listed on a securities exchange</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;NakedWarrant">
@@ -187,12 +195,41 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-raw;PerpetualWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:label>perpetual warrant</rdfs:label>
+		<skos:definition>warrant without an expiration date, giving the holder the right, but not the obligation, to buy (call warrant) or to sell (put warrant) an underlying asset at a certain strike price</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The strike price, in the case of a perpetual warrant, is usually higher than the market value of the underlying asset at the time of issue.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-raw;PrivateWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;NonNegotiableSecurity"/>
+		<rdfs:label>private warrant</rdfs:label>
+		<skos:definition>warrant that is not tradable</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-raw;PublicWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;NegotiableSecurity"/>
+		<rdfs:label>public warrant</rdfs:label>
+		<skos:definition>warrant that may be traded over the counter (OTC) or through an exchange</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-raw;PurchaseRight">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
 		<rdfs:label xml:lang="en">purchase right</rdfs:label>
 		<skos:definition xml:lang="en">anti-takeover device that gives a prospective acquiree&apos;s shareholders the right to buy usually shares of the firm or shares of anyone who acquires the firm at a deep discount to their fair market value</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The underlying is usually shares but this not necessarily the case. Also known as &quot;Poison Pill&quot;.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-raw;PutWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:label xml:lang="en">put warrant</rdfs:label>
+		<skos:definition xml:lang="en">warrant giving the buyer (holder) the right, but not the obligation, to sell the assets specified (i.e., acquire cash in exchange for the underlying assets) back to the issuer at a fixed price or formula, on or before a specified date</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;SubscriptionRight">
@@ -226,40 +263,20 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Warrants are for any kind of instrument. Warrants may be privately issued and may not necessarily be traded on an exchange.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-raw;WarrantListing">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;Listing"/>
-		<rdfs:label xml:lang="en">warrant listing</rdfs:label>
-		<skos:definition xml:lang="en">The listing of a warrant on a securities exchange. Action: confirm whether all the facts shown for listing of tradable securities generally, apply to the listing of a warrant. Also determine whether any of the terms in Listing need to be specialized or added to for Warrant Listing.</skos:definition>
-	</owl:Class>
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;hasConversionRatio">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasFactor"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
+		<rdfs:label xml:lang="en">has securities factor</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
+		<rdfs:range rdf:resource="&xsd;decimal"/>
+		<skos:definition xml:lang="en">indicates the factor used to determine the number of warrants needed in order to buy or sell a specific number of securities or investment units</skos:definition>
+	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;hasOversubscribeOption">
 		<rdfs:label xml:lang="en">has oversubscribe option</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">indicates whether the holders of the rights instrument may get securities in the event that other right holders choose not to subscribe ??</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;hasSecuritiesFactor">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasFactor"/>
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
-		<rdfs:label xml:lang="en">has securities factor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
-		<rdfs:range rdf:resource="&xsd;decimal"/>
-		<skos:definition xml:lang="en">indicates the factor used to determine the number of securities the recipient is entitled to based on the number of instruments they hold</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;perpetualMaturity">
-		<rdfs:label xml:lang="en">perpetual maturity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;Warrant"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether this is a perpetual warrant, in other words it has no expiry date.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;putWarrant">
-		<rdfs:label xml:lang="en">put warrant</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;Warrant"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">If Yes, this warrant gives the holder the right to sell the underlying security back to the issuer at a predetermined price; if No, the warrant gives the holder the right to purchase the instrument at the predetermined price (a call warrant).</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Entitlement">

--- a/DER/DerivativesContracts/RightsAndWarrants.rdf
+++ b/DER/DerivativesContracts/RightsAndWarrants.rdf
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
+	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-der-drc-comm "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/">
 	<!ENTITY fibo-der-drc-raw "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/">
+	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
+	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
+	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-sec-ast "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/">
+	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -24,19 +28,23 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
+	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-der-drc-comm="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"
 	xmlns:fibo-der-drc-raw="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"
+	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
+	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
+	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-sec-ast="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"
+	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -48,139 +56,107 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/">
 		<rdfs:label xml:lang="en">Rights and Warrants Ontology</rdfs:label>
 		<dct:abstract>This covers a range of special contracts or arrangement with selected holders such as company participants. These include rights (privileges) extended to existing security holders to make new securities available to them at reduced prices or free, and warrants whereby the holder can purchase or sell back a given quantity of the instrument, commodity or currency during a specified period at a pre-defined price.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/"/>
 		<sm:fileAbbreviation>fibo-der-drc-raw</sm:fileAbbreviation>
+		<sm:filename>RightsAndWarrants.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;AllotmentRight">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;StockholdersRightsInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;numberOfSecuritiesDeterminedBy"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasFormula"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-raw;AllotmentRightFormula"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">allotment right</rdfs:label>
-		<skos:definition xml:lang="en">Privileges allotted to existing security holders, entitling them to receive new securities free of charge.</skos:definition>
+		<skos:definition xml:lang="en">privileges allotted to existing security holders, entitling them to receive new securities free of charge</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Allotment generally means the distribution of equity, particularly shares granted to a participating underwriting firm during an initial public offering (IPO).</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">bonus right</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;AllotmentRightFormula">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Formula"/>
 		<rdfs:label xml:lang="en">allotment right formula</rdfs:label>
-		<skos:definition xml:lang="en">A formula used to calculate the number of securities for an Allotment Right, based on the number of these instruments that the holder holds. Conesnsus:Review</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-raw;AllotmentRightHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;Investor"/>
-		<rdfs:label xml:lang="en">allotment right holder</rdfs:label>
-		<skos:definition xml:lang="en">The party which is the holder of an allotment right. This is identified as being a party which is also an existing holder of the security identified as the underlying security.</skos:definition>
+		<skos:definition xml:lang="en">formula used to calculate the number of securities for an allotment right, typically based on the number of these instruments that the holder holds</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;CommodityWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-comm;CommodityDerivative"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-raw;CommodityWarrantExerciseTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;hasWarrantUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">commodity warrant</rdfs:label>
-		<skos:definition xml:lang="en">A derivative based on commodities contracts traded on exchanges.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Example: Commodity Warrants Australia (CWA) is a locally owned outfit that has been in business for 18 months. It sells warrants based on 12 commodities and financial markets - crude oil, gold, silver, live cattle, corn, orange juice, soy, coffee, cocoa, the Dow Jones Industrial Average, the NASDAQ Composite Index and the S&amp;P 500 Index</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-raw;CommodityWarrantExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;WarrantExerciseTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodity warrant exercise terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out how a commodity warrant may be exercised, including the form which delivery takes.</skos:definition>
+		<skos:definition xml:lang="en">warrant that permits the holder to acquire a specified amount of a commodity during a specified period at a specified price</skos:definition>
+		<skos:example xml:lang="en">Commodity Warrants Australia (CWA) sells warrants based on 12 commodities and financial markets - crude oil, gold, silver, live cattle, corn, orange juice, soy, coffee, cocoa, the Dow Jones Industrial Average, the NASDAQ Composite Index and the S&amp;P 500 Index.</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;CompanyWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;EquityWarrant"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;TraditionalWarrant"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-raw;CompanyWarrantExerciseTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;hasWarrantUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+						<owl:allValuesFrom rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+					</owl:Restriction>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">company warrant</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-drc-raw;CoveredWarrant"/>
-		<skos:definition xml:lang="en">Warrants which are issued by the issuer of the underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-raw;CompanyWarrantExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;WarrantExerciseTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">company warrant exercise terms set</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-drc-raw;CoveredWarrantExerciseTerms"/>
-		<skos:definition xml:lang="en">Terms setting out how a company warrant or naked warrant may be exercised, including the form which delivery takes.</skos:definition>
+		<rdfs:seeAlso rdf:resource="https://www.lawinsider.com/dictionary/company-warrant"/>
+		<skos:definition xml:lang="en">equity warrant to purchase shares of capital stock issued by the corporation whose equity is the underlying asset</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;CoveredWarrant">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-raw;CoveredWarrantExerciseTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;hasWarrantUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">covered warrant</rdfs:label>
+		<skos:definition xml:lang="en">warrant that gives the holder the right, but not the obligation, to buy (call warrant) or to sell (put warrant) an underlying asset at a specified price (the strike or exercise price) by a predetermined date, issued without an accompanying security by a third party that holds as many securities as would be required if all the warrants are exercised</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Covered warrants are very similar to options in that they can be created to allow holders to benefit from either rising prices or falling prices, by having both put and call warrants. They can also be created on a wide variety of underlying instruments, not just equities and they are fairly standardised and are mostly traded on exchanges. The main difference is that warrants tend to have longer maturity dates, typically measured in years instead of months (as with options), and are easier to access for individuals as they can be bought and sold in the same way as shares in the stock exchange.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In contrast to traditional equity warrants, with covered warrants, no new issuance of common stock occurs if the warrant is exercised. The underlying shares of common stock are usually either owned by the issuer of the covered warrants or the issuer has a mechanism, such as owning equity warrants for the underlying shares, through which they can obtain the shares.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-raw;CoveredWarrantExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;WarrantExerciseTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">covered warrant exercise terms</rdfs:label>
+	<owl:Class rdf:about="&fibo-der-drc-raw;EquityWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
+		<rdfs:label xml:lang="en">equity warrant</rdfs:label>
+		<skos:definition xml:lang="en">warrant that permits the holder to acquire a specified amount of an equity instrument during a specified period at a specified price</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;ExchangeTradedWarrant">
@@ -188,7 +164,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;hasListing"/>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;isListedVia"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-raw;WarrantListing"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -197,116 +173,57 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be any kind of warrant except a (usually) Company Warrant. According to notes on Traditional Wwarrant: Warrants may be privately issued and may not necessarily be traded on an exchange. (Wikipedia)</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-raw;NakedWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">naked warrant</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-raw;CoveredWarrant"/>
+		<skos:definition xml:lang="en">warrant that gives the holder the right, but not the obligation, to buy (call warrant) or to sell (put warrant) an underlying asset at a specified price (the strike or exercise price) by a predetermined date, issued without an accompanying security by a third party that does not hold as many securities as would be required if all the warrants are exercised</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-raw;PurchaseRight">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;StockholdersRightsInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
 		<rdfs:label xml:lang="en">purchase right</rdfs:label>
-		<skos:definition xml:lang="en">Anti-takeover device that gives a prospective acquiree’s shareholders the right to buy usually shares of the firm or shares of anyone who acquires the firm at a deep discount to their fair market value.</skos:definition>
+		<skos:definition xml:lang="en">anti-takeover device that gives a prospective acquiree&apos;s shareholders the right to buy usually shares of the firm or shares of anyone who acquires the firm at a deep discount to their fair market value</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The underlying is usually shares but this not necessarily the case. Also known as &quot;Poison Pill&quot;.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-raw;StockholdersRightsInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;givesTheRightToBuy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-oac-opty;Investor">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-oac-cown;Shareholder">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">stockholders rights instrument</rdfs:label>
-		<skos:definition xml:lang="en">A security giving stockholders entitlement to purchase new securities issued by the corporation at a predetermined price (normally less than the current market price) in proportion to the number of securities already owned.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Stockholders may sell these to non stockholders if they wish. Rights are issued only for a short period of time, after which they expire.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-raw;SubscriptionRight">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;StockholdersRightsInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;givesRightToBuy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
 		<rdfs:label xml:lang="en">subscription right</rdfs:label>
-		<skos:definition xml:lang="en">Privileges allotted to existing security holders, entitling them to subscribe to new securities at a price normally lower than the prevailing market price.</skos:definition>
+		<skos:definition xml:lang="en">privileges allotted to existing security holders, entitling them to subscribe to new securities at a price normally lower than the prevailing market price</skos:definition>
 		<skos:editorialNote xml:lang="en">Why prevailing? It could be a new security of exactly the same class. Is this always new securities? Notes May 25: May be more an accounting or legal term for bonus issue, more accurate than scrip or bonus issue which reflects what happens in the books of the company. THis would mean that capitalization issue is seemingly synonymous with Bonus Issue / Scrip Issue (see moneytterms.co.uk which says that capitalization is less common but more correct, for scrip. &quot;The share capital on the balance sheet has to increate by the nominal value of the newly issued shares. This is balanced by an equal decrease in another part of hte shareholder&apos;s funds such as retained income of valuation reserves&quot;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-raw;ThirdPartyWarrantIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;WarrantIssuer"/>
-		<rdfs:label xml:lang="en">third party warrant issuer</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-drc-raw;UnderlyingIssuer"/>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;TraditionalWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;CompanyWarrant"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
 		<rdfs:label xml:lang="en">traditional warrant</rdfs:label>
-		<skos:definition xml:lang="en">Financial instruments which permit the holder to purchase or sell back to the issuer a specified amount of a share.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Warrants may be privately issued and may not necessarily be traded on an exchange. From Wikipedia: A warrant issued with a bond gives the holder the right to purchase equity shares issued by the company that issued the bond with the warrant.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-raw;UnderlyingIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;WarrantIssuer"/>
-		<rdfs:label xml:lang="en">underlying issuer</rdfs:label>
-		<skos:definition xml:lang="en">A party which is the issuer of a Covered Warrant. This party is by definition the issuer of the underlying securities.</skos:definition>
-		<skos:editorialNote xml:lang="en">Specializes the term &quot;Issuer&quot; for different instrument classes; this specialization is not present in ISO FIBIM where the term is &quot;Issuer&quot; in each case.</skos:editorialNote>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-raw;CoveredWarrant"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-raw;NakedWarrant"/>
+		<skos:definition xml:lang="en">warrant that gives the holder the right, but not the obligation, to buy (call warrant) or to sell (put warrant) an underlying asset at a specified price (the strike or exercise price) by a predetermined date, issued by the issuer of the underlying instrument</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;Warrant">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-raw;WarrantExerciseTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;hasWarrantUnderlying"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-raw;WarrantIssuer"/>
+				<owl:onProperty rdf:resource="&fibo-sec-dbt-ex;hasExerciseTerms"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">warrant</rdfs:label>
-		<skos:definition xml:lang="en">Financial instruments which permit the holder to purchase or sell back to the issuer a specified amount of a financial instrument, commodity, currency or other during a specified period at a specified price.</skos:definition>
+		<skos:definition xml:lang="en">entitlement that permits the holder to purchase a specified amount of a financial instrument, commodity, currency or other asset during a specified period at a specified price</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Warrants are for any kind of instrument. Warrants may be privately issued and may not necessarily be traded on an exchange.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-raw;WarrantExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-raw;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">warrant exercise terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out how a warrant instrument may be exercised. Further Notes Exercise terms as defined here also cover the automatic exercise of the warrant in the event of its expiry. These terms include the exercise style (FIBIM = OptionStyle type OptionStyleCode) and the delivery.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-raw;WarrantIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
-		<rdfs:label xml:lang="en">warrant issuer</rdfs:label>
-		<skos:definition xml:lang="en">The issuer of a Warrant. This is defined in terms of what individual entity is the issuer and also what other roles they may or may not play for a specific type of warranty, specifically whether or not they are also the issuer of the underlying, if the underlying is a security.</skos:definition>
-		<skos:editorialNote xml:lang="en">Specializes the term &quot;Issuer&quot; for different instrument classes; this specialization is not present in ISO FIBIM where the term is &quot;Issuer&quot; in each case.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;WarrantListing">
@@ -315,72 +232,20 @@
 		<skos:definition xml:lang="en">The listing of a warrant on a securities exchange. Action: confirm whether all the facts shown for listing of tradable securities generally, apply to the listing of a warrant. Also determine whether any of the terms in Listing need to be specialized or added to for Warrant Listing.</skos:definition>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-raw;delivery">
-		<rdfs:label xml:lang="en">delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;WarrantExerciseTerms"/>
-		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;formulaText">
-		<rdfs:label xml:lang="en">formula text</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;AllotmentRightFormula"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">The formula stated as text.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-raw;givesRightToBuy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-drc-raw;givesTheRightToBuy"/>
-		<rdfs:label xml:lang="en">gives right to buy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;SubscriptionRight"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-raw;givesTheRightToBuy">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-		<rdfs:label xml:lang="en">gives the right to buy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;StockholdersRightsInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-raw;hasExerciseTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has exercise terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;Warrant"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-raw;WarrantExerciseTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-raw;hasListing">
-		<rdfs:label xml:lang="en">has listing</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;ExchangeTradedWarrant"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-raw;WarrantListing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-raw;hasWarrantUnderlying">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-		<rdfs:label xml:lang="en">has warrant underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;Warrant"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;numberOfSecurities">
-		<rdfs:label xml:lang="en">number of securities</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;AllotmentRight"/>
-		<rdfs:range rdf:resource="&xsd;decimal"/>
-		<skos:definition xml:lang="en">The number of securities based on the number of these instruments that the holder holds.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-raw;numberOfSecuritiesDeterminedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">number of securities determined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;AllotmentRight"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-raw;AllotmentRightFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;oversubscribeOption">
-		<rdfs:label xml:lang="en">oversubscribe option</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;StockholdersRightsInstrument"/>
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;hasOversubscribeOption">
+		<rdfs:label xml:lang="en">has oversubscribe option</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Option whereby the holders of the rights instrument may get securities in the event that other right holders choose not to subscribe to theirs.</skos:definition>
+		<skos:definition xml:lang="en">indicates whether the holders of the rights instrument may get securities in the event that other right holders choose not to subscribe ??</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;hasSecuritiesFactor">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasFactor"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
+		<rdfs:label xml:lang="en">has securities factor</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
+		<rdfs:range rdf:resource="&xsd;decimal"/>
+		<skos:definition xml:lang="en">indicates the factor used to determine the number of securities the recipient is entitled to based on the number of instruments they hold</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;perpetualMaturity">
@@ -397,16 +262,14 @@
 		<skos:definition xml:lang="en">If Yes, this warrant gives the holder the right to sell the underlying security back to the issuer at a predetermined price; if No, the warrant gives the holder the right to purchase the instrument at the predetermined price (a call warrant).</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;ratio">
-		<rdfs:label xml:lang="en">ratio</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;CompanyWarrant"/>
-		<rdfs:domain rdf:resource="&fibo-der-drc-raw;CoveredWarrant"/>
-		<rdfs:range rdf:resource="&xsd;decimal"/>
-		<skos:definition xml:lang="en">The ratio of warrant units to underlying security units for delivery when the warrant is exercised.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Entitlement">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+				<owl:onClass rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 	</owl:Class>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/RightsAndWarrants.rdf
+++ b/DER/DerivativesContracts/RightsAndWarrants.rdf
@@ -108,10 +108,10 @@
 		<skos:definition xml:lang="en">formula used to calculate the number of securities for an allotment right, typically based on the number of these instruments that the holder holds</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-raw;CallAndPutWarrant">
+	<owl:Class rdf:about="&fibo-der-drc-raw;CallPutWarrant">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;CallWarrant"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;PutWarrant"/>
-		<rdfs:label xml:lang="en">call and put warrant</rdfs:label>
+		<rdfs:label xml:lang="en">call put warrant</rdfs:label>
 		<skos:definition xml:lang="en">warrant that either does not specify call or put features, or that explicitly includes both a call and put feature</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -87,7 +87,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20210701/FinancialInstruments/FinancialInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20211001/FinancialInstruments/FinancialInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified for the FIBO 2.0 RFC, including minor bug fixes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified as a part of organizational hierarchy simplification, to add maturity-related properties, and to add exempt security.</skos:changeNote>
@@ -98,6 +98,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to add a property indicating the currency that an instrument is issued in, simplify the contract party hierarchy and add properties relating financial instruments to shareholders.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to incorporate a hasMaturityDate property given that it can apply to debt instruments and preferred shares, as well as to other financial instruments, eliminated the redundant hasScheduledMaturityDate property, cleaned up circular definitions, eliminated the property &apos;mayBeTradedIn&apos;, which was only used in one place and was redundant with the concept of a ListedSecurity / Listing in SEC, added a synonym and additional explanatory note to packaged financial product, added hasNominalValue, which was a gap, and added back restrictions on debt instrument for hasMaturityDate (min 0 to account for rare instruments (e.g., consul) that have no maturity date), hasDurationToMaturity and hasTimeToMaturity.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to add the concept of a spot contract and clarify the definition of time to maturity, as well as add a property for days to maturity.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210701/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to make Entitlement a subclass of Security.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -172,6 +173,7 @@
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Entitlement">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
 		<rdfs:label>entitlement</rdfs:label>
 		<skos:definition>financial instrument that provides the holder the privilege to subscribe to or to receive specific assets on terms specified</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</fibo-fnd-utl-av:adaptedFrom>

--- a/SEC/Debt/ExerciseConventions.rdf
+++ b/SEC/Debt/ExerciseConventions.rdf
@@ -52,11 +52,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210901/Debt/ExerciseConventions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Debt/ExerciseConventions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190101/Debt/ExerciseConventions.rdf version of this ontology was added to support integration of Bonds and Options in SEC and DER, respectively.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190101/Debt/ExerciseConventions.rdf version of this ontology was modified to add the hasExerciseTerms property.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/ExerciseConventions.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Debt/ExerciseConventions.rdf version of this ontology was modified to revise the definition of American exercise terms to say that an option with such terms may be exercised on or before the expiration date of the contract.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210901/Debt/ExerciseConventions.rdf version of this ontology was modified to loosen the domain of hasExerciseTerms to allow for entitlements to have such terms.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -171,7 +172,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">exercise terms</rdfs:label>
-		<skos:definition xml:lang="en">contract terms specific to the conditions, conventions and other stipulations related to the exercise of an option</skos:definition>
+		<skos:definition xml:lang="en">contract terms specific to the conditions, conventions and other stipulations related to the exercise of an option or entitlement</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ex;hasExerciseDate">
@@ -184,9 +185,9 @@
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ex;hasExerciseTerms">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 		<rdfs:label xml:lang="en">has exercise terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
-		<skos:definition xml:lang="en">links an option contract to any exercise terms that are specified therein</skos:definition>
+		<skos:definition xml:lang="en">links a derivative, such as an option or entitlement, to any exercise terms that are specified therein</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ex;hasExerciseWindow">

--- a/SEC/Securities/SecuritiesIssuance.rdf
+++ b/SEC/Securities/SecuritiesIssuance.rdf
@@ -66,8 +66,8 @@
 		<dct:abstract>This ontology defines the fundamental concepts for issuing securities, including securities offering, offering document, offering statement, securities underwriter, prospectus, and so forth.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -99,12 +99,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesIssuance/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Securities/SecuritiesIssuance/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIssuance/ version of this ontology was modified to refine the concept of a securities underwriter.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20181201/Securities/SecuritiesIssuance/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesIssuance/ version of this ontology was modified to add the concept of the form the security is issued in, namely bearer or registered.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesIssuance/ version of this ontology was modified to refactor conversion terms as a child of redemption provision, move redemption provision to financial instruments, and eliminate the unnecessary securities contract terms class.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Securities/SecuritiesIssuance/ version of this ontology was modified to add book entry form as a kind of registered security, make registered security a class with two individuals, namely book entry and &apos;bearer and registered&apos;, and clean up definitions to eliminate ambiguity where possible and conform to ISO 704.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesIssuance/ version of this ontology was modified to clarify the definition of isIssuedInForm.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -464,7 +465,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>security form</rdfs:label>
-		<skos:definition>the form that evidence of ownership of a security takes</skos:definition>
+		<skos:definition>nature of the proof of ownership of a security</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Securities are typically issued in one of two forms, registered or bearer. Most securities issued today are in registered form, which enables the issuing firm or registrar to keep records of a security&apos;s owner and mail them any dividend, coupon, or other payments. Registered securities may be issued in book entry (digital only) or certificate (physical) form, but most today are entirely digital.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Initial pass to clean up the rights and warrants ontology for release, including (1) enabling exercise terms to apply to entitlements, (2) revising the class hierarchy for financial instruments to include entitlements under securities, (3) clean up the definition of security form to make it clearer and not circular, and (4) a number of revisions to rights and warrants to add CFI definitions where appropriate, eliminate duplication, and adjust the hierarchy based on the fact that most entitlements apply to more than simply equities

Fixes: #1615 / DER-114


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


