### PR TITLE
DER-1628 - Illegal punning for hasConversionRatio

### DIFF
--- a/DER/DerivativesContracts/RightsAndWarrants.rdf
+++ b/DER/DerivativesContracts/RightsAndWarrants.rdf
@@ -264,7 +264,6 @@
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-raw;hasConversionRatio">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasFactor"/>
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
 		<rdfs:label xml:lang="en">has conversion ratio</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminated punning (erroneous superproperty) on hasConversionRatio in Rights and Warrants

Fixes: #1628 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


