### PR TITLE
SEC-162 - Need to distinguish REMICs from other CDOs and REITs

### DIFF
--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -94,13 +94,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220101/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220301/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away, to support collateral agreements such as deeds of trust, UCC filings and the like, to add the concept of a rate reset time of day, to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/DebtAndEquities/Debt/ version of this ontology was modified to make redemption provision a child of contractual commitment and move it to financial instruments, as such provisions apply to preferred shares and other instruments in addition to debt.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200801/DebtAndEquities/Debt/ version of this ontology was modified to move the concept of an extension provision from Debt to Contracts to support representation of preferred shares and other extendable contracts, eliminate remaining circular definitions, integrate concepts defining credit facilities, and refine the concept of collateral to differentiate collateral that is real property from financial assets such as cash, various accounts, securities, and receivables.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/DebtAndEquities/Debt/ version of this ontology was modified to (1) add concepts including credit agreement whose principal is repaid at maturity and those whose principal is repaid over the course of the agreement, (2) move properties related to maturity to this ontology from FinancialInstruments and restructure the relationship between these two ontologies, (3) add the concept of a borrower identifier and the related scheme, and (4) add the concept of an interest rate cap as a potential provision with respect to interest rate terms.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/DebtAndEquities/Debt/ version of this ontology was modified to (1) add concepts including credit agreement whose principal is repaid at maturity and those whose principal is repaid over the course of the agreement, (2) move properties related to maturity to this ontology from FinancialInstruments and restructure the relationship between these two ontologies, (3) add the concept of a borrower identifier and the related scheme, (4) add the concept of an interest rate cap as a potential provision with respect to interest rate terms, and (5) clarified the definition of promissory note.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -820,7 +820,7 @@
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PromissoryNote">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 		<rdfs:label>promissory note</rdfs:label>
-		<skos:definition>negotiable instrument that is an unconditional and unsecured promise by one party to another that commits the principal party to pay a specified sum on demand or within a specified time frame under specified terms</skos:definition>
+		<skos:definition>negotiable instrument that is a written promise by one party to another that commits that party to pay a specified sum on demand or within a specified time frame under specified terms</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Promissory notes are generally fully fungible.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/SEC/Debt/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/MortgageBackedSecurities.rdf
@@ -13,6 +13,7 @@
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -49,6 +50,7 @@
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -104,6 +106,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -275,7 +278,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;MBSTrancheNote">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mbs;SecurityNote"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
 		<rdfs:label xml:lang="en">m b s tranche note</rdfs:label>
 		<skos:definition xml:lang="en">An individual note of a tranche.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Tranche is made up of e.g. $500m in notes and so on. These may be in different notes, with different denominations. Analytics that would apply to the Tranche would by implication apply to each slice of the tranche.</fibo-fnd-utl-av:explanatoryNote>
@@ -471,7 +474,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;PassThroughMBSInstrumentNote">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mbs;SecurityNote"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
 		<rdfs:label xml:lang="en">pass through m b s instrument note</rdfs:label>
 		<skos:definition xml:lang="en">An individual note of a pass through instrument.</skos:definition>
 	</owl:Class>
@@ -499,11 +502,19 @@ Consensus:Review.</skos:editorialNote>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;RealEstateMortgageInvestmentConduit">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;SpecialPurposeVehicle"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;owns"/>
+				<owl:onClass rdf:resource="&fibo-sec-dbt-mbs;MortgagePool"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">real estate mortgage investment conduit</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/r/real-estate-mortgage-investment-conduit-remic.asp"/>
 		<skos:definition xml:lang="en">special purpose vehicle that pools mortgage loans together and issues mortgage-backed securities</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">REMIC</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A real estate mortgage investment conduit may be organized as a partnership, a trust, a corporation, or an association and is exempt from federal taxes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">CMOs exist within REMICs, although CMOs are separate legal entities for tax and legal purposes.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;RegularFloaterTranche">
@@ -531,12 +542,6 @@ Consensus:Review.</skos:editorialNote>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mbs;MortgagePool"/>
 		<rdfs:label xml:lang="en">SBA pool</rdfs:label>
 		<skos:editorialNote xml:lang="en">Unknown pool type, from Cutter SME reviews; other pool types listed under Agency are from or validated by AdeptAdvisory SME review.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mbs;SecurityNote">
-		<rdfs:label xml:lang="en">security note</rdfs:label>
-		<skos:definition xml:lang="en">An individually denominated note within a security or tranche of a security, where this is issued in notes of different denominations.</skos:definition>
-		<skos:editorialNote xml:lang="en">Introduced for MBS Proof of Concept, to model MBS tranches where one tranche may have notes of multiple denominations. Other applications of this concept are not known at present. Trivially, all securities could be said to be in &quot;notes&quot; in this sense but the term is not normally referred to.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;SeniorMBSTranche">
@@ -650,7 +655,7 @@ Consensus:Review.</skos:editorialNote>
 		<rdfs:subPropertyOf rdf:resource="&lcc-cr;hasPart"/>
 		<rdfs:label xml:lang="en">has note</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-mbs;MortgageBackedSecurity"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mbs;SecurityNote"/>
+		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mbs;hasTrancheType">
@@ -674,7 +679,7 @@ Consensus:Review.</skos:editorialNote>
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mbs;isSliceOf">
 		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isPartOf"/>
 		<rdfs:label xml:lang="en">is slice of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mbs;SecurityNote"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-mbs;MortgageBackedSecurity"/>
 		<owl:inverseOf rdf:resource="&fibo-sec-dbt-mbs;hasNote"/>
 	</owl:ObjectProperty>

--- a/SEC/Debt/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/MortgageBackedSecurities.rdf
@@ -514,7 +514,6 @@ Consensus:Review.</skos:editorialNote>
 		<skos:definition xml:lang="en">special purpose vehicle that pools mortgage loans together and issues mortgage-backed securities</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">REMIC</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A real estate mortgage investment conduit may be organized as a partnership, a trust, a corporation, or an association and is exempt from federal taxes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">CMOs exist within REMICs, although CMOs are separate legal entities for tax and legal purposes.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;RegularFloaterTranche">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Clarified the definition of RealEstateMortgageInvestmentConduit (REMIC) and eliminated a duplicate definition for promissory note

Fixes: #1738 / SEC-162


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


