### PR TITLE
Fix to wrong IRI in onto-viewer config (WIP)

### DIFF
--- a/etc/onto-viewer-web-app/config/ontology_config.yaml
+++ b/etc/onto-viewer-web-app/config/ontology_config.yaml
@@ -1,7 +1,7 @@
 ontologies:
   source:
-    - url: 'https://spec.edmcouncil.org/auto/ontology/MetadataAUTO/'
-    - url: 'https://spec.edmcouncil.org/auto/ontology/AboutAUTODev/'
+    - url: 'https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/'
+    - url: 'https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/'
     - path: staticOntologies
   catalog_path:
     - ontologies/catalog-v001.xml


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

Wrong IRIs are fixed.

Fixes: #1775 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


