### PR TITLE
SEC-169 - Simplify the CFI codes for equity instruments to eliminate the restrictions on hasDenotation

### DIFF
--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -43,8 +43,8 @@
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:copyright>Copyright (c) 2020-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/</sm:dependsOn>
@@ -61,10 +61,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityCFIClassificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Equities/EquityCFIClassificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form, eliminate embedded restrictions, and build out additional classes representing the various feature-based descriptions supported by the CFI standard.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to complete the set of possible common share representations corresponding to the CFI standard, complete the set of corresponding codes for common shares (non-convertible), and add the set of possible combinations for preferred shares (non-convertible).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to simplify the encoding of the individual instrument classifiers to eliminate unnecessary restrictions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -77,12 +78,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETFR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -102,12 +97,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETOR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, enhanced voting, restricted, nil paid, registered share</rdfs:label>
 		<skos:definition>common share that confers multiple votes per share, is restricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
 	</owl:Class>
@@ -121,12 +110,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETPR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -146,12 +129,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUFR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, enhanced voting, unrestricted, fully-paid, registered share</rdfs:label>
 		<skos:definition>common share that confers multiple votes per share, is not restricted from a sales / transfer perspective, is fully paid and is registered</skos:definition>
 	</owl:Class>
@@ -165,12 +142,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUOR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -190,12 +161,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUPR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, enhanced voting, unrestricted, partly paid, registered share</rdfs:label>
 		<skos:definition>common share that confers multiple votes per share, is not restricted from a sales / transfer perspective, is partially paid and is registered</skos:definition>
 	</owl:Class>
@@ -209,12 +174,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTFR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -234,12 +193,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTOR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, non-voting, restricted, nil paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly 0 votes per share, is restricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
 	</owl:Class>
@@ -253,12 +206,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTPR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -278,12 +225,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUFR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted, fully-paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
 	</owl:Class>
@@ -297,12 +238,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUOR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -322,12 +257,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUPR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted, partly paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is partially paid and is registered</skos:definition>
 	</owl:Class>
@@ -341,12 +270,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTFR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -366,12 +289,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTOR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, restricted voting, restricted, nil paid, registered share</rdfs:label>
 		<skos:definition>common share that confers less than one vote per share, is restricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
 	</owl:Class>
@@ -385,12 +302,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTPR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -410,12 +321,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUFR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, restricted voting, unrestricted, fully-paid, registered share</rdfs:label>
 		<skos:definition>common share that confers less than one vote per share, is unrestricted from a sales / transfer perspective, is fully paid and is registered</skos:definition>
 	</owl:Class>
@@ -429,12 +334,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUOR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -454,12 +353,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUPR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, restricted voting, unrestricted, partly paid, registered share</rdfs:label>
 		<skos:definition>common share that confers less than one vote per share, is unrestricted from a sales / transfer perspective, is partially paid and is registered</skos:definition>
 	</owl:Class>
@@ -473,12 +366,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTFR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -498,12 +385,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTOR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, voting, restricted, nil paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly one vote per share, is restricted from a sales / transfer perspective, is nil paid and is registered</skos:definition>
 	</owl:Class>
@@ -517,12 +398,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTPR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -542,12 +417,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, voting, unrestricted, fully-paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly one vote per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
 	</owl:Class>
@@ -564,12 +433,6 @@
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUOR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, voting, unrestricted, nil paid, registered share</rdfs:label>
 		<skos:definition>common share that confers exactly one vote per share, is unrestricted from a sales perspective, is nil paid and is registered</skos:definition>
 	</owl:Class>
@@ -583,12 +446,6 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUPR"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasDenotation"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Simplified individual common shares with respect to their individual instrument classifiers by eliminating unnecessary restrictions

Fixes: #1704 / SEC-169


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


