### PR TITLE
Wrong references in catalog-v001.xml fixed

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -249,12 +249,12 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/" uri="./SEC/AllSEC.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ExampleIndividuals/" uri="./SEC/AllSEC-ExampleIndividuals.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/" uri="./SEC/AllSEC-ReferenceIndividuals.rdf"/>
-	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/" uri="./SEC/Debt/AssetBackedSecurities/AssetBackedSecurities.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/" uri="./SEC/Debt/AssetBackedSecurities/CollateralizedDebtObligations.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/LoanParticipationNotes/" uri="./SEC/Debt/AssetBackedSecurities/LoanParticipationNotes.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/" uri="./SEC/Debt/AssetBackedSecurities/MortgageBackedSecurities.rdf"/>
-	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/" uri="./SEC/Debt/AssetBackedSecurities/PoolBackedSecurities.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyntheticCDOs/" uri="./SEC/Debt/AssetBackedSecurities/SyntheticCDOs.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/" uri="./SEC/Debt/AssetBackedSecurities.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/" uri="./SEC/Debt/CollateralizedDebtObligations.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/LoanParticipationNotes/" uri="./SEC/Debt/LoanParticipationNotes.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/" uri="./SEC/Debt/MortgageBackedSecurities.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/" uri="./SEC/Debt/PoolBackedSecurities.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyntheticCDOs/" uri="./SEC/Debt/SyntheticCDOs.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/" uri="./SEC/Debt/Bonds.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/" uri="./SEC/Debt/DebtInstruments.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/" uri="./SEC/Debt/ExerciseConventions.rdf"/>


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

This fixes the wrong references to files in catalog-v001.xml

Fixes: #1695 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


