### PR TITLE
SEC-1684 - Wrong dateTime in MetadataSECDebt

### DIFF
--- a/SEC/Debt/MetadataSECDebt.rdf
+++ b/SEC/Debt/MetadataSECDebt.rdf
@@ -24,7 +24,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/">
 		<rdfs:label>Metadata about the EDMC-FIBO Securities (SEC) Debt Module</rdfs:label>
 		<dct:abstract>The SEC Debt Module covers content specific to debt instruments, including but not limited to bonds and asset-backed securities. This ontology provides metadata about the Debt module and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-02-31T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
 		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>


### PR DESCRIPTION
corrected time stamp for the Q1 2022 quarterly release in ……SEC/Debt metadata

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Corrected time stamp for the Q1 2022 quarterly release in SEC/Debt metadata

Fixes: #1684 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


