### PR TITLE
IND-114 - Generate the latest FpML interest rates as reference data in the Common Interest Rates ontology

### DIFF
--- a/IND/InterestRates/CommonInterestRates.rdf
+++ b/IND/InterestRates/CommonInterestRates.rdf
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-fbc-fct-eufseind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/">
 	<!ENTITY fibo-fbc-fct-usfsind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/">
 	<!ENTITY fibo-fbc-fct-usjrga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/">
 	<!ENTITY fibo-fnd-acc-4217 "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ir-cm "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/">
@@ -20,11 +18,9 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-fbc-fct-eufseind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"
 	xmlns:fibo-fbc-fct-usfsind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"
 	xmlns:fibo-fbc-fct-usjrga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"
 	xmlns:fibo-fnd-acc-4217="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ir-cm="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"
@@ -50,103 +46,90 @@
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
 		<sm:fileAbbreviation>fibo-ind-ir-cm</sm:fileAbbreviation>
 		<sm:filename>CommonInterestRates.rdf</sm:filename>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210301/InterestRates/CommonInterestRates/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20211201/InterestRates/CommonInterestRates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/InterestRates/InterestRates.rdf version of this ontology was modified to normalize the prefix for the EU individuals ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190101/InterestRates/InterestRates.rdf version of this ontology was revised extensively to restructure the way in which interest rate benchmarks are modeled and eliminate references to the merged interest rate publishers ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190101/InterestRates/InterestRates.rdf version of this ontology was revised to reflect the latest FpML rates.</skos:changeNote>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/floating-rate-index-2-32.xml</fibo-fnd-utl-av:adaptedFrom>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/InterestRates/InterestRates.rdf version of this ontology was revised to reflect the latest FpML rates, which include a number of changes, including deprecating some rates and replacing them with others.</skos:changeNote>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/floating-rate-index-3-2.xml</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AED-EBOR-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AED-EIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>AED-EBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AED-EBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>AED-EBOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>AED-EIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>AED-EIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;UAEDirham"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-AONIA-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-AONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>AUD-AONIA-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-AONIA-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>AUD-AONIA-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>AUD-AONIA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>AUD-AONIA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-AONIA-OIS-COMPOUND-SwapMarker">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-AONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>AUD-AONIA-OIS-COMPOUND-SwapMarker</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-AONIA-OIS-COMPOUND-SwapMarker</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
-		<fibo-fnd-utl-av:abbreviation>AUD-AONIA-OIS-COMPOUND-SwapMarker</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBR-AUBBSW">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>AUD-BBR-AUBBSW</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-BBR-AUBBSW</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>AUD-BBR-AUBBSW</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBR-BBSW">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>AUD-BBR-BBSW</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-BBR-BBSW</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>AUD-BBR-BBSW</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBR-BBSW-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>AUD-BBR-BBSW-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-BBR-BBSW-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>AUD-BBR-BBSW-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBR-BBSY_BID">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>AUD-BBR-BBSY (BID)</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-BBR-BBSY (BID)</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>AUD-BBR-BBSY (BID)</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>AUD-AONIA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>AUD-AONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBR-ISDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-BBR-ISDC</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-BBR-ISDC</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>AUD-BBR-ISDC</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBSW">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>AUD-BBSW</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>AUD-BBSW</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBSW_Quarterly_Swap_Rate_ICAP">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>AUD-BBSW Quarterly Swap Rate ICAP</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>AUD-BBSW Quarterly Swap Rate ICAP</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBSW_Semi_Annual_Swap_Rate_ICAP">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>AUD-BBSW Semi Annual Swap Rate ICAP</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>AUD-BBSW Semi Annual Swap Rate ICAP</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBSY_Bid">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>AUD-BBSY Bid</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>AUD-BBSY Bid</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-LIBOR-BBA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-LIBOR-BBA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-LIBOR-BBA</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>AUD-LIBOR-BBA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
@@ -155,7 +138,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-LIBOR-BBA-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-LIBOR-BBA-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-LIBOR-BBA-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>AUD-LIBOR-BBA-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -165,26 +147,14 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-LIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-LIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>AUD-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Quarterly_Swap_Rate-ICAP">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>AUD-Quarterly Swap Rate-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-Quarterly Swap Rate-ICAP</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>AUD-Quarterly Swap Rate-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
-		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
-	</owl:NamedIndividual>
-	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Quarterly_Swap_Rate-ICAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Quarterly Swap Rate-ICAP-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-Quarterly Swap Rate-ICAP-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>AUD-Quarterly Swap Rate-ICAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
@@ -194,7 +164,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-Semi-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>AUD-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -205,7 +174,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Semi-Annual_Swap_Rate-BGCANTOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>AUD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
@@ -215,18 +183,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Semi-Annual_Swap_Rate-ICAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Semi-Annual Swap Rate-ICAP-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-Semi-Annual Swap Rate-ICAP-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>AUD-Semi-Annual Swap Rate-ICAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
-		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Semi-annual_Swap_Rate-ICAP">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>AUD-Semi-annual Swap Rate-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-Semi-annual Swap Rate-ICAP</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>AUD-Semi-annual Swap Rate-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
@@ -235,7 +192,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Swap_Rate-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Swap Rate-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the AUD-Swap Rate-Reuters</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>AUD-Swap Rate-Reuters</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -245,35 +201,14 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;BRL-CDI">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>BRL-CDI</rdfs:label>
-		<skos:definition>the FpML floating interest index for the BRL-CDI</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>BRL-CDI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Refers to the Overnight Brazilian Interbank Deposit Rate Annualized known as the average (Media) of the DI-OVER-EXTRA Grupo as published by CETIP (Camara de Custodia e Liquidacao).</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;BrazilianReal"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-CDOR">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CAD-BA-CDOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-BA-CDOR</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CAD-BA-CDOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-CDOR-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CAD-BA-CDOR-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-BA-CDOR-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>CAD-BA-CDOR-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-ISDD">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-BA-ISDD</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-BA-ISDD</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CAD-BA-ISDD</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
@@ -282,18 +217,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-BA-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-BA-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CAD-BA-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-Reuters">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CAD-BA-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-BA-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>CAD-BA-Reuters</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 	</owl:NamedIndividual>
@@ -301,26 +225,39 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-BA-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-BA-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>CAD-BA-Telerate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-CORRA-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-CDOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CAD-CORRA-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-CORRA-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CAD-CORRA-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CAD-CDOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CAD-CDOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-CORRA">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>CAD-CORRA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CAD-CORRA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-CORRA-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>CAD-CORRA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CAD-CORRA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-ISDA-Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-ISDA-Swap Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-ISDA-Swap Rate</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CAD-ISDA-Swap Rate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
@@ -329,7 +266,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-BBA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-BBA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-LIBOR-BBA</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CAD-LIBOR-BBA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
@@ -338,7 +274,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-BBA-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-BBA-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-LIBOR-BBA-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>CAD-LIBOR-BBA-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -348,7 +283,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-BBA-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-BBA-SwapMarker</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-LIBOR-BBA-SwapMarker</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-fnd-utl-av:abbreviation>CAD-LIBOR-BBA-SwapMarker</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -358,7 +292,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-LIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CAD-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
@@ -367,7 +300,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-REPO-CORRA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-REPO-CORRA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-REPO-CORRA</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CAD-REPO-CORRA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
@@ -376,7 +308,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-ISDD">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-ISDD</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-TBILL-ISDD</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CAD-TBILL-ISDD</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
@@ -385,7 +316,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-TBILL-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CAD-TBILL-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
@@ -394,7 +324,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-TBILL-Reuters</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>CAD-TBILL-Reuters</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -404,7 +333,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CAD-TBILL-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>CAD-TBILL-Telerate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -414,7 +342,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-3M LIBOR SWAP-CME vs LCH-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-3M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -424,7 +351,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>CHF-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -435,7 +361,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -445,7 +370,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -456,7 +380,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBORSWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBORSWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-6M LIBORSWAP-CME vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>CHF-6M LIBORSWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -467,7 +390,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-6M LIBOR SWAP-CME vs LCH-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-6M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -477,7 +399,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -487,7 +408,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -498,7 +418,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-Annual_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-Annual Swap Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-Annual Swap Rate</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-Annual Swap Rate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -508,7 +427,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-Annual_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-Annual Swap Rate-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-Annual Swap Rate-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-Annual Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -518,7 +436,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -528,7 +445,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-Basis_Swap-3m_vs_6m-LIBOR-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-Basis Swap-3m vs 6m-LIBOR-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-Basis Swap-3m vs 6m-LIBOR-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-Basis Swap-3m vs 6m-LIBOR-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -537,35 +453,22 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-ISDAFIX-Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-ISDAFIX-Swap Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-ISDAFIX-Swap Rate</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-ISDAFIX-Swap Rate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-LIBOR-BBA">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CHF-LIBOR-BBA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-LIBOR-BBA</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CHF-LIBOR-BBA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-LIBOR-BBA-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CHF-LIBOR-BBA-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-LIBOR-BBA-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>CHF-LIBOR-BBA-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CHF-LIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CHF-LIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-LIBOR-ISDA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-LIBOR-ISDA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-LIBOR-ISDA</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-LIBOR-ISDA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -574,7 +477,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-LIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-LIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -583,25 +485,30 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-OIS-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-OIS-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-OIS-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-OIS-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-SARON-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-SARON">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CHF-SARON-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-SARON-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CHF-SARON-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CHF-SARON</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CHF-SARON</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-SARON-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>CHF-SARON-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CHF-SARON-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-TOIS-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-TOIS-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF-TOIS-OIS-COMPOUND</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF-TOIS-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
@@ -610,76 +517,72 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF_USD-Basis_Swaps-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF USD-Basis Swaps-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CHF USD-Basis Swaps-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CHF USD-Basis Swaps-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CL-CLICP-Bloomberg">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CLP-ICP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CL-CLICP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CL-CLICP-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>CL-CLICP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CLP-ICP</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CLP-ICP</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;ChileanPeso"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CLP-TNA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CLP-TNA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CLP-TNA</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CLP-TNA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Refers to the Indice Camara Promedio (&quot;ICP&quot;) rate for Chilean Pesos which, for a Reset Date, is determined and published by the Asociacion de Bancos e Instituciones Financieras de Chile A.G. (&quot;ABIF&quot;) in accordance with the &quot;Reglamento Indice de Camara Promedio&quot; of the ABIF as published in the Diario Oficial de la Republica de Chile (the &quot;ICP Rules&quot;) and which is reported on the ABIF website by not later than 10:00 a.m., Santiago time, on that Reset Date.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;ChileanPeso"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNH-HIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>CNH-HIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CNH-HIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNH-HIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNH-HIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNH-HIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CNH-HIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNH-HIBOR-TMA">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Deposit_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CNH-HIBOR-TMA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNH-HIBOR-TMA</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CNH-HIBOR-TMA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CNY-Deposit Rate</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CNY-Deposit Rate</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-CNREPOFIX_CFXS-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Fixing_Repo_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CNY-CNREPOFIX=CFXS-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNY-CNREPOFIX=CFXS-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>CNY-CNREPOFIX=CFXS-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CNY-Fixing Repo Rate</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CNY-Fixing Repo Rate</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-PBOCB-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-LPR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CNY-PBOCB-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNY-PBOCB-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>CNY-PBOCB-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CNY-LPR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CNY-LPR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Quarterly_7_day_Repo_Non_Deliverable_Swap_Rate-TRADITION">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Quarterly_7D_Repo_NDS_Rate_Tradition">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CNY-Quarterly 7 day Repo Non Deliverable Swap Rate-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNY-Quarterly 7 day Repo Non Deliverable Swap Rate-TRADITION</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>CNY-Quarterly 7 day Repo Non Deliverable Swap Rate-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CNY-Quarterly 7D Repo NDS Rate Tradition</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CNY-Quarterly 7D Repo NDS Rate Tradition</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 	</owl:NamedIndividual>
@@ -687,27 +590,31 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Quarterly_7_day_Repo_Non_Deliverable_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Quarterly 7 day Repo Non Deliverable Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNY-Quarterly 7 day Repo Non Deliverable Swap Rate-TRADITION-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CNY-Quarterly 7 day Repo Non Deliverable Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-SHIBOR-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-SHIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CNY-SHIBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNY-SHIBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>CNY-SHIBOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction..</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CNY-SHIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CNY-SHIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-SHIBOR-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>CNY-SHIBOR-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CNY-SHIBOR-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNY-Semi-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>CNY-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -718,44 +625,33 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNY-Semi-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CNY-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Shibor-OIS-Compounding">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CNY-Shibor-OIS-Compounding</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNY-Shibor-OIS-Compounding</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CNY-Shibor-OIS-Compounding</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
-	</owl:NamedIndividual>
-	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY_7-Repo_Compounding_Date">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY 7-Repo Compounding Date</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CNY 7-Repo Compounding Date</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>CNY 7-Repo Compounding Date</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: CNY 7-Repo Compounding Date - is not an floating rate index and should not be in the floating-rate-index list (it is a date).</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;COP-IBR-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;COP-IBR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>COP-IBR-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the COP-IBR-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>COP-IBR-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>COP-IBR-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>COP-IBR-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;ColombianPeso"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CZK-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>CZK-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -766,100 +662,87 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CZK-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CZK-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-PRIBOR-PRBO">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-CZEONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>CZK-PRIBOR-PRBO</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CZK-PRIBOR-PRBO</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CZK-PRIBOR-PRBO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>CZK-CZEONIA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CZK-CZEONIA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-CZEONIA-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>CZK-CZEONIA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CZK-CZEONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-PRIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>CZK-PRIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>CZK-PRIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-PRIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-PRIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the CZK-PRIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CZK-PRIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR-DKNA13">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>DKK-CIBOR-DKNA13</rdfs:label>
-		<skos:definition>the FpML floating interest index for the DKK-CIBOR-DKNA13</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR-DKNA13</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR-DKNA13-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>DKK-CIBOR-DKNA13-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the DKK-CIBOR-DKNA13-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR-DKNA13-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>DKK-CIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>DKK-CIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the DKK-CIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR2-Bloomberg">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR2">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>DKK-CIBOR2-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the DKK-CIBOR2-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR2-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>DKK-CIBOR2</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR2</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR2-DKNA13">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CITA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>DKK-CIBOR2-DKNA13</rdfs:label>
-		<skos:definition>the FpML floating interest index for the DKK-CIBOR2-DKNA13</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR2-DKNA13</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>DKK-CITA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>DKK-CITA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CITA-DKNA14-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-Tom_Next-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>DKK-CITA-DKNA14-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the DKK-CITA-DKNA14-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>DKK-CITA-DKNA14-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-DKKOIS-OIS-COMPOUND">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>DKK-DKKOIS-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the DKK-DKKOIS-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>DKK-DKKOIS-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>DKK-Tom Next-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>DKK-Tom Next-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-3M_EURIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-3M EURIBOR SWAP-CME vs LCH-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -870,7 +753,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-3M_EURIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-3M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
@@ -882,7 +764,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-3M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -893,7 +774,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-3M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
@@ -905,7 +785,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-6M EURIBOR SWAP-CME vs LCH-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -916,7 +795,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-6M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
@@ -928,7 +806,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -939,7 +816,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
@@ -951,7 +827,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-10:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -961,7 +836,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-10:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -972,7 +846,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-10:00-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -983,7 +856,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-10:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -993,7 +865,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-SwapMarker</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-10:00-SwapMarker</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-SwapMarker</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1004,7 +875,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-10:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1015,7 +885,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-11:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1025,7 +894,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-11:00-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-11:00-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1036,7 +904,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1046,7 +913,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00-SwapMarker</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-11:00-SwapMarker</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-11:00-SwapMarker</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1057,7 +923,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-3_Month">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-3 Month</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-3 Month</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-3 Month</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1067,7 +932,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-3_Month-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-3 Month-SwapMarker</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-3 Month-SwapMarker</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-3 Month-SwapMarker</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1078,7 +942,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-4:15-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-4:15-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1089,27 +952,41 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-AVERAGE">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-CNO_TEC10">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-EONIA-AVERAGE</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EONIA-AVERAGE</skos:definition>
+		<rdfs:label>EUR-CNO TEC10</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-CNO TEC10</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EONIA</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-AVERAGE</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:abbreviation>EUR-EONIA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-Average">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EONIA-Average</rdfs:label>
+		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
+		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-Average</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-10_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-10:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EONIA-OIS-10:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-10:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
@@ -1120,7 +997,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-10_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-10:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EONIA-OIS-10:00-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-10:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1130,7 +1006,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-10_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-10:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EONIA-OIS-10:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-10:00-TRADITION</fibo-fnd-utl-av:abbreviation>
@@ -1141,7 +1016,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EONIA-OIS-11:00-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1151,7 +1025,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-4:15-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EONIA-OIS-4:15-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
@@ -1159,41 +1032,36 @@
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-EONIA-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EONIA-OIS-COMPOUND</skos:definition>
+		<rdfs:label>EUR-EONIA-OIS Compound</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-COMPOUND-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-EONIA-OIS-COMPOUND-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EONIA-OIS-COMPOUND-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-COMPOUND-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-Swap-Index">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-Swap-Index</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EONIA-Swap-Index</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-Swap-Index</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EURIBOR</rdfs:label>
+		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
+		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Act_365">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR-Act/365</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EURIBOR-Act/365</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR-Act/365</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1203,7 +1071,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Act_365-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR-Act/365-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EURIBOR-Act/365-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR-Act/365-Bloomberg</fibo-fnd-utl-av:abbreviation>
@@ -1214,20 +1081,8 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EURIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Reuters">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-EURIBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EURIBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR-Reuters</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
@@ -1235,7 +1090,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EURIBOR-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR-Telerate</fibo-fnd-utl-av:abbreviation>
@@ -1243,48 +1097,99 @@
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURONIA-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR_ICE_Swap_Rate-11_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-EURONIA-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EURONIA-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURONIA-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR-COMPOUND">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-EuroSTR-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-EuroSTR-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-ISDA-EURIBOR_Swap_Rate-11_00">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-ISDA-EURIBOR Swap Rate-11:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-ISDA-EURIBOR Swap Rate-11:00</skos:definition>
+		<rdfs:label>EUR-EURIBOR ICE Swap Rate-11:00</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-ISDA-EURIBOR Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR ICE Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-ISDA-EURIBOR_Swap_Rate-12_00">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR_ICE_Swap_Rate-12_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-ISDA-EURIBOR Swap Rate-12:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-ISDA-EURIBOR Swap Rate-12:00</skos:definition>
+		<rdfs:label>EUR-EURIBOR ICE Swap Rate-12:00</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-ISDA-EURIBOR Swap Rate-12:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR ICE Swap Rate-12:00</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURONIA-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EURONIA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-EURONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EuroSTR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EuroSTR-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_12M">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EuroSTR Average 12M</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 12M</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_1M">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EuroSTR Average 1M</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 1M</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_1W">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EuroSTR Average 1W</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 1W</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_3M">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EuroSTR Average 3M</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 3M</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_6M">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EuroSTR Average 6M</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 6M</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Compounded_Index">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>EUR-EuroSTR Compounded Index</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Compounded Index</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-ISDA-LIBOR_Swap_Rate-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-ISDA-LIBOR Swap Rate-10:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-ISDA-LIBOR Swap Rate-10:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-ISDA-LIBOR Swap Rate-10:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1293,35 +1198,22 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-ISDA-LIBOR_Swap_Rate-11_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-ISDA-LIBOR Swap Rate-11:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-ISDA-LIBOR Swap Rate-11:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-ISDA-LIBOR Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-LIBOR-BBA">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-LIBOR-BBA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-LIBOR-BBA</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>EUR-LIBOR-BBA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-LIBOR-BBA-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-LIBOR-BBA-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-LIBOR-BBA-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-LIBOR-BBA-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>EUR-LIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>EUR-LIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-LIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-LIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1330,27 +1222,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TAM-CDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TAM-CDC</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-TAM-CDC</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-TAM-CDC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC10-CNO">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-TEC10-CNO</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-TEC10-CNO</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>EUR-TEC10-CNO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC10-CNO-SwapMarker">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>EUR-TEC10-CNO-SwapMarker</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-TEC10-CNO-SwapMarker</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-TEC10-CNO-SwapMarker</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
@@ -1358,7 +1230,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC10-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TEC10-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-TEC10-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-TEC10-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1367,7 +1238,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC5-CNO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TEC5-CNO</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-TEC5-CNO</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-TEC5-CNO</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1376,7 +1246,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC5-CNO-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TEC5-CNO-SwapMarker</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-TEC5-CNO-SwapMarker</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-fnd-utl-av:abbreviation>EUR-TEC5-CNO-SwapMarker</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1386,7 +1255,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC5-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TEC5-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-TEC5-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-TEC5-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1395,7 +1263,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TMM-CDC-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TMM-CDC-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR-TMM-CDC-COMPOUND</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR-TMM-CDC-COMPOUND</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1404,7 +1271,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_Basis_Swap-EONIA_vs_3m_EUR_IBOR_Swap_Rates-A_360-10_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR Basis Swap-EONIA vs 3m EUR+IBOR Swap Rates-A/360-10:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR Basis Swap-EONIA vs 3m EUR+IBOR Swap Rates-A/360-10:00-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR Basis Swap-EONIA vs 3m EUR+IBOR Swap Rates-A/360-10:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1414,7 +1280,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_EURIBOR-Annual_Bond_Swap_vs_1m-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR EURIBOR-Annual Bond Swap vs 1m-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR EURIBOR-Annual Bond Swap vs 1m-11:00-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR EURIBOR-Annual Bond Swap vs 1m-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1425,7 +1290,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_EURIBOR-Basis_Swap-1m_vs_3m-Euribor-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR EURIBOR-Basis Swap-1m vs 3m-Euribor-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR EURIBOR-Basis Swap-1m vs 3m-Euribor-11:00-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR EURIBOR-Basis Swap-1m vs 3m-Euribor-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1435,7 +1299,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_EURIBOR-Basis_Swap-3m_vs_6m-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR EURIBOR-Basis Swap-3m vs 6m-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR EURIBOR-Basis Swap-3m vs 6m-11:00-ICAP</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-utl-av:abbreviation>EUR EURIBOR-Basis Swap-3m vs 6m-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1445,7 +1308,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_USD-Basis_Swaps-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR USD-Basis Swaps-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the EUR USD-Basis Swaps-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>EUR USD-Basis Swaps-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1454,7 +1316,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-6M LIBOR SWAP-CME vs LCH-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP-6M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
@@ -1464,7 +1325,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>GBP-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1475,7 +1335,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
@@ -1485,7 +1344,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1493,38 +1351,17 @@
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-ISDA-Swap_Rate">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>GBP-ISDA-Swap Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-ISDA-Swap Rate</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>GBP-ISDA-Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR-BBA">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>GBP-LIBOR-BBA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-LIBOR-BBA</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR-BBA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR-BBA-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>GBP-LIBOR-BBA-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-LIBOR-BBA-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR-BBA-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>GBP-LIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR-ISDA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-LIBOR-ISDA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-LIBOR-ISDA</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR-ISDA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
@@ -1533,25 +1370,46 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-LIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-LIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR_ICE_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>GBP-SONIA-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-SONIA-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>GBP-LIBOR ICE Swap Rate</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR ICE Swap Rate</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-RONIA">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>GBP-RONIA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-RONIA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-RONIA-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>GBP-RONIA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-RONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>GBP-SONIA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-SONIA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA-OIS-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-SONIA-OIS-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-OIS-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
@@ -1560,7 +1418,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA-OIS-11:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-SONIA-OIS-11:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-OIS-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1570,26 +1427,55 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA-OIS-4:15-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-SONIA-OIS-4:15-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-OIS-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_Swap_Rate">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>GBP-SONIA Swap Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-SONIA Swap Rate</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>GBP-SONIA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_Compounded_Index">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>GBP-SONIA Compounded Index</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-SONIA Compounded Index</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_ICE_Swap_Rate">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>GBP-SONIA ICE Swap Rate</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-SONIA ICE Swap Rate</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_ICE_Term">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>GBP-SONIA ICE Term</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-SONIA ICE Term</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_Refinitiv_Term">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>GBP-SONIA Refinitiv Term</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-SONIA Refinitiv Term</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi-Annual_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi-Annual Swap Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-Semi-Annual Swap Rate</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP-Semi-Annual Swap Rate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
@@ -1599,7 +1485,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi-Annual_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi-Annual Swap Rate-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-Semi-Annual Swap Rate-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP-Semi-Annual Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
@@ -1609,7 +1494,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-Semi-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
@@ -1619,7 +1503,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi-Annual_Swap_Rate-SwapMarker26">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi-Annual Swap Rate-SwapMarker26</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-Semi-Annual Swap Rate-SwapMarker26</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP-Semi-Annual Swap Rate-SwapMarker26</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
@@ -1629,7 +1512,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi_Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi Annual Swap Rate-11:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-Semi Annual Swap Rate-11:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>GBP-Semi Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1640,7 +1522,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi_Annual_Swap_Rate-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi Annual Swap Rate-4:15-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-Semi Annual Swap Rate-4:15-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>GBP-Semi Annual Swap Rate-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1648,29 +1529,17 @@
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-WMBA-RONIA-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-UK_Base_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>GBP-WMBA-RONIA-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-WMBA-RONIA-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>GBP-WMBA-RONIA-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-WMBA-SONIA-COMPOUND">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>GBP-WMBA-SONIA-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP-WMBA-SONIA-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>GBP-WMBA-SONIA-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;GBP-SONIA-COMPOUND&quot; replaces &quot;GBP-WMBA-SONIA-COMPOUND&quot;.&quot;GBP-WMBA-SONIA-COMPOUND&quot; code has been deprecated in supplement 55 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>GBP-UK Base Rate</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>GBP-UK Base Rate</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP_USD-Basis_Swaps-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP USD-Basis Swaps-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GBP USD-Basis Swaps-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GBP USD-Basis Swaps-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
@@ -1679,7 +1548,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIBOR-ATHIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIBOR-ATHIBOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GRD-ATHIBOR-ATHIBOR</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GRD-ATHIBOR-ATHIBOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1688,7 +1556,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GRD-ATHIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GRD-ATHIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1697,7 +1564,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIBOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIBOR-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GRD-ATHIBOR-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>GRD-ATHIBOR-Telerate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1707,7 +1573,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIMID-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIMID-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GRD-ATHIMID-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>GRD-ATHIMID-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -1716,19 +1581,27 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIMID-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIMID-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the GRD-ATHIMID-Reuters</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>GRD-ATHIMID-Reuters</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>HKD-HIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-HIBOR-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HIBOR-HIBOR-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-HIBOR-HIBOR-Bloomberg</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-HIBOR-Bloomberg</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-HIBOR-HIBOR-Bloomberg&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 	</owl:NamedIndividual>
@@ -1736,27 +1609,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-HIBOR_">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HIBOR-HIBOR=</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-HIBOR-HIBOR=</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-HIBOR=</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-HKAB">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>HKD-HIBOR-HKAB</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-HIBOR-HKAB</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-HKAB</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-HKAB-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>HKD-HIBOR-HKAB-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-HIBOR-HKAB-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-HKAB-Bloomberg</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-HIBOR-HIBOR=&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 	</owl:NamedIndividual>
@@ -1764,7 +1619,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-ISDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HIBOR-ISDC</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-HIBOR-ISDC</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-ISDC</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
@@ -1773,25 +1627,30 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-HIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HONIX-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>HKD-HONIX-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-HONIX-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>HKD-HONIX-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>HKD-HONIA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>HKD-HONIA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HONIA-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>HKD-HONIA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>HKD-HONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-ISDA-Swap_Rate-11_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-ISDA-Swap Rate-11:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-ISDA-Swap Rate-11:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>HKD-ISDA-Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
@@ -1800,7 +1659,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-ISDA-Swap_Rate-4_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-ISDA-Swap Rate-4:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-ISDA-Swap Rate-4:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>HKD-ISDA-Swap Rate-4:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
@@ -1809,9 +1667,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
@@ -1820,9 +1679,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-11:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-Quarterly-Annual Swap Rate-11:00-TRADITION</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-11:00-TRADITION&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
@@ -1831,9 +1691,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-4_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
@@ -1842,8 +1703,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-Quarterly-Annual Swap Rate-Reference Banks</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-Reference Banks&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
@@ -1852,8 +1714,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Quarterly_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Quarterly Swap Rate-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-Quarterly-Quarterly Swap Rate-11:00-ICAP</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Quarterly Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Quarterly Swap Rate-11:00-ICAP&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
@@ -1862,8 +1725,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Quarterly_Swap_Rate-4_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Quarterly Swap Rate-4:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-Quarterly-Quarterly Swap Rate-4:00-ICAP</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Quarterly Swap Rate-4:00-ICAP</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Quarterly Swap Rate-4:00-ICAP&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
@@ -1872,36 +1736,41 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Quarterly_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Quarterly Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HKD-Quarterly-Quarterly Swap Rate-Reference Banks</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Quarterly Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Quarterly Swap Rate-Reference Banks&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HUF-BUBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>HUF-BUBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>HUF-BUBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Forint"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HUF-BUBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HUF-BUBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HUF-BUBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>HUF-BUBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Forint"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HUF-BUBOR-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HUF-HUFONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>HUF-BUBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the HUF-BUBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>HUF-BUBOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>HUF-HUFONIA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>HUF-HUFONIA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Forint"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-IDMA-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-IDMA-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the IDR-IDMA-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>IDR-IDMA-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1911,26 +1780,22 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-IDRFIX">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-IDRFIX</rdfs:label>
-		<skos:definition>the FpML floating interest index for the IDR-IDRFIX</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>IDR-IDRFIX</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-JIBOR-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-JIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>IDR-JIBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the IDR-JIBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>IDR-JIBOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>IDR-JIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>IDR-JIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SBI-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SBI-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the IDR-SBI-Reuters</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>IDR-SBI-Reuters</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1940,7 +1805,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the IDR-SOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>IDR-SOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
@@ -1949,10 +1813,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SOR-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the IDR-SOR-Reuters</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>IDR-SOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;IDR-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;IDR-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 	</owl:NamedIndividual>
@@ -1960,7 +1824,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SOR-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the IDR-SOR-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>IDR-SOR-Telerate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1970,7 +1833,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the IDR-Semi-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>IDR-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -1981,28 +1843,33 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the IDR-Semi-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>IDR-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ILS-TELBOR-Reference_Banks">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-Semi_Annual_Swap_Rate-Non-deliverable-16_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>ILS-TELBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ILS-TELBOR-Reference Banks</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ILS-TELBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
+		<rdfs:label>IDR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>IDR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ILS-TELBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>ILS-TELBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>ILS-TELBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewIsraeliSheqel"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ILS-TELBOR01-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ILS-TELBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>ILS-TELBOR01-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ILS-TELBOR01-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>ILS-TELBOR01-Reuters</fibo-fnd-utl-av:abbreviation>
+		<rdfs:label>ILS-TELBOR-Reference Banks</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>ILS-TELBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewIsraeliSheqel"/>
 	</owl:NamedIndividual>
@@ -2010,9 +1877,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-BMK">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-BMK</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-BMK</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>INR-BMK</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;INR-BMK&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;INR-BMK&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 	</owl:NamedIndividual>
@@ -2020,18 +1887,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-CMT">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-CMT</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-CMT</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>INR-CMT</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;INR-CMT&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-FBIL-MIBOR-OIS-COMPOUND">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>INR-FBIL-MIBOR-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-FBIL-MIBOR-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>INR-FBIL-MIBOR-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;INR-CMT&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 	</owl:NamedIndividual>
@@ -2039,9 +1897,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-INBMK-REUTERS">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-INBMK-REUTERS</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-INBMK-REUTERS</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>INR-INBMK-REUTERS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;INR-INBMK-REUTERS&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;INR-INBMK-REUTERS&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 	</owl:NamedIndividual>
@@ -2049,44 +1907,56 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MIBOR-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-MIBOR-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-MIBOR-OIS-COMPOUND</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>INR-MIBOR-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MIBOR-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>INR-MIBOR-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>INR-MIBOR-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MIBOR_OIS">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>INR-MIBOR OIS</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>INR-MIBOR OIS</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MIFOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-MIFOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-MIFOR</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>INR-MIFOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MIOIS">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>INR-MIOIS</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-MIOIS</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>INR-MIOIS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MITOR-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-MITOR-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-MITOR-OIS-COMPOUND</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>INR-MITOR-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;INR-MITOR-OIS-COMPOUND&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;INR-MITOR-OIS-COMPOUND&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Modified_MIFOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>INR-Modified MIFOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>INR-Modified MIFOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>INR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
@@ -2095,7 +1965,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Semi-Annual_Swap_Rate-11_30-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Semi-Annual Swap Rate-11:30-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-Semi-Annual Swap Rate-11:30-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>INR-Semi-Annual Swap Rate-11:30-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2106,7 +1975,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-Semi-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>INR-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
@@ -2116,28 +1984,24 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Semi_Annual_Swap_Rate-Non-deliverable-16_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</rdfs:label>
-		<skos:definition>the FpML floating interest index for the INR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>INR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ISK-REIBOR-Reference_Banks">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ISK-REIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>ISK-REIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ISK-REIBOR-Reference Banks</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ISK-REIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>ISK-REIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>ISK-REIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IcelandKrona"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ISK-REIBOR-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ISK-REIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>ISK-REIBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ISK-REIBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>ISK-REIBOR-Reuters</fibo-fnd-utl-av:abbreviation>
+		<rdfs:label>ISK-REIBOR-Reference Banks</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>ISK-REIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IcelandKrona"/>
 	</owl:NamedIndividual>
@@ -2145,7 +2009,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-Annual Swap Rate-11:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-Annual Swap Rate-11:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>JPY-Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2156,7 +2019,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Annual_Swap_Rate-3_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-Annual Swap Rate-3:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-Annual Swap Rate-3:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>JPY-Annual Swap Rate-3:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2167,7 +2029,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-BBSF-Bloomberg-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-BBSF-Bloomberg-10:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-BBSF-Bloomberg-10:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-BBSF-Bloomberg-10:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2176,16 +2037,22 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-BBSF-Bloomberg-15_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-BBSF-Bloomberg-15:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-BBSF-Bloomberg-15:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-BBSF-Bloomberg-15:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Euroyen_TIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-Euroyen TIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-Euroyen TIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-ISDA-Swap_Rate-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-ISDA-Swap Rate-10:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-ISDA-Swap Rate-10:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-ISDA-Swap Rate-10:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2194,44 +2061,22 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-ISDA-Swap_Rate-15_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-ISDA-Swap Rate-15:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-ISDA-Swap Rate-15:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-ISDA-Swap Rate-15:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR-BBA">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-LIBOR-BBA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-LIBOR-BBA</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR-BBA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR-BBA-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-LIBOR-BBA-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-LIBOR-BBA-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR-BBA-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR-FRASETT">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-LIBOR-FRASETT</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-LIBOR-FRASETT</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR-FRASETT</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>JPY-LIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR-ISDA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LIBOR-ISDA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-LIBOR-ISDA</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR-ISDA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2240,34 +2085,46 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-LIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LTPR-MHCB">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR_TSR-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-LTPR-MHCB</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-LTPR-MHCB</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>JPY-LTPR-MHCB</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>JPY-LIBOR TSR-10:00</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR TSR-10:00</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR_TSR-15_00">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-LIBOR TSR-15:00</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR TSR-15:00</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LTPR-TBC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LTPR-TBC</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-LTPR-TBC</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-LTPR-TBC</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LTPR_MHBK">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-LTPR MHBK</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-LTPR MHBK</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-MUTANCALL-TONAR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-MUTANCALL-TONAR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-MUTANCALL-TONAR</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-MUTANCALL-TONAR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2276,7 +2133,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-OIS-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-OIS-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-OIS-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-OIS-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2285,7 +2141,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-OIS-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-OIS-11:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-OIS-11:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>JPY-OIS-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2295,7 +2150,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-OIS-3_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-OIS-3:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-OIS-3:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>JPY-OIS-3:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2305,7 +2159,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Quoting_Banks-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-Quoting Banks-LIBOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-Quoting Banks-LIBOR</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-Quoting Banks-LIBOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2314,26 +2167,23 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-STPR-Quoting_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-STPR-Quoting Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-STPR-Quoting Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-STPR-Quoting Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-TIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-17096">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-17096</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-17096</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-17096</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-17097">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-TIBOR-17097</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-17097</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-17097</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
@@ -2341,7 +2191,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-DTIBOR01">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-DTIBOR01</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-DTIBOR01</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-DTIBOR01</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2350,7 +2199,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-TIBM</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2359,7 +2207,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-TIBM-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2368,9 +2215,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM_10_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM (10 Banks)</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-TIBM (10 Banks)</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM (10 Banks)</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;JPY-TIBOR-TIBM (10 Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;JPY-TIBOR-TIBM (10 Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
@@ -2378,9 +2225,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM_5_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM (5 Banks)</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-TIBM (5 Banks)</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM (5 Banks)</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;JPY-TIBOR-TIBM (5 Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;JPY-TIBOR-TIBM (5 Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
@@ -2388,64 +2235,89 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM_All_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM (All Banks)</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-TIBM (All Banks)</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM (All Banks)</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;JPY-TIBOR-TIBM (All Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;JPY-TIBOR-TIBM (All Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM_All_Banks-Bloomberg">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-TIBOR-TIBM (All Banks)-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-TIBM (All Banks)-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM (All Banks)-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>JPY-TONA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TONA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-ZTIBOR">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-TIBOR-ZTIBOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TIBOR-ZTIBOR</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-ZTIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>JPY-TONA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TONA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_Average_180D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-TONA-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TONA-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>JPY-TONA-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>JPY-TONA Average 180D</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TONA Average 180D</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_Average_30D">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-TONA Average 30D</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TONA Average 30D</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_Average_90D">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-TONA Average 90D</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TONA Average 90D</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_Compounded_Index">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-TONA Compounded Index</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TONA Compounded Index</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_TSR-10_00">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-TONA TSR-10:00</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TONA TSR-10:00</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_TSR-15_00">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-TONA TSR-15:00</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TONA TSR-15:00</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TORF_QUICK">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>JPY-TORF QUICK</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>JPY-TORF QUICK</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TSR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TSR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TSR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-TSR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TSR-Reuters-10_00">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-TSR-Reuters-10:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TSR-Reuters-10:00</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>JPY-TSR-Reuters-10:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TSR-Reuters-15_00">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>JPY-TSR-Reuters-15:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TSR-Reuters-15:00</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>JPY-TSR-Reuters-15:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
@@ -2453,7 +2325,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TSR-Telerate-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TSR-Telerate-10:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TSR-Telerate-10:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-TSR-Telerate-10:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2462,7 +2333,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TSR-Telerate-15_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TSR-Telerate-15:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY-TSR-Telerate-15:00</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY-TSR-Telerate-15:00</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2471,7 +2341,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY_USD-Basis_Swaps-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY USD-Basis Swaps-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the JPY USD-Basis Swaps-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>JPY USD-Basis Swaps-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
@@ -2480,82 +2349,65 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;KRW-Bond-3222">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>KRW-Bond-3222</rdfs:label>
-		<skos:definition>the FpML floating interest index for the KRW-Bond-3222</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>KRW-Bond-3222</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Won"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;KRW-CD-3220">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;KRW-CD_91D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>KRW-CD-3220</rdfs:label>
-		<skos:definition>the FpML floating interest index for the KRW-CD-3220</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>KRW-CD-3220</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Won"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;KRW-CD-KSDA-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>KRW-CD-KSDA-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the KRW-CD-KSDA-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>KRW-CD-KSDA-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>KRW-CD 91D</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>KRW-CD 91D</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Won"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;KRW-Quarterly_Annual_Swap_Rate-3_30-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>KRW-Quarterly Annual Swap Rate-3:30-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the KRW-Quarterly Annual Swap Rate-3:30-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>KRW-Quarterly Annual Swap Rate-3:30-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Won"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MXN-TIIE-Banxico">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MXN-TIIE">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>MXN-TIIE-Banxico</rdfs:label>
-		<skos:definition>the FpML floating interest index for the MXN-TIIE-Banxico</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>MXN-TIIE-Banxico</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MXN-TIIE-Banxico-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>MXN-TIIE-Banxico-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the MXN-TIIE-Banxico-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>MXN-TIIE-Banxico-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>MXN-TIIE</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>MXN-TIIE</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MXN-TIIE-Banxico-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MXN-TIIE-Banxico-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the MXN-TIIE-Banxico-Reference Banks</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>MXN-TIIE-Banxico-Reference Banks</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: MXN-TIIE-Banxico-Reference Banks. It was added to FpML in error, MXN-TIIE-Reference Banks should be used instead.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-KLIBOR-BNM">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MXN-TIIE-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>MYR-KLIBOR-BNM</rdfs:label>
-		<skos:definition>the FpML floating interest index for the MYR-KLIBOR-BNM</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>MYR-KLIBOR-BNM</fibo-fnd-utl-av:abbreviation>
+		<rdfs:label>MXN-TIIE-Reference Banks</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>MXN-TIIE-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-KLIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>MYR-KLIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>MYR-KLIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-KLIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MYR-KLIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the MYR-KLIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>MYR-KLIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
@@ -2564,7 +2416,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-Quarterly_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MYR-Quarterly Swap Rate-11:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the MYR-Quarterly Swap Rate-11:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>MYR-Quarterly Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2575,19 +2426,26 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-Quarterly_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MYR-Quarterly Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the MYR-Quarterly Swap Rate-TRADITION-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>MYR-Quarterly Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>NOK-NIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>NOK-NIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NIBOR-NIBR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NOK-NIBOR-NIBR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NOK-NIBOR-NIBR</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>NOK-NIBOR-NIBR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;NOK-NIBOR-NIBR&quot; code has been deprecated in supplement 49 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;NOK-NIBOR-NIBR&quot; code has been deprecated in supplement 49 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
 	</owl:NamedIndividual>
@@ -2595,17 +2453,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NIBOR-NIBR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NOK-NIBOR-NIBR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NOK-NIBOR-NIBR-Reference Banks</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>NOK-NIBOR-NIBR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NIBOR-OIBOR">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>NOK-NIBOR-OIBOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NOK-NIBOR-OIBOR</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NOK-NIBOR-OIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: NOK-NIBOR-NIBR-Reference Banks. It was added to FpML in error, NOK-NIBOR-Reference Banks should be used instead.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
 	</owl:NamedIndividual>
@@ -2613,34 +2463,30 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NOK-NIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NOK-NIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>NOK-NIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BBR-BID">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NOWA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>NZD-BBR-BID</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-BBR-BID</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NZD-BBR-BID</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<rdfs:label>NOK-NOWA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>NOK-NOWA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BBR-FRA">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NOWA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>NZD-BBR-FRA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-BBR-FRA</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NZD-BBR-FRA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<rdfs:label>NOK-NOWA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>NOK-NOWA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BBR-ISDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BBR-ISDC</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-BBR-ISDC</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>NZD-BBR-ISDC</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
@@ -2649,7 +2495,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BBR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BBR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-BBR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>NZD-BBR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
@@ -2658,26 +2503,55 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BBR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BBR-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-BBR-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>NZD-BBR-Telerate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-NZIONA-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BKBM_Bid">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>NZD-NZIONA-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-NZIONA-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NZD-NZIONA-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>NZD-BKBM Bid</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>NZD-BKBM Bid</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BKBM_FRA">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>NZD-BKBM FRA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>NZD-BKBM FRA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BKBM_FRA_Swap_Rate_ICAP">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>NZD-BKBM FRA Swap Rate ICAP</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>NZD-BKBM FRA Swap Rate ICAP</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-NZIONA">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>NZD-NZIONA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>NZD-NZIONA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-NZIONA-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>NZD-NZIONA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>NZD-NZIONA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-Semi-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>NZD-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2688,46 +2562,34 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-Semi-Annual_Swap_Rate-BGCANTOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>NZD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-Swap_Rate-ICAP">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>NZD-Swap Rate-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-Swap Rate-ICAP</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NZD-Swap Rate-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
-	</owl:NamedIndividual>
-	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-Swap_Rate-ICAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-Swap Rate-ICAP-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the NZD-Swap Rate-ICAP-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>NZD-Swap Rate-ICAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-PHIREF-BAP">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-PHIREF">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>PHP-PHIREF-BAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PHP-PHIREF-BAP</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PHP-PHIREF-BAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>PHP-PHIREF</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>PHP-PHIREF</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-PHIREF-Bloomberg">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-PHIREF-BAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>PHP-PHIREF-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PHP-PHIREF-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>PHP-PHIREF-Bloomberg</fibo-fnd-utl-av:abbreviation>
+		<rdfs:label>PHP-PHIREF-BAP</rdfs:label>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<fibo-fnd-utl-av:abbreviation>PHP-PHIREF-BAP</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;PHP-PHIREF-BAP&quot; code has been deprecated in supplement 45 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
 	</owl:NamedIndividual>
@@ -2735,7 +2597,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-PHIREF-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PHP-PHIREF-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PHP-PHIREF-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>PHP-PHIREF-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
@@ -2744,7 +2605,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PHP-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PHP-Semi-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>PHP-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2755,36 +2615,48 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PHP-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PHP-Semi-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>PHP-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-POLONIA-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-POLONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>PLN-POLONIA-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PLN-POLONIA-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PLN-POLONIA-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>PLN-POLONIA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>PLN-POLONIA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-POLONIA-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>PLN-POLONIA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>PLN-POLONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-WIBID">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>PLN-WIBID</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>PLN-WIBID</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-WIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>PLN-WIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>PLN-WIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-WIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLN-WIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PLN-WIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>PLN-WIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-WIBOR-WIBO">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>PLN-WIBOR-WIBO</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PLN-WIBOR-WIBO</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PLN-WIBOR-WIBO</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
 	</owl:NamedIndividual>
@@ -2792,7 +2664,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLZ-WIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLZ-WIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PLZ-WIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>PLZ-WIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
@@ -2801,7 +2672,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLZ-WIBOR-WIBO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLZ-WIBOR-WIBO</rdfs:label>
-		<skos:definition>the FpML floating interest index for the PLZ-WIBOR-WIBO</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>PLZ-WIBOR-WIBO</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
@@ -2810,7 +2680,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;REPOFUNDS_RATE-FRANCE-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>REPOFUNDS RATE-FRANCE-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the REPOFUNDS RATE-FRANCE-OIS-COMPOUND</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>REPOFUNDS RATE-FRANCE-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -2819,7 +2688,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;REPOFUNDS_RATE-GERMANY-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>REPOFUNDS RATE-GERMANY-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the REPOFUNDS RATE-GERMANY-OIS-COMPOUND</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>REPOFUNDS RATE-GERMANY-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -2828,7 +2696,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;REPOFUNDS_RATE-ITALY-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>REPOFUNDS RATE-ITALY-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the REPOFUNDS RATE-ITALY-OIS-COMPOUND</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>REPOFUNDS RATE-ITALY-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -2837,7 +2704,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RON-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RON-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>RON-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2848,27 +2714,31 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RON-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RON-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>RON-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-RBOR-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-ROBID">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>RON-RBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RON-RBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>RON-RBOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>RON-ROBID</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>RON-ROBID</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-ROBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>RON-ROBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>RON-ROBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RUB-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2879,7 +2749,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-12_45-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-12:45-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RUB-Annual Swap Rate-12:45-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-12:45-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2890,7 +2759,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-4:15-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RUB-Annual Swap Rate-4:15-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -2901,7 +2769,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RUB-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
@@ -2911,54 +2778,64 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RUB-Annual Swap Rate-TRADITION-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-MOSPRIME-NFEA">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Key_Rate_CBRF">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>RUB-MOSPRIME-NFEA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RUB-MOSPRIME-NFEA</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RUB-MOSPRIME-NFEA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>RUB-Key Rate CBRF</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>RUB-Key Rate CBRF</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-MOSPRIME-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-MOSPRIME-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RUB-MOSPRIME-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>RUB-MOSPRIME-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-RUONIA-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-MosPrime">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>RUB-RUONIA-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the RUB-RUONIA-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RUB-RUONIA-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>RUB-MosPrime</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>RUB-MosPrime</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-RUONIA">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>RUB-RUONIA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>RUB-RUONIA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-RUONIA-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>RUB-RUONIA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>RUB-RUONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SAR-SAIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>SAR-SAIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>SAR-SAIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SaudiRiyal"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SAR-SRIOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SAR-SRIOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SAR-SRIOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SAR-SRIOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SaudiRiyal"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SAR-SRIOR-SUAA">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>SAR-SRIOR-SUAA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SAR-SRIOR-SUAA</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SAR-SRIOR-SUAA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SaudiRiyal"/>
 	</owl:NamedIndividual>
@@ -2966,7 +2843,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-Annual_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SEK-Annual Swap Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SEK-Annual Swap Rate</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SEK-Annual Swap Rate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
@@ -2976,65 +2852,48 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-Annual_Swap_Rate-SESWFI">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SEK-Annual Swap Rate-SESWFI</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SEK-Annual Swap Rate-SESWFI</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SEK-Annual Swap Rate-SESWFI</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-SIOR-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-STIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>SEK-SIOR-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SEK-SIOR-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SEK-SIOR-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>SEK-STIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>SEK-STIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-STIBOR-Bloomberg">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-STIBOR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>SEK-STIBOR-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SEK-STIBOR-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>SEK-STIBOR-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>SEK-STIBOR-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>SEK-STIBOR-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-STIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SEK-STIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SEK-STIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SEK-STIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-STIBOR-SIDE">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>SEK-STIBOR-SIDE</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SEK-STIBOR-SIDE</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SEK-STIBOR-SIDE</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
+		<rdfs:label>SGD-SIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>SGD-SIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-SIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SIBOR-Reuters">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>SGD-SIBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SIBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>SGD-SIBOR-Reuters</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
@@ -3042,7 +2901,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SIBOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SIBOR-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SIBOR-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>SGD-SIBOR-Telerate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3052,39 +2910,27 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SONAR-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SONAR-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SONAR-OIS-COMPOUND</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>SGD-SONAR-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;SGD-SONAR-OIS-COMPOUND&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;SGD-SONAR-OIS-COMPOUND&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SONAR-OIS-VWAP-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>SGD-SONAR-OIS-VWAP-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SONAR-OIS-VWAP-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SGD-SONAR-OIS-VWAP-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>SGD-SOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>SGD-SOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SOR-Reference Banks</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>SGD-SOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;SGD-SOR-Reference Banks&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-Reuters">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>SGD-SOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>SGD-SOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;SGD-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;SGD-SOR-Reference Banks&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
@@ -3092,18 +2938,8 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SOR-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SOR-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>SGD-SOR-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-VWAP">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>SGD-SOR-VWAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SOR-VWAP</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SGD-SOR-VWAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
@@ -3111,25 +2947,30 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-VWAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SOR-VWAP-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SOR-VWAP-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-SOR-VWAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SORA-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SORA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>SGD-SORA-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-SORA-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SGD-SORA-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>SGD-SORA</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>SGD-SORA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SORA-OIS_Compound">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>SGD-SORA-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>SGD-SORA-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Currency_Basis_Swap_Rate-11_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Currency Basis Swap Rate-11:00-Tullett Prebon</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Currency Basis Swap Rate-11:00-Tullett Prebon</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Currency Basis Swap Rate-11:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
@@ -3139,7 +2980,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Currency_Basis_Swap_Rate-16_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Currency Basis Swap Rate-16:00-Tullett Prebon</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Currency Basis Swap Rate-16:00-Tullett Prebon</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Currency Basis Swap Rate-16:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
@@ -3149,7 +2989,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-11.00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-11.00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Swap Rate-11.00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-11.00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3160,7 +2999,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3171,7 +3009,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-11_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-11:00-Tullett Prebon</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Swap Rate-11:00-Tullett Prebon</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-11:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
@@ -3181,7 +3018,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-16_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-16:00-Tullett Prebon</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Swap Rate-16:00-Tullett Prebon</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-16:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
@@ -3191,7 +3027,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Swap Rate-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
@@ -3201,7 +3036,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-ICAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-ICAP-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Swap Rate-ICAP-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-ICAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
@@ -3211,7 +3045,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
@@ -3221,7 +3054,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SGD-Semi-Annual Swap Rate-TRADITION-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
@@ -3231,7 +3063,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-BRBO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SKK-BRIBOR-BRBO</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SKK-BRIBOR-BRBO</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SKK-BRIBOR-BRBO</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -3240,7 +3071,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SKK-BRIBOR-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SKK-BRIBOR-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>SKK-BRIBOR-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3250,7 +3080,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-NBSK07">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SKK-BRIBOR-NBSK07</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SKK-BRIBOR-NBSK07</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SKK-BRIBOR-NBSK07</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -3259,7 +3088,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SKK-BRIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the SKK-BRIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>SKK-BRIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
@@ -3268,9 +3096,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-SOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-SOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the THB-SOR-Reference Banks</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>THB-SOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;THB-SOR-Reference Banks&quot; code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;THB-SOR-Reference Banks&quot; code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 	</owl:NamedIndividual>
@@ -3278,10 +3106,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-SOR-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-SOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the THB-SOR-Reuters</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>THB-SOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>&quot;THB-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;THB-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 	</owl:NamedIndividual>
@@ -3289,7 +3117,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-SOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-SOR-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the THB-SOR-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>THB-SOR-Telerate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3299,9 +3126,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the THB-Semi-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>THB-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
@@ -3310,45 +3138,49 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the THB-Semi-Annual Swap Rate-Reference Banks</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>THB-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THBFIX">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>THB-THBFIX</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>THB-THBFIX</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THBFIX-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-THBFIX-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the THB-THBFIX-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>THB-THBFIX-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THBFIX-Reuters">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>THB-THBFIX-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the THB-THBFIX-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>THB-THBFIX-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>THB-THOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>THB-THOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THOR-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THOR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>THB-THOR-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the THB-THOR-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>THB-THOR-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>THB-THOR-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>THB-THOR-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-Annual_Swap_Rate-11_15-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-Annual Swap Rate-11:15-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TRY-Annual Swap Rate-11:15-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>TRY-Annual Swap Rate-11:15-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3359,7 +3191,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TRY-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TRY-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
@@ -3369,37 +3200,32 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-Semi-Annual_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-Semi-Annual Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TRY-Semi-Annual Swap Rate-TRADITION-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TRY-Semi-Annual Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TLREF-OIS-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TLREF-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>TRY-TLREF-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TRY-TLREF-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>TRY-TLREF-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>TRY-TLREF-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>TRY-TLREF-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TRLIBOR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>TRY-TRLIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>TRY-TRLIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TRYIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-TRYIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TRY-TRYIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TRY-TRYIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TRYIBOR-Reuters">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>TRY-TRYIBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TRY-TRYIBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>TRY-TRYIBOR-Reuters</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 	</owl:NamedIndividual>
@@ -3407,7 +3233,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY_Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY Annual Swap Rate-11:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TRY Annual Swap Rate-11:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>TRY Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3418,7 +3243,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Quarterly-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>TWD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3429,7 +3253,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Quarterly-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Quarterly-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-Quarterly-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TWD-Quarterly-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
@@ -3439,7 +3262,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Reference Dealers</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-Reference Dealers</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TWD-Reference Dealers</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
@@ -3448,7 +3270,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Reuters-6165">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Reuters-6165</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-Reuters-6165</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TWD-Reuters-6165</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
@@ -3457,45 +3278,30 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TAIBIR01">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-TAIBIR01</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-TAIBIR01</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TWD-TAIBIR01</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TAIBIR02">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-TAIBIR02</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-TAIBIR02</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TWD-TAIBIR02</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TAIBOR-Bloomberg">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TAIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>TWD-TAIBOR-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-TAIBOR-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>TWD-TAIBOR-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TAIBOR-Reuters">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>TWD-TAIBOR-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-TAIBOR-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>TWD-TAIBOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>TWD-TAIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>TWD-TAIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TWCPBA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-TWCPBA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-TWCPBA</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TWD-TWCPBA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
@@ -3504,25 +3310,14 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Telerate-6165">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Telerate-6165</rdfs:label>
-		<skos:definition>the FpML floating interest index for the TWD-Telerate-6165</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>TWD-Telerate-6165</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;UK_Base_Rate">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>UK Base Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the UK Base Rate</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>UK Base Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
-	</owl:NamedIndividual>
-	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-3M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-3M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-3M LIBOR SWAP-CME vs LCH-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-3M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3532,7 +3327,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-3M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>USD-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3543,7 +3337,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-6M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-6M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-6M LIBOR SWAP-CME vs LCH-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-6M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3553,7 +3346,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-6M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>USD-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3564,34 +3356,46 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-AMERIBOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-AMERIBOR</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Average_30D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-AMERIBOR Average 30D</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-AMERIBOR Average 30D</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Average 30D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Average_90D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-AMERIBOR Average 90D</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-AMERIBOR Average 90D</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Average 90D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Term">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-AMERIBOR Term</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Term</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Term_Structure">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-AMERIBOR Term Structure</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Term Structure</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>USD-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3602,7 +3406,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Annual Swap Rate-11:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Annual Swap Rate-11:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>USD-Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3613,7 +3416,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-4_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Annual Swap Rate-4:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Annual Swap Rate-4:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>USD-Annual Swap Rate-4:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3624,7 +3426,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-BA-H.15">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-BA-H.15</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-BA-H.15</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
 		<fibo-fnd-utl-av:abbreviation>USD-BA-H.15</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3634,7 +3435,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-BA-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-BA-Reference Dealers</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-BA-Reference Dealers</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-BA-Reference Dealers</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3643,16 +3443,22 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-BMA_Municipal_Swap_Index">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-BMA Municipal Swap Index</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-BMA Municipal Swap Index</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-BMA Municipal Swap Index</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-BSBY">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-BSBY</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-BSBY</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CD-H.15">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CD-H.15</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CD-H.15</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
 		<fibo-fnd-utl-av:abbreviation>USD-CD-H.15</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3662,7 +3468,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CD-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CD-Reference Dealers</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CD-Reference Dealers</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-CD-Reference Dealers</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3671,7 +3476,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CMS-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-CMS-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3680,7 +3484,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Reference_Banks-ICAP_SwapPX">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Reference Banks-ICAP SwapPX</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CMS-Reference Banks-ICAP SwapPX</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-CMS-Reference Banks-ICAP SwapPX</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3689,7 +3492,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CMS-Reuters</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>USD-CMS-Reuters</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3699,187 +3501,112 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CMS-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>USD-CMS-Telerate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMT-T7051">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMT">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-CMT-T7051</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CMT-T7051</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-CMT-T7051</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-CMT</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-CMT</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMT-T7052">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMT_Average_1W">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-CMT-T7052</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CMT-T7052</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-CMT-T7052</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-COF11-FHLBSF">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-COF11-FHLBSF</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-COF11-FHLBSF</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-COF11-FHLBSF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-COF11-Reuters">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-COF11-Reuters</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-COF11-Reuters</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>USD-COF11-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-CMT Average 1W</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-CMT Average 1W</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-COF11-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-COF11-Telerate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-COF11-Telerate</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-fnd-utl-av:abbreviation>USD-COF11-Telerate</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CP-H.15">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-COFI">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-CP-H.15</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CP-H.15</skos:definition>
-		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
-		<fibo-fnd-utl-av:abbreviation>USD-CP-H.15</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-COFI</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-COFI</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CP-Money_Market_Yield">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-CP-Money Market Yield</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-CP-Money Market Yield</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CP-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CP-Reference Dealers</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-CP-Reference Dealers</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-CP-Reference Dealers</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CRITR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-CRITR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-CRITR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-FFCB-DISCO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-FFCB-DISCO</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-FFCB-DISCO</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-FFCB-DISCO</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Federal_Funds-H.15">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Federal_Funds">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-Federal Funds-H.15</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Federal Funds-H.15</skos:definition>
-		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
-		<fibo-fnd-utl-av:abbreviation>USD-Federal Funds-H.15</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-Federal Funds</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-Federal Funds</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Federal_Funds-H.15-Bloomberg">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Federal_Funds-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-Federal Funds-H.15-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Federal Funds-H.15-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>USD-Federal Funds-H.15-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Federal_Funds-H.15-OIS-COMPOUND">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-Federal Funds-H.15-OIS-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Federal Funds-H.15-OIS-COMPOUND</skos:definition>
-		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
-		<fibo-fnd-utl-av:abbreviation>USD-Federal Funds-H.15-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-Federal Funds-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-Federal Funds-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Federal_Funds-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Federal Funds-Reference Dealers</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Federal Funds-Reference Dealers</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Federal Funds-Reference Dealers</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-ISDA-Swap_Rate">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-ISDA-Swap Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-ISDA-Swap Rate</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-ISDA-Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-ISDA-Swap_Rate-3_00">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-ISDA-Swap Rate-3:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-ISDA-Swap Rate-3:00</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-ISDA-Swap Rate-3:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-ISDAFIX3-Swap_Rate">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-ISDAFIX3-Swap Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-ISDAFIX3-Swap Rate</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-ISDAFIX3-Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-ISDAFIX3-Swap_Rate-3_00">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-ISDAFIX3-Swap Rate-3:00</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-ISDAFIX3-Swap Rate-3:00</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-ISDAFIX3-Swap Rate-3:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR-BBA">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-LIBOR-BBA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-LIBOR-BBA</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-LIBOR-BBA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR-BBA-Bloomberg">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-LIBOR-BBA-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-LIBOR-BBA-Bloomberg</skos:definition>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>USD-LIBOR-BBA-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-LIBOR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-LIBOR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR-ISDA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-LIBOR-ISDA</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-LIBOR-ISDA</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-LIBOR-ISDA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3888,7 +3615,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR-LIBO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-LIBOR-LIBO</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-LIBOR-LIBO</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-LIBOR-LIBO</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3897,16 +3623,38 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-LIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-LIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR_ICE_Swap_Rate-11_00">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-LIBOR ICE Swap Rate-11:00</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-LIBOR ICE Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR_ICE_Swap_Rate-15_00">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-LIBOR ICE Swap Rate-15:00</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-LIBOR ICE Swap Rate-15:00</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Municipal_Swap_Index">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-Municipal Swap Index</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-Municipal Swap Index</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Municipal_Swap_Libor_Ratio-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Municipal Swap Libor Ratio-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Municipal Swap Libor Ratio-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Municipal Swap Libor Ratio-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3915,7 +3663,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Municipal_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Municipal Swap Rate-11:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Municipal Swap Rate-11:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Municipal Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3924,7 +3671,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-OIS-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>USD-OIS-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3934,7 +3680,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-LON-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-LON-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-OIS-11:00-LON-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-OIS-11:00-LON-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3943,7 +3688,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-NY-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-NY-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-OIS-11:00-NY-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-OIS-11:00-NY-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3952,7 +3696,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-OIS-11:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>USD-OIS-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3962,7 +3705,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-3_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-3:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-OIS-3:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>USD-OIS-3:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3972,7 +3714,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-3_00-NY-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-3:00-NY-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-OIS-3:00-NY-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-OIS-3:00-NY-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -3981,7 +3722,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-4_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-4:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-OIS-4:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>USD-OIS-4:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -3991,26 +3731,22 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Overnight_Bank_Funding_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Overnight Bank Funding Rate</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Overnight Bank Funding Rate</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Overnight Bank Funding Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Prime-H.15">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Prime">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-Prime-H.15</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Prime-H.15</skos:definition>
-		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
-		<fibo-fnd-utl-av:abbreviation>USD-Prime-H.15</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-Prime</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-Prime</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Prime-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Prime-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Prime-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Prime-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4019,7 +3755,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-SIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-SIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4028,43 +3763,88 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SIBOR-SIBO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SIBOR-SIBO</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-SIBOR-SIBO</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-utl-av:abbreviation>USD-SIBOR-SIBO</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 36 to the 2006 ISDA definitions (Section 7.1 (ab) (xxviii) USD-SIBOR-SIBO is deleted in its entirety). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SIFMA_Municipal_Swap_Index">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-SIFMA Municipal Swap Index</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-SIFMA Municipal Swap Index</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-SIFMA Municipal Swap Index</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-SOFR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-SOFR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR-COMPOUND">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-SOFR-COMPOUND</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-SOFR-COMPOUND</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-SOFR-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-SOFR-OIS Compound</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-SOFR-OIS Compound</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-S_P_Index-High_Grade">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_Average_180D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-S&amp;P Index-High Grade</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-S&amp;P Index-High Grade</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-S&amp;P Index-High Grade</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-SOFR Average 180D</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-SOFR Average 180D</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_Average_30D">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-SOFR Average 30D</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-SOFR Average 30D</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_Average_90D">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-SOFR Average 90D</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-SOFR Average 90D</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_CME_Term">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-SOFR CME Term</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-SOFR CME Term</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_Compounded_Index">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-SOFR Compounded Index</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-SOFR Compounded Index</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_ICE_Swap_Rate">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-SOFR ICE Swap Rate</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-SOFR ICE Swap Rate</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SandP_Index_High_Grade">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>USD-SandP Index High Grade</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-SandP Index High Grade</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TBILL-H.15">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-TBILL-H.15</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-TBILL-H.15</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
 		<fibo-fnd-utl-av:abbreviation>USD-TBILL-H.15</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -4074,7 +3854,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TBILL-H.15-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-TBILL-H.15-Bloomberg</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-TBILL-H.15-Bloomberg</skos:definition>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-fnd-utl-av:abbreviation>USD-TBILL-H.15-Bloomberg</fibo-fnd-utl-av:abbreviation>
@@ -4082,19 +3861,17 @@
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TBILL-Secondary_Market">
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TBILL_Secondary_Market-Bond_Equivalent_Yield">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>USD-TBILL-Secondary Market</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-TBILL-Secondary Market</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>USD-TBILL-Secondary Market</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>USD-TBILL Secondary Market-Bond Equivalent Yield</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>USD-TBILL Secondary Market-Bond Equivalent Yield</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TIBOR-ISDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-TIBOR-ISDC</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-TIBOR-ISDC</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-TIBOR-ISDC</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4103,7 +3880,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-TIBOR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-TIBOR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-TIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4112,7 +3888,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury-19901-3_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury-19901-3:00-ICAP</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Treasury-19901-3:00-ICAP</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Treasury-19901-3:00-ICAP</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4121,7 +3896,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-ICAP_BrokerTec">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-ICAP BrokerTec</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Treasury Rate-ICAP BrokerTec</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-ICAP BrokerTec</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4130,7 +3904,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-SwapMarker100">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-SwapMarker100</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Treasury Rate-SwapMarker100</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-SwapMarker100</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4139,7 +3912,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-SwapMarker99">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-SwapMarker99</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Treasury Rate-SwapMarker99</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-SwapMarker99</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4148,7 +3920,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-T19901">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-T19901</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Treasury Rate-T19901</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-T19901</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4157,7 +3928,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-T500">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-T500</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD-Treasury Rate-T500</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-T500</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4166,7 +3936,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD_Swap_Rate-BCMP1">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD Swap Rate-BCMP1</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD Swap Rate-BCMP1</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD Swap Rate-BCMP1</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4175,7 +3944,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD_Treasury_Rate-BCMP1">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD Treasury Rate-BCMP1</rdfs:label>
-		<skos:definition>the FpML floating interest index for the USD Treasury Rate-BCMP1</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>USD Treasury Rate-BCMP1</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
@@ -4184,7 +3952,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;VND-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>VND-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<skos:definition>the FpML floating interest index for the VND-Semi-Annual Swap Rate-11:00-BGCANTOR</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-fnd-utl-av:abbreviation>VND-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -4195,7 +3962,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;VND-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>VND-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the VND-Semi-Annual Swap Rate-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>VND-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Dong"/>
@@ -4205,7 +3971,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-DEPOSIT-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-DEPOSIT-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ZAR-DEPOSIT-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>ZAR-DEPOSIT-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
@@ -4214,35 +3979,23 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-DEPOSIT-SAFEX">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-DEPOSIT-SAFEX</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ZAR-DEPOSIT-SAFEX</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>ZAR-DEPOSIT-SAFEX</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-JIBAR">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>ZAR-JIBAR</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>ZAR-JIBAR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-JIBAR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-JIBAR-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ZAR-JIBAR-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>ZAR-JIBAR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-JIBAR-SAFEX">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>ZAR-JIBAR-SAFEX</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ZAR-JIBAR-SAFEX</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ZAR-JIBAR-SAFEX</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-PRIME-AVERAGE">
-		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
-		<rdfs:label>ZAR-PRIME-AVERAGE</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ZAR-PRIME-AVERAGE</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ZAR-PRIME-AVERAGE</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 	</owl:NamedIndividual>
@@ -4250,16 +4003,22 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-PRIME-AVERAGE-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-PRIME-AVERAGE-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ZAR-PRIME-AVERAGE-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>ZAR-PRIME-AVERAGE-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Prime_Average">
+		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
+		<rdfs:label>ZAR-Prime Average</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation>ZAR-Prime Average</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Quarterly_Swap_Rate-1_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-Quarterly Swap Rate-1:00-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ZAR-Quarterly Swap Rate-1:00-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>ZAR-Quarterly Swap Rate-1:00-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -4270,7 +4029,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Quarterly_Swap_Rate-5_30-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-Quarterly Swap Rate-5:30-TRADITION</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ZAR-Quarterly Swap Rate-5:30-TRADITION</skos:definition>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-fnd-utl-av:abbreviation>ZAR-Quarterly Swap Rate-5:30-TRADITION</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
@@ -4281,7 +4039,6 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Quarterly_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-Quarterly Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<skos:definition>the FpML floating interest index for the ZAR-Quarterly Swap Rate-TRADITION-Reference Banks</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>ZAR-Quarterly Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised the common interest rates reference data ontology to reflect the latest 2021 FpML rates, which include a number of changes, deprecating some rates and replacing them with others; also revised how some rates are represented, eliminating duplication where feasible in cases where multiple publishers make exactly the same rate available - users can add the source from which they reference the rate in those cases where it is important for valuation / documentation purposes

Fixes: #1655 / IND-114


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


