### PR TITLE
Hygiene test for deprecated resources refactored

### DIFF
--- a/etc/testing/hygiene/testHygiene1610.sparql
+++ b/etc/testing/hygiene/testHygiene1610.sparql
@@ -1,14 +1,23 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 ##
-# banner Deprecated resources should be monitored and removed if possible.
+# banner Deprecated resources should not be used.
 
-SELECT DISTINCT ?error
-WHERE 
+SELECT DISTINCT ?warning ?resource
+WHERE
 {
-	?resource owl:deprecated ?deprecated .
-	FILTER (str(?deprecated) = "true")
-       
-  BIND (concat ("WARN: Resource <", str(?resource), "> is deprecated.") AS ?error)
+    ?resource owl:deprecated "true"^^xsd:boolean .
+    FILTER (CONTAINS(str(?resource), "edmcouncil"))
+    {
+        ?resource ?property1 ?object.
+        FILTER (?property1 != owl:equivalentClass && ?property1 != owl:deprecated && ?property1 != rdf:type && ?property1 != owl:equivalentProperty)
+    }
+    UNION
+    {
+        ?subject ?property2 ?resource .
+        FILTER (?property2 != owl:equivalentClass && ?property2 != owl:deprecated && ?property2 != rdf:type && ?property2 != owl:equivalentProperty)
+    }
+    BIND ("WARN: Deprecated resource " + str(?resource) + " is still in use." as ?warning)
 }


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

This PR refactors the test for deprecated resources so that only in-use deprecated ones are reported.
For the time being it is a warning test.

Fixes: #1610


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


