### PR TITLE
Typo in label of JurisdictionOfPoland fixed

### DIFF
--- a/BE/GovernmentEntities/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions.rdf
@@ -240,7 +240,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-eeuj;JurisdictionOfPoland">
 		<rdf:type rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:label xml:lang="en">jurisdiction of Poland</rdfs:label>
-		<rdfs:label xml:lang="pl">jurysdykcji polskiej</rdfs:label>
+		<rdfs:label xml:lang="pl">jurysdykcja Polski</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Poland, a four-tier court system composed of the Supreme Court, the Supreme Administrative Court, Common Courts (District, Regional, Appellate) and the Military Court</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-eeuj;GovernmentOfTheRepublicOfPoland"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Poland"/>


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

This fix the typo in the label of [JurisdictionOfPoland](https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions/JurisdictionOfPoland)

Fixes: #1715 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


