### PR TITLE
FND-366 - Wrong URI for USPostalServiceAddressesIndividuals ontology

### DIFF
--- a/FND/Places/MetadataFNDPlaces.rdf
+++ b/FND/Places/MetadataFNDPlaces.rdf
@@ -24,31 +24,31 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Places/MetadataFNDPlaces/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Places Module</rdfs:label>
 		<dct:abstract>This is the metadata ontology used to describe the Foundations Places Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-03-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-14T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2017-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2017-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-fnd-plc-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataFNDPlaces.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Places/MetadataFNDPlaces/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20220601/Places/MetadataFNDPlaces/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-mod;PlacesModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Places</rdfs:label>
 		<dct:abstract>This module includes ontologies defining concepts to do with real or virtual places and the addresses to such places.</dct:abstract>
-		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>Financial Industry Business Ontology (FIBO) Foundations (FND) Places Module</dct:title>
-		<sm:copyright>Copyright (c) 2017-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2017-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2017-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-fnd-plc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised the URI in the metadata for Places that improperly referenced the US Postal Service Addresses Individuals ontology to correct it per the issue raised

Fixes: #1779 / FND-366


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


