### PR TITLE
Use latest ISO and LCC files, hand edits for VED

### DIFF
--- a/FND/Accounting/ISO4217-CurrencyCodes.rdf
+++ b/FND/Accounting/ISO4217-CurrencyCodes.rdf
@@ -34,7 +34,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/">
 		<rdfs:label>ISO 4217-1 Currency Codes Ontology</rdfs:label>
 		<dct:abstract>This ontology represents the subset of the ISO 4217 standard that include the actual currency codes.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2021-10-01T00:00:00&gt;</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2021-10-01T00:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:contributor>Adaptive, Inc.</sm:contributor>
@@ -42,6 +42,7 @@
 		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
 		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2022 Thematix Partners LLC</sm:copyright>
 		<sm:copyright>Copyright (c) 2022 agnos.ai UK Ltd.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/</sm:dependsOn>
@@ -2402,12 +2403,12 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Paanga">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<rdfs:label>Pa’anga</rdfs:label>
-		<skos:definition>the currency Pa’anga</skos:definition>
+		<rdfs:label>Pa&#x02BB;anga</rdfs:label>
+		<skos:definition>the currency Pa&#x02BB;anga</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>776</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tonga"/>
-		<lcc-lr:hasName>Pa’anga</lcc-lr:hasName>
+		<lcc-lr:hasName>Pa&#x02BB;anga</lcc-lr:hasName>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PakistanRupee">
@@ -3039,7 +3040,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TOP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TOP</rdfs:label>
-		<skos:definition>the currency identifier for Pa’anga</skos:definition>
+		<skos:definition>the currency identifier for Pa&#x02BB;anga</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Paanga"/>
 		<lcc-lr:hasTag>TOP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Paanga"/>

--- a/FND/Accounting/ISO4217-CurrencyCodes.rdf
+++ b/FND/Accounting/ISO4217-CurrencyCodes.rdf
@@ -15,7 +15,7 @@
 	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"
+<rdf:RDF
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-acc-4217="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -34,12 +34,15 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/">
 		<rdfs:label>ISO 4217-1 Currency Codes Ontology</rdfs:label>
 		<dct:abstract>This ontology represents the subset of the ISO 4217 standard that include the actual currency codes.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2021-10-01T00:00:00&gt;</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:contributor>Adaptive, Inc.</sm:contributor>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
+		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2022 agnos.ai UK Ltd.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
@@ -55,11 +58,12 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Accounting/ISO4217-CurrencyCodes/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20220101/Accounting/ISO4217-CurrencyCodes/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to replace Swaziland with Eswatini, which was revised by the LCC 1.1 RTF to reflect the change to the country name per the U.N.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190401/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate unnecessary dependencies on the relations ontology, and to replace skos:definition with skos:definition per FIBO policy.</skos:changeNote>
-		<skos:changeNote>This version is now generated from the ISO XML file as published on 2018-08-29</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate unnecessary dependencies on the relations ontology, and to replace rdfs:comment with skos:definition per FIBO policy.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220101/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to reflect latest ISO and LCC data.</skos:changeNote>
+		<skos:changeNote>This version was generated from the ISO XML file as published on October 1, 2021</skos:changeNote>
 		<fibo-fnd-utl-av:explanatoryNote>This release includes all codes included in the ISO 4217 published code set.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -504,6 +508,7 @@
 		<rdfs:label>Bolívar Soberano</rdfs:label>
 		<skos:definition>the currency Bolívar Soberano</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
+		<fibo-fnd-acc-cur:hasNumericCode>926</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-acc-cur:hasNumericCode>928</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Venezuela"/>
 		<lcc-lr:hasName>Bolívar Soberano</lcc-lr:hasName>
@@ -963,7 +968,7 @@
 		<skos:definition>the currency Denar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>807</fibo-fnd-acc-cur:hasNumericCode>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Macedonia"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;NorthMacedonia"/>
 		<lcc-lr:hasName>Denar</lcc-lr:hasName>
 	</owl:NamedIndividual>
 	
@@ -2397,12 +2402,12 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Paanga">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<rdfs:label>Pa&apos;anga</rdfs:label>
-		<skos:definition>the currency Pa&apos;anga</skos:definition>
+		<rdfs:label>Pa’anga</rdfs:label>
+		<skos:definition>the currency Pa’anga</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>776</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tonga"/>
-		<lcc-lr:hasName>Pa&apos;anga</lcc-lr:hasName>
+		<lcc-lr:hasName>Pa’anga</lcc-lr:hasName>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PakistanRupee">
@@ -3034,7 +3039,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TOP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TOP</rdfs:label>
-		<skos:definition>the currency identifier for Pa&apos;anga</skos:definition>
+		<skos:definition>the currency identifier for Pa’anga</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Paanga"/>
 		<lcc-lr:hasTag>TOP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Paanga"/>
@@ -3235,6 +3240,7 @@
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesMinorOutlyingIslands"/>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;VirginIslandsBritish"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;VirginIslandsUS"/>
 		<lcc-lr:hasName>US Dollar</lcc-lr:hasName>
 	</owl:NamedIndividual>
 	
@@ -3281,9 +3287,9 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UYW">
-		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
+		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UYW</rdfs:label>
-		<skos:definition>the funds identifier for Unidad Previsional</skos:definition>
+		<skos:definition>the currency identifier for Unidad Previsional</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;UnidadPrevisional"/>
 		<lcc-lr:hasTag>UYW</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;UnidadPrevisional"/>
@@ -3311,13 +3317,11 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UnidadPrevisional">
-		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
+		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Unidad Previsional</rdfs:label>
-		<skos:definition>the funds Unidad Previsional</skos:definition>
-		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;PesoUruguayo"/>
+		<skos:definition>the currency Unidad Previsional</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>4</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>927</fibo-fnd-acc-cur:hasNumericCode>
-		<fibo-fnd-utl-av:explanatoryNote>The Unidad Previsional (UP) is a daily accounting unit that tracks changes to the nominal wage index. The value of UP is expressed in terms of Uruguayan Pesos per UP, with the initial value of one peso (UYU 1.00) on 04/30/2018. The institution responsible for the calculation and publication is the Instituto Nacional de Estadística (National Bureau of Statistics) according to Law 19,608.</fibo-fnd-utl-av:explanatoryNote>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uruguay"/>
 		<lcc-lr:hasName>Unidad Previsional</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -3366,6 +3370,24 @@
 		<fibo-fnd-acc-cur:hasNumericCode>860</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uzbekistan"/>
 		<lcc-lr:hasName>Uzbekistan Sum</lcc-lr:hasName>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;VED">
+		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
+		<rdfs:label>VED</rdfs:label>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<skos:definition>the currency identifier for Bolívar Soberano</skos:definition>
+		<skos:explanatoryNote>The Bolívar Soberano (VES) is redenominated by removing six zeros from the denominations. 
+         A new currency code VED/926 representing the new valuation (1,000,000 times old VES/928) is introduced on 1
+         October 2021 for any internal needs during the redenomination process, but is not replacing VES as the
+         official currency code. The Central Bank of Venezuela will not adopt the new codes in the local system,
+         VES/928 remains in use.
+         The actual currency code VES/928 remains the valid code after 1 October 2021 to use in any future
+         transactions to indicate the redenominated Bolívar Soberano.</skos:explanatoryNote>
+		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>
+		<lcc-lr:hasTag>VED</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;VES">

--- a/FND/Accounting/ISO4217-CurrencyCodes.rdf
+++ b/FND/Accounting/ISO4217-CurrencyCodes.rdf
@@ -62,7 +62,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to replace Swaziland with Eswatini, which was revised by the LCC 1.1 RTF to reflect the change to the country name per the U.N.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190401/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate unnecessary dependencies on the relations ontology, and to replace rdfs:comment with skos:definition per FIBO policy.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220101/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to reflect latest ISO and LCC data.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220101/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to reflect latest ISO 4217 and LCC data.</skos:changeNote>
 		<skos:changeNote>This version was generated from the ISO XML file as published on October 1, 2021</skos:changeNote>
 		<fibo-fnd-utl-av:explanatoryNote>This release includes all codes included in the ISO 4217 published code set.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>

--- a/etc/testing/hygiene/testHygiene0114.sparql
+++ b/etc/testing/hygiene/testHygiene0114.sparql
@@ -14,7 +14,7 @@ WHERE {
   FILTER (DATATYPE(?o)=xsd:string)
   FILTER (REGEX (xsd:string (?s), "edmcouncil")) 
   BIND (afn:localname (?p) AS ?prop)
-  BIND ("[ÁáÇçÉéÍíÕõÖöäÄèÈμΜσΣa-zA-Z\\\\;'?@$%#&:/\"<*>,._+÷=)(\\[\\]{}0-9\n\t -]" AS ?reg)
+  BIND ("[ÁáÇçÉéÍíÕõÖöäÄèÈμΜσΣʻa-zA-Z\\\\;'?@$%#&:/\"<*>,._+÷=)(\\[\\]{}0-9\n\t -]" AS ?reg)
   BIND (REPLACE (xsd:string (?o), ?reg, "")  AS ?bads)
   FILTER (?bads != "")
   BIND (concat ("PRODERROR:", xsd:string(?o), " has a bad character |", ?bads, "|")


### PR DESCRIPTION
## Description

Reflects ISO codes published Oct 2021, and reconciles with latest LCC 1.2 - specifically change to North Macedonia.
Adds explanation for transitional code VED in Venezuela based on official ISO notice.

Fixes: BE-244


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x ] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x ] The issue has been tested locally using a reasoner (for ontology changes).


