### PR TITLE
BE-244 - References to Macedonia in BE (and in currencies in FND) should be revised to reference NorthMacedonia instead

### DIFF
--- a/BE/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions.rdf
@@ -36,8 +36,8 @@
 		<dct:abstract>This ontology provides government entities and jurisdictions for countries that are defined as being part of Southern Europe in the U.N. M49 codes, primarily those that are considered independent countries in ISO 3166, or are important from a banking perspective.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2010-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2010-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2010-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2010-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
@@ -49,8 +49,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20220101/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200801/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to address hygiene issues with diacritical marks that are language-specific.</skos:changeNote>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20210201/GovernmentEntities/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to replace references to Macedonia with NorthMacedonia from LCC 1.2.</skos:changeNote>
 		<skos:scopeNote>The initial version of this ontology reflects the national level only.</skos:scopeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -212,7 +213,7 @@
 		<rdfs:seeAlso rdf:resource="https://vlada.mk/"/>
 		<skos:definition>unitary parliamentary, constitutional, democratic republic, located in the Balkan Peninsula in Southeast Europe</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-seuj;JurisdictionOfNorthMacedonia"/>
-		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Macedonia"/>
+		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;NorthMacedonia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfSanMarino">
@@ -356,7 +357,7 @@
 		<rdfs:seeAlso rdf:resource="https://www.sobranie.mk/the-constitution-of-the-republic-of-macedonia-ns_article-constitution-of-the-republic-of-north-macedonia.nspx"/>
 		<skos:definition>jurisdiction of the judiciary of North Macedonia, an independent judicial branch that includes a constitutional court</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfNorthMacedonia"/>
-		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Macedonia"/>
+		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;NorthMacedonia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-seuj;JurisdictionOfPortugal">
@@ -438,7 +439,7 @@
 		<rdfs:label xml:lang="en">North Macedonian entity</rdfs:label>
 		<rdfs:label xml:lang="mk">Северномакедонски субјект</rdfs:label>
 		<skos:definition>sovereign state and polity that is North Macedonia</skos:definition>
-		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Macedonia"/>
+		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;NorthMacedonia"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-seuj;GovernmentOfTheRepublicOfNorthMacedonia"/>
 	</owl:NamedIndividual>
 	


### PR DESCRIPTION
Revised the definitions for government entities related to North Macedonia to reference the updated LCC ISO 3166 country definition for NorthMacedonia

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised the definitions for government entities related to North Macedonia to reference the updated LCC ISO 3166 country definition for NorthMacedonia

Fixes: #1669 / BE-244


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


