### PR TITLE
Tests for deprecated resources were modified

### DIFF
--- a/etc/testing/hygiene/testHygiene1610.sparql
+++ b/etc/testing/hygiene/testHygiene1610.sparql
@@ -1,6 +1,7 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
 
 ##
 # banner Deprecated resources should not be used.

--- a/etc/testing/hygiene/testHygiene1610.sparql
+++ b/etc/testing/hygiene/testHygiene1610.sparql
@@ -9,6 +9,7 @@ SELECT DISTINCT ?warning ?resource
 WHERE
 {
     ?resource owl:deprecated "true"^^xsd:boolean .
+    FILTER NOT EXISTS {?resource rdf:type/rdf:type/(rdfs:subClassOf*) owl:Class.}
     FILTER (CONTAINS(str(?resource), "edmcouncil"))
     {
         ?resource ?property1 ?object.

--- a/etc/testing/hygiene/testHygiene1675_classes.sparql
+++ b/etc/testing/hygiene/testHygiene1675_classes.sparql
@@ -1,0 +1,12 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner Count of OWL classes
+
+SELECT ("INFO: count of OWL classes" as ?info) (COUNT(?resource) as ?count)
+WHERE
+{
+    ?resource rdf:type owl:Class.
+}

--- a/etc/testing/hygiene/testHygiene1675_datatypeproperties.sparql
+++ b/etc/testing/hygiene/testHygiene1675_datatypeproperties.sparql
@@ -1,0 +1,12 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner Count of OWL data type properties
+
+SELECT ("INFO: count of OWL data type properties" as ?info) (COUNT(?resource) as ?count)
+WHERE
+{
+    ?resource rdf:type/rdfs:subClassOf* owl:DatatypeProperty.
+}

--- a/etc/testing/hygiene/testHygiene1675_deprecated_resources.sparql
+++ b/etc/testing/hygiene/testHygiene1675_deprecated_resources.sparql
@@ -1,0 +1,12 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner Count of deprecated resources
+
+SELECT ("INFO: count of deprecated resources" as ?info) (COUNT(?resource) as ?count)
+WHERE
+{
+    ?resource owl:deprecated "true"^^xsd:boolean .
+}

--- a/etc/testing/hygiene/testHygiene1675_individuals.sparql
+++ b/etc/testing/hygiene/testHygiene1675_individuals.sparql
@@ -1,0 +1,12 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner Count of individuals
+
+SELECT ("INFO: count of individuals" as ?info) (COUNT(?resource) as ?count)
+WHERE
+{
+    ?resource rdf:type/rdf:type/(rdfs:subClassOf*) owl:Class.
+}

--- a/etc/testing/hygiene/testHygiene1675_objectproperties.sparql
+++ b/etc/testing/hygiene/testHygiene1675_objectproperties.sparql
@@ -1,0 +1,12 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+
+##
+# banner Count of OWL object properties
+
+SELECT ("INFO: count of OWL object properties" as ?info) (COUNT(?resource) as ?count)
+WHERE
+{
+    ?resource rdf:type/rdfs:subClassOf* owl:ObjectProperty.
+}


### PR DESCRIPTION
## Description

This PR modifies the test for deprecated resources so that deprecated individuals are not reported.
It also added a number of INFO-level tests that count number of individuals, classes, and properties.

Fixes: #1675


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


