### PR TITLE
Vocabulary config data added to FIBO repository

### DIFF
--- a/etc/vocabulary/README.md
+++ b/etc/vocabulary/README.md
@@ -1,0 +1,3 @@
+# Setup for "vocabulary" product
+
+These are SPARQL queries and RDF triples used by ontology-publisher to create the vocabulary product.

--- a/etc/vocabulary/classes.sparql
+++ b/etc/vocabulary/classes.sparql
@@ -1,0 +1,36 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX fibo-skos: <https://spec.edmcouncil.org/fibo/vocabulary/>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX bla: <http://bla.da#>
+
+CONSTRUCT 
+{
+    ?vocClassIRI a skos:Concept ; 
+        ?annotationPropertyForClass ?annotation ;
+        rdfs:isDefinedBy ?classIRI ;
+        skos:prefLabel ?label ;
+        skos:inScheme fibo-skos:ClassConcepts .
+}
+WHERE
+{
+    SELECT DISTINCT *
+    {
+        ?classIRI a owl:Class
+        FILTER (isIRI(?classIRI))
+        FILTER (CONTAINS(str(?classIRI), 'edmcouncil')) .
+
+        BIND (IRI(REPLACE(str(?classIRI), "/ontology/", "/vocabulary/")) as ?vocClassIRI)
+
+        ?classIRI rdfs:label ?label .
+         
+        OPTIONAL 
+        {
+            ?classIRI ?annotationPropertyForClass ?annotation . 
+            ?annotationPropertyForClass rdf:type owl:AnnotationProperty .
+	    ?propertyIRI ?annotationPropertyForClass ?annotation . FILTER (str(?annotationPropertyForClass) != 'http://www.w3.org/2000/01/rdf-schema#label')
+        }
+    }
+}
+

--- a/etc/vocabulary/classes.sparql
+++ b/etc/vocabulary/classes.sparql
@@ -3,7 +3,6 @@ PREFIX fibo-skos: <https://spec.edmcouncil.org/fibo/vocabulary/>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
-PREFIX bla: <http://bla.da#>
 
 CONSTRUCT 
 {

--- a/etc/vocabulary/properties.sparql
+++ b/etc/vocabulary/properties.sparql
@@ -1,0 +1,49 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX fibo-skos: <https://spec.edmcouncil.org/fibo/vocabulary/>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+CONSTRUCT 
+{
+    ?vocPropertyIRI a skos:Concept ; 
+        ?annotationPropertyForProperty ?annotation ;
+        fibo-skos:rangeRelated ?vocRangeIRI ;
+        fibo-skos:domainRelated ?vocDomainIRI ;
+        rdfs:isDefinedBy ?propertyIRI ;
+        skos:inScheme fibo-skos:PropertyConcepts ;
+        skos:prefLabel ?label .
+}
+WHERE
+{
+    SELECT DISTINCT *
+    {
+        ?propertyIRI a owl:ObjectProperty 
+        FILTER (isIRI(?propertyIRI))
+        FILTER (CONTAINS(str(?propertyIRI), 'edmcouncil')).
+        BIND (IRI(REPLACE(str(?propertyIRI), "/ontology/", "/vocabulary/")) as ?vocPropertyIRI)
+
+        ?propertyIRI rdfs:label ?label .
+
+        OPTIONAL 
+        {
+            ?propertyIRI rdfs:range ?rangeIRI
+            FILTER (isIRI(?rangeIRI)) .
+            BIND (IRI(REPLACE(str(?rangeIRI), "/ontology/", "/vocabulary/")) as ?vocRangeIRI)
+        }
+        OPTIONAL 
+        {
+            ?propertyIRI rdfs:domain ?domainIRI
+            FILTER (isIRI(?domainIRI)) .
+            BIND (IRI(REPLACE(str(?domainIRI), "/ontology/", "/vocabulary/")) as ?vocDomainIRI)
+        }
+                
+        OPTIONAL 
+	{ 
+	    ?propertyIRI ?annotationPropertyForProperty ?annotation . 
+	    ?annotationPropertyForProperty rdf:type owl:AnnotationProperty .
+	    FILTER (str(?annotationPropertyForProperty) != 'http://www.w3.org/2000/01/rdf-schema#label')
+	}
+    }
+}
+

--- a/etc/vocabulary/scaffolding.ttl
+++ b/etc/vocabulary/scaffolding.ttl
@@ -1,0 +1,32 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix fibo-skos: <https://spec.edmcouncil.org/fibo/vocabulary/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>
+
+
+
+fibo-skos:PropertyConcepts
+        a             skos:ConceptScheme ;
+        rdfs:isDefinedBy  "concept scheme for concepts derived from ontology properties"@en ;
+        rdfs:label    "FIBO property scheme"@en .
+
+fibo-skos:ClassConcepts
+        a             skos:ConceptScheme ;
+        rdfs:isDefinedBy  "concept scheme for concepts derived from ontology classes"@en ;
+        rdfs:label    "FIBO classes scheme"@en .
+
+fibo-skos:domainRelated
+        a                   owl:ObjectProperty ;
+        rdfs:isDefinedBy        "denotes an rdfs:domain relationship between concepts"@en ;
+        rdfs:label          "has in domain"@en ;
+        rdfs:subPropertyOf  skos:related .
+
+fibo-skos:rangeRelated
+        a                   owl:ObjectProperty ;
+        rdfs:isDefinedBy        "denotes an rdfs:range relationship between concepts"@en ;
+        rdfs:label          "has in range"@en ;
+        rdfs:subPropertyOf  skos:related .
+		
+fibo-skos:  a        owl:Ontology ;
+        rdfs:label           "FIBO SKOS Vocabulary"@en ;
+        owl:imports <http://www.w3.org/2004/02/skos/core>.

--- a/etc/vocabulary/subclasses.sparql
+++ b/etc/vocabulary/subclasses.sparql
@@ -1,0 +1,27 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX fibo-skos: <https://spec.edmcouncil.org/fibo/vocabulary/>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+CONSTRUCT 
+{
+    ?vocClassIRI skos:broader ?vocClassParentIRI.
+
+}
+WHERE
+{
+    SELECT DISTINCT *
+    {
+        ?classIRI a owl:Class .
+        FILTER (isIRI(?classIRI))
+        FILTER (CONTAINS(str(?classIRI), 'edmcouncil')) .
+        BIND (IRI(REPLACE(str(?classIRI), "/ontology/", "/vocabulary/")) as ?vocClassIRI)
+        
+        ?classIRI rdfs:subClassOf ?parentClassIRI 
+        FILTER (isIRI(?parentClassIRI)) 
+        FILTER (CONTAINS(str(?parentClassIRI), 'edmcouncil')) .
+        BIND (IRI(REPLACE(str(?parentClassIRI), "/ontology/", "/vocabulary/")) as ?vocClassParentIRI)
+    }
+}
+

--- a/etc/vocabulary/subproperties.sparql
+++ b/etc/vocabulary/subproperties.sparql
@@ -1,0 +1,28 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX fibo-skos: <https://spec.edmcouncil.org/fibo/vocabulary/>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+CONSTRUCT 
+{
+    ?vocPropertyIRI skos:broader ?vocParentPropertyIRI
+}
+WHERE
+{
+    SELECT DISTINCT *
+    {
+        ?propertyIRI a owl:ObjectProperty 
+        FILTER (isIRI(?propertyIRI))
+        FILTER (CONTAINS(str(?propertyIRI), 'edmcouncil')) .
+        BIND (IRI(REPLACE(str(?propertyIRI), "/ontology/", "/vocabulary/")) as ?vocPropertyIRI)
+     
+        ?propertyIRI rdfs:subPropertyOf ?parentPropertyIRI .
+    
+        ?parentPropertyIRI a owl:ObjectProperty 
+        FILTER (isIRI(?parentPropertyIRI))
+        FILTER (CONTAINS(str(?parentPropertyIRI), 'edmcouncil')) .
+        BIND (IRI(REPLACE(str(?parentPropertyIRI), "/ontology/", "/vocabulary/")) as ?vocParentPropertyIRI)
+    }
+}
+


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

This adds the config data used by the ontology-publisher to create the vocabulary product. 

Fixes: #1735 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


