### PR TITLE
SEC-174 - Misquoted properties in PROD

### DIFF
--- a/DER/RateDerivatives/IRSwapExampleIndividuals.rdf
+++ b/DER/RateDerivatives/IRSwapExampleIndividuals.rdf
@@ -15,6 +15,7 @@
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -47,6 +48,7 @@
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -68,8 +70,8 @@
 		<dct:abstract>This ontology provides examples of how to represent individuals for interest rate swaps and swap legs based on the Mizuho mocked-up sample data provided in the FIBO wiki.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
@@ -92,6 +94,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"/>
@@ -100,9 +103,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210101/RateDerivatives/IRSwapExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220101/RateDerivatives/IRSwapExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200601/RateDerivatives/IRSwapExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200701/RateDerivatives/IRSwapExampleIndividuals.rdf version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210101/RateDerivatives/IRSwapExampleIndividuals.rdf version of this ontology was modified to correct properties that were modified in the main ontology but not in the examples.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -123,12 +127,12 @@
 		<rdf:type rdf:resource="&fibo-der-rtd-irswp;FixedInterestRateLeg"/>
 		<rdfs:label>contract leg 1 IY7VKEUR45886</rdfs:label>
 		<skos:definition>contract IY7VKEUR45886 swap leg 1 that is a fixed interest rate leg</skos:definition>
-		<fibo-der-drc-swp:hasPayingParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-ZZZWWK96TRQY0F2IY7VK"/>
-		<fibo-der-drc-swp:hasReceivingParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-A"/>
 		<fibo-fbc-dae-dbt:hasInterestRate rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-InterestRate"/>
 		<fibo-fnd-acc-cur:hasNotionalAmount rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-NotionalAmount"/>
 		<fibo-fnd-agr-ctr:hasEffectiveDate rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-EffectiveDate"/>
 		<fibo-fnd-arr-doc:hasTerminationDate rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-TerminationDate"/>
+		<fibo-fnd-pas-pas:hasBuyer rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-ZZZWWK96TRQY0F2IY7VK"/>
+		<fibo-fnd-pas-pas:hasSeller rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-A"/>
 		<fibo-fnd-rel-rel:isMandatedBy rdf:resource="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886"/>
 		<fibo-fnd-utl-av:explanatoryNote>Need to create the 1st period fixing date, payment days offset, discount notional amount, average remaining notional currency, net present value currency (pair, of type monetary amount)</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-sec-dbt-dbti:hasInterestPaymentTerms rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-InterestPaymentTerms"/>
@@ -173,12 +177,12 @@
 		<rdf:type rdf:resource="&fibo-der-rtd-irswp;FloatingInterestRateLeg"/>
 		<rdfs:label>contract leg 2 IY7VKEUR45886</rdfs:label>
 		<skos:definition>contract IY7VKEUR45886 swap leg 2 that is a floating interest rate leg</skos:definition>
-		<fibo-der-drc-swp:hasPayingParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-A"/>
-		<fibo-der-drc-swp:hasReceivingParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-ZZZWWK96TRQY0F2IY7VK"/>
 		<fibo-fbc-dae-dbt:hasInterestRate rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-InterestRate"/>
 		<fibo-fnd-acc-cur:hasNotionalAmount rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-NotionalAmount"/>
 		<fibo-fnd-agr-ctr:hasEffectiveDate rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-EffectiveDate"/>
 		<fibo-fnd-arr-doc:hasTerminationDate rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-TerminationDate"/>
+		<fibo-fnd-pas-pas:hasBuyer rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-A"/>
+		<fibo-fnd-pas-pas:hasSeller rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-ZZZWWK96TRQY0F2IY7VK"/>
 		<fibo-fnd-rel-rel:isMandatedBy rdf:resource="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886"/>
 		<fibo-fnd-utl-av:explanatoryNote>Need to create the interest rate reset schedule or add a simple payment frequency, need a separate property for reference interest rate, need rate tenor</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-sec-dbt-dbti:hasInterestPaymentTerms rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-InterestPaymentTerms"/>

--- a/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
+++ b/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
@@ -60,8 +60,8 @@
 		<dct:abstract>This ontology defines concepts and primarily individuals required to identify securities, including the individuals that represent a number of well-known securities identifiers and related schemes, registries, and registration authorities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -89,7 +89,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20211201/Securities/SecuritiesIdentificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Securities/SecuritiesIdentificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was updated to represent identifiers as classes rather than individuals and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
@@ -98,6 +98,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues) and add the Telekurs Id (now retired) and Valoren as securities identifiers.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to correct a bad character in a note on the Valoren.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to eliminate punning with respect to the FIGI registry entry.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211201/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to correct a typo in an annotation property name.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -398,7 +399,7 @@
 		<rdfs:label>financial instrument global identifier</rdfs:label>
 		<skos:definition>financial instrument identifier that is defined as specified in the Object Management Group (OMG) Financial Instrument Global Identifier (FIGI) Specification</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>FIGI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explantoryNote>While in most cases, a FIGI uniquely identifies a security, there are situations outside of the U.S. where it instead identifies a listing for a security, similarly to a ticker symbol.</fibo-fnd-utl-av:explantoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>While in most cases, a FIGI uniquely identifies a security, there are situations outside of the U.S. where it instead identifies a listing for a security, similarly to a ticker symbol.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This resolution corrects a typo in the securities identifiers individuals ontology and two cases in the IR Swaps examples where a property in the main ontology had changed but the examples were not updated as they should have been.

Fixes: #1707 / SEC-147


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


