### PR TITLE
typo in prefix for explanatoryNote in ISO currency codes

### DIFF
--- a/FND/Accounting/ISO4217-CurrencyCodes.rdf
+++ b/FND/Accounting/ISO4217-CurrencyCodes.rdf
@@ -54,7 +54,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20220201/Accounting/ISO4217-CurrencyCodes/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20220301/Accounting/ISO4217-CurrencyCodes/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to replace Swaziland with Eswatini, which was revised by the LCC 1.1 RTF to reflect the change to the country name per the U.N.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190401/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate unnecessary dependencies on the relations ontology, and to replace rdfs:comment with skos:definition per FIBO policy.</skos:changeNote>
@@ -3374,13 +3374,13 @@
 		<rdfs:label>VED</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<skos:definition>the currency identifier for Bolívar Soberano</skos:definition>
-		<skos:explanatoryNote>The Bolívar Soberano (VES) is redenominated by removing six zeros from the denominations. 
+		<fibo-fnd-utl-av:explanatoryNote>The Bolívar Soberano (VES) is redenominated by removing six zeros from the denominations. 
          A new currency code VED/926 representing the new valuation (1,000,000 times old VES/928) is introduced on 1
          October 2021 for any internal needs during the redenomination process, but is not replacing VES as the
          official currency code. The Central Bank of Venezuela will not adopt the new codes in the local system,
          VES/928 remains in use.
          The actual currency code VES/928 remains the valid code after 1 October 2021 to use in any future
-         transactions to indicate the redenominated Bolívar Soberano.</skos:explanatoryNote>
+         transactions to indicate the redenominated Bolívar Soberano.</fibo-fnd-utl-av:explanatoryNote>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>
 		<lcc-lr:hasTag>VED</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Corrected prefix for explanatory note in currency codes

Fixes: #1749 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


