### PR TITLE
IND-116 - Revise corporate actions to cover GLEIF actions

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -115,6 +115,7 @@
      -->	 
 
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>	 
 	

--- a/CAE/CorporateEvents/CorporateActions.rdf
+++ b/CAE/CorporateEvents/CorporateActions.rdf
@@ -37,10 +37,10 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 		<rdfs:label xml:lang="en">Corporate Actions Ontology</rdfs:label>
-		<dct:abstract>This ontology provides a high level overview of actions including corporate, market, and regulatory actions, ranging from business oriented events such as address and name changes, to those that are specific to securities.</dct:abstract>
+		<dct:abstract>This ontology provides a high level overview of actions including corporate, market, and regulatory actions, ranging from business oriented events such as address and name changes, to those that are more specific to securities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -142,6 +142,46 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">ISO 15022 classifies events as impacting income vs. others. Other classification schemes distinguish between actions that return profits to shareholders, actions that are designed to influence the share price, and actions involving a change in structure to the issuer organization.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-cae-ce-act;ActionStatus">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-fi-fi;Security">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">action status</rdfs:label>
+		<skos:definition xml:lang="en">classifier and/or event that provides information about the state of some action at some point in time</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-cae-ce-act;BusinessStrategyClassifier">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;ActionClassifier"/>
+		<rdfs:label xml:lang="en">business strategy classifier</rdfs:label>
+		<skos:definition xml:lang="en">classifier of corporate actions that involve improving liquidity or changing the overall structure of the organization through diversification, combining and closing parts of the business, etc, to increase long-term profitability</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-cae-ce-act;ChangeAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">change action</rdfs:label>
@@ -172,6 +212,21 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Corporate actions are typically approved by a company&apos;s board of directors and authorized by the shareholders.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-cae-ce-act;CorporateActionNotificationEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;NotificationEvent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-cae-ce-act;ActionStatus"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">corporate action notification event</rdfs:label>
+		<skos:definition xml:lang="en">action that provides information specifically regarding a corporate action</skos:definition>
+		<skos:note xml:lang="en">Certain messages regarding corporate actions provide details that are not included in an original announcement.</skos:note>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-cae-ce-act;CorporateInformationAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">corporate information action</rdfs:label>
@@ -182,21 +237,34 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">disclosure action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This event only occurs with the characteristic VOLU, otherwise it is part of the SRD II.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-cae-ce-act;DivestitureAction">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">divestiture action</rdfs:label>
+		<skos:definition xml:lang="en">corporate action involving the sales of subsidiary business interests or investments</skos:definition>
+		<skos:note xml:lang="en">Divestiture is an action or process involving the sale, spinoff, or liquidation of business assets, including product lines, services, subsidiaries, business property, or even an entire business. Companies may pursue a divestment strategy to refocus on their core business, in response to the operating environment in their industry, to raise capital, or to release underperforming assets.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-cae-ce-act;IncomeOrientedClassifier">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;ActionClassifier"/>
+		<rdfs:label xml:lang="en">income-oriented classifier</rdfs:label>
+		<skos:definition xml:lang="en">classifier of corporate actions that impacts income to shareholders</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Cash dividends are a classic example where a public company declares a dividend to be paid on each outstanding share. Bonus is another case where the shareholder is rewarded. In a stricter sense, the bonus issue should not impact the share price but in reality, in rare cases, it does and results in an overall increase in value.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;LegalFormChange">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
 		<rdfs:label xml:lang="en">legal form change</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that informs stakeholders of a modification of the legal form of the organization</skos:definition>
-		<skos:example xml:lang="en">In the United States it is common for companies established as Subchapter S Corporations (S-Corp), typically early stage companies, modify their structure to become full-fledged Subchapter C Corporations (C-Corp) to facilitate outside fundraising, mergers, acquisitions, and public offerings.  Other common form changes include migration from sole proprietorships to more formally registered organizations (e.g., LLC, S-Corp, C-Corp, etc.)</skos:example>
+		<skos:example xml:lang="en">In the United States it is common for companies established as Subchapter S Corporations (S-Corp), typically early stage companies, to modify their structure to become full-fledged Subchapter C Corporations (C-Corp) to facilitate outside fundraising, mergers, acquisitions, and public offerings.  Other common form changes include migration from sole proprietorships to more formally registered organizations (e.g., LLC, S-Corp, C-Corp, etc.)</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;LiquidationAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;DivestitureAction"/>
 		<rdfs:label xml:lang="en">liquidation action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action consisting of distribution of cash, assets, or both</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by the security.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by a security.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en">liquidation dividend</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym xml:lang="en">liquidation payment</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -204,9 +272,9 @@
 	<owl:Class rdf:about="&fibo-cae-ce-act;MandatoryCorporateAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateAction"/>
 		<rdfs:label xml:lang="en">mandatory corporate action</rdfs:label>
-		<skos:definition xml:lang="en">event initiated by the board of directors of the corporation that affects all shareholders</skos:definition>
+		<skos:definition xml:lang="en">event initiated by the board of directors of a corporation that affects all shareholders</skos:definition>
 		<skos:example xml:lang="en">Examples of mandatory corporate actions include cash dividends, stock splits, mergers, pre-refunding, return of capital, bonus issue, asset ID change, and spin-offs.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Mandatory means mandatory participation by all shareholders, however the shareholder is not required to do anything.  Shareholders are passive beneficiaries of mandatory actions.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Mandatory means mandatory participation by all shareholders, however the shareholder is not required to do anything. Shareholders are passive beneficiaries of mandatory actions.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction">
@@ -230,21 +298,23 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;NotificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;Action"/>
 		<rdfs:label xml:lang="en">notification event</rdfs:label>
-		<skos:definition xml:lang="en">A notification to the shareholders that there is a corporate action out there. This is distinct from the CA itself. not the same as Event Announcement. There are steps between when the announcement happens and the rest Announcement: at the level of sub custodians. then you gether the people who are affected by the event that&apos;s to come. Then you send the announcement - a notification to the holder, informing them of the options that are available to them. If it&apos;s mandatory these distinctions still happen, but there is no choice. So still announcement is made, then when it effects people you send out notificaiton and collect responses. &quot;EVENT&quot;: two aspects: The event itself Events within the Corporat eAction, e.g. notification, deadline when a responses is due by, payment dates, Define as: lifecycle of the Corporate Action. Sometimes have to re-notify, there may be changes in the life oc the &quot;Corporate Event&quot;. So the Corporate Event is a sequence of events.</skos:definition>
+		<skos:definition xml:lang="en">action that provides information regarding, for example, a corporate action, or some other activity</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-cae-ce-act;OrganizationAddressChange">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
+		<rdfs:label xml:lang="en">organization address change</rdfs:label>
+		<skos:definition xml:lang="en">information action that provides details of address changes for a legal entity</skos:definition>
+		<skos:note xml:lang="en">Address changes may impact customer 360 and/or securities master data management, including but not limited to where shares are registered and by whom.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;OrganizationNameChange">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
 		<rdfs:label xml:lang="en">organization name change</rdfs:label>
-		<skos:definition xml:lang="en">The issuing company changes it&apos;s name. Event shows the change from old name to new name and may involve surrendering physical shares with the old name to the registrar. SWIFT = NAME</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-act;PlaceOfIncorporationChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
-		<rdfs:label xml:lang="en">place of incorporation change</rdfs:label>
-		<skos:definition xml:lang="en">Changes in the state of incorporation for US companies and changes in the place of incorporation for foreign companies. Where shares need to be registered following the incorporation change, the holder(s) may have to elect the registrar. SWIFT = PLAC</skos:definition>
+		<skos:definition xml:lang="en">information action that provides details of name changes for a legal entity</skos:definition>
+		<skos:note xml:lang="en">Name changes may include legal name changes as well as &apos;doing business as&apos;, and other operational names for an organization, some of which may impact customer 360 and/or securities master data management.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;PriorityIssue">
@@ -260,10 +330,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;SpinOff">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;DivestitureAction"/>
 		<rdfs:label xml:lang="en">spin off</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Spin-off represents a form of divestiture usually resulting in an independent company or in an existing company. For example, demerger, distribution, unbundling.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Spin-off represents a form of divestiture usually resulting in an independent company or in an existing company. Examples include demerger, distribution, and unbundling.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;VoluntaryCorporateAction">

--- a/CAE/CorporateEvents/CorporateActions.rdf
+++ b/CAE/CorporateEvents/CorporateActions.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
+	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -23,6 +24,7 @@
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
+	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -50,6 +52,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -143,23 +146,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;ActionStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fbc-fi-fi;Security">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStatus"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
@@ -173,7 +160,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">action status</rdfs:label>
-		<skos:definition xml:lang="en">classifier and/or event that provides information about the state of some action at some point in time</skos:definition>
+		<skos:definition xml:lang="en">state of some action at some point in time</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;BusinessStrategyClassifier">
@@ -212,36 +199,15 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Corporate actions are typically approved by a company&apos;s board of directors and authorized by the shareholders.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-act;CorporateActionNotificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;NotificationEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-cae-ce-act;ActionStatus"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">corporate action notification event</rdfs:label>
-		<skos:definition xml:lang="en">action that provides information specifically regarding a corporate action</skos:definition>
-		<skos:note xml:lang="en">Certain messages regarding corporate actions provide details that are not included in an original announcement.</skos:note>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-act;CorporateInformationAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
-		<rdfs:label xml:lang="en">corporate information action</rdfs:label>
-		<skos:definition xml:lang="en">corporate action involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-act;DisclosureAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">disclosure action</rdfs:label>
-		<skos:definition xml:lang="en">corporate action involving a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
+		<skos:definition xml:lang="en">corporate action involving a request for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-act;DivestitureAction">
+	<owl:Class rdf:about="&fibo-cae-ce-act;Divestiture">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
-		<rdfs:label xml:lang="en">divestiture action</rdfs:label>
+		<rdfs:label xml:lang="en">divestiture</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving the sales of subsidiary business interests or investments</skos:definition>
 		<skos:note xml:lang="en">Divestiture is an action or process involving the sale, spinoff, or liquidation of business assets, including product lines, services, subsidiaries, business property, or even an entire business. Companies may pursue a divestment strategy to refocus on their core business, in response to the operating environment in their industry, to raise capital, or to release underperforming assets.</skos:note>
 	</owl:Class>
@@ -254,27 +220,25 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;LegalFormChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">legal form change</rdfs:label>
-		<skos:definition xml:lang="en">corporate action that informs stakeholders of a modification of the legal form of the organization</skos:definition>
+		<skos:definition xml:lang="en">corporate action indicating a modification of the legal form of the organization</skos:definition>
 		<skos:example xml:lang="en">In the United States it is common for companies established as Subchapter S Corporations (S-Corp), typically early stage companies, to modify their structure to become full-fledged Subchapter C Corporations (C-Corp) to facilitate outside fundraising, mergers, acquisitions, and public offerings.  Other common form changes include migration from sole proprietorships to more formally registered organizations (e.g., LLC, S-Corp, C-Corp, etc.)</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-act;LiquidationAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;DivestitureAction"/>
-		<rdfs:label xml:lang="en">liquidation action</rdfs:label>
-		<skos:definition xml:lang="en">corporate action consisting of distribution of cash, assets, or both</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by a security.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">liquidation dividend</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">liquidation payment</fibo-fnd-utl-av:synonym>
+	<owl:Class rdf:about="&fibo-cae-ce-act;Liquidation">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;Divestiture"/>
+		<rdfs:label xml:lang="en">liquidation</rdfs:label>
+		<skos:definition xml:lang="en">corporate action related to winding up a business, including but not limited to distribution of cash, assets, or both</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by a security, for example.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;MandatoryCorporateAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateAction"/>
 		<rdfs:label xml:lang="en">mandatory corporate action</rdfs:label>
-		<skos:definition xml:lang="en">event initiated by the board of directors of a corporation that affects all shareholders</skos:definition>
+		<skos:definition xml:lang="en">action initiated by the board of directors of a corporation that affects all shareholders</skos:definition>
 		<skos:example xml:lang="en">Examples of mandatory corporate actions include cash dividends, stock splits, mergers, pre-refunding, return of capital, bonus issue, asset ID change, and spin-offs.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Mandatory means mandatory participation by all shareholders, however the shareholder is not required to do anything. Shareholders are passive beneficiaries of mandatory actions.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Mandatory means mandatory participation by all shareholders, however the shareholder is not required to do anything.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction">
@@ -297,24 +261,24 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such consolidation may be accomplished via financial transactions such as mergers, acquisitions, consolidations, tender offers, purchase of assets, and management acquisitions.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-act;NotificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;Action"/>
-		<rdfs:label xml:lang="en">notification event</rdfs:label>
-		<skos:definition xml:lang="en">action that provides information regarding, for example, a corporate action, or some other activity</skos:definition>
+	<owl:Class rdf:about="&fibo-cae-ce-act;Notification">
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
+		<rdfs:label xml:lang="en">notification</rdfs:label>
+		<skos:definition xml:lang="en">corporate action involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;OrganizationAddressChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;Notification"/>
 		<rdfs:label xml:lang="en">organization address change</rdfs:label>
 		<skos:definition xml:lang="en">information action that provides details of address changes for a legal entity</skos:definition>
-		<skos:note xml:lang="en">Address changes may impact customer 360 and/or securities master data management, including but not limited to where shares are registered and by whom.</skos:note>
+		<skos:note xml:lang="en">Address changes may impact securities master data management, including but not limited to where shares are registered and by whom.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;OrganizationNameChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;Notification"/>
 		<rdfs:label xml:lang="en">organization name change</rdfs:label>
 		<skos:definition xml:lang="en">information action that provides details of name changes for a legal entity</skos:definition>
-		<skos:note xml:lang="en">Name changes may include legal name changes as well as &apos;doing business as&apos;, and other operational names for an organization, some of which may impact customer 360 and/or securities master data management.</skos:note>
+		<skos:note xml:lang="en">Name changes may include legal name changes as well as &apos;doing business as&apos;, and other operational names for an organization.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;PriorityIssue">
@@ -330,7 +294,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;SpinOff">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;DivestitureAction"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;Divestiture"/>
 		<rdfs:label xml:lang="en">spin off</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Spin-off represents a form of divestiture usually resulting in an independent company or in an existing company. Examples include demerger, distribution, and unbundling.</fibo-fnd-utl-av:explanatoryNote>

--- a/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
@@ -101,7 +101,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;BREAKUP">
-		<rdf:type rdf:resource="&fibo-cae-ce-act;DivestitureAction"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;Divestiture"/>
 		<rdfs:label xml:lang="en">BREAKUP</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions in which a single company splits into two or more independent, separately-run companies</skos:definition>
 		<skos:note xml:lang="en">Regulators also can mandate break-ups of companies for anti-trust reasons.</skos:note>
@@ -158,7 +158,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;DEMERGER">
-		<rdf:type rdf:resource="&fibo-cae-ce-act;DivestitureAction"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;Divestiture"/>
 		<rdfs:label xml:lang="en">DEMERGER</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a distribution of securities issued by another legal entity</skos:definition>
 		<skos:note xml:lang="en">The distributed securities may either be of a newly created or of an existing legal entity. For example, spin-off, demerger, unbundling, divestment.</skos:note>
@@ -193,7 +193,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;LIQUIDATION">
 		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
-		<rdf:type rdf:resource="&fibo-cae-ce-act;LiquidationAction"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;Liquidation"/>
 		<rdf:type rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
 		<rdfs:label xml:lang="en">LIQUIDATION</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>

--- a/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-cae-ce-GLEIF "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/">
+	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
+	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
+	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-cae-ce-GLEIF="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"
+	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
+	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
+	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/">
+		<rdfs:label xml:lang="en">GLEIF Corporate Action Individuals Ontology</rdfs:label>
+		<dct:abstract>This ontology includes the codes for corporate action events as specified in GLEIF LEI Common Data Format (CDF) schema, as of 4 March 2021.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:copyright>Copyright (c) 2022 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-cae-ce-GLEIF</sm:fileAbbreviation>
+		<sm:filename>GLEIF-CorporateActionIndividuals.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;ABSORPTION">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;MergerAcquisition"/>
+		<rdfs:label xml:lang="en">ABSORPTION</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions that is a kind of merger where there is a combination of two or more companies into an existing company</skos:definition>
+		<skos:note xml:lang="en">In the case of absorption, only one company survives and all others lose their identity.</skos:note>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>ABSORPTION</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;ACQUISITION_BRANCH">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;MergerAcquisition"/>
+		<rdfs:label xml:lang="en">ACQUISITION_BRANCH</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions where the acquiring legal entity purchases an international branch entity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>ACQUISITION_BRANCH</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-cae-ce-GLEIF;ActionGroup">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">action group</rdfs:label>
+		<skos:definition xml:lang="en">classifier that differentiates corporate actions based on a GLEIF specific grouping</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;BANKRUPTCY">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-fbc-dae-cre;Bankruptcy"/>
+		<rdfs:label xml:lang="en">BANKRUPTCY</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions in which the status of a legal entity is that it is unable to pay creditors</skos:definition>
+		<skos:note xml:lang="en">Bankruptcy usually involves a formal court ruling. Securities may become valueless (event completed).</skos:note>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>BANKRUPTCY</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;BREAKUP">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;DivestitureAction"/>
+		<rdfs:label xml:lang="en">BREAKUP</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions in which a single company splits into two or more independent, separately-run companies</skos:definition>
+		<skos:note xml:lang="en">Regulators also can mandate break-ups of companies for anti-trust reasons.</skos:note>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>BREAKUP</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;CHANGE_HQ_ADDRESS">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;OrganizationAddressChange"/>
+		<rdfs:label xml:lang="en">CHANGE_HQ_ADDRESS</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the headquarters address of the legal entity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>CHANGE_HQ_ADDRESS</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;CHANGE_LEGAL_ADDRESS">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;OrganizationAddressChange"/>
+		<rdfs:label xml:lang="en">CHANGE_LEGAL_ADDRESS</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the legal address of the legal entity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>CHANGE_LEGAL_ADDRESS</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;CHANGE_LEGAL_FORM">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;LegalFormChange"/>
+		<rdfs:label xml:lang="en">CHANGE_LEGAL_FORM</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the legal form of the legal entity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>CHANGE_LEGAL_FORM</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;CHANGE_LEGAL_NAME">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;OrganizationNameChange"/>
+		<rdfs:label xml:lang="en">CHANGE_LEGAL_NAME</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the legal name of the legal entity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>CHANGE_LEGAL_NAME</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;CHANGE_OTHER_NAMES">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;OrganizationNameChange"/>
+		<rdfs:label xml:lang="en">CHANGE_OTHER_NAMES</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the trade- or doing business name of the legal entity</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>CHANGE_OTHER_NAMES</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;ComplexLegalFormGroup">
+		<rdf:type rdf:resource="&fibo-cae-ce-GLEIF;ActionGroup"/>
+		<rdfs:label xml:lang="en">complex legal form group</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a more complex legal entity event including change of the legal entity status triggered by change of the legal form</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>COMPLEX_CHANGE_LEGAL_FORM</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;DEMERGER">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;DivestitureAction"/>
+		<rdfs:label xml:lang="en">DEMERGER</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a distribution of securities issued by another legal entity</skos:definition>
+		<skos:note xml:lang="en">The distributed securities may either be of a newly created or of an existing legal entity. For example, spin-off, demerger, unbundling, divestment.</skos:note>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>DEMERGER</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;DISSOLUTION">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
+		<rdfs:label xml:lang="en">DISSOLUTION</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving (i) A voluntary termination of operations, (ii) a general assignment for the benefit of the legal entity&apos;s creditors or (iii) any other liquidation, dissolution or winding up of the legal entity (excluding a Liquidity Event), whether voluntary or involuntary (event completed)</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>DISSOLUTION</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;ActionClassificationScheme"/>
+		<rdfs:label>GLEIF corporate action classification scheme</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.gleif.org/content/2-about-lei/6-common-data-file-format/1-upcoming-versions/2021-03-04_lei-cdf-v3-1.xsd"/>
+		<skos:definition>scheme for classifying corporate actions according to the GLEIF LEI Common Data Format (CDF) schema</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;INSOLVENCY">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
+		<rdfs:label xml:lang="en">INSOLVENCY</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving the entry of a decree or order by a court or agency or supervisory authority having jurisdiction in the premises the appointment of a trustee-in-bankruptcy or similar official for such party in any insolvency, readjustment of debt, marshalling of assets and liabilities, or similar proceedings, or for the winding up or liquidation of their respective affairs (event completed)</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>INSOLVENCY</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;LIQUIDATION">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;LiquidationAction"/>
+		<rdf:type rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
+		<rdfs:label xml:lang="en">LIQUIDATION</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
+		<skos:note xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by the security (event completed).</skos:note>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>LIQUIDATION</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;LegalFormNameGroup">
+		<rdf:type rdf:resource="&fibo-cae-ce-GLEIF;ActionGroup"/>
+		<rdfs:label xml:lang="en">legal form and name group</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a change in the legal form, name, or other information such as an address change for an organization</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>CHANGE_LEGAL_FORM_AND_NAME</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;MERGERS_AND_ACQUISITIONS">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;MergerAcquisition"/>
+		<rdfs:label xml:lang="en">MERGERS_AND_ACQUISITIONS</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions in which a single company splits into two or more independent, separately-run companies</skos:definition>
+		<skos:note xml:lang="en">Regulators also can mandate break-ups of companies for anti-trust reasons.</skos:note>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>MERGERS_AND_ACQUISITIONS</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;ReverseTakeoverGroup">
+		<rdf:type rdf:resource="&fibo-cae-ce-GLEIF;ActionGroup"/>
+		<rdfs:label xml:lang="en">reverse takeover group</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions that are part of a reverse takeover event</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>REVERSE_TAKEOVER</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;SPINOFF">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;SpinOff"/>
+		<rdfs:label xml:lang="en">SPINOFF</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions where the shareholders of the original entity are compensated for the value loss of the original entity via shares of the new entity or via dividend</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>SPINOFF</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;StandaloneGroup">
+		<rdf:type rdf:resource="&fibo-cae-ce-GLEIF;ActionGroup"/>
+		<rdfs:label xml:lang="en">standalone group</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions that are single, standalone events rather than a combination of multiple events</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>STANDALONE</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;TRANSFORMATION_BRANCH_TO_SUBSIDIARY">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;MergerAcquisition"/>
+		<rdfs:label xml:lang="en">TRANSFORMATION_BRANCH_TO_SUBSIDIARY</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving the transfer of all of the assets and liabilities of an International Branch to the new subsidiary entity in exchange for the transfer of securities representing the capital of the subsidiary entity receiving the transfer</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>TRANSFORMATION_BRANCH_TO_SUBSIDIARY</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;TRANSFORMATION_SUBSIDIARY_TO_BRANCH">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;MergerAcquisition"/>
+		<rdfs:label xml:lang="en">TRANSFORMATION_SUBSIDIARY_TO_BRANCH</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving the transfer of all of the assets and liabilities of a subsidiary to an International Branch entity in exchange for the transfer of securities representing the capital of the International Branch entity receiving the transfer</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>TRANSFORMATION_SUBSIDIARY_TO_BRANCH</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;TRANSFORMATION_UMBRELLA_TO_STANDALONE">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;LegalFormChange"/>
+		<rdfs:label xml:lang="en">TRANSFORMATION_UMBRELLA_TO_STANDALONE</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the legal form from a Fund legal entity structure with one or more than one sub-funds/compartments to a Fund legal entity structure without sub-funds/compartments</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>TRANSFORMATION_UMBRELLA_TO_STANDALONE</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;VOLUNTARY_ARRANGEMENT">
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
+		<rdfs:label xml:lang="en">VOLUNTARY_ARRANGEMENT</rdfs:label>
+		<skos:definition xml:lang="en">GLEIF classifier for corporate actions consisting of a procedure that allows a legal entity to settle debts by paying only a proportion of the amount that it owes to creditors or to come to some other arrangement with its creditors over the payment of its debts (event completed)</skos:definition>
+		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
+		<lcc-lr:hasTag>VOLUNTARY_ARRANGEMENT</lcc-lr:hasTag>
+	</owl:NamedIndividual>
+
+</rdf:RDF>

--- a/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
@@ -56,7 +56,7 @@
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BIDS">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">BIDS</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -66,7 +66,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BONU">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">BONU</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -76,7 +76,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BPUT">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">BPUT</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -86,7 +86,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CAPD">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">CAPD</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -96,7 +96,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CAPG">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">CAPG</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that distribute profits resulting from the sale of company assets to shareholders</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -106,7 +106,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CHAN">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">CHAN</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that disseminate information regarding a change further described in the corporate action details</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -116,7 +116,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CLSA">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">CLSA</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving a situation where interested parties seek restitution for financial loss</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -126,7 +126,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CONS">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">CONS</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve procedures aiming to obtain consent of holder to a proposal by the issuer or a third party without convening a meeting</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -136,7 +136,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CONV">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">CONV</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve conversion of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price/ratio</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -146,7 +146,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DECR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">DECR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that reduce the face value of a share or the value of fund assets</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -156,7 +156,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DFLT">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">DFLT</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that indicate a failure by the issuer to perform obligations defined as default events under the bond agreement and that have not been remedied</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -166,7 +166,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DRIP">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">DRIP</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -176,7 +176,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DSCL">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">DSCL</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -186,7 +186,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DTCH">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">DTCH</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving parties wishing to acquire a security</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -196,7 +196,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DVCA">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">DVCA</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that distribute cash to shareholders in proportion to their equity holding</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -206,7 +206,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DVOP">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">DVOP</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -216,7 +216,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DVSE">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">DVSE</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders in the form of equities of the issuing corporation</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -226,7 +226,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXOF">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">EXOF</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that reflect an exchange of holdings for other securities and/or cash</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -236,7 +236,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXRI">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">EXRI</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -246,7 +246,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXTM">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">EXTM</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve prolonging the maturity date of a bond</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -256,8 +256,8 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXWA">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">EXWA</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that offer holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -267,7 +267,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;INFO">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">INFO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -277,7 +277,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;INTR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">INTR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a regular interest payment to holders of an interest-bearing asset</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -293,7 +293,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;LIQU">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">LIQU</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -303,7 +303,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;MCAL">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">MCAL</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -313,7 +313,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;MRGR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">MRGR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve the exchange of outstanding securities, initiated by the issuer which may include options, as the result of two or more companies combining assets, that is, an external, third party company</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -323,7 +323,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PARI">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">PARI</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that occur when securities with different characteristics become identical in all respects</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -333,7 +333,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PCAL">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">PCAL</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -343,7 +343,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PRED">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">PRED</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -353,7 +353,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PRIO">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">PRIO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a public offer where priority is given to existing shareholders</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -363,7 +363,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;REDM">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">REDM</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities at final maturity</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -373,7 +373,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;REDO">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">REDO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions by which the unit (currency and/or nominal) of a security is restated</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -383,7 +383,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;RHDI">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">RHDI</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -393,7 +393,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SHPR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">SHPR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the shares premium reserve</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -403,7 +403,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SOFF">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">SOFF</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -413,7 +413,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SPLF">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">SPLF</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve an increase in a corporation&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -423,7 +423,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SPLR">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">SPLR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -433,7 +433,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;TEND">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
 		<rdfs:label xml:lang="en">TEND</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
@@ -443,8 +443,8 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;WRTH">
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;BusinessStrategyClassifier"/>
-		<rdf:type rdf:resource="&fibo-cae-ce-srca;IncomeOrientedClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
+		<rdf:type rdf:resource="&fibo-cae-ce-act;IncomeOrientedClassifier"/>
 		<rdfs:label xml:lang="en">WRTH</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve booking out of valueless securities</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>

--- a/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
@@ -271,7 +271,7 @@
 		<rdfs:label xml:lang="en">INFO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;CorporateInformationAction"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;Notification"/>
 		<lcc-lr:hasTag>INFO</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
@@ -297,7 +297,7 @@
 		<rdfs:label xml:lang="en">LIQU</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;LiquidationAction"/>
+		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;Liquidation"/>
 		<lcc-lr:hasTag>LIQU</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>

--- a/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
+++ b/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
@@ -37,6 +37,7 @@
 		<rdfs:label>Corporate Events Module</rdfs:label>
 		<dct:abstract>This module contains ontologies that define common, general corporate events and securities-related actions.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>

--- a/CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf
+++ b/CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf
@@ -105,12 +105,6 @@
 		<skos:definition xml:lang="en">Event in which shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications. SWIFT Definition (adapted above) &quot;Typically found in Australia, shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications.&quot; To be researches further. There are certainly Share Plans in Australia, where you can take a dividend as shares. Thewse would be in the nature of Bonus Shares. They are a tradeoff from cash dividends. Other terms to model: A &quot;Scheme of Arrangment&quot; - does this change the capital reserves or is it just another word for restructure. An arrangement with the company&apos;s debtors, and coule potentially change the capital base by converting the debt to shares (see other diagram note with these in).</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-cae-ce-srca;BusinessStrategyClassifier">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;ActionClassifier"/>
-		<rdfs:label xml:lang="en">business strategy classifier</rdfs:label>
-		<skos:definition xml:lang="en">classifier of corporate actions that involves improving liquidity or changing the overall structure of the organization through diversification, combining and closing parts of the business, etc, to increase long-term profitability</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;CallOnIntermediateSecurities">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">call on intermediate securities</rdfs:label>
@@ -293,13 +287,6 @@
 		<rdfs:label xml:lang="en">full call early redemption action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
 		<skos:example xml:lang="en">Examples securities that may be subject to a full call/early redemption include bonds, preferred equity, funds, that may be redeemed by the issuer or its agent before final maturity.</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-srca;IncomeOrientedClassifier">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;ActionClassifier"/>
-		<rdfs:label xml:lang="en">income-oriented classifier</rdfs:label>
-		<skos:definition xml:lang="en">classifier of corporate actions that impacts income to shareholders</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Cash dividends are a classic example where a public company declares a dividend to be paid on each outstanding share. Bonus is another case where the shareholder is rewarded. In a stricter sense, the bonus issue should not impact the share price but in reality, in rare cases, it does and results in an overall increase in value.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;InterestPaymentAction">

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -65,6 +65,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MuniIssuance/" uri="./BP/SecuritiesIssuance/MuniIssuance.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/" uri="./BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/" uri="./CAE/CorporateEvents/CorporateActions.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/" uri="./CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/" uri="./CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/" uri="./CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/" uri="./CAE/CorporateEvents/MetadataCAECorporateEvents.rdf"/>


### PR DESCRIPTION
Revised the corporate actions and related ontologies and added a new ontology defining GLEIF-specific corporate actions to cover the content published by the GLEIF in the 3.1 version of their level 1 data for legal entities.  

Note that this work is a step in our process of releasing the corporate actions ontologies but these ontologies are still provisional.

Fixes: #1736 / IND-116


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


