### PR TITLE
LOAN-165 - Release the primary Loans ontology under LoansGeneral

### DIFF
--- a/AboutFIBOProd-IncludingReferenceData.rdf
+++ b/AboutFIBOProd-IncludingReferenceData.rdf
@@ -24,7 +24,7 @@
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-IncludingReferenceData/">
   		<rdfs:label>About FIBO Production - including Reference Data</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, including reference data but excluding examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. By reference data we mean ISO currency codes and USPS individuals in FND, juridictions and governments in BE, regulatory agencies and related financial services entities as well as business centers and MIC codes in FBC, FpML interest rates in IND, CFI codes in SEC (incomplete but planned for extension in subsequent releases), and so forth. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-03-31T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2022 EDM Council, Inc.</sm:copyright>
@@ -332,6 +332,16 @@
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		
+	<!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Loan (LOAN) Domain
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+
 	<!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //

--- a/AboutFIBOProd-TBoxOnly.rdf
+++ b/AboutFIBOProd-TBoxOnly.rdf
@@ -24,7 +24,7 @@
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-TBoxOnly/">
   		<rdfs:label>About FIBO Production - T-Box Only</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, excluding reference data and examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-03-31T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2022 EDM Council, Inc.</sm:copyright>
@@ -32,7 +32,7 @@
 		<sm:fileAbbreviation>fibo-prod-tbox</sm:fileAbbreviation>
 		<sm:filename>AboutFIBOProd-TBoxOnly.rdf</sm:filename>		
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
-		<fibo-fnd-utl-av:usageNote>As of the Q1 2022 release of FIBO, there is one ontology, Bonds, in Securities, that brings in some reference individuals. The intent is to address this for the Q2 2022 release.</fibo-fnd-utl-av:usageNote>
+		<fibo-fnd-utl-av:usageNote>As of the Q2 2022 release of FIBO, there is one ontology, Bonds, in Securities, that brings in some reference individuals. The intent is to address this for the Q3 2022 release.</fibo-fnd-utl-av:usageNote>
 		
 	<!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -207,6 +207,16 @@
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>		
 		
+	<!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Loan (LOAN) Domain
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+
 	<!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -24,7 +24,7 @@
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/">
   		<rdfs:label>About FIBO Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users.  It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release.  Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-03-31T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
@@ -248,6 +248,16 @@
 	<!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
+    // Loan (LOAN) Domain
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+
+	<!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
     // Securities (SEC) Domain
     //
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -277,7 +287,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20220301/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20220601/AboutFIBOProd/"/>
   </owl:Ontology>
 
 </rdf:RDF>

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -98,8 +98,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/LoansGeneral/Loans/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestPaymentTerms">
@@ -338,7 +338,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;hasTotalNumberOfPayments"/>
+				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;hasAnticipatedNumberOfPayments"/>
 				<owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -586,6 +586,13 @@
 		<skos:definition>loan granted based on the strength of the borrower&apos;s credit history or reputation in the community</skos:definition>
 	</owl:Class>
 	
+	<owl:DatatypeProperty rdf:about="&fibo-loan-ln-ln;hasAnticipatedNumberOfPayments">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasCount"/>
+		<rdfs:label>has anticipated number of payments</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;positiveInteger"/>
+		<skos:definition>specifies the number payments promised per the terms of the contract over the lifetime of the contract assuming all payments are made</skos:definition>
+	</owl:DatatypeProperty>
+	
 	<owl:DatatypeProperty rdf:about="&fibo-loan-ln-ln;hasBalloonPayment">
 		<rdfs:label xml:lang="en">has balloon payment</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
@@ -668,13 +675,6 @@
 		<skos:definition>indicates the total the amount paid at the closing of a real estate transaction, i.e., at the time when the title to the property is conveyed (transferred) to the buyer</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Closing costs may be incurred by either the buyer or the seller, and may include fees paid by either or both parties for the preparation and recording of documents, title service costs, such as for title search and insurance (typically paid by the seller, depending on the jurisdiction), other recording costs, other document or transaction stamps or taxes, brokerage commissions, survey, appraisal, inspection and other such fees, home warranties, private mortgage insurance (PMI), and so forth.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-ln-ln;hasTotalNumberOfPayments">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasCount"/>
-		<rdfs:label>has total number of payments</rdfs:label>
-		<rdfs:range rdf:resource="&xsd;positiveInteger"/>
-		<skos:definition>specifies the number payments over the lifetime of the contract if all payments are made</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-ln-ln;hasTotalPointsAndFees">
 		<rdfs:subPropertyOf rdf:resource="&fibo-loan-ln-ln;hasCost"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised the name of the property 'has total number of payments' to 'has anticipated number of payments' and released the LOAN/LoansGeneral/Loans ontology


Fixes: #1784 / LOAN-165


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


