### PR TITLE
DER-124 - Need to address gaps with respect to the CFI representation of swaps

### DIFF
--- a/DER/DerivativesContracts/CurrencyContracts.rdf
+++ b/DER/DerivativesContracts/CurrencyContracts.rdf
@@ -67,8 +67,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220201/DerivativesContracts/CurrencyContracts/"/>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20210701/DerivativesContracts/CurrencyContracts/ version of this ontology was modified to reflect the addition of the concept of a rates swap and the corresponding rate-based leg to the Swaps ontology to facilitate mapping to the CFI standard.</skos:changeNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220301/DerivativesContracts/CurrencyContracts/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20210701/DerivativesContracts/CurrencyContracts/ version of this ontology was modified to reflect the addition of the concept of a rates swap and the corresponding rate-based leg to the Swaps ontology, as well as the concept of a spot forward currency swap, to facilitate mapping to the CFI standard.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -177,6 +177,19 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">foreign exchange spot contract</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-cur;CurrencySpotForwardSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-cur;CurrencySwap"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-cur;CurrencySpotContract"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">currency spot forward swap</rdfs:label>
+		<skos:definition xml:lang="en">foreign exchange agreement between two parties involving both an exchange of two currencies on the spot settlement date at a fixed rate that is agreed upon at the inception of the contract covering the exchange; and a reverse exchange of the same two currencies at a later date and at a fixed rate that is agreed upon at the inception of the contract covering the exchange</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-cur;CurrencySwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-cur;CurrencyDerivative"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;RatesSwap"/>
@@ -186,14 +199,9 @@
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-cur;CurrencyForward"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-cur;CurrencySpotContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">currency swap</rdfs:label>
 		<skos:definition xml:lang="en">foreign exchange agreement between two parties to exchange a given amount of one currency for another currency for spot delivery or for forward delivery at an agreed rate after a specified period of time</skos:definition>
+		<skos:note xml:lang="en">In the case of a &apos;forward-forward&apos; swap, both legs will be of type CurrencyFoward.</skos:note>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	

--- a/DER/DerivativesContracts/CurrencyContracts.rdf
+++ b/DER/DerivativesContracts/CurrencyContracts.rdf
@@ -186,8 +186,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">currency spot forward swap</rdfs:label>
-		<skos:definition xml:lang="en">foreign exchange agreement between two parties involving both an exchange of two currencies on the spot settlement date at a fixed rate that is agreed upon at the inception of the contract covering the exchange; and a reverse exchange of the same two currencies at a later date and at a fixed rate that is agreed upon at the inception of the contract covering the exchange</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition xml:lang="en">foreign exchange agreement between two parties involving an exchange of two currencies at agreed fixed rates: a) on the spot settlement date and b) a reverse exchange on a later specified date</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-cur;CurrencySwap">
@@ -202,7 +202,7 @@
 		<rdfs:label xml:lang="en">currency swap</rdfs:label>
 		<skos:definition xml:lang="en">foreign exchange agreement between two parties to exchange a given amount of one currency for another currency for spot delivery or for forward delivery at an agreed rate after a specified period of time</skos:definition>
 		<skos:note xml:lang="en">In the case of a &apos;forward-forward&apos; swap, both legs will be of type CurrencyFoward.</skos:note>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-cur;CurrencyVolatilityOption">

--- a/DER/DerivativesContracts/CurrencyContracts.rdf
+++ b/DER/DerivativesContracts/CurrencyContracts.rdf
@@ -48,8 +48,8 @@
 		<dct:abstract>This ontology defines concepts common to currency spot contracts and foreign exchange derivatives (forwards, options and swaps).</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
@@ -67,7 +67,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/CurrencyContracts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220201/DerivativesContracts/CurrencyContracts/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20210701/DerivativesContracts/CurrencyContracts/ version of this ontology was modified to reflect the addition of the concept of a rates swap and the corresponding rate-based leg to the Swaps ontology to facilitate mapping to the CFI standard.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -178,7 +179,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-cur;CurrencySwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-cur;CurrencyDerivative"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;RatesSwap"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>

--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -266,12 +266,13 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;RateBasedLeg"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-swp;RateBasedLeg"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>rates swap</rdfs:label>
 		<skos:definition>swap in two counterparties each agree to pay the other cash flows on defined dates during an agreed period, based on a specified notional amount and a floating interest, floating inflation or fixed interest rate</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, 2019-10</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;RealizedVariableLeg">
@@ -391,7 +392,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>swap</rdfs:label>
 		<skos:definition>derivative instrument whereby two counterparties agree to exchange periodic streams of cash flows with each other</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, 2019-10</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The underlying instruments can be almost anything, representing various asset classes, but most swaps involve cash flows (streams of payments or other commitments over time) based on a notional principal amount that both parties agree to.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Usually, the principal does not change hands. Each cash flow comprises one leg of the swap. One cash flow is generally fixed, while the other is variable, that is, based on a a benchmark interest rate, floating currency exchange rate or index price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>

--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
+	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -32,6 +33,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
+	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -62,8 +64,8 @@
 		<dct:abstract>This ontology defines concepts specific to swap contracts, including relevant trading organizations, data repositories, and intermediaries.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
@@ -72,6 +74,7 @@
 		<sm:fileAbbreviation>fibo-der-drc-swp</sm:fileAbbreviation>
 		<sm:filename>Swaps.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
@@ -90,18 +93,19 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/Swaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220201/DerivativesContracts/Swaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/Swaps/ version of this ontology was modified to refine the concept of a unique swap identifier (USI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20190201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate the property &apos;hasPaymentSchedule&apos; from this ontology in favor of the equivalent property with the same name from FND, adding concepts related to statistical swaps, and revising definitions to be ISO 704 compliant.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200901/DerivativesContracts/Swaps/ version of this ontology was modified to integrate return swaps and connect swap legs to the swap they comprise, as appropriate, simplify the contract party hierarchy, add basic fixed and floating legs as higher level concepts common to many swaps, and eliminate ambiguity in definitions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/DerivativesContracts/Swaps/ version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only, facilitate the elimination of the property &apos;mayBeTradedIn&apos;, which was only used in one place and was redundant with the concept of a ListedSecurity / Listing in SEC, and move two properties, hasPayingParty and hasReceivingParty to DerivativesBasics to facilitate wider use.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/Swaps/ version of this ontology was modified to move swap execution facility to the markets ontology in FBC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/Swaps/ version of this ontology was modified to add the concept of a rates swap and the corresponding rate-based leg to facilitate mapping to the CFI standard.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;BasisSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;RatesSwap"/>
 		<rdfs:label>basis swap</rdfs:label>
 		<skos:definition>swap in which payment streams are referenced to different bases</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>A basis swap can have two legs of the same tenor but different indices, e.g., 3 month LIBOR vs. 3 month TIBOR. The difference in this case is not driven by different interest rate periods but from different markets, i.e., the difference in efficiency between the two markets. The objective is to hedge against basis risk which is the difference in price between two markets. See also forward swap, as a means for controlling interest rate.</fibo-fnd-utl-av:explanatoryNote>
@@ -239,6 +243,37 @@
 		<skos:definition>floating leg of a swap that depends on some statistical measure of the performance of the underlier</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-swp;RateBasedLeg">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLeg"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-rtd;RateBasedObservable"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-swp;isLegOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;RatesSwap"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">rate-based leg</rdfs:label>
+		<skos:definition xml:lang="en">swap leg of a rate-based swap based on a floating interest, floating inflation or fixed interest rate</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-swp;RatesSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;RateBasedLeg"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>rates swap</rdfs:label>
+		<skos:definition>swap in two counterparties each agree to pay the other cash flows on defined dates during an agreed period, based on a specified notional amount and a floating interest, floating inflation or fixed interest rate</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, 2019-10</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-swp;RealizedVariableLeg">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;PerformanceBasedVariableLeg"/>
 		<rdfs:label>realized variable leg</rdfs:label>
@@ -356,7 +391,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>swap</rdfs:label>
 		<skos:definition>derivative instrument whereby two counterparties agree to exchange periodic streams of cash flows with each other</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, 2019-10</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The underlying instruments can be almost anything, representing various asset classes, but most swaps involve cash flows (streams of payments or other commitments over time) based on a notional principal amount that both parties agree to.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Usually, the principal does not change hands. Each cash flow comprises one leg of the swap. One cash flow is generally fixed, while the other is variable, that is, based on a a benchmark interest rate, floating currency exchange rate or index price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -62,8 +62,8 @@
 		<dct:abstract>This ontology defines concepts specific to interest rate swap contracts, including but not limited to fixed and floating rate combinations, single and cross-currency contracts, etc.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
@@ -92,12 +92,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20211201/RateDerivatives/IRSwaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220201/RateDerivatives/IRSwaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/RateDerivatives/IRSwaps.rdf version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20190501/RateDerivatives/IRSwaps/ version of this ontology was modified to eliminate the property &apos;hasPaymentSchedule&apos; from the Swaps ontology in favor of the equivalent property with the same name from FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200701/RateDerivatives/IRSwaps/ version of this ontology was modified take advantage of basic fixed and floating legs as higher level concepts common to many swaps, and to refine definitions to eliminate ambiguity and conform with ISO 704.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/RateDerivatives/IRSwaps/ version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210101/RateDerivatives/IRSwaps/ version of this ontology was modified to enable representation of plain vanilla interest rate swaps as a separate concept, to integrate the concept of an inflation swap and correct spelling.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20211201/RateDerivatives/IRSwaps/ version of this ontology was modified to reflect the addition of the concept of a rates swap and the corresponding rate-based leg to the Swaps ontology to facilitate mapping to the CFI standard.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -339,7 +340,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;InflationSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;RatesSwap"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;RateBasedDerivativeInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -356,7 +357,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">inflation swap</rdfs:label>
 		<skos:definition xml:lang="en">rate swap in which one party pays an amount calculated using an inflation rate index, and the other party pays an amount calculated using another inflation rate index, or a fixed or floating interest rate</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019-10.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateStreamEvent">
@@ -366,7 +367,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;RatesSwap"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;InterestRateDerivativeInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -393,7 +394,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateSwapLeg">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLeg"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;RateBasedLeg"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -357,7 +357,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">inflation swap</rdfs:label>
 		<skos:definition xml:lang="en">rate swap in which one party pays an amount calculated using an inflation rate index, and the other party pays an amount calculated using another inflation rate index, or a fixed or floating interest rate</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019-10.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateStreamEvent">
@@ -546,7 +546,7 @@
 		<rdfs:label xml:lang="en">overnight index swap</rdfs:label>
 		<skos:definition xml:lang="en">swap in which the periodic payments for one leg are based on an overnight interest rate index multiplied by the same notional amount upon which payments for the other leg of the swap are based</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">OIS swap</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019-10.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The interest of the overnight rate portion of the swap is compounded and paid at reset dates. The present value for the leg is determined by either compounding of the overnight rate or by taking the geometric average of the rate over a given period.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -560,7 +560,7 @@
 			</owl:Restriction>
 		</owl:equivalentClass>
 		<skos:definition>floating leg in which periodic payments are based on an overnight interest rate index multiplied by the same notional amount on which the payments for the other leg of the swap are based</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019-10.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;PlainVanillaInterestRateSwap">
@@ -699,7 +699,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>zero coupon interest rate swap</rdfs:label>
 		<skos:definition>fixed-float single currency interest rate swap in which payments on the floating leg are made periodically, similar to a plain vanilla interest rate swap, but the fixed rate cash flows are compounded and paid as a lump sum on the expiration date, rather than periodically</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019-10.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-rtd-irswp;hasFirstNotionalStepDate">

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -98,7 +98,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200701/RateDerivatives/IRSwaps/ version of this ontology was modified take advantage of basic fixed and floating legs as higher level concepts common to many swaps, and to refine definitions to eliminate ambiguity and conform with ISO 704.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/RateDerivatives/IRSwaps/ version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210101/RateDerivatives/IRSwaps/ version of this ontology was modified to enable representation of plain vanilla interest rate swaps as a separate concept, to integrate the concept of an inflation swap and correct spelling.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20211201/RateDerivatives/IRSwaps/ version of this ontology was modified to reflect the addition of the concept of a rates swap and the corresponding rate-based leg to the Swaps ontology to facilitate mapping to the CFI standard.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20211201/RateDerivatives/IRSwaps/ version of this ontology was modified to reflect the addition of the concept of a rates swap and the corresponding rate-based leg to the Swaps ontology and augment this ontology to include both OIS and zero coupon swaps to facilitate mapping to the CFI standard.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -535,6 +535,34 @@
 		<skos:definition>schedule of changes in the notional amount on which interest is paid, comprising the regular sequence of step events</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-rtd-irswp;OvernightIndexSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateSwap"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;OvernightRateIndexLeg"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">overnight index swap</rdfs:label>
+		<skos:definition xml:lang="en">swap in which the periodic payments for one leg are based on an overnight interest rate index multiplied by the same notional amount upon which payments for the other leg of the swap are based</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">OIS swap</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019-10.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The interest of the overnight rate portion of the swap is compounded and paid at reset dates. The present value for the leg is determined by either compounding of the overnight rate or by taking the geometric average of the rate over a given period.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-rtd-irswp;OvernightRateIndexLeg">
+		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;FloatingInterestRateLeg"/>
+		<rdfs:label>overnight rate index leg</rdfs:label>
+		<owl:equivalentClass>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasInterestRate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ir-ir;OvernightRate"/>
+			</owl:Restriction>
+		</owl:equivalentClass>
+		<skos:definition>floating leg in which periodic payments are based on an overnight interest rate index multiplied by the same notional amount on which the payments for the other leg of the swap are based</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019-10.</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;PlainVanillaInterestRateSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;FixedFloatSingleCurrencyInterestRateSwap"/>
 		<rdfs:subClassOf>
@@ -658,6 +686,20 @@
 		</rdfs:subClassOf>
 		<rdfs:label>swap stream interest setting relative date</rdfs:label>
 		<skos:definition>date on which an interest rate is revised if that date is relative to a rate reset event</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-rtd-irswp;ZeroCouponInterestRateSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;FixedFloatSingleCurrencyInterestRateSwap"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasNotionalAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>zero coupon interest rate swap</rdfs:label>
+		<skos:definition>fixed-float single currency interest rate swap in which payments on the floating leg are made periodically, similar to a plain vanilla interest rate swap, but the fixed rate cash flows are compounded and paid as a lump sum on the expiration date, rather than periodically</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019-10.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-rtd-irswp;hasFirstNotionalStepDate">

--- a/DER/SecurityBasedDerivatives/EquitySwaps.rdf
+++ b/DER/SecurityBasedDerivatives/EquitySwaps.rdf
@@ -145,7 +145,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">dividend swap</rdfs:label>
 		<skos:definition xml:lang="en">equity swap that has at least one leg whose underlier is a dividend stream</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Dividend swaps include those that are fixed-term contracts between two parties where one party makes an interest rate payment for each interval and the other party pays the total dividends received as pay-out by a selected underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -167,8 +167,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">equity price return swap</rdfs:label>
-		<skos:definition xml:lang="en">equity swap whose return leg underlier is an equity observable</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition xml:lang="en">return swap whose return leg underlier is an equity observable</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A price return equity swap is similar to a total return swap, except that dividends are not passed through to the buyer).</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -193,8 +193,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
 		<rdfs:label xml:lang="en">equity swap</rdfs:label>
-		<skos:definition xml:lang="en">swap whose payments are linked to the change in value of an underlying equity (e.g. shares, basket of equities or index).</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition xml:lang="en">swap whose payments are linked to the change in value of an underlying equity (e.g. shares, basket of equities or index) or its cashflow</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equity swaps can be physically or cash settled.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -218,7 +218,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">equity total return swap</rdfs:label>
 		<skos:definition xml:lang="en">total return swap whose return leg underlier is an equity observable</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquityVarianceSwap">
@@ -226,7 +226,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-eqs;EquitySwap"/>
 		<rdfs:label xml:lang="en">equity variance swap</rdfs:label>
 		<skos:definition xml:lang="en">dispersion swap in which the parties agree to exchange payments based on the difference between (i) the realized variance of the price changes of a specified equity underlier over a stated observation period and (ii) a fixed amount of variance that is agreed when the contract is executed</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An equity variance swap is a forward swap that uses the variance (being the volatility squared) of an underlying&apos;s price movement over a period as the basis for the payoff calculation.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -234,9 +234,9 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;DispersionSwap"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-eqs;EquitySwap"/>
 		<rdfs:label xml:lang="en">equity volatility swap</rdfs:label>
-		<skos:definition xml:lang="en">dispersion swap that is a forward contract on the future realized volatility of its underlying equity observable</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An equity volatility swap is a forward swap whose payments depend on the variability of movements in a security or underlying instrument&apos;s price; it is a measure of the amount by which an asset&apos;s price is expected to fluctuate over a given period of time; it is normally measured by the annual standard deviation of daily price changes.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">dispersion swap that is a forward contract on the variability of movements in the price of its underlying equity observable</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An equity volatility swap is a measure of the amount by which an asset&apos;s price is expected to fluctuate over a given period of time; it is normally measured by the annual standard deviation of daily price changes.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;QualifyingDividendPeriod">

--- a/DER/SecurityBasedDerivatives/EquitySwaps.rdf
+++ b/DER/SecurityBasedDerivatives/EquitySwaps.rdf
@@ -46,8 +46,8 @@
 		<dct:abstract>This ontology defines concepts specific to swap contracts in which one leg gives some form of return on an equity asset, including dividend returns, total asset returns equity dispersion and correlation measurement terms. Many of these return calculations are based on a variety of calculation methods and may vary widely.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
@@ -69,8 +69,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20211201/SecurityBasedDerivatives/EquitySwaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220301/SecurityBasedDerivatives/EquitySwaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/SecurityBasedDerivatives/EquitySwaps.rdf version of this ontology was modified to fix spelling errors.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20211201/SecurityBasedDerivatives/EquitySwaps.rdf version of this ontology was modified to add the concept of a high-level equity swap as well as an equity volatility swap per the ISO CFI standard and to add references to the CFI where appropriate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -135,8 +136,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;DividendSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-eqs;EquitySwap"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>
@@ -145,45 +145,98 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">dividend swap</rdfs:label>
 		<skos:definition xml:lang="en">equity swap that has at least one leg whose underlier is a dividend stream</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Dividend swaps include those that are fixed-term contracts between two parties where one party makes an interest rate payment for each interval and the other party pays the total dividends received as pay-out by a selected underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquityCorrelationSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;CorrelationSwap"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-eqs;EquitySwap"/>
 		<rdfs:label xml:lang="en">equity correlation swap</rdfs:label>
 		<skos:definition xml:lang="en">correlation swap that allows one to hedge risks associated with the observed average correlation of a collection of underlying equity products</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The underlier for the leg can be any of (1) dividend stream for a single stock, (2) change in value for a single share, (3) change in value for a basket of shares, (4) change in value for an index, (5) value of a dividend stream for a basket of shares, or (6) comparison of the change in value of a given share or basket or index against something else - for example, a single share against an index, which is the thing you are cross-correlating with the volatility of the share.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquityPriceReturnSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;ReturnSwap"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-eqs;EquitySwap"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasReturnLeg"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-eqs;EquityReturnLeg"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">equity price return swap</rdfs:label>
+		<skos:definition xml:lang="en">equity swap whose return leg underlier is an equity observable</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A price return equity swap is similar to a total return swap, except that dividends are not passed through to the buyer).</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquityReturnLeg">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;ReturnLeg"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-sbd;EquityObservable"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">equity return leg</rdfs:label>
+		<skos:definition xml:lang="en">return leg whose income is based on an equity observable</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquityReturnSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;TotalReturnSwap"/>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-der-sbd-eqs;EquityTotalReturnSwap"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquitySwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
+		<rdfs:label xml:lang="en">equity swap</rdfs:label>
+		<skos:definition xml:lang="en">swap whose payments are linked to the change in value of an underlying equity (e.g. shares, basket of equities or index).</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equity swaps can be physically or cash settled.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquityTotalReturnSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;TotalReturnSwap"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-eqs;EquitySwap"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasReturnLeg"/>
 				<owl:someValuesFrom>
 					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-der-sbd-eqs;EquityReturnLeg">
+							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-der-drc-swp;TotalReturnLeg">
 							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-								<owl:someValuesFrom rdf:resource="&fibo-der-sbd-sbd;EquityObservable"/>
-							</owl:Restriction>
-						</owl:unionOf>
+						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity return swap</rdfs:label>
+		<rdfs:label xml:lang="en">equity total return swap</rdfs:label>
 		<skos:definition xml:lang="en">total return swap whose return leg underlier is an equity observable</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquityVarianceSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;DispersionSwap"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-eqs;EquitySwap"/>
 		<rdfs:label xml:lang="en">equity variance swap</rdfs:label>
 		<skos:definition xml:lang="en">dispersion swap in which the parties agree to exchange payments based on the difference between (i) the realized variance of the price changes of a specified equity underlier over a stated observation period and (ii) a fixed amount of variance that is agreed when the contract is executed</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An equity variance swap is a forward swap that uses the variance (being the volatility squared) of an underlying&apos;s price movement over a period as the basis for the payoff calculation.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquityVolatilitySwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;DispersionSwap"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-eqs;EquitySwap"/>
+		<rdfs:label xml:lang="en">equity volatility swap</rdfs:label>
+		<skos:definition xml:lang="en">dispersion swap that is a forward contract on the future realized volatility of its underlying equity observable</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An equity volatility swap is a forward swap whose payments depend on the variability of movements in a security or underlying instrument&apos;s price; it is a measure of the amount by which an asset&apos;s price is expected to fluctuate over a given period of time; it is normally measured by the annual standard deviation of daily price changes.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;QualifyingDividendPeriod">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added the concept of a rates swap and the corresponding rate-based leg to the swaps ontology and integrated it with the relevant subordinate ontologies to facilitate mapping to the CFI standard

Fixes: #1727 / DER-124


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


