### PR TITLE
Hygiene test for object/datatype properties punning

### DIFF
--- a/etc/testing/hygiene/testHygiene1624.sparql
+++ b/etc/testing/hygiene/testHygiene1624.sparql
@@ -1,0 +1,14 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner We should avoid punning object and datatype properties
+
+SELECT DISTINCT ?error ?property
+WHERE
+{
+    ?property rdfs:subPropertyOf*/rdf:type owl:DatatypeProperty.
+    ?property rdfs:subPropertyOf*/rdf:type owl:ObjectProperty.
+    FILTER regex(str(?property), "edmcouncil")
+    BIND (concat ("ERROR: Property ", str(?property), " is declared both as an object and a datatype property.") AS ?error)
+}

--- a/etc/testing/hygiene/testHygiene1624_chain.sparql
+++ b/etc/testing/hygiene/testHygiene1624_chain.sparql
@@ -1,0 +1,16 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner We should avoid punning object and datatype properties
+
+
+SELECT DISTINCT ?error ?property
+WHERE
+{
+    ?resource owl:propertyChainAxiom ?axiom.
+    ?axiom rdf:rest*/rdf:first ?property .
+    ?property rdfs:subPropertyOf*/rdf:type owl:DatatypeProperty.
+    FILTER regex(str(?property), "edmcouncil")
+    BIND (concat ("WARN: Datatype property ", str(?property), " occurs in a property chain") AS ?error)
+}

--- a/etc/testing/hygiene/testHygiene1624_disjoint.sparql
+++ b/etc/testing/hygiene/testHygiene1624_disjoint.sparql
@@ -1,0 +1,22 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner We should avoid punning object and datatype properties
+
+SELECT DISTINCT ?error ?property1 ?property2
+WHERE
+{
+    ?property1 owl:propertyDisjointWith ?property2.
+    FILTER (regex(str(?property1), "edmcouncil") || regex(str(?property2), "edmcouncil"))
+    {
+        ?property1 rdfs:subPropertyOf*/rdf:type owl:DatatypeProperty.
+        ?property2 rdfs:subPropertyOf*/rdf:type owl:ObjectProperty.
+    }
+    UNION
+    {
+        ?property2 rdfs:subPropertyOf*/rdf:type owl:DatatypeProperty.
+        ?property1 rdfs:subPropertyOf*/rdf:type owl:ObjectProperty.
+    }
+    BIND (concat ("ERROR: Disjoint property axiom for ", str(?property1), str(?property2), " mixes up object and datatype properties.") AS ?error)
+}

--- a/etc/testing/hygiene/testHygiene1624_equivalent.sparql
+++ b/etc/testing/hygiene/testHygiene1624_equivalent.sparql
@@ -1,0 +1,22 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner We should avoid punning object and datatype properties
+
+SELECT DISTINCT ?error ?property1 ?property2
+WHERE
+{
+    ?property1 owl:equivalentProperty ?property2.
+    FILTER (regex(str(?property1), "edmcouncil") || regex(str(?property2), "edmcouncil"))
+    {
+        ?property1 rdfs:subPropertyOf*/rdf:type owl:DatatypeProperty.
+        ?property2 rdfs:subPropertyOf*/rdf:type owl:ObjectProperty.
+    }
+    UNION
+    {
+        ?property2 rdfs:subPropertyOf*/rdf:type owl:DatatypeProperty.
+        ?property1 rdfs:subPropertyOf*/rdf:type owl:ObjectProperty.
+    }
+    BIND (concat ("ERROR: Equivalent property axiom for ", str(?property1), str(?property2), " mixes up object and datatype properties.") AS ?error)
+}

--- a/etc/testing/hygiene/testHygiene1624_inverse.sparql
+++ b/etc/testing/hygiene/testHygiene1624_inverse.sparql
@@ -1,0 +1,17 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner We should avoid punning object and datatype properties
+
+
+SELECT DISTINCT ?error ?property1 ?property2
+WHERE
+{
+    ?property1 owl:inverseOf ?property2.
+    FILTER (regex(str(?property1), "edmcouncil") || regex(str(?property2), "edmcouncil"))
+    {?property1 rdfs:subPropertyOf*/rdf:type owl:DatatypeProperty.}
+    UNION
+    {?property2 rdfs:subPropertyOf*/rdf:type owl:DatatypeProperty.}
+    BIND (concat ("ERROR: Inverse axiom for ", str(?property1), str(?property2), " applies to datatype property(ies).") AS ?error)
+}

--- a/etc/testing/hygiene/testHygiene1624_subProperty.sparql
+++ b/etc/testing/hygiene/testHygiene1624_subProperty.sparql
@@ -1,0 +1,14 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner We should avoid punning object and datatype properties
+
+SELECT DISTINCT ?error ?property
+WHERE
+{
+    ?property rdfs:subPropertyOf*/rdf:type owl:DatatypeProperty.
+    ?property rdfs:subPropertyOf*/rdf:type owl:ObjectProperty.
+    FILTER regex(str(?property), "edmcouncil")
+    BIND (concat ("ERROR: Property ", str(?property), " is both as an object and a datatype property.") AS ?error)
+}


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

This PR adds a couple of hygiene tests to detect illegal punning for object and datatype properties.

Fixes: #1624 (and refers back to #1619)


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


