### PR TITLE
Hygiene test filter out non-EDMC resources in the same way

### DIFF
--- a/etc/testing/hygiene/testHygiene0001_objects.sparql
+++ b/etc/testing/hygiene/testHygiene0001_objects.sparql
@@ -13,15 +13,15 @@ prefix lcc-cr: <https://www.omg.org/spec/LCC/Countries/CountryRepresentation/>
 
 SELECT DISTINCT ?error
 WHERE {
-  ?s ?p ?o .
-  FILTER NOT EXISTS {?o owl:deprecated "true"^^xsd:boolean} .
-  FILTER (ISIRI (?o))
-  FILTER (REGEX (xsd:string (?o), "edmcouncil"))
-  FILTER NOT EXISTS {?o a []}
-  FILTER (! (?p IN (owl:versionIRI, sm:dependsOn , owl:imports , sm:specificationVersionURL,
+  ?s ?property ?object .
+  FILTER NOT EXISTS {?object owl:deprecated "true"^^xsd:boolean} .
+  FILTER (ISIRI (?object))
+  FILTER regex(str(?object), "edmcouncil")
+  FILTER NOT EXISTS {?object a []}
+  FILTER (! (?property IN (owl:versionIRI, sm:dependsOn , owl:imports , sm:specificationVersionURL,
                     rdfs:seeAlso, dct:isPartOf, lcc-cr:isPartOf, lcc-cr:hasPart, dct:hasPart))) 
   BIND (
-    concat ("ERROR:", xsd:string (?o), " is referenced by ", afn:localname (?p), " but has no type.")
+    concat ("ERROR:", xsd:string (?object), " is referenced by ", afn:localname (?property), " but has no type.")
 	  AS ?error
 	)
 }

--- a/etc/testing/hygiene/testHygiene0001_properties.sparql
+++ b/etc/testing/hygiene/testHygiene0001_properties.sparql
@@ -13,14 +13,11 @@ prefix lcc-cr: <https://www.omg.org/spec/LCC/Countries/CountryRepresentation/>
 
 SELECT DISTINCT ?error
 WHERE {
-  ?s ?p ?o .
-  FILTER NOT EXISTS {?p owl:deprecated "true"^^xsd:boolean} .
-  FILTER (REGEX (xsd:string (?p), "edmcouncil"))
-  FILTER NOT EXISTS {?p a []}
-  FILTER (! (?p IN (owl:versionIRI, sm:dependsOn , owl:imports , sm:specificationVersionURL,
+  ?s ?property ?o .
+  FILTER NOT EXISTS {?property owl:deprecated "true"^^xsd:boolean} .
+  FILTER regex(str(?property), "edmcouncil")
+  FILTER NOT EXISTS {?property a []}
+  FILTER (! (?property IN (owl:versionIRI, sm:dependsOn , owl:imports , sm:specificationVersionURL,
                     rdfs:seeAlso, dct:isPartOf, lcc-cr:isPartOf, lcc-cr:hasPart, dct:hasPart))) 
-  BIND (
-    concat ("ERROR: Property ", xsd:string (?p), " is used but has no type.")
-	  AS ?error
-	)
+  BIND (concat ("ERROR: Property ", xsd:string (?property), " is used but has no type.") AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene0001_subjects.sparql
+++ b/etc/testing/hygiene/testHygiene0001_subjects.sparql
@@ -15,7 +15,7 @@ SELECT DISTINCT ?error
 WHERE {
   ?s ?p ?o .
   FILTER NOT EXISTS {?s owl:deprecated "true"^^xsd:boolean} .
-  FILTER (REGEX (xsd:string (?s), "edmcouncil"))
+  FILTER regex(str(?s), "edmcouncil")
   FILTER NOT EXISTS {?s a []}
   FILTER (! (?p IN (owl:versionIRI, sm:dependsOn , owl:imports , sm:specificationVersionURL,
                     rdfs:seeAlso, dct:isPartOf, lcc-cr:isPartOf, lcc-cr:hasPart, dct:hasPart))) 

--- a/etc/testing/hygiene/testHygiene0002.sparql
+++ b/etc/testing/hygiene/testHygiene0002.sparql
@@ -11,13 +11,15 @@ prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?error
 WHERE {
 
-  ?p1 rdfs:domain ?D1 .
-  ?p1 rdfs:subPropertyOf ?p2 .
-  ?p2 rdfs:domain ?D2 .
-  ?D2 rdfs:subClassOf + ?D1 .
-  FILTER NOT EXISTS {?p1 owl:deprecated "true"^^xsd:boolean} .
-  FILTER NOT EXISTS {?p2 owl:deprecated "true"^^xsd:boolean} .
+  ?property1 rdfs:domain ?D1 .
+  ?property1 rdfs:subPropertyOf ?property2 .
+  ?property2 rdfs:domain ?D2 .
+  ?D2 rdfs:subClassOf+ ?D1 .
+  FILTER NOT EXISTS {?property1 owl:deprecated "true"^^xsd:boolean} .
+  FILTER NOT EXISTS {?property2 owl:deprecated "true"^^xsd:boolean} .
+  FILTER regex(str(?property1), "edmcouncil")
+  FILTER regex(str(?property2), "edmcouncil")
   BIND (
-    concat ("PRODERROR: Crossed domains. ", afn:localname(?p1), " < ", afn:localname (?p2), " but the domain ", afn:localname (?D1), " is a superclass of ", afn:localname (?D2)) AS ?error
+    concat ("PRODERROR: Crossed domains. ", afn:localname(?property1), " < ", afn:localname (?property2), " but the domain ", afn:localname (?D1), " is a superclass of ", afn:localname (?D2)) AS ?error
   )
 }

--- a/etc/testing/hygiene/testHygiene0003.sparql
+++ b/etc/testing/hygiene/testHygiene0003.sparql
@@ -10,11 +10,13 @@ prefix afn: <http://jena.apache.org/ARQ/function#>
 
 SELECT DISTINCT ?error
 WHERE {
-  ?p1 rdfs:range ?D1 . 
-  ?p1 rdfs:subPropertyOf ?p2 .
-  ?p2 rdfs:range ?D2 .
+  ?property1 rdfs:range ?D1 . 
+  ?property1 rdfs:subPropertyOf ?property2 .
+  ?property2 rdfs:range ?D2 .
   ?D2 rdfs:subClassOf+ ?D1 .
-  FILTER NOT EXISTS {?p1 owl:deprecated "true"^^xsd:boolean} .
-  FILTER NOT EXISTS {?p2 owl:deprecated "true"^^xsd:boolean} .
-   BIND (concat ("PRODERROR: Crossed ranges. ", afn:localname(?p1), " < ", afn:localname (?p2), " but the range ", afn:localname (?D1), " is a superclass of ", afn:localname (?D2)) AS ?error)
+  FILTER NOT EXISTS {?property1 owl:deprecated "true"^^xsd:boolean} .
+  FILTER NOT EXISTS {?property2 owl:deprecated "true"^^xsd:boolean} .
+  FILTER regex(str(?property1), "edmcouncil")
+  FILTER regex(str(?property2), "edmcouncil")
+   BIND (concat ("PRODERROR: Crossed ranges. ", afn:localname(?property1), " < ", afn:localname (?property2), " but the range ", afn:localname (?D1), " is a superclass of ", afn:localname (?D2)) AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene0004.sparql
+++ b/etc/testing/hygiene/testHygiene0004.sparql
@@ -12,17 +12,17 @@ prefix fibo-fnd-utl-av:  <https://spec.edmcouncil.org/fibo/ontology/FND/Utilitie
 
 SELECT DISTINCT ?error
 WHERE {
-  ?e a ?c .
-  FILTER NOT EXISTS {?e owl:deprecated "true"^^xsd:boolean} .
-  FILTER (REGEX (xsd:string (?e), "edmcouncil"))
-  FILTER NOT EXISTS {?e owl:deprecated "true"^^xsd:boolean} .
+  ?subject a ?c .
+  FILTER NOT EXISTS {?subject owl:deprecated "true"^^xsd:boolean} .
+  FILTER regex(str(?subject), "edmcouncil")
+  FILTER NOT EXISTS {?subject owl:deprecated "true"^^xsd:boolean} .
   FILTER (?c in (owl:Class,
           owl:ObjectProperty,
           owl:AnnotationProperty,
           owl:DatatypeProperty))
   FILTER NOT EXISTS {
-    ?e rdfs:label | fibo-fnd-utl-av:abbreviation ?l  ;
+    ?subject rdfs:label | fibo-fnd-utl-av:abbreviation ?l  ;
           skos:definition ?def .
   }
-  BIND (concat ("PRODERROR: ", xsd:string(?e), " has to have label and definition.") AS ?error)
+  BIND (concat ("PRODERROR: ", xsd:string(?subject), " has to have label and definition.") AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene0005.sparql
+++ b/etc/testing/hygiene/testHygiene0005.sparql
@@ -14,7 +14,7 @@ SELECT DISTINCT ?error
 WHERE {
   ?ont a owl:Ontology .
   FILTER NOT EXISTS {?ont owl:deprecated "true"^^xsd:boolean} .
-  FILTER (REGEX (xsd:string (?ont), "edmcouncil"))	
+  FILTER regex(str(?ont), "edmcouncil")	
   FILTER NOT EXISTS {
 	?ont rdfs:label ?l  ;
 	sm:copyright ?cr ;

--- a/etc/testing/hygiene/testHygiene0114.sparql
+++ b/etc/testing/hygiene/testHygiene0114.sparql
@@ -9,10 +9,10 @@ prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?error
 WHERE {
-  ?s ?p ?o .
+  ?subject ?p ?o .
   FILTER NOT EXISTS {?o owl:deprecated "true"^^xsd:boolean} .
   FILTER (DATATYPE(?o)=xsd:string)
-  FILTER (REGEX (xsd:string (?s), "edmcouncil")) 
+  FILTER regex(str(?subject), "edmcouncil") 
   BIND (afn:localname (?p) AS ?prop)
   BIND ("[ÁáÇçÉéÍíÕõÖöäÄèÈμΜσΣʻa-zA-Z\\\\;'?@$%#&:/\"<*>,._+÷=)(\\[\\]{}0-9\n\t -]" AS ?reg)
   BIND (REPLACE (xsd:string (?o), ?reg, "")  AS ?bads)

--- a/etc/testing/hygiene/testHygiene0268.sparql
+++ b/etc/testing/hygiene/testHygiene0268.sparql
@@ -17,7 +17,7 @@ WHERE {
   {?s rdfs:subClassOf|owl:equivalentClass [?p owl:Thing]}
   }
   FILTER NOT EXISTS {?s owl:deprecated "true"^^xsd:boolean} .
-  FILTER (REGEX (xsd:string (?s), "edmcouncil")) 
+  FILTER regex(str(?s), "edmcouncil") 
   FILTER (?p != owl:someValuesFrom)
   BIND (afn:localname (?p) AS ?prop)
   BIND (concat ("PRODERROR: ", xsd:string (?s), " has an explicit reference to owl:Thing (", ?prop, ").")

--- a/etc/testing/hygiene/testHygiene1068.sparql
+++ b/etc/testing/hygiene/testHygiene1068.sparql
@@ -9,15 +9,16 @@ prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 SELECT DISTINCT ?error ?definition ?label
 WHERE {
-  ?s rdfs:label ?label .
-  FILTER NOT EXISTS {?s owl:deprecated "true"^^xsd:boolean} .
-  ?s skos:definition ?definition .
-  FILTER NOT EXISTS {?s a owl:NamedIndividual} .
+  ?subject rdfs:label ?label .
+  FILTER NOT EXISTS {?subject owl:deprecated "true"^^xsd:boolean} .
+  ?subject skos:definition ?definition .
+  FILTER NOT EXISTS {?subject a owl:NamedIndividual} .
   FILTER (REGEX(?definition, "\\W"+?label+"\\W"))
-  FILTER (CONTAINS(str(?s), "edmcouncil"))
+  FILTER regex(str(?subject), "edmcouncil")
+
 
   BIND (
-    concat ("PRODERROR: Definition of ", str(?s), " is immediately circular ")
+    concat ("PRODERROR: Definition of ", str(?subject), " is immediately circular ")
       AS ?error
     )
 }

--- a/etc/testing/hygiene/testHygiene1078.sparql
+++ b/etc/testing/hygiene/testHygiene1078.sparql
@@ -4,23 +4,23 @@ prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 ##
 # banner Object properties shouldn't have more than one inverse.
 
-SELECT ?error ?p1 ?p2 
+SELECT ?error ?property1 ?property2 
 WHERE
 {
 {
-?p owl:inverseOf ?p1. 
-?p owl:inverseOf ?p2. 
-FILTER (?p1 != ?p2) 
+?property owl:inverseOf ?property1. 
+?property owl:inverseOf ?property2. 
+FILTER (?property1 != ?property2) 
 } 
 UNION
 {
-?p1 owl:inverseOf ?p. 
-?p2 owl:inverseOf ?p. 
-FILTER (?p1 != ?p2) 
+?property1 owl:inverseOf ?property. 
+?property2 owl:inverseOf ?property. 
+FILTER (?property1 != ?property2) 
 }
-FILTER NOT EXISTS {?p owl:deprecated "true"^^xsd:boolean} .
-FILTER (CONTAINS(str(?p), "edmcouncil"))
-FILTER (CONTAINS(str(?p1), "edmcouncil"))
-FILTER (CONTAINS(str(?p2), "edmcouncil"))
-BIND (concat ("PRODERROR: object property whose iri is ", str(?p), " has more than one inverse object property") AS ?error)
+FILTER NOT EXISTS {?property owl:deprecated "true"^^xsd:boolean} .
+FILTER regex(str(?property), "edmcouncil")
+FILTER regex(str(?property1), "edmcouncil")
+FILTER regex(str(?property2), "edmcouncil")
+BIND (concat ("PRODERROR: object property whose iri is ", str(?property), " has more than one inverse object property") AS ?error)
 } 

--- a/etc/testing/hygiene/testHygiene1079.sparql
+++ b/etc/testing/hygiene/testHygiene1079.sparql
@@ -8,8 +8,8 @@ prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 SELECT DISTINCT ?error
 WHERE 
 {
-  ?s rdfs:comment ?o .
-  FILTER NOT EXISTS {?s owl:deprecated "true"^^xsd:boolean} .
-  FILTER (CONTAINS(str(?s), "edmcouncil"))
-  BIND (concat ("PRODERROR: ", str(?s), " has an rdfs:comment annotation: ", str(?o)) AS ?error)
+  ?subject rdfs:comment ?o .
+  FILTER NOT EXISTS {?subject owl:deprecated "true"^^xsd:boolean} .
+  FILTER regex(str(?subject), "edmcouncil")
+  BIND (concat ("PRODERROR: ", str(?subject), " has an rdfs:comment annotation: ", str(?o)) AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1103.sparql
+++ b/etc/testing/hygiene/testHygiene1103.sparql
@@ -7,10 +7,10 @@ prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 SELECT DISTINCT ?error
 WHERE {
   FILTER (ISIRI(?class1))
-  FILTER (REGEX(str(?class1), "edmcouncil"))
+  FILTER regex(str(?class1), "edmcouncil")
   FILTER NOT EXISTS {?class1 owl:deprecated "true"^^xsd:boolean}
   FILTER (ISIRI (?class2))
-  FILTER (REGEX(str(?class2), "edmcouncil"))
+  FILTER regex(str(?class2), "edmcouncil")
   FILTER NOT EXISTS {?class2 owl:deprecated "true"^^xsd:boolean}
   ?class1 owl:equivalentClass ?class2 .
   FILTER NOT EXISTS {?class1 owl:deprecated "true"^^xsd:boolean} .

--- a/etc/testing/hygiene/testHygiene1177.sparql
+++ b/etc/testing/hygiene/testHygiene1177.sparql
@@ -9,6 +9,6 @@ WHERE
 {
     ?ontology owl:imports ?ontology.
     FILTER NOT EXISTS {?ontology owl:deprecated "true"^^xsd:boolean} .
-    FILTER (CONTAINS(str(?ontology), "edmcouncil"))
+    FILTER regex(str(?ontology), "edmcouncil")
     BIND (concat ("PRODERROR: ", str(?ontology), " imports itself.") AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1190.sparql
+++ b/etc/testing/hygiene/testHygiene1190.sparql
@@ -8,7 +8,7 @@ prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 SELECT DISTINCT ?error ?class
 WHERE 
 {
-  FILTER (CONTAINS(str(?class), "edmcouncil"))
+  FILTER regex(str(?class), "edmcouncil")
   ?class rdfs:subClassOf+ ?class .
   FILTER NOT EXISTS {?class owl:deprecated "true"^^xsd:boolean} .
 

--- a/etc/testing/hygiene/testHygiene1190_properties.sparql
+++ b/etc/testing/hygiene/testHygiene1190_properties.sparql
@@ -8,7 +8,7 @@ prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 SELECT DISTINCT ?error ?property
 WHERE 
 {
-  FILTER (CONTAINS(str(?property), "edmcouncil"))
+  FILTER regex(str(?property), "edmcouncil")
   ?property rdfs:subPropertyOf+ ?property .
   FILTER NOT EXISTS {?property owl:deprecated "true"^^xsd:boolean} .
 

--- a/etc/testing/hygiene/testHygiene1198.sparql
+++ b/etc/testing/hygiene/testHygiene1198.sparql
@@ -14,7 +14,7 @@ WHERE
     {?resource rdf:type/rdfs:subClassOf* rdfs:Class .}
     ?resource rdf:type ?resourceType .
     FILTER NOT EXISTS {?resource owl:deprecated "true"^^xsd:boolean} .
-    FILTER (CONTAINS(str(?resource), "edmcouncil"))
+    FILTER regex(str(?resource), "edmcouncil")
     FILTER (CONTAINS(STRAFTER(str(?resource),"https://spec.edmcouncil.org/fibo/ontology/"), "."))
     BIND (concat ("PRODERROR: Resource ", str(?resource), " has the dot in its local name. ") AS ?error) 
 }

--- a/etc/testing/hygiene/testHygiene1290.sparql
+++ b/etc/testing/hygiene/testHygiene1290.sparql
@@ -12,7 +12,7 @@ WHERE
     ?class a owl:Class .
     FILTER NOT EXISTS {?class owl:deprecated "true"^^xsd:boolean} .
     FILTER NOT EXISTS {?class rdfs:subClassOf ?classParent}
-    FILTER (CONTAINS(str(?class), "edmcouncil"))
+    FILTER regex(str(?class), "edmcouncil")
     BIND (STRBEFORE(STRAFTER(str(?class),"https://spec.edmcouncil.org/fibo/ontology/"),"/") As ?domainIdentifier)
     FILTER (?domainIdentifier NOT IN ('FND', 'LCC', 'FBC'))
     BIND (concat ("PRODERROR: Class ", str(?class), " is a top-level class outside FIBO foundations.") AS ?error)

--- a/etc/testing/hygiene/testHygiene1293.sparql
+++ b/etc/testing/hygiene/testHygiene1293.sparql
@@ -12,7 +12,7 @@ WHERE {
   {{?restriction owl:minQualifiedCardinality ?cardinality} UNION {?restriction owl:minCardinality ?cardinality}}.
   ?class rdfs:subClassOf ?restriction .
   FILTER NOT EXISTS {?class owl:deprecated "true"^^xsd:boolean} .
-  FILTER (CONTAINS(str(?class), "edmcouncil"))
+  FILTER regex(str(?class), "edmcouncil")
   FILTER (?cardinality = 1)
   BIND (concat ("ERROR: OWL class", str(?class), " is a subclass of a restriction of type owl:minCardinality or owl:minQualifiedCardinality equal to 1") AS ?error)
 }

--- a/etc/testing/hygiene/testHygiene1610.sparql
+++ b/etc/testing/hygiene/testHygiene1610.sparql
@@ -11,7 +11,7 @@ WHERE
 {
     ?resource owl:deprecated "true"^^xsd:boolean .
     FILTER NOT EXISTS {?resource rdf:type/rdf:type/(rdfs:subClassOf*) owl:Class.}
-    FILTER (CONTAINS(str(?resource), "edmcouncil"))
+    FILTER regex(str(?resource), "edmcouncil")
     {
         ?resource ?property1 ?object.
         FILTER (?property1 != owl:equivalentClass && ?property1 != owl:deprecated && ?property1 != rdf:type && ?property1 != owl:equivalentProperty)


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

This implements the change mentioned in the issue: now all hygiene tests filter out non-EDMC entities in the same way.

Fixes: #1719


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


