### PR TITLE
IND-115 - Move corporate actions individuals from the current general securities-specific corporate actions ontology to a separate code set specific ontology

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -115,6 +115,7 @@
      -->	 
 
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>	 
 	
 	<!-- 

--- a/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-cae-ce-15022 "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/">
+	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
+	<!ENTITY fibo-cae-ce-srca "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/">
+	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-cae-ce-15022="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"
+	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
+	xmlns:fibo-cae-ce-srca="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"
+	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/">
+		<rdfs:label xml:lang="en">ISO 15022 Corporate Action Individuals Ontology</rdfs:label>
+		<dct:abstract>This ontology includes the codes for income and corporate action events as specified in ISO 15022, including extensions as of 3 September 2020. Scope excludes lower-level notification and meetings related events and message definitions associated with ISO 15022 as well as related messages covered by ISO 20022.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-cae-ce-15022</sm:fileAbbreviation>
+		<sm:filename>ISO15022-CorporateActionIndividuals.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BIDS">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">BIDS</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RepurchaseOffer"/>
+		<lcc-lr:hasTag>BIDS</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BONU">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">BONU</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;BonusIssue"/>
+		<lcc-lr:hasTag>BONU</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BPUT">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">BPUT</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PutRedemptionAction"/>
+		<lcc-lr:hasTag>BPUT</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CAPD">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">CAPD</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CapitalDistribution"/>
+		<lcc-lr:hasTag>CAPD</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CAPG">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">CAPG</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that distribute profits resulting from the sale of company assets to shareholders</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CapitalGainsDistribution"/>
+		<lcc-lr:hasTag>CAPG</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CHAN">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">CHAN</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that disseminate information regarding a change further described in the corporate action details</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;ChangeAction"/>
+		<lcc-lr:hasTag>CHAN</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CLSA">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">CLSA</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving a situation where interested parties seek restitution for financial loss</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;ClassAction"/>
+		<lcc-lr:hasTag>CLSA</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CONS">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">CONS</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve procedures aiming to obtain consent of holder to a proposal by the issuer or a third party without convening a meeting</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;ConsentSolicitation"/>
+		<lcc-lr:hasTag>CONS</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CONV">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">CONV</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve conversion of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price/ratio</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ConversionAction"/>
+		<lcc-lr:hasTag>CONV</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DECR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">DECR</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that reduce the face value of a share or the value of fund assets</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DecreaseInValueAction"/>
+		<lcc-lr:hasTag>DECR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DFLT">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">DFLT</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that indicate a failure by the issuer to perform obligations defined as default events under the bond agreement and that have not been remedied</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;BondDefaultAction"/>
+		<lcc-lr:hasTag>DFLT</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DRIP">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">DRIP</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DividendReinvestmentAction"/>
+		<lcc-lr:hasTag>DRIP</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DSCL">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">DSCL</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;DisclosureAction"/>
+		<lcc-lr:hasTag>DSCL</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DTCH">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">DTCH</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving parties wishing to acquire a security</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DutchAuction"/>
+		<lcc-lr:hasTag>DTCH</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DVCA">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">DVCA</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that distribute cash to shareholders in proportion to their equity holding</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CashDividendAction"/>
+		<lcc-lr:hasTag>DVCA</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DVOP">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">DVOP</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DividendOptionAction"/>
+		<lcc-lr:hasTag>DVOP</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DVSE">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">DVSE</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders in the form of equities of the issuing corporation</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;StockDividendAction"/>
+		<lcc-lr:hasTag>DVSE</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXOF">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">EXOF</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that reflect an exchange of holdings for other securities and/or cash</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ExchangeAction"/>
+		<lcc-lr:hasTag>EXOF</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXRI">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">EXRI</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CallOnIntermediateSecurities"/>
+		<lcc-lr:hasTag>EXRI</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXTM">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">EXTM</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve prolonging the maturity date of a bond</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-fbc-dae-cre;MaturityExtension"/>
+		<lcc-lr:hasTag>EXTM</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXWA">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">EXWA</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that offer holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;WarrantExerciseAction"/>
+		<lcc-lr:hasTag>EXWA</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;INFO">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">INFO</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
+		<lcc-lr:hasTag>INFO</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;INTR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">INTR</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a regular interest payment to holders of an interest-bearing asset</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;InterestPaymentAction"/>
+		<lcc-lr:hasTag>INTR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;ActionClassificationScheme"/>
+		<rdfs:label>ISO 15022 corporate action classification scheme</rdfs:label>
+		<skos:definition>scheme for classifying corporate actions according to ISO 15022 Securities - Scheme for Messages (Data Field Dictionary)</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;LIQU">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">LIQU</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;LiquidationAction"/>
+		<lcc-lr:hasTag>LIQU</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;MCAL">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">MCAL</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;FullCallEarlyRedemptionAction"/>
+		<lcc-lr:hasTag>MCAL</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;MRGR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">MRGR</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve the exchange of outstanding securities, initiated by the issuer which may include options, as the result of two or more companies combining assets, that is, an external, third party company</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PostMergerSecuritiesExchange"/>
+		<lcc-lr:hasTag>MRGR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PARI">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">PARI</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that occur when securities with different characteristics become identical in all respects</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PariPassuAction"/>
+		<lcc-lr:hasTag>PARI</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PCAL">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">PCAL</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithReductionOfNominalValueAction"/>
+		<lcc-lr:hasTag>PCAL</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PRED">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">PRED</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithoutReductionOfNominalValueAction"/>
+		<lcc-lr:hasTag>PRED</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PRIO">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">PRIO</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a public offer where priority is given to existing shareholders</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;PriorityIssue"/>
+		<lcc-lr:hasTag>PRIO</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;REDM">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">REDM</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities at final maturity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RedemptionAtMaturityAction"/>
+		<lcc-lr:hasTag>REDM</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;REDO">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">REDO</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions by which the unit (currency and/or nominal) of a security is restated</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RedenominationAction"/>
+		<lcc-lr:hasTag>REDO</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;RHDI">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">RHDI</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution"/>
+		<lcc-lr:hasTag>RHDI</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SHPR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">SHPR</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the shares premium reserve</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;SharesPremiumDividendAction"/>
+		<lcc-lr:hasTag>SHPR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SOFF">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">SOFF</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;SpinOff"/>
+		<lcc-lr:hasTag>SOFF</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SPLF">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">SPLF</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve an increase in a corporation&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;StockSplit"/>
+		<lcc-lr:hasTag>SPLF</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SPLR">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">SPLR</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ReverseStockSplit"/>
+		<lcc-lr:hasTag>SPLR</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;TEND">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdfs:label xml:lang="en">TEND</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;TenderOffer"/>
+		<lcc-lr:hasTag>TEND</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;WRTH">
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdfs:label xml:lang="en">WRTH</rdfs:label>
+		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve booking out of valueless securities</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;WorthlessSecurityAction"/>
+		<lcc-lr:hasTag>WRTH</lcc-lr:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+	</owl:NamedIndividual>
+
+</rdf:RDF>

--- a/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
+++ b/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
@@ -22,25 +22,25 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/">
 		<rdfs:label>Metadata for the EDMC-FIBO Corporate Actions and Events (CAE) Corporate Events Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of general corporate events and securities-related actions.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2021-12-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-cae-ce-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataCAECorporateEvents.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20211101/CorporateEvents/MetadataCAECorporateEvents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20220201/CorporateEvents/MetadataCAECorporateEvents/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-mod;CorporateEventsModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Corporate Events Module</rdfs:label>
-		<dct:abstract>This module contains ontologies of general corporate events and securities-related actions.</dct:abstract>
+		<dct:abstract>This module contains ontologies that define common, general corporate events and securities-related actions.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
+		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>

--- a/CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf
+++ b/CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf
@@ -14,8 +14,6 @@
 	<!ENTITY fibo-md-temx-trs "https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
-	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -38,8 +36,6 @@
 	xmlns:fibo-md-temx-trs="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
-	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -49,18 +45,15 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/">
 		<rdfs:label xml:lang="en">Security-related Corporate Actions Ontology</rdfs:label>
-		<dct:abstract>This ontology covers income and corporate action events as specified in SWIFT ISO 15022, including extensions as of 3 September 2020. Scope has been limited to security-related events and actions only, and excludes notification and meetings related events and message definitions associated with ISO 15022 as well as related messages covered by ISO 20022.</dct:abstract>
+		<dct:abstract>This ontology defines the kinds of income and corporate action events covered by ISO 15022 and other standards, including recent extensions to those standards. Scope has been limited to security-related events and actions, and excludes most notification and meetings related events.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-cae-ce-srca</sm:fileAbbreviation>
 		<sm:filename>SecurityRelatedCorporateActions.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -73,44 +66,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;BIDS">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">BIDS</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RepurchaseOffer"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;RepurchaseOffer"/>
-		<lcc-lr:hasTag>BIDS</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;BONU">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">BONU</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;BonusIssue"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;BonusIssue"/>
-		<lcc-lr:hasTag>BONU</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;BPUT">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">BPUT</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PutRedemptionAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PutRedemptionAction"/>
-		<lcc-lr:hasTag>BPUT</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;BondDefaultAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
@@ -152,72 +110,6 @@
 		<rdfs:label xml:lang="en">business strategy classifier</rdfs:label>
 		<skos:definition xml:lang="en">classifier of corporate actions that involves improving liquidity or changing the overall structure of the organization through diversification, combining and closing parts of the business, etc, to increase long-term profitability</skos:definition>
 	</owl:Class>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CAPD">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">CAPD</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CapitalDistribution"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;CapitalDistribution"/>
-		<lcc-lr:hasTag>CAPD</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CAPG">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">CAPG</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that distribute profits resulting from the sale of company assets to shareholders</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CapitalGainsDistribution"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;CapitalGainsDistribution"/>
-		<lcc-lr:hasTag>CAPG</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CHAN">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">CHAN</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that disseminate information regarding a change further described in the corporate action details</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;ChangeAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-act;ChangeAction"/>
-		<lcc-lr:hasTag>CHAN</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CLSA">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">CLSA</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving a situation where interested parties seek restitution for financial loss</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;ClassAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-act;ClassAction"/>
-		<lcc-lr:hasTag>CLSA</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CONS">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">CONS</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve procedures aiming to obtain consent of holder to a proposal by the issuer or a third party without convening a meeting</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;ConsentSolicitation"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-act;ConsentSolicitation"/>
-		<lcc-lr:hasTag>CONS</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;CONV">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">CONV</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve conversion of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price/ratio</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ConversionAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;ConversionAction"/>
-		<lcc-lr:hasTag>CONV</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;CallOnIntermediateSecurities">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction"/>
@@ -334,94 +226,6 @@
 		<skos:definition xml:lang="en">Coupon stripping is the process whereby interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DECR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">DECR</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that reduce the face value of a share or the value of fund assets</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DecreaseInValueAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;DecreaseInValueAction"/>
-		<lcc-lr:hasTag>DECR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DFLT">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">DFLT</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that indicate a failure by the issuer to perform obligations defined as default events under the bond agreement and that have not been remedied</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;BondDefaultAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;BondDefaultAction"/>
-		<lcc-lr:hasTag>DFLT</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DRIP">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">DRIP</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DividendReinvestmentAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;DividendReinvestmentAction"/>
-		<lcc-lr:hasTag>DRIP</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DSCL">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">DSCL</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;DisclosureAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-act;DisclosureAction"/>
-		<lcc-lr:hasTag>DSCL</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DTCH">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">DTCH</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving parties wishing to acquire a security</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DutchAuction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;DutchAuction"/>
-		<lcc-lr:hasTag>DTCH</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DVCA">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">DVCA</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that distribute cash to shareholders in proportion to their equity holding</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CashDividendAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;CashDividendAction"/>
-		<lcc-lr:hasTag>DVCA</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DVOP">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">DVOP</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DividendOptionAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;DividendOptionAction"/>
-		<lcc-lr:hasTag>DVOP</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;DVSE">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">DVSE</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders in the form of equities of the issuing corporation</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;StockDividendAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;StockDividendAction"/>
-		<lcc-lr:hasTag>DVSE</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;DecreaseInValueAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">decrease in value action</rdfs:label>
@@ -457,51 +261,6 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Holders of the security are invited to make an offer to sell, within a specific price range. The acquiring party will buy from the holder with lowest offer.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;EXOF">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">EXOF</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that reflect an exchange of holdings for other securities and/or cash</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ExchangeAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;ExchangeAction"/>
-		<lcc-lr:hasTag>EXOF</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;EXRI">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">EXRI</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CallOnIntermediateSecurities"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;CallOnIntermediateSecurities"/>
-		<lcc-lr:hasTag>EXRI</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;EXTM">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">EXTM</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve prolonging the maturity date of a bond</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-fbc-dae-cre;MaturityExtension"/>
-		<lcc-lr:denotes rdf:resource="&fibo-fbc-dae-cre;MaturityExtension"/>
-		<lcc-lr:hasTag>EXTM</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;EXWA">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">EXWA</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that offer holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;WarrantExerciseAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;WarrantExerciseAction"/>
-		<lcc-lr:hasTag>EXWA</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;ExchangeAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateAction"/>
 		<rdfs:label xml:lang="en">exchange action</rdfs:label>
@@ -535,34 +294,6 @@
 		<skos:definition xml:lang="en">corporate action that involves redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
 		<skos:example xml:lang="en">Examples securities that may be subject to a full call/early redemption include bonds, preferred equity, funds, that may be redeemed by the issuer or its agent before final maturity.</skos:example>
 	</owl:Class>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;INFO">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">INFO</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
-		<lcc-lr:hasTag>INFO</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;INTR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">INTR</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve distribution of a regular interest payment to holders of an interest-bearing asset</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;InterestPaymentAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;InterestPaymentAction"/>
-		<lcc-lr:hasTag>INTR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme">
-		<rdf:type rdf:resource="&fibo-cae-ce-act;ActionClassificationScheme"/>
-		<rdfs:label>ISO 15022 corporate action classification scheme</rdfs:label>
-		<skos:definition>scheme for classifying corporate actions according to ISO 15022 Securities - Scheme for Messages (Data Field Dictionary)</skos:definition>
-	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;IncomeOrientedClassifier">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;ActionClassifier"/>
@@ -610,94 +341,17 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">rights distribution</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;LIQU">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">LIQU</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;LiquidationAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-act;LiquidationAction"/>
-		<lcc-lr:hasTag>LIQU</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;ListingStatusDelistingMessage">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
 		<rdfs:label xml:lang="en">listing status delisting message</rdfs:label>
 		<skos:definition xml:lang="en">Security is no longer able to comply with the listing requirements of a stock exchange and is removed from official board quotation.</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;MCAL">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">MCAL</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;FullCallEarlyRedemptionAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;FullCallEarlyRedemptionAction"/>
-		<lcc-lr:hasTag>MCAL</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;MRGR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">MRGR</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve the exchange of outstanding securities, initiated by the issuer which may include options, as the result of two or more companies combining assets, that is, an external, third party company</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PostMergerSecuritiesExchange"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PostMergerSecuritiesExchange"/>
-		<lcc-lr:hasTag>MRGR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;OddLotOffer">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">odd lot offer</rdfs:label>
 		<skos:definition xml:lang="en">Offer by issuer to allow holders of an odd lot of a security to order a commission-free transaction at market price, to sell the odd lot, or to buy an amount of shares which will bring the position to a round lot (board lot). SWIFT = ODLT</skos:definition>
 	</owl:Class>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;PARI">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">PARI</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that occur when securities with different characteristics become identical in all respects</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PariPassuAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PariPassuAction"/>
-		<lcc-lr:hasTag>PARI</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;PCAL">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">PCAL</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithReductionOfNominalValueAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithReductionOfNominalValueAction"/>
-		<lcc-lr:hasTag>PCAL</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;PRED">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">PRED</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithoutReductionOfNominalValueAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithoutReductionOfNominalValueAction"/>
-		<lcc-lr:hasTag>PRED</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;PRIO">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">PRIO</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a public offer where priority is given to existing shareholders</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;PriorityIssue"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-act;PriorityIssue"/>
-		<lcc-lr:hasTag>PRIO</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;PariPassuAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
@@ -754,39 +408,6 @@
 		<skos:definition xml:lang="en">corporate action involving early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;REDM">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">REDM</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities at final maturity</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RedemptionAtMaturityAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;RedemptionAtMaturityAction"/>
-		<lcc-lr:hasTag>REDM</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;REDO">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">REDO</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions by which the unit (currency and/or nominal) of a security is restated</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RedenominationAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;RedenominationAction"/>
-		<lcc-lr:hasTag>REDO</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;RHDI">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">RHDI</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution"/>
-		<lcc-lr:hasTag>RHDI</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;RedemptionAtMaturityAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">redemption at maturity action</rdfs:label>
@@ -831,50 +452,6 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is a rights trading period overlaps with rights subscriptiuon period (you can trade the rights) Rights exercise period - expiry date. Some time after the expiry the new shares are distributed. This is the distribution.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;SHPR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">SHPR</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the shares premium reserve</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;SharesPremiumDividendAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;SharesPremiumDividendAction"/>
-		<lcc-lr:hasTag>SHPR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;SOFF">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">SOFF</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;SpinOff"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-act;SpinOff"/>
-		<lcc-lr:hasTag>SOFF</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;SPLF">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">SPLF</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve an increase in a corporation&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;StockSplit"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;StockSplit"/>
-		<lcc-lr:hasTag>SPLF</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;SPLR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">SPLR</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ReverseStockSplit"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;ReverseStockSplit"/>
-		<lcc-lr:hasTag>SPLR</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;SharesPremiumDividendAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">shares premium dividend action</rdfs:label>
@@ -902,17 +479,6 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">change in nominal value</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym xml:lang="en">subdivision</fibo-fnd-utl-av:synonym>
 	</owl:Class>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;TEND">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdfs:label xml:lang="en">TEND</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;TenderOffer"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;TenderOffer"/>
-		<lcc-lr:hasTag>TEND</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;TenderOffer">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;VoluntaryCorporateAction"/>
@@ -960,18 +526,6 @@
 		<rdfs:label xml:lang="en">trading status suspended message</rdfs:label>
 		<skos:definition xml:lang="en">Trading in the security has been suspended.</skos:definition>
 	</owl:Class>
-	
-	<owl:NamedIndividual rdf:about="&fibo-cae-ce-srca;WRTH">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
-		<rdfs:label xml:lang="en">WRTH</rdfs:label>
-		<skos:definition xml:lang="en">SWIFT ISO 15022 classifier for corporate actions that involve booking out of valueless securities</skos:definition>
-		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;WorthlessSecurityAction"/>
-		<lcc-lr:denotes rdf:resource="&fibo-cae-ce-srca;WorthlessSecurityAction"/>
-		<lcc-lr:hasTag>WRTH</lcc-lr:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-srca;ISO15022CorporateActionClassificationScheme"/>
-	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;WarrantExerciseAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateAction"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -65,6 +65,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MuniIssuance/" uri="./BP/SecuritiesIssuance/MuniIssuance.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/" uri="./BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/" uri="./CAE/CorporateEvents/CorporateActions.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/" uri="./CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/" uri="./CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/" uri="./CAE/CorporateEvents/MetadataCAECorporateEvents.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/" uri="./CAE/MetadataCAE.rdf"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Moved individuals representing the ISO 15022 (SWIFT) codes for corporate actions to a separate ontology to enable the addition of the GLIEF codes for corporate actions in their own namespace and others as appropriate

Fixes: #1730 / IND-115


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


