### PR TITLE
IND-118 - Finalize the high-level corporate actions ontology for release

### DIFF
--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -89,6 +89,16 @@
 	<!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
+    // Corporate Actions and Events (CAE) Domain
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->	 
+
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/> 
+	
+	<!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
     // Derivatives (DER) Domain
     //
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -267,7 +277,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20220101/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20220301/AboutFIBOProd/"/>
   </owl:Ontology>
 
 </rdf:RDF>

--- a/CAE/AllCAE.rdf
+++ b/CAE/AllCAE.rdf
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-cae-all "https://spec.edmcouncil.org/fibo/ontology/CAE/AllCAE/">
+	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/AllCAE/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-cae-all="https://spec.edmcouncil.org/fibo/ontology/CAE/AllCAE/"
+	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/AllCAE/">
+		<rdfs:label>Corporate Actions and Events Domain</rdfs:label>
+		<dct:abstract>This ontology provides metadata about the FIBO Corporate Actions and Events (CAE) Domain, which covers actions including corporate, market, and regulatory actions, ranging from business oriented events such as address and name changes, to those that are more specific to securities.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Corporate Actions and Events (CAE) Domain</dct:title>
+		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
+		<sm:contributor>Citigroup</sm:contributor>
+		<sm:contributor>Deutsche Bank</sm:contributor>
+		<sm:contributor>John F. Gemski</sm:contributor>
+		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
+		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
+		<sm:contributor>Thematix Partners LLC</sm:contributor>
+		<sm:contributor>agnos.ai UK Ltd</sm:contributor>
+		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-cae-all</sm:fileAbbreviation>
+		<sm:filename>AllCAE.rdf</sm:filename>
+		<sm:keyword>corporate actions</sm:keyword>
+		<sm:moduleAbbreviation>fibo-cae</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20220301/AllCAE/"/>
+		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for CAE is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports the Production (Released) ontologies that comprise the FIBO Corporate Actions and Events (CAE) domain, including all of SEC but excluding reference and example individuals.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Ontology>
+
+</rdf:RDF>

--- a/CAE/CorporateEvents/CorporateActions.rdf
+++ b/CAE/CorporateEvents/CorporateActions.rdf
@@ -58,8 +58,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20220301/CorporateEvents/CorporateActions/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;Action">
@@ -220,7 +220,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;LegalFormChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;BusinessStrategyClassifier"/>
+		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">legal form change</rdfs:label>
 		<skos:definition xml:lang="en">corporate action indicating a modification of the legal form of the organization</skos:definition>
 		<skos:example xml:lang="en">In the United States it is common for companies established as Subchapter S Corporations (S-Corp), typically early stage companies, to modify their structure to become full-fledged Subchapter C Corporations (C-Corp) to facilitate outside fundraising, mergers, acquisitions, and public offerings.  Other common form changes include migration from sole proprietorships to more formally registered organizations (e.g., LLC, S-Corp, C-Corp, etc.)</skos:example>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This resolution includes updating the metadata in the Corporate Actions ontology to change its status to release and add a version to the version IRI, revise the hierarchy related to actions that notify stakeholders of changes in corporate legal form, adding a new AllCAE "make file" in the CAE domain, and adding the Corporate Actions ontology to the About FIBO Prod "make file".

Fixes: #1743 / IND-118


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


