### PR TITLE
Missing prefix declaration added to hygiene test for deprecated resources

### DIFF
--- a/etc/testing/hygiene/testHygiene1675_deprecated_resources.sparql
+++ b/etc/testing/hygiene/testHygiene1675_deprecated_resources.sparql
@@ -1,6 +1,7 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Count of deprecated resources

--- a/etc/testing/hygiene_parameterized/testHygiene1675_deprecated_resources.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene1675_deprecated_resources.sparql
@@ -1,6 +1,7 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 
 ##
 # banner Count of deprecated resources


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

This adds the missing prefix declaration to the hygiene test for deprecated resources.

Fixes: #1725 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


