### PR TITLE
Prefixes in hygiene tests were refactored

### DIFF
--- a/etc/testing/hygiene/testHygiene0002.sparql
+++ b/etc/testing/hygiene/testHygiene0002.sparql
@@ -1,18 +1,9 @@
-prefix ex:    <http://www.example.org/time#>
-prefix sp:    <http://spinrdf.org/sp#>
 prefix afn:   <http://jena.apache.org/ARQ/function#>
 prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
-prefix spin:  <http://spinrdf.org/spin#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
-prefix fibo-ind-ir-ir: <https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/>
-prefix fibo-fnd-utl-av: <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/>
-prefix fibo-fnd-pty-rl: <https://spec.edmcouncil.org/fibo/FND/Parties/Roles/>
-prefix fibo-fnd-aap-agt: <https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/>
-prefix fibo-der-drc-swp: <https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/>
-prefix fibo-test-lattice: <http://www.omg.org/spec/fibo/etc/testing/patterns/lattice#>
-prefix fibo-der-rtd-irswp: <https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/>
+
 
 ##
 # banner Subproperties domains should not cross

--- a/etc/testing/hygiene/testHygiene0003.sparql
+++ b/etc/testing/hygiene/testHygiene0003.sparql
@@ -1,18 +1,9 @@
-prefix fibo-der-rtd-irswp: <https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/>
-prefix fibo-der-drc-swp: <https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/>
-prefix fibo-ind-ir-ir: <https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/>
-prefix ex:    <http://www.example.org/time#> 
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
-prefix spin:  <http://spinrdf.org/spin#> 
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#> 
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
-prefix sp:    <http://spinrdf.org/sp#> 
-prefix fibo-test-lattice: <http://www.omg.org/spec/fibo/etc/testing/patterns/lattice#> 
-prefix fibo-fnd-aap-agt: <https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/>
-prefix fibo-fnd-pty-rl: <https://spec.edmcouncil.org/fibo/FND/Parties/Roles/>
 prefix afn: <http://jena.apache.org/ARQ/function#>
-prefix fibo-fnd-utl-av: <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/>
+
 
 ##
 # banner Subproperties ranges should not cross

--- a/etc/testing/hygiene/testHygiene0005.sparql
+++ b/etc/testing/hygiene/testHygiene0005.sparql
@@ -1,21 +1,11 @@
-prefix fibo-der-rtd-irswp: <https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/>
-prefix fibo-der-drc-swp: <https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/>
-prefix fibo-ind-ir-ir: <https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/>
-prefix ex:    <http://www.example.org/time#> 
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
 prefix spin:  <http://spinrdf.org/spin#> 
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#> 
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
-prefix sp:    <http://spinrdf.org/sp#> 
-prefix fibo-test-lattice: <http://www.omg.org/spec/fibo/etc/testing/patterns/lattice#> 
-prefix fibo-fnd-aap-agt: <https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/>
-prefix fibo-fnd-pty-rl: <https://spec.edmcouncil.org/fibo/FND/Parties/Roles/>
-prefix afn: <http://jena.apache.org/ARQ/function#>
 prefix sm: <http://www.omg.org/techprocess/ab/SpecificationMetadata/>
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
 prefix dct: <http://purl.org/dc/terms/>
-prefix fibo-fnd-utl-av: <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/>
 
 ##
 # banner Every Ontology defined in FIBO must have a rdfs:label,  sm:copyright, dct:license, dct:abstract

--- a/etc/testing/hygiene/testHygiene0268.sparql
+++ b/etc/testing/hygiene/testHygiene0268.sparql
@@ -1,19 +1,8 @@
-prefix fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/> 
-prefix fibo-der-rtd-irswp: <https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/>
-prefix fibo-der-drc-swp: <https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/>
-prefix fibo-ind-ir-ir: <https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/>
-prefix ex:    <http://www.example.org/time#> 
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
-prefix spin:  <http://spinrdf.org/spin#> 
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#> 
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
-prefix sp:    <http://spinrdf.org/sp#> 
-prefix fibo-test-lattice: <http://www.omg.org/spec/fibo/etc/testing/patterns/lattice#> 
-prefix fibo-fnd-aap-agt: <https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/>
-prefix fibo-fnd-pty-rl: <https://spec.edmcouncil.org/fibo/FND/Parties/Roles/>
 prefix afn: <http://jena.apache.org/ARQ/function#>
-prefix fibo-fnd-utl-av: <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/>
 prefix sm: <http://www.omg.org/techprocess/ab/SpecificationMetadata/>
 prefix dct: <http://purl.org/dc/terms/> 
 

--- a/etc/testing/hygiene/testHygiene1067.sparql
+++ b/etc/testing/hygiene/testHygiene1067.sparql
@@ -1,4 +1,4 @@
-PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl:   <http://www.w3.org/2002/07/owl#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 

--- a/etc/testing/hygiene/testHygiene1624.sparql
+++ b/etc/testing/hygiene/testHygiene1624.sparql
@@ -1,5 +1,6 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
-prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 ##
 # banner We should avoid punning object and datatype properties

--- a/etc/testing/hygiene/testHygiene1624_chain.sparql
+++ b/etc/testing/hygiene/testHygiene1624_chain.sparql
@@ -1,5 +1,6 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
-prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
 
 ##
 # banner We should avoid punning object and datatype properties

--- a/etc/testing/hygiene/testHygiene1624_disjoint.sparql
+++ b/etc/testing/hygiene/testHygiene1624_disjoint.sparql
@@ -1,5 +1,6 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
-prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
 
 ##
 # banner We should avoid punning object and datatype properties

--- a/etc/testing/hygiene/testHygiene1624_equivalent.sparql
+++ b/etc/testing/hygiene/testHygiene1624_equivalent.sparql
@@ -1,5 +1,6 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
-prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
 
 ##
 # banner We should avoid punning object and datatype properties

--- a/etc/testing/hygiene/testHygiene1624_inverse.sparql
+++ b/etc/testing/hygiene/testHygiene1624_inverse.sparql
@@ -1,5 +1,6 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
-prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
 
 ##
 # banner We should avoid punning object and datatype properties

--- a/etc/testing/hygiene/testHygiene1624_subProperty.sparql
+++ b/etc/testing/hygiene/testHygiene1624_subProperty.sparql
@@ -1,5 +1,6 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
-prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 ##
 # banner We should avoid punning object and datatype properties


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This cleans up prefixes in hygiene tests by:
- adding the required ones
- removing the unused ones

Fixes: #1626 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


