### PR TITLE
DER-122 - Need to add the major types of Exotic Options

### DIFF
--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -226,6 +226,20 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">rachet option</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-exo;CommodoreOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;DigitalOption"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">commodore option</rdfs:label>
+		<skos:definition xml:lang="en">exotic option consisting of a number of digital barrier options that pay a coupon if a pre-determined level of the underlying or basket of underlyings is reached</skos:definition>
+		<skos:example xml:lang="en">A three-year commodore option with annual barriers would have three potential payoffs. The first would pay at the end of the first year and would be dependent on the pre-determined barrier being reached or exceeded. For example, if the underlying or basket of underlyings reached or exceeded 102% of its initial level at the end of year one, a coupon of 6% would be paid. At the end of year two, if the underlying reached or exceeded 104% of its initial level, another 6% coupon would be paid. The coupon in the final year would be 6% if the underlying reached or exceeded 106%. The coupon should exceed the performance level of the underlying, otherwise the investor would achieve the same result by investing directly in the underlying.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Sometimes the digital barrier increases with the number of years since the trade began. All of the options are active from the start of the trade.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-exo;ConditionalPayoutCommitment">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
 		<rdfs:label xml:lang="en">conditional payout commitment</rdfs:label>
@@ -236,6 +250,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
 		<rdfs:label xml:lang="en">defined conditions payout commitment</rdfs:label>
 		<skos:definition xml:lang="en">A commitment which is only made when certain defined conditions are met. Further notes: Like all contractual commitments, the details of the commitment (and in this case, the conditions) are defined in the corresponding Contractual Terms. These set out what the commitment is and what the conditions are under which it is to be met. Term introduced in order to support digital and other exotic options. Note this is similar to but distinct from commitments where the specific nature of the commitment (typically a cashflow) is defined by resolving some mathematical formula i.e. where the commitment to do something is not conditional but the precise monetary amounts (payment, settlement) are.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-exo;DigitalOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:label xml:lang="en">digital option</rdfs:label>
+		<skos:definition xml:lang="en">exotic option has a fixed payout if the underlying asset moves past the predetermined threshold or strike price</skos:definition>
+		<skos:example xml:lang="en">For example, let&apos;s say the ABC Index is trading at a level of 2,795 on June 2. An investor believes the ABC Index will trade above 2,800 before the end of the trading day, June 4th. The trader purchases 10 ABC Index options at a strike price of 2,800 options for $40 per contract. If the ABC Index closes above 2,800 at the end of the trading day on June 4, the investor is paid $100 per contract, which is a profit of $60 per contract or $600 (($100 - $40) x 10 contracts). However, if the ABC Index closes below 2,800 on June 4. The investor loses all of the premium amount or $400 ($40 x 10 contracts).</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is an upfront fee called the premium for digital options, which is the maximum loss for the option. Unlike traditional options, digital options don&apos;t convert or exercise to the underlying asset&apos;s shares. Instead, they pay out a fixed reward if the asset&apos;s price is above or below the option&apos;s strike price.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">binary option</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;DoubleBarrierOption">
@@ -402,24 +425,12 @@
 		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;InterestRateCapOption"/>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-exo;KnockIn">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionFeature"/>
-		<rdfs:label xml:lang="en">knock in</rdfs:label>
-		<skos:definition xml:lang="en">An option which comes into existence if the knock-in event happens. It works exactly the reverse of a knock-out. In a knock-in, an option comes into existence if a certain level is hit.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-exo;KnockInOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
 		<rdfs:label xml:lang="en">knock-in option</rdfs:label>
 		<skos:definition xml:lang="en">barrier option is not an option until a certain price is met</skos:definition>
 		<skos:example xml:lang="en">Assume an investor purchases a knock-in put option with a down Direction, with a barrier price of $90 and a strike price of $100. The underlying security is trading at $110, and the option expires in three months. If the price of the underlying security reaches $90, the option comes into existence and becomes a vanilla option with a strike price of $100. Thereafter, the holder of the option has the right to sell the underlying asset at the strike price of $100, even though it is trading below $90. It is this right that gives the option value. The put option remains active until the expiration date, even if the underlying security rebounds back above $90. However, if the underlying asset does not fall below the barrier price during the life of the contract, the down-and-in option expires worthless. Just because the barrier is reached does not assure a profit on the trade since the underlying would need to stay below $100 (after triggering the barrier) in order for the option to have value.</skos:example>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the price is never reached, it is as if the contract never existed. However, if the underlying asset reaches a specified barrier, the knock-in option comes into existence. The difference between a knock-in and knock-out option is that a knock-in option comes into existence only when the underlying security reaches a barrier, while a knock-out option ceases to exist when the underlying security reaches a barrier.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;KnockOut">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionFeature"/>
-		<rdfs:label xml:lang="en">knock out</rdfs:label>
-		<skos:definition xml:lang="en">An option which ceases to exist if the knock-out event occurs. A knock out happens when a particular level is hit (like the Swiss franc touching the level of 1.10 against the dollar), when the option ceases to exist.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;KnockOutOption">
@@ -498,6 +509,14 @@
 		<rdfs:label xml:lang="en">lookback strike terms</rdfs:label>
 		<skos:definition xml:lang="en">Strike terms in which the value of some observed variable (the underlying) is looked back at during some period, typically a period ending in the maturity of the Option, and the payoff is determined by comparing the agreed strike with the value of this variable.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The payoff may either be the difference between a fixed, pre-agreed Strike Price and the observable, or the difference between the best or worst valuable of the observable and the value of that same observable at maturity of the contract (these are the Fixed and Floating lookback terms respectively). This (per review at Nordea) is not mutually exclusive with the terms for Fixed Strike and Resettable Strike, that is, either of those kinds of strike terms may apply, and Lookback strike terms may also apply.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-exo;LookbacktOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
+		<rdfs:label xml:lang="en">lookback option</rdfs:label>
+		<skos:definition xml:lang="en">exotic option that allows the holder the advantage of knowing history when determining when to exercise their option</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As a type of exotic option, the lookback allows the user to &apos;look back,&apos; or review, the prices of an underlying asset over the lifespan of the option after it has been purchased. The holder may then exercise the option based on the most beneficial price of the underlying asset. The holder can take advantage of the widest differential between the strike price and the price of the underlying asset. Lookback options do not trade on major exchanges. Instead, they are unlisted and trade over-the-counter (OTC). This type of option reduces uncertainties associated with the timing of market entry and reduces the chances the option will expire worthlessly. Lookback options are expensive to execute, so these advantages come at a cost.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Lookback options are cash settled options, which means the holder receives a cash settlement at execution based on the most advantageous differential between high and low prices during the purchase period. Sellers of lookback options would price the option at or near the widest expected distance of price differential based on past volatility and demand for the options. The cost to purchase this option would be taken up front. The settlement will equate to the profits they could have made from buying or selling the underlying asset. If the settlement was greater than the initial cost of the option, then the option buyer would have profit at settlement, otherwise loss.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;ObservableBestValue">
@@ -824,6 +843,21 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">The price or other variable (as a number) which has to be met for the event to be deemed to have occurred.</skos:definition>
 	</owl:DatatypeProperty>
+	
+	<owl:Class rdf:about="&fibo-der-drc-opt;CompoundOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">compound option</rdfs:label>
+		<skos:definition xml:lang="en">exotic option for which the underlying asset is another option</skos:definition>
+		<skos:example xml:lang="en">For example, assume an investor wants to buy a put to sell 100 shares of stock at $50. The stock is currently trading at $55. The investor could buy a Call-Put, which allows them to buy a call now, for say $1 per share ($100), which will allow them to buy a put with a $50 strike in the future. They pay the $1 per share now, but only need to pay the fee for the second option if they exercise the first resulting in them receiving the second option.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Therefore, there are two strike prices and two exercise dates. They are available for any combination of calls and puts. For example, a put where the underlying is a call option or a call where the underlying is a put option.  The underlying is the second option, while the initial option is called the overlying. If the compound option is exercised, there are two premiums.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">split-fee options</fibo-fnd-utl-av:synonym>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;OptionPremium">
 		<rdfs:subClassOf>

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-der-der-exo "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-der-drc-exo "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/">
 	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
@@ -28,8 +28,8 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-der-der-exo="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-der-drc-exo="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"
 	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
@@ -55,14 +55,14 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/">
 		<rdfs:label xml:lang="en">Exotic Options Ontology</rdfs:label>
-		<dct:abstract>Concepts common to exotic option contracts and their corresponding transactions. Includes option features, these being definitions of how the option comes into or ceases being in force when a given event occurs along with a range of other variations.</dct:abstract>
+		<dct:abstract>This ontology covers exotic options, a category of options contracts that differ from traditional options in their payment structures, expiration dates, and strike prices. The underlying asset or security can vary with exotic options allowing for more investment alternatives. Exotic options are hybrid securities that are often customizable to the needs of the investor. Exotic options are traded OTC.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/"/>
-		<sm:fileAbbreviation>fibo-der-der-exo</sm:fileAbbreviation>
+		<sm:fileAbbreviation>fibo-der-drc-exo</sm:fileAbbreviation>
 		<sm:filename>ExoticOptions.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
@@ -85,7 +85,7 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;AsianOption">
+	<owl:Class rdf:about="&fibo-der-drc-exo;AsianOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -95,28 +95,36 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">Asian option</rdfs:label>
-		<skos:definition xml:lang="en">option whose exercise terms involve a payoff that is determined by the average underlying price over some pre-set period of time</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Because of the averaging feature, Asian options reduce the volatility inherent in the option; therefore, Asian options are typically cheaper than European or American options.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">option whose exercise terms involve a payoff that is determined by the average underlying price of the underlying asset over some pre-set period of time</skos:definition>
+		<skos:example xml:lang="en">For an Asian call option using arithmetic averaging and a 30-day period for sampling the data: On Nov. 1, a trader purchased a 90-day arithmetic call option on stock XYZ with an exercise price of $22, where the averaging is based on the value of the stock after each 30-day period. The stock price after 30, 60, and 90 days was $21.00, $22.00, and $24.00. The arithmetic average (mean) is (21.00 + 22.00 + 24.00) / 3 = 22.33. The profit is the average minus the strike price 22.33 - 22 = 0.33 or $33.00 per 100 share contract. As with standard options, if the average price is below the strike price, the loss is limited to the premium paid for the call options.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These options allow the buyer to purchase (or sell) the underlying asset at the average price instead of the spot price. There are various ways to interpret the word &apos;average,&apos; and that needs to be specified in the options contract. Typically, the average price is a geometric or arithmetic average of the price of the underlying asset at discreet intervals, which are also specified in the options contract. Because of the averaging feature, Asian options reduce the volatility inherent in the option; therefore, Asian options are typically cheaper than European or American options. They are used by traders who are exposed to the underlying asset over some time, such as consumers and suppliers of commodities, etc.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;AssetMaximumOrMinimumPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;ConditionalPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;AssetMaximumOrMinimumPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
 		<rdfs:label xml:lang="en">asset maximum or minimum payout commitment</rdfs:label>
 		<skos:definition xml:lang="en">A commitment to pay out on the maximum or minimum of a set of assets. Further Notes Maximum of n Assets This rainbow is similar to the best of n assets plus cash we referred to in part a, with the exception that no cash payoff is possible and there is a strike price for this type of option. The payoff of a call and put are given as: Rainbow-Call = max[0, max(S1, S2) - X] Rainbow-Put = max[0, X - max(S1, S2)] Minimum of n Assets The counterpart to a maximum of n assets, this rainbow pays out the value of the underperformer of the n assets. The payoff for minimum of 2 asset rainbow calls and puts are given as: Rainbow-Call = max[0, mainS1, S2) - X] Rainbow-Put = max[0, X - min(S1, S2)]</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;AssetOrNothingPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;BinaryPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;AssetOrNothingPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BinaryPayoutCommitment"/>
 		<rdfs:label xml:lang="en">asset or nothing payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-exo;CashOrNothingPayoutCommitment"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;CashOrNothingPayoutCommitment"/>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;BestOfAssetsPlusCashPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;ConditionalPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;BarrierOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
+		<rdfs:label xml:lang="en">barrier option</rdfs:label>
+		<skos:definition xml:lang="en">option whose payoff depends on whether or not the underlying asset has reached or exceeded a predetermined price</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A barrier option can be a knock-out, meaning it expires worthless if the underlying exceeds a certain price, limiting profits for the holder and limiting losses for the writer. It can also be a knock-in, meaning it has no value until the underlying reaches a certain price. Barrier options can be puts or calls. Barrier options typically have cheaper premiums than traditional vanilla options, primarily because the barrier increases the chances of the option expiring worthless. A trader may choose the cheaper (relative to a comparable vanilla) barrier option if they feel it is quite likely the underlying will hit the barrier.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-exo;BestOfAssetsPlusCashPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;PayoffAssetsList"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;PayoffAssetsList"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">best of assets plus cash payout commitment</rdfs:label>
@@ -124,12 +132,12 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This type of rainbow effectively has n + 1 payoff possibilities. If we consider a 2 asset &quot;best of plus cash&quot;, the payoff at expiry is a choice between Asset 1, Asset 2, or the predetermined cash amount. There is no strike price and the payoff is given as: Rainbow = max(S1, S2, Cash;T)</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;BetterOrWorseOfAssetsPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;ConditionalPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;BetterOrWorseOfAssetsPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;PayoffAssetsList"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;PayoffAssetsList"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">better or worse of assets payout commitment</rdfs:label>
@@ -137,53 +145,53 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Better of n Assets This type of rainbow is similar to the best of n assets plus cash but with the exception that there is no possible cash payoff, and X is set to 0. With this in mind, a better of 2 assets rainbow is essentially a two-asset call option, with a payoff being: Rainbow = max[0, max(S1, S2)] Worse of n Assets Essentially the opposite to the better of n assets, with the payoff being on the asset with the lower value. We can give the payoff for this option on 2 assets as: Rainbow = max[0, min(S1, S2)]</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;BinaryPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;BinaryPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
 		<rdfs:label xml:lang="en">binary payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-exo;ConditionalPayoutCommitment"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;CalculatedPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;CalculatedPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
 		<rdfs:label xml:lang="en">calculated payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-exo;ConditionalPayoutCommitment"/>
-		<owl:disjointWith rdf:resource="&fibo-der-der-exo;LinearPayoutCommitment"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;LinearPayoutCommitment"/>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;CapDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;CapOrFloorDetermination"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;CapDetermination">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;CapOrFloorDetermination"/>
 		<rdfs:label xml:lang="en">cap determination</rdfs:label>
 		<skos:definition xml:lang="en">The Strike rate is to be subtracted from the Observable rate on the reset date, to determine the settlement amount. This is incorrect. Cap applies to borrower. the Cap is the max amount I will pay to borrow. I take a capped rate. I am the buyer of the option. The market rate this time is higher than the capped rate. You as the seller of the option will pay me thedifference bwteen the capped rate and the market reate. If the market rate is lower than the capped rate no one pays anything because I will not exercise my right to that capped rate. So no money changes hands at settlement. Then: capped Loan: What I would be paying would be interest at the market rate if the market rate is lower, but if the market rate is higher then I would pay interest at the capped rate. This is the difference between a cap as a loan or as a cash settled thing. These represent different kinds of contract: Non loan one: Cap talks of settlement being difference between the market rate and the strike rate. This is cash settled. Name: &quot;Cap&quot; Loan one: Cap talks about a maximum interest rate payable by the holder, so the holder pays an amount each time, up to a maximum which is the Cap rate. Name: &quot;Capped Loan&quot; What manner of thin is this? A loan. Its ancestors are not OTC derivatives contracts thet are Loan.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;CapLoan">
+	<owl:Class rdf:about="&fibo-der-drc-exo;CapLoan">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DebtInstrument"/>
 		<rdfs:label xml:lang="en">cap loan</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;CapOrFloorDetermination">
+	<owl:Class rdf:about="&fibo-der-drc-exo;CapOrFloorDetermination">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label xml:lang="en">cap or floor determination</rdfs:label>
 		<skos:definition xml:lang="en">Whether a given thing is treated as a Cap (something goes no higher than this amount) or as a Floor (something goes no lower than this).</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;CashOrNothingPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;BinaryPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;CashOrNothingPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BinaryPayoutCommitment"/>
 		<rdfs:label xml:lang="en">cash or nothing payout commitment</rdfs:label>
 		<skos:definition xml:lang="en">A commitment to pay out on a binary option, as cash or nothing.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;ChooserOption">
+	<owl:Class rdf:about="&fibo-der-drc-exo;ChooserOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-exo;hasOptionTypeElectionDate"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasOptionTypeElectionDate"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -198,69 +206,93 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">chooser option</rdfs:label>
 		<skos:definition xml:lang="en">exotic option that is transacted in the present, but that at some specified future date is chosen to be either a put or a call option</skos:definition>
+		<skos:example xml:lang="en">For example, assume a trader wants to have an option position for the updated XYZ Inc. earnings release. They think the stock will have a big move, but they are not sure in which direction. The earnings release is in one month, so the trader decides to buy a chooser option that will expire about three weeks after the earnings release. They believe this should provide enough time for the stock to make a significant move if it is going to make one, and fully digest the earnings release. Therefore, the option they choose will expire in seven to eight weeks. The chooser option allows them to exercise the option as a call if the price of XYZ rises, or as a put if the price falls. At the time of the chooser option purchase, XYZ is trading at $28. The trader chooses an at-the-money strike price of $28 and pays a premium of $2 or $200 for one contract ($2 x 100 shares). The buyer can&apos;t exercise the option prior to expiry since it is a European option. At expiry, the trader will determine if they will exercise the option as a call or put. Assume the price of XYZ at the time of expiry is $31. This is higher than the strike price of $28, therefore the trader will exercise the option as a call. Their profit is $1 ($31 - $28 - $2) or $100. If XYZ is trading between $28 and $29.99 the trader will still choose to exercise the option as a call, but they will still be losing money since the profit is not enough to offset their $2 cost. $30 is the breakeven point on the call. If the price of BAC is below $28, the trader will exercise the option as a put. In this case, $26 is the breakeven point ($28 - $2). If the underlying is trading between $28 and $26.01 the trader will lose money since the price didn&apos;t fall enough to offset the cost of the option. If the price of BAC falls below $26, say to $24, the trader will make money on the put. Their profit is $2 ($28 - $24 - $2) or $200.</skos:example>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">Commodity Futures Trading Commission (CFTC) glossary, https://www.cftc.gov/LearnAndProtect/EducationCenter/CFTCGlossary/glossary_c.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A chooser option is an option contract that allows the holder to decide whether it is a call or put prior to the expiration date. Chooser options usually have the same strike price and expiration date regardless of what decision the holder makes. Because the option could benefit from upside or downside movement, chooser options provide investors a great deal of flexibility and thus may cost more than comparable vanilla options. Chooser options are typically European style, and have one strike price and one expiration date regardless of whether the option is exercised as a call or put.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;ConditionalPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;CliquetOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;ForwardStartOption"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">cliquet option</rdfs:label>
+		<skos:definition xml:lang="en">exotic option that is a series of at-the-money (ATM) options, either puts or calls, where each successive option becomes active when the previous one expires</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A cliquet is a cash-settled, exotic option that settles at predetermined dates and then resets its strike price based on the price of the underlying security at the time of settlement. Each new option within the cliquet enters into force when the previous option expires. The total premium and the exact reset dates are known at the time of transacting a cliquet. Investors can opt to receive their payout when each option expires or wait until the entire series plays out.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A cliquet is a series of forward start options, all related to each other. Each forward start option represents the advance purchase of a put, or call, option with an at-the-money (ATM) strike price to be determined at a later date, typically when the option becomes active. A forward start option becomes active at a specified date in the future. The premium is paid in advance, while the time to expiration and the underlying security are established at the time the forward start option is purchased. If at the first settlement date the underlying security trades below the strike price of the option (for a call), then it expires worthless and resets to the price of the underlying security at the time of settlement. If at the end of the next settlement the underlying security trades above the new strike, the holder may elect to receive the difference between the market price of the underlying security and the strike price. Alternatively, the holder can let it ride to receive the sum of all payouts at maturity. The main advantage of initiating a cliquet is, if an investor expects volatility to rise, they can lock in their profits at predetermined levels and thus maximize their overall portfolio return.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">rachet option</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-exo;ConditionalPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
 		<rdfs:label xml:lang="en">conditional payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-exo;LinearPayoutCommitment"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;LinearPayoutCommitment"/>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;DefinedConditionsPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;DefinedConditionsPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
 		<rdfs:label xml:lang="en">defined conditions payout commitment</rdfs:label>
 		<skos:definition xml:lang="en">A commitment which is only made when certain defined conditions are met. Further notes: Like all contractual commitments, the details of the commitment (and in this case, the conditions) are defined in the corresponding Contractual Terms. These set out what the commitment is and what the conditions are under which it is to be met. Term introduced in order to support digital and other exotic options. Note this is similar to but distinct from commitments where the specific nature of the commitment (typically a cashflow) is defined by resolving some mathematical formula i.e. where the commitment to do something is not conditional but the precise monetary amounts (payment, settlement) are.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FixedLookbackStrikeFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;StrikeFormula"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;DoubleBarrierOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:label xml:lang="en">double barrier option</rdfs:label>
+		<skos:definition xml:lang="en">barrier option applied to currencies or over the counter stocks that works as a binary, or digital option in that it pays out only under defined circumstances, or it is worthless, at expiration</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Considered an exotic option, a double barrier option is a combination of two single barrier options, with one barrier above and one barrier below the current price of the underlying. It is a bet by the holder that the underlying asset will move significantly, in the case of a knock-in barrier option, or will move by a very small amount, in the case of a knock-out barrier option, over the life of the contract. Traders use these options when they have an opinion on volatility but not on the direction of the underlying asset&apos;s next price move. A barrier option is a type of option where the payoff, and the very existence of the option, depends on whether or not the underlying asset reaches a predetermined price.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-exo;FixedLookbackStrikeFormula">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;StrikeFormula"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasExpression"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;FixedLookbackStrikeFormulaExpression"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;FixedLookbackStrikeFormulaExpression"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fixed lookback strike formula</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FixedLookbackStrikeFormulaExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;LookbackExpression"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;FixedLookbackStrikeFormulaExpression">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;LookbackExpression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasMinuend"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;FixedStrikeAmount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;FixedStrikeAmount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasSubtrahend"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;ObservableBestValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;ObservableBestValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fixed lookback strike formula expression</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FixedLookbackStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;LookbackStrikeTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;FixedLookbackStrikeTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;LookbackStrikeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;FixedLookbackStrikeFormula"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;FixedLookbackStrikeFormula"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fixed lookback strike terms</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-exo;FloatingLookbackStrikeTerms"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;FloatingLookbackStrikeTerms"/>
 		<skos:definition xml:lang="en">Strike terms which reflect the difference between a running maximum value of the observable during the lookback period, and the pre-agreed strike. The agreed settlement is based on the difference between these. Further Notes This is only settled in cash and the strike is predetermined at payoff and the payoff is the max diff between the optimal price and the strike price.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FixedStrikeAmount">
+	<owl:Class rdf:about="&fibo-der-drc-exo;FixedStrikeAmount">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
 		<rdfs:label xml:lang="en">fixed strike amount</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FixedStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionStrikeTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;FixedStrikeTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionStrikeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
@@ -268,120 +300,161 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fixed strike terms</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-exo;ResettableStrikeTerms"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;ResettableStrikeTerms"/>
 		<skos:definition xml:lang="en">Contractual terms setting out a fixed, pre-agreed price or level at which the option is to be struck.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is similar to the FpML term for Strike, but there are two other types of Strike specification - look back and reset. FpML strike: &apos;Defines whether it is a price or level at which the option has been, or will be, struck.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FloatingLookbackFormulaExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;LookbackExpression"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;FloatingLookbackFormulaExpression">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;LookbackExpression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasMinuend"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;ObservableFinalValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;ObservableFinalValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasSubtrahend"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;ObservableBestValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;ObservableBestValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">floating lookback formula expression</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FloatingLookbackStrikeFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;StrikeFormula"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;FloatingLookbackStrikeFormula">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;StrikeFormula"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasExpression"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;FloatingLookbackFormulaExpression"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;FloatingLookbackFormulaExpression"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">floating lookback strike formula</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FloatingLookbackStrikeSchedule">
+	<owl:Class rdf:about="&fibo-der-drc-exo;FloatingLookbackStrikeSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
 		<rdfs:label xml:lang="en">floating lookback strike schedule</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FloatingLookbackStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;LookbackStrikeTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;FloatingLookbackStrikeTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;LookbackStrikeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;FloatingLookbackStrikeFormula"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;FloatingLookbackStrikeFormula"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">floating lookback strike terms</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FloorDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;CapOrFloorDetermination"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;FloorDetermination">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;CapOrFloorDetermination"/>
 		<rdfs:label xml:lang="en">floor determination</rdfs:label>
 		<skos:definition xml:lang="en">The Observable rate is to be subtracted from the Strike rate on the reset date, to determine the settlement amount. Floor: I am an investor and I am specifying the minimum return I will get for that investment.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;FloorLoan">
+	<owl:Class rdf:about="&fibo-der-drc-exo;FloorLoan">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DebtInstrument"/>
 		<rdfs:label xml:lang="en">floor loan</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;InterestRateCapOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionStripContract"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;ForwardStartOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-der-drc-opt;CallOption">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-der-drc-opt;PutOption">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">forward start option</rdfs:label>
+		<skos:definition xml:lang="en">exotic option that is fully specified with respect to a set expiry date, underlying asset and other parameters, purchased and paid for on initiation, but that becomes active at a set activation date with a strike price determined at the time of activation</skos:definition>
+		<skos:example xml:lang="en">For example, assume that two parties agree to enter into a call forward start option on XYZ stock. It is September and they agree that the forward start option will activate on January 1 at the money. That means on January 1 the strike price for the option will be the price that stock is trading at on that day. The option will expire in June. The exact strike price is unknown, but the parties do know the strike and underlying&apos;s price will be the same at activation. They can look at current six-month options (January to June) and assess volatility to determine a premium for the option. They agree to trade one contract, equivalent to 100 shares of the underlying stock. They decide on a premium of $40, or $4,000 for the contract ($40 x 100 shares). The call buyer agrees to pay the $4,000 now (September), even though the option doesn&apos;t activate till January. On January 1, assume the stock price is $400. The strike is set at $400, and an option is now a vanilla option with a June expiry. At the June expiry, assume XYZ is trading at $420. In this case, the option is worth $20 ($420 - $400 strike). If they settle in cash, the buyer receives $2,000, or if they exercise, they receive 100 shares at $400 and can keep them, or sell them at $420 to make $2,000. Notice that this still results in a loss for the buyer, since they paid $4,000 but are only receiving back $2,000. To make money on the call, the price of the underlying needs to move above the strike price plus the premium. Therefore, if the price moves up to $450 by expiration, the option is worth $50 ($450 - $400 strike), and the buyer receives $5,000. That&apos;s a net profit of $1,000 over their $4,000 cost. If the underlying is trading below the $400 strike at expiry, the call option expires worthless and the buyer&apos;s premium is lost ($4,000 profit to the seller).</skos:example>
+		<skos:example xml:lang="en">For example, the people buying/selling the option could specify that the strike will be at the money (ATM) at activation, or 3% or 5% in the money or out of the money (OTM). Since it is a customized contract, they can negotiate any terms they want.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Forward start options typically attempt to keep future strike prices at the money or near the money. In this way, the holder will have the right, but not the obligation, to buy (call) or sell (put) the underlying asset in the future at or near the then-current market price. Knowing where the strike price will be in relation to the underlying&apos;s price makes it easier to come up with the premium (cost) of the option, which is also typically determined and paid at the initiation of the contract prior to the activation date. If, at the expiration date, the underlying trades below the strike price of the option (for a call), then it expires worthless. If the underlying is above the strike (for a call), then the holder exercises it and owns the underlying at the strike price. For a put option, if the underlying is below the strike price, the option has value and will be sold or exercised to realize a gain. If the underlying is above the strike price, the option will expire worthless. Typically, as with most options, the holder may sell the option if it is in the money and take the cash instead of exercising the option. Since it is an exotic option, the seller and buyer of the option may also agree to settle the option with cash instead of delivering the underlying. Once a forward start option becomes active (strike price is set), then the option is valued like a vanilla option.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The only unknown for the contract is the strike price. In terms of pricing the contract, the future price of the underlying asset is also unknown. The contract typically stipulates some parameters for where the strike price will be in relation to the underlying asset&apos;s price.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-exo;InterestRateCapOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionStripContract"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;InterestRateOption"/>
 		<rdfs:label xml:lang="en">interest rate cap option</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-exo;InterestRateFloorOption"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;InterestRateFloorOption"/>
 		<skos:definition xml:lang="en">A strip of options in which interest payable in each period is either the Observable (Underlying) rate or the Strike rate, at the holder&apos;s discretion, and in which the Strike rate represents a rate above which the holder can elect not to pay.</skos:definition>
 		<skos:editorialNote xml:lang="en">Definition and editorial note against the property &apos;strike effect&apos; for this class (property is now a restriction): The Strike rate is to be subtracted from the Observable rate on the reset date, to determine the settlement amount. REVIEW SESSION NOTES: This is incorrect. Cap applies to borrower. the Cap is the max amount I will pay to borrow. I take a capped rate. I am the buyer of the option. The market rate this time is higher than the capped rate. You as the seller of the option will pay me thedifference bwteen the capped rate and the market reate. If the market rate is lower than the capped rate no one pays anything because I will not exercise my right to that capped rate. So no money changes hands at settlement. Then: capped Loan: What I would be paying would be interest at the market rate if the market rate is lower, but if the market rate is higher then I would pay interest at the capped rate. This is the difference between a cap as a loan or as a cash settled thing. These represent different kinds of contract: Non loan one: Cap talks of settlement being difference between the market rate and the strike rate. This is cash settled. Name: &quot;Cap&quot; Loan one: Cap talks about a maximum interest rate payable by the holder, so the holder pays an amount each time, up to a maximum which is the Cap rate. Name: &quot;Capped Loan&quot; What manner of thin is this? A loan. Its ancestors are not OTC derivatives contracts thet are Loan.</skos:editorialNote>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The interest in each period is effectively capped by the Strike rate. That is, the rate of interest may not go above the Strike rate because the Holder is expected to exercise the option to take the Strike as the rate of interest instead.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;InterestRateFloorOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionStripContract"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;InterestRateFloorOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionStripContract"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;InterestRateOption"/>
 		<rdfs:label xml:lang="en">interest rate floor option</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-exo;InterestRateCapOption"/>
+		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;InterestRateCapOption"/>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;KnockIn">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionFeature"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;KnockIn">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionFeature"/>
 		<rdfs:label xml:lang="en">knock in</rdfs:label>
 		<skos:definition xml:lang="en">An option which comes into existence if the knock-in event happens. It works exactly the reverse of a knock-out. In a knock-in, an option comes into existence if a certain level is hit.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;KnockOut">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionFeature"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;KnockInOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:label xml:lang="en">knock-in option</rdfs:label>
+		<skos:definition xml:lang="en">barrier option is not an option until a certain price is met</skos:definition>
+		<skos:example xml:lang="en">Assume an investor purchases a knock-in put option with a down Direction, with a barrier price of $90 and a strike price of $100. The underlying security is trading at $110, and the option expires in three months. If the price of the underlying security reaches $90, the option comes into existence and becomes a vanilla option with a strike price of $100. Thereafter, the holder of the option has the right to sell the underlying asset at the strike price of $100, even though it is trading below $90. It is this right that gives the option value. The put option remains active until the expiration date, even if the underlying security rebounds back above $90. However, if the underlying asset does not fall below the barrier price during the life of the contract, the down-and-in option expires worthless. Just because the barrier is reached does not assure a profit on the trade since the underlying would need to stay below $100 (after triggering the barrier) in order for the option to have value.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the price is never reached, it is as if the contract never existed. However, if the underlying asset reaches a specified barrier, the knock-in option comes into existence. The difference between a knock-in and knock-out option is that a knock-in option comes into existence only when the underlying security reaches a barrier, while a knock-out option ceases to exist when the underlying security reaches a barrier.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-exo;KnockOut">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionFeature"/>
 		<rdfs:label xml:lang="en">knock out</rdfs:label>
 		<skos:definition xml:lang="en">An option which ceases to exist if the knock-out event occurs. A knock out happens when a particular level is hit (like the Swiss franc touching the level of 1.10 against the dollar), when the option ceases to exist.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;LinearPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;KnockOutOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:label xml:lang="en">knock-out option</rdfs:label>
+		<skos:definition xml:lang="en">barrier option with a built-in mechanism to expire worthless if a specified price level in the underlying asset is reached</skos:definition>
+		<skos:example xml:lang="en">Assume an investor purchases a Knock-Out call option with a down Direction, also called a &apos;Down and Out Option&apos;, on a stock that is trading at $60 with a strike price of $55 and a barrier of $50. Assume the stock trades below $50, at any time, before the call option expires. Therefore, the down-and-out call option promptly ceases to exist.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A knock-out option sets a cap on the level an option can reach in the holder&apos;s favor. As knock-out options limit the profit potential for the option buyer, they can be purchased for a smaller premium than an equivalent option without a knock-out stipulation.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-exo;LinearPayoutCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
 		<rdfs:label xml:lang="en">linear payout commitment</rdfs:label>
 		<skos:definition xml:lang="en">The commitment to pay out on a straight vanilla option.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;LinearPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPayoutTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;LinearPayoutTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;LinearPayoutCommitment"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;LinearPayoutCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">linear payout terms</rdfs:label>
 		<skos:definition xml:lang="en">Terms governing the payment commitment on a vanilla option.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;LookbackExpression">
+	<owl:Class rdf:about="&fibo-der-drc-exo;LookbackExpression">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
 		<rdfs:label xml:lang="en">lookback expression</rdfs:label>
 		<skos:definition xml:lang="en">An expression of a lookback formula</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;LookbackObservableValue">
+	<owl:Class rdf:about="&fibo-der-drc-exo;LookbackObservableValue">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -392,17 +465,17 @@
 		<rdfs:label xml:lang="en">lookback observable value</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;LookbackObservableValueAtMaturity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;LookbackObservableValue"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;LookbackObservableValueAtMaturity">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;LookbackObservableValue"/>
 		<rdfs:label xml:lang="en">lookback observable value at maturity</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;LookbackObservableValueDuringLookbackPeriod">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;LookbackObservableValue"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;LookbackObservableValueDuringLookbackPeriod">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;LookbackObservableValue"/>
 		<rdfs:label xml:lang="en">lookback observable value during lookback period</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;LookbackStrikeObservable">
+	<owl:Class rdf:about="&fibo-der-drc-exo;LookbackStrikeObservable">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -414,12 +487,12 @@
 		<skos:definition xml:lang="en">The agreed parameter which is used in the formula for fixed OR floating lookback.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;LookbackStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionStrikeTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;LookbackStrikeTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionStrikeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;FloatingLookbackStrikeSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;FloatingLookbackStrikeSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">lookback strike terms</rdfs:label>
@@ -427,34 +500,34 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The payoff may either be the difference between a fixed, pre-agreed Strike Price and the observable, or the difference between the best or worst valuable of the observable and the value of that same observable at maturity of the contract (these are the Fixed and Floating lookback terms respectively). This (per review at Nordea) is not mutually exclusive with the terms for Fixed Strike and Resettable Strike, that is, either of those kinds of strike terms may apply, and Lookback strike terms may also apply.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;ObservableBestValue">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;LookbackStrikeObservable"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;ObservableBestValue">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;LookbackStrikeObservable"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;LookbackObservableValueDuringLookbackPeriod"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;LookbackObservableValueDuringLookbackPeriod"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">observable best value</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;ObservableFinalValue">
+	<owl:Class rdf:about="&fibo-der-drc-exo;ObservableFinalValue">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;LookbackObservableValueAtMaturity"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;LookbackObservableValueAtMaturity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">observable final value</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionBarrierFeatureEvent">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionBarrierFeatureEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-exo;hasDirection"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;UpOrDown"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasDirection"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;UpOrDown"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -467,18 +540,18 @@
 		<skos:definition xml:lang="en">An event which defines when an option feature comes into effect.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionBarrierFeatureTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionBarrierFeatureTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;OptionBarrierFeatureEvent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;OptionBarrierFeatureEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;OptionFeature"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;OptionFeature"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option barrier feature terms</rdfs:label>
@@ -487,41 +560,41 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Barrier features include any terms related to exercising the option ahead of the expiry date.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionBinaryPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPayoutTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionBinaryPayoutTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;BinaryPayoutCommitment"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;BinaryPayoutCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option binary payout terms</rdfs:label>
 		<skos:definition xml:lang="en">Terms governing a binary payout commitment.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionConditionalPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPayoutTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionConditionalPayoutTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;ConditionalPayoutCommitment"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option conditional payout terms</rdfs:label>
 		<skos:definition xml:lang="en">Terms governing a conditional payment commitment on an option.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionFeature">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionFeature">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label xml:lang="en">option feature</rdfs:label>
 		<skos:definition xml:lang="en">Types of feature for an option. This itemizes whether the option comes into force (Knock In) or ceases being in force (Knock Out) when the stated event occurs.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionPayoutCommitment">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionPayoutCommitment">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-exo;enteredIntoBy"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;enteredIntoBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -530,27 +603,27 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This commitment is set out in formal Exercise Terms.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionPayoutTerms">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionPayoutTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ParametricCashflowTerms"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionTerms"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;OptionPayoutCommitment"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option payout terms</rdfs:label>
 		<skos:definition xml:lang="en">Terms governing the payout on an option. These formally define the commitment(s) entered into by the writing party to the option.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionPremiumFormula">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionPremiumFormula">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Formula"/>
 		<rdfs:label xml:lang="en">option premium formula</rdfs:label>
 		<skos:definition xml:lang="en">formula used to calculate the premium</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a choice between expressing amount of premium paid as either price per option, or percentage of notional amount. FpML: &apos;Choice between expressing amount of premium paid as either price per option, or percentage of notional amount.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionPremiumPaymentArrangement">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionPremiumPaymentArrangement">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label xml:lang="en">option premium payment arrangement</rdfs:label>
 		<skos:definition xml:lang="en">Premium Type for Forward Start Equity Options.</skos:definition>
@@ -560,28 +633,28 @@ Earlier SME Review note:
 Further notes: REVIEW THIS - there appear to be two separate semantics in this list; are they mutually exclusive? Answers: You can pay the premium up front or in arrears (pre v pos tpaid) or you can pay it at any agreed time (indeed the time is already defined as terms see Payment Date), so this simply reflects that. Then there are other types of &quot;Participating OptionS&quot; where the anmount you pay depends on something else - so you don&apos;t pay the Premium up front. If it ends up outt of the money then you don&apos;t have to pay as much. So this is &quot;Variable&quot; premium. The alternative to this is &quot;Fixed&quot;. If it&apos;s prepaid it&apos;s firxed If it&apos;s post paid it can bt variable or fixed. SO these are two facts. FpML: Premium Type for Forward Start Equity Option</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionPremiumPreOrPostType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionPremiumPaymentArrangement"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionPremiumPreOrPostType">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPremiumPaymentArrangement"/>
 		<rdfs:label xml:lang="en">option premium pre or post type</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionStrikeResetSchedule">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionStrikeResetSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
 		<rdfs:label xml:lang="en">option strike reset schedule</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionStrikeTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionTerms"/>
 		<rdfs:label xml:lang="en">option strike terms</rdfs:label>
 		<skos:definition xml:lang="en">Contractual terms setting out the price or level at which the option is to be struck. FpML strike: &apos;Defines whether it is a price or level at which the option has been, or will be, struck.&apos;</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionStripContract">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionStripContract">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-exo;hasResetSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;OptionStripResetSchedule"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasResetSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;OptionStripResetSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option strip contract</rdfs:label>
@@ -589,13 +662,13 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<skos:editorialNote xml:lang="en">The defining fact is that it is a set of sequential options. So in principal this is a strip of any kind of option. Can you strip forwards? In principal, but usually you would have a Commodity Swap which would be a strip of Forwards. Other strips? Don&apos;t always buy a string of caplets and floorlets but buy an individual cap or floor. for IR Options These are always Caps or Floors, that is the option settlement takes the form of the difference between the Strike rate and the designated underlying (observable) rate on the stated dates. Review notes: caps and floors are always strips, but there are strips for other assets as well. SO: There are strips besides Options; There are Option Strips besides IR (Cap and Floor) ones. See eg. in France where you may have a strip of options where the strike is set at each rollover. Details to come by email. In this case it would be an asset option, specifically Equity.</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionStripResetSchedule">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionStripResetSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
 		<rdfs:label xml:lang="en">option strip reset schedule</rdfs:label>
 		<skos:definition xml:lang="en">Schedule of dates on which the Option Strip rate is determined and reset.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;OptionTerms">
+	<owl:Class rdf:about="&fibo-der-drc-exo;OptionTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -606,29 +679,29 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:label xml:lang="en">option terms</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;PayoffAssetsList">
+	<owl:Class rdf:about="&fibo-der-drc-exo;PayoffAssetsList">
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;SecurityUnderlier"/>
 		<rdfs:label xml:lang="en">payoff assets list</rdfs:label>
 		<skos:definition xml:lang="en">The list of n assets which are used to determine a best or worst value in determining conditional payoff commitments.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;ResettableStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-exo;OptionStrikeTerms"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;ResettableStrikeTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionStrikeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-exo;hasResetSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;OptionStrikeResetSchedule"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasResetSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;OptionStrikeResetSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">resettable strike terms</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;StrikeFormula">
+	<owl:Class rdf:about="&fibo-der-drc-exo;StrikeFormula">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CashflowFormula"/>
 		<rdfs:label xml:lang="en">strike formula</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;Swaption">
+	<owl:Class rdf:about="&fibo-der-drc-exo;Swaption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OverTheCounterInstrument"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
@@ -643,111 +716,111 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<fibo-fnd-utl-av:synonym xml:lang="en">swap option</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-exo;UpOrDown">
+	<owl:Class rdf:about="&fibo-der-drc-exo;UpOrDown">
 		<rdfs:label xml:lang="en">up or down</rdfs:label>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;enteredIntoBy">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;enteredIntoBy">
 		<rdfs:label xml:lang="en">entered into by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;OptionPayoutCommitment"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;exerciseDateOffset">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;exerciseDateOffset">
 		<rdfs:label xml:lang="en">exercise date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;OptionStripContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripContract"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition xml:lang="en">The period in days between the Reset Date and the date on which the Option may be exercised.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-exo;fixedStrikeAmount">
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-exo;fixedStrikeAmount">
 		<rdfs:label xml:lang="en">fixed strike amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;FixedStrikeAmount"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;FixedStrikeAmount"/>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;hasDirection">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasDirection">
 		<rdfs:label xml:lang="en">has direction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;OptionBarrierFeatureEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-der-exo;UpOrDown"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionBarrierFeatureEvent"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-exo;UpOrDown"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;hasOptionTypeElectionDate">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasOptionTypeElectionDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label xml:lang="en">has option type election date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;ChooserOption"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;ChooserOption"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition xml:lang="en">The date on which the holder of the Chooser option contract determines a choice of either a Call or a Put,</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML: &apos;Date where the holder of a Chooser option contract determines a choice of either a Call or a Put&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;hasPremiumType">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasPremiumType">
 		<rdfs:label xml:lang="en">has premium type</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-der-der-exo;OptionPremiumPaymentArrangement"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-exo;OptionPremiumPaymentArrangement"/>
 		<skos:definition xml:lang="en">The type of premium payment. FpML: &apos;Premium type for a forward starting equity option.&apos;</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;hasResetSchedule">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasResetSchedule">
 		<rdfs:label xml:lang="en">has reset schedule</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;OptionStripContract"/>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;ResettableStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-exo;OptionStrikeResetSchedule"/>
-		<rdfs:range rdf:resource="&fibo-der-der-exo;OptionStripResetSchedule"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;ResettableStrikeTerms"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-exo;OptionStrikeResetSchedule"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-exo;OptionStripResetSchedule"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;hasStrikeEffect">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasStrikeEffect">
 		<rdfs:label xml:lang="en">has strike effect</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-exo;CapOrFloorDetermination"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripContract"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-exo;CapOrFloorDetermination"/>
 		<skos:definition xml:lang="en">Whether the Strike rate is to be subtracted from the Observable rate on the reset date, or whether the Observable rate is to be subtracted from the Strike rate, to determine the settlement amount.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;hasStrikePercentageAmount">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasStrikePercentageAmount">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
 		<rdfs:label xml:lang="en">has strike percentage amount</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
 		<skos:definition xml:lang="en">strike price or level expressed as a percentage of the value of the underlying asset</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;interestAccrualDateOffset">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;interestAccrualDateOffset">
 		<rdfs:label xml:lang="en">interest accrual date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;OptionStripContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripContract"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition xml:lang="en">The period in days between each Reset Date and the commencement of accrual of interest for the next period.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;lookbackPeriod">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;lookbackPeriod">
 		<rdfs:label xml:lang="en">lookback period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;LookbackStrikeTerms"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;LookbackStrikeTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
 		<skos:definition xml:lang="en">The period in which the strike</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-exo;openOutcry">
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-exo;openOutcry">
 		<rdfs:label xml:lang="en">open outcry</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fct-mkt;DesignatedContractMarket"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether trading on the exchange is by way of open outcry in the form of physical interaction between participants. No means that trading is carried out electronically.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;settlementDateOffset">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;settlementDateOffset">
 		<rdfs:label xml:lang="en">settlement date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;OptionStripContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripContract"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition xml:lang="en">The period in days between each Reset Date and the corresponding Settlement Date.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-exo;strikeDeterminationDate">
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;strikeDeterminationDate">
 		<rdfs:label xml:lang="en">strike determination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;FixedStrikeTerms"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;FixedStrikeTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The date on which the strike is determined,</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-exo;threshold">
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-exo;threshold">
 		<rdfs:label xml:lang="en">threshold</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-exo;OptionBarrierFeatureEvent"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionBarrierFeatureEvent"/>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">The price or other variable (as a number) which has to be met for the event to be deemed to have occurred.</skos:definition>
 	</owl:DatatypeProperty>
@@ -756,7 +829,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasFormula"/>
-				<owl:onClass rdf:resource="&fibo-der-der-exo;OptionPremiumFormula"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-exo;OptionPremiumFormula"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -766,7 +839,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-exo;OptionStrikeTerms"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;OptionStrikeTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -18,6 +18,7 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
 	<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -46,6 +47,7 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
 	xmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -82,6 +84,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"/>
@@ -108,7 +111,8 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/MarketRate"/>
+				<owl:onClass rdf:resource="&fibo-ind-ind-ind;MarketRate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">barrier feature event</rdfs:label>
@@ -129,21 +133,9 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Barrier features include any terms related to exercising the option ahead of the expiry date.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-exo;CapDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;CapOrFloorDetermination"/>
-		<rdfs:label xml:lang="en">cap determination</rdfs:label>
-		<skos:definition xml:lang="en">The Strike rate is to be subtracted from the Observable rate on the reset date, to determine the settlement amount. This is incorrect. Cap applies to borrower. the Cap is the max amount I will pay to borrow. I take a capped rate. I am the buyer of the option. The market rate this time is higher than the capped rate. You as the seller of the option will pay me thedifference bwteen the capped rate and the market reate. If the market rate is lower than the capped rate no one pays anything because I will not exercise my right to that capped rate. So no money changes hands at settlement. Then: capped Loan: What I would be paying would be interest at the market rate if the market rate is lower, but if the market rate is higher then I would pay interest at the capped rate. This is the difference between a cap as a loan or as a cash settled thing. These represent different kinds of contract: Non loan one: Cap talks of settlement being difference between the market rate and the strike rate. This is cash settled. Name: &quot;Cap&quot; Loan one: Cap talks about a maximum interest rate payable by the holder, so the holder pays an amount each time, up to a maximum which is the Cap rate. Name: &quot;Capped Loan&quot; What manner of thin is this? A loan. Its ancestors are not OTC derivatives contracts thet are Loan.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-exo;CapLoan">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DebtInstrument"/>
 		<rdfs:label xml:lang="en">cap loan</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;CapOrFloorDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
-		<rdfs:label xml:lang="en">cap or floor determination</rdfs:label>
-		<skos:definition xml:lang="en">Whether a given thing is treated as a Cap (something goes no higher than this amount) or as a Floor (something goes no lower than this).</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;ChooserOption">
@@ -323,12 +315,6 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">floating lookback strike terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;FloorDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;CapOrFloorDetermination"/>
-		<rdfs:label xml:lang="en">floor determination</rdfs:label>
-		<skos:definition xml:lang="en">The Observable rate is to be subtracted from the Strike rate on the reset date, to determine the settlement amount. Floor: I am an investor and I am specifying the minimum return I will get for that investment.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;FloorLoan">
@@ -590,7 +576,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;Swaption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OverTheCounterInstrument"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -639,13 +624,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:domain rdf:resource="&fibo-der-drc-exo;ResettableStrikeTerms"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-exo;OptionStrikeResetSchedule"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-exo;OptionStripResetSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasStrikeEffect">
-		<rdfs:label xml:lang="en">has strike effect</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-exo;CapOrFloorDetermination"/>
-		<skos:definition xml:lang="en">Whether the Strike rate is to be subtracted from the Observable rate on the reset date, or whether the Observable rate is to be subtracted from the Strike rate, to determine the settlement amount.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasStrikePercentageAmount">

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -19,6 +19,7 @@
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
+	<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -46,6 +47,7 @@
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
+	xmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -81,6 +83,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
@@ -100,62 +103,30 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These options allow the buyer to purchase (or sell) the underlying asset at the average price instead of the spot price. There are various ways to interpret the word &apos;average,&apos; and that needs to be specified in the options contract. Typically, the average price is a geometric or arithmetic average of the price of the underlying asset at discreet intervals, which are also specified in the options contract. Because of the averaging feature, Asian options reduce the volatility inherent in the option; therefore, Asian options are typically cheaper than European or American options. They are used by traders who are exposed to the underlying asset over some time, such as consumers and suppliers of commodities, etc.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-exo;AssetMaximumOrMinimumPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
-		<rdfs:label xml:lang="en">asset maximum or minimum payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to pay out on the maximum or minimum of a set of assets. Further Notes Maximum of n Assets This rainbow is similar to the best of n assets plus cash we referred to in part a, with the exception that no cash payoff is possible and there is a strike price for this type of option. The payoff of a call and put are given as: Rainbow-Call = max[0, max(S1, S2) - X] Rainbow-Put = max[0, X - max(S1, S2)] Minimum of n Assets The counterpart to a maximum of n assets, this rainbow pays out the value of the underperformer of the n assets. The payoff for minimum of 2 asset rainbow calls and puts are given as: Rainbow-Call = max[0, mainS1, S2) - X] Rainbow-Put = max[0, X - min(S1, S2)]</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;AssetOrNothingPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BinaryPayoutCommitment"/>
-		<rdfs:label xml:lang="en">asset or nothing payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;CashOrNothingPayoutCommitment"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;BarrierFeatureEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
+				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/MarketRate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">barrier feature event</rdfs:label>
+		<skos:definition xml:lang="en">event that defines when an option feature comes into effect</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;BarrierOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
-		<rdfs:label xml:lang="en">barrier option</rdfs:label>
-		<skos:definition xml:lang="en">option whose payoff depends on whether or not the underlying asset has reached or exceeded a predetermined price</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A barrier option can be a knock-out, meaning it expires worthless if the underlying exceeds a certain price, limiting profits for the holder and limiting losses for the writer. It can also be a knock-in, meaning it has no value until the underlying reaches a certain price. Barrier options can be puts or calls. Barrier options typically have cheaper premiums than traditional vanilla options, primarily because the barrier increases the chances of the option expiring worthless. A trader may choose the cheaper (relative to a comparable vanilla) barrier option if they feel it is quite likely the underlying will hit the barrier.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;BestOfAssetsPlusCashPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;PayoffAssetsList"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;BarrierFeatureEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">best of assets plus cash payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to pay out on the best of a number of assets, plus cash.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This type of rainbow effectively has n + 1 payoff possibilities. If we consider a 2 asset &quot;best of plus cash&quot;, the payoff at expiry is a choice between Asset 1, Asset 2, or the predetermined cash amount. There is no strike price and the payoff is given as: Rainbow = max(S1, S2, Cash;T)</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;BetterOrWorseOfAssetsPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;PayoffAssetsList"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">better or worse of assets payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to pay out on the best or worst of a number of assets.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Better of n Assets This type of rainbow is similar to the best of n assets plus cash but with the exception that there is no possible cash payoff, and X is set to 0. With this in mind, a better of 2 assets rainbow is essentially a two-asset call option, with a payoff being: Rainbow = max[0, max(S1, S2)] Worse of n Assets Essentially the opposite to the better of n assets, with the payoff being on the asset with the lower value. We can give the payoff for this option on 2 assets as: Rainbow = max[0, min(S1, S2)]</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;BinaryPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">binary payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;CalculatedPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">calculated payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
-		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;LinearPayoutCommitment"/>
+		<rdfs:label xml:lang="en">barrier option</rdfs:label>
+		<skos:definition xml:lang="en">option whose payoff depends on whether or not the underlying asset has reached or exceeded a predetermined price</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A barrier option can be a knock-out, meaning it expires worthless if the underlying exceeds a certain price, limiting profits for the holder and limiting losses for the writer. It can also be a knock-in, meaning it has no value until the underlying reaches a certain price. Barrier options can be puts or calls. Barrier options typically have cheaper premiums than traditional vanilla options, primarily because the barrier increases the chances of the option expiring worthless. A trader may choose the cheaper (relative to a comparable vanilla) barrier option if they feel it is quite likely the underlying will hit the barrier.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Barrier features include any terms related to exercising the option ahead of the expiry date.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;CapDetermination">
@@ -173,12 +144,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label xml:lang="en">cap or floor determination</rdfs:label>
 		<skos:definition xml:lang="en">Whether a given thing is treated as a Cap (something goes no higher than this amount) or as a Floor (something goes no lower than this).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;CashOrNothingPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BinaryPayoutCommitment"/>
-		<rdfs:label xml:lang="en">cash or nothing payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to pay out on a binary option, as cash or nothing.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;ChooserOption">
@@ -238,18 +203,6 @@
 		<skos:definition xml:lang="en">exotic option consisting of a number of digital barrier options that pay a coupon if a pre-determined level of the underlying or basket of underlyings is reached</skos:definition>
 		<skos:example xml:lang="en">A three-year commodore option with annual barriers would have three potential payoffs. The first would pay at the end of the first year and would be dependent on the pre-determined barrier being reached or exceeded. For example, if the underlying or basket of underlyings reached or exceeded 102% of its initial level at the end of year one, a coupon of 6% would be paid. At the end of year two, if the underlying reached or exceeded 104% of its initial level, another 6% coupon would be paid. The coupon in the final year would be 6% if the underlying reached or exceeded 106%. The coupon should exceed the performance level of the underlying, otherwise the investor would achieve the same result by investing directly in the underlying.</skos:example>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Sometimes the digital barrier increases with the number of years since the trade began. All of the options are active from the start of the trade.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;ConditionalPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">conditional payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;LinearPayoutCommitment"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;DefinedConditionsPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">defined conditions payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment which is only made when certain defined conditions are met. Further notes: Like all contractual commitments, the details of the commitment (and in this case, the conditions) are defined in the corresponding Contractual Terms. These set out what the commitment is and what the conditions are under which it is to be met. Term introduced in order to support digital and other exotic options. Note this is similar to but distinct from commitments where the specific nature of the commitment (typically a cashflow) is defined by resolving some mathematical formula i.e. where the commitment to do something is not conditional but the precise monetary amounts (payment, settlement) are.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;DigitalOption">
@@ -413,9 +366,9 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;InterestRateOption"/>
 		<rdfs:label xml:lang="en">interest rate cap option</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;InterestRateFloorOption"/>
-		<skos:definition xml:lang="en">A strip of options in which interest payable in each period is either the Observable (Underlying) rate or the Strike rate, at the holder&apos;s discretion, and in which the Strike rate represents a rate above which the holder can elect not to pay.</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition and editorial note against the property &apos;strike effect&apos; for this class (property is now a restriction): The Strike rate is to be subtracted from the Observable rate on the reset date, to determine the settlement amount. REVIEW SESSION NOTES: This is incorrect. Cap applies to borrower. the Cap is the max amount I will pay to borrow. I take a capped rate. I am the buyer of the option. The market rate this time is higher than the capped rate. You as the seller of the option will pay me thedifference bwteen the capped rate and the market reate. If the market rate is lower than the capped rate no one pays anything because I will not exercise my right to that capped rate. So no money changes hands at settlement. Then: capped Loan: What I would be paying would be interest at the market rate if the market rate is lower, but if the market rate is higher then I would pay interest at the capped rate. This is the difference between a cap as a loan or as a cash settled thing. These represent different kinds of contract: Non loan one: Cap talks of settlement being difference between the market rate and the strike rate. This is cash settled. Name: &quot;Cap&quot; Loan one: Cap talks about a maximum interest rate payable by the holder, so the holder pays an amount each time, up to a maximum which is the Cap rate. Name: &quot;Capped Loan&quot; What manner of thin is this? A loan. Its ancestors are not OTC derivatives contracts thet are Loan.</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The interest in each period is effectively capped by the Strike rate. That is, the rate of interest may not go above the Strike rate because the Holder is expected to exercise the option to take the Strike as the rate of interest instead.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">interest rate derivative in which the buyer receives payments at the end of each period in which the interest rate exceeds the agreed strike price</skos:definition>
+		<skos:example xml:lang="en">An example of a cap would be an agreement to receive a payment for each month the LIBOR rate exceeds 2.5%.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The interest in each period is effectively capped by the strike rate. That is, the rate of interest may not go above the strike rate because the holder is expected to exercise the option to take the strike as the rate of interest instead.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;InterestRateFloorOption">
@@ -423,6 +376,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;InterestRateOption"/>
 		<rdfs:label xml:lang="en">interest rate floor option</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-der-drc-exo;InterestRateCapOption"/>
+		<skos:definition xml:lang="en">interest rate derivative in which the buyer receives payments at the end of each period in which the interest rate is below the agreed strike price</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;KnockInOption">
@@ -439,24 +393,6 @@
 		<skos:definition xml:lang="en">barrier option with a built-in mechanism to expire worthless if a specified price level in the underlying asset is reached</skos:definition>
 		<skos:example xml:lang="en">Assume an investor purchases a Knock-Out call option with a down Direction, also called a &apos;Down and Out Option&apos;, on a stock that is trading at $60 with a strike price of $55 and a barrier of $50. Assume the stock trades below $50, at any time, before the call option expires. Therefore, the down-and-out call option promptly ceases to exist.</skos:example>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A knock-out option sets a cap on the level an option can reach in the holder&apos;s favor. As knock-out options limit the profit potential for the option buyer, they can be purchased for a smaller premium than an equivalent option without a knock-out stipulation.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;LinearPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">linear payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">The commitment to pay out on a straight vanilla option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;LinearPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;LinearPayoutCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">linear payout terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing the payment commitment on a vanilla option.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;LookbackExpression">
@@ -486,6 +422,14 @@
 		<rdfs:label xml:lang="en">lookback observable value during lookback period</rdfs:label>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-exo;LookbackOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
+		<rdfs:label xml:lang="en">lookback option</rdfs:label>
+		<skos:definition xml:lang="en">exotic option that allows the holder the advantage of knowing history when determining when to exercise their option</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As a type of exotic option, the lookback allows the user to &apos;look back,&apos; or review, the prices of an underlying asset over the lifespan of the option after it has been purchased. The holder may then exercise the option based on the most beneficial price of the underlying asset. The holder can take advantage of the widest differential between the strike price and the price of the underlying asset. Lookback options do not trade on major exchanges. Instead, they are unlisted and trade over-the-counter (OTC). This type of option reduces uncertainties associated with the timing of market entry and reduces the chances the option will expire worthlessly. Lookback options are expensive to execute, so these advantages come at a cost.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Lookback options are cash settled options, which means the holder receives a cash settlement at execution based on the most advantageous differential between high and low prices during the purchase period. Sellers of lookback options would price the option at or near the widest expected distance of price differential based on past volatility and demand for the options. The cost to purchase this option would be taken up front. The settlement will equate to the profits they could have made from buying or selling the underlying asset. If the settlement was greater than the initial cost of the option, then the option buyer would have profit at settlement, otherwise loss.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-exo;LookbackStrikeObservable">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
 		<rdfs:subClassOf>
@@ -511,12 +455,19 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The payoff may either be the difference between a fixed, pre-agreed Strike Price and the observable, or the difference between the best or worst valuable of the observable and the value of that same observable at maturity of the contract (these are the Fixed and Floating lookback terms respectively). This (per review at Nordea) is not mutually exclusive with the terms for Fixed Strike and Resettable Strike, that is, either of those kinds of strike terms may apply, and Lookback strike terms may also apply.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-exo;LookbacktOption">
+	<owl:Class rdf:about="&fibo-der-drc-exo;MountainRangeOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
-		<rdfs:label xml:lang="en">lookback option</rdfs:label>
-		<skos:definition xml:lang="en">exotic option that allows the holder the advantage of knowing history when determining when to exercise their option</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As a type of exotic option, the lookback allows the user to &apos;look back,&apos; or review, the prices of an underlying asset over the lifespan of the option after it has been purchased. The holder may then exercise the option based on the most beneficial price of the underlying asset. The holder can take advantage of the widest differential between the strike price and the price of the underlying asset. Lookback options do not trade on major exchanges. Instead, they are unlisted and trade over-the-counter (OTC). This type of option reduces uncertainties associated with the timing of market entry and reduces the chances the option will expire worthlessly. Lookback options are expensive to execute, so these advantages come at a cost.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Lookback options are cash settled options, which means the holder receives a cash settlement at execution based on the most advantageous differential between high and low prices during the purchase period. Sellers of lookback options would price the option at or near the widest expected distance of price differential based on past volatility and demand for the options. The cost to purchase this option would be taken up front. The settlement will equate to the profits they could have made from buying or selling the underlying asset. If the settlement was greater than the initial cost of the option, then the option buyer would have profit at settlement, otherwise loss.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-bsk;MixedBasket"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">mountain range option</rdfs:label>
+		<skos:definition xml:lang="en">exotic option based on multiple underlying securities</skos:definition>
+		<skos:example xml:lang="en">Mountain range options are named after a series of mountains, each representing a different type of contract. Some of the most common include: (a) Altiplano options: Altiplano options provide investors with the features of both a traditional vanilla option along with a coupon payment, (b) Annapurna options: coupon rates are determined by the performance of the basket&apos;s worst-performing security when it drops under a specified range, (c) Everest options: Everest options place a long-term limit on an investor&apos;s option while offering a payout based on the lagging performers in the basket, (d) Atlas options: this type of option eliminates both the best - and worst - performing stocks in a basket of securities, and (e) Himalayan options: traders receive a payout based on the basket&apos;s best performing stock; payouts are provided on multiple dates.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The price of a mountain range option is based on multiple variables, the most important of which are the correlations between the individual securities in the basket. Some options have discrete payout levels, such as double the investment or triple the investment, if certain performance metrics are hit by the underlying securities while the option is in effect. Mountain range options cannot be priced with standard closed-form approaches. These exotic instruments instead require Monte Carlo simulation methods. Effects such as volatility skew, which is found in most options, can be even more pronounced within mountain range options.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These options blend some of the key characteristics of basket-style or rainbow options—both of which have more than one underlying security or asset—and range options with multiyear time ranges. Prices are based on multiple variables - notably the correlations between the individual securities in the basket.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;ObservableBestValue">
@@ -539,100 +490,6 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">observable final value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;OptionBarrierFeatureEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasDirection"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;UpOrDown"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/MarketRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option barrier feature event</rdfs:label>
-		<skos:definition xml:lang="en">An event which defines when an option feature comes into effect.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;OptionBarrierFeatureTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;OptionBarrierFeatureEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;OptionFeature"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option barrier feature terms</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms setting out when and under what circumstances the option contract is deemed to be in force. This takes the form of an event and the relationship between the event and the applicability of the option.</skos:definition>
-		<skos:editorialNote xml:lang="en">After some research it was determined that the nature of the thing normally called &quot;Feature&quot; in an option is a contractual term defining when and under what circumstances the option itself is deemed be in force. Option features in this sense are &quot;Knock In&quot; or &quot;Knock Out&quot;, each relating to a market event (usually a price reaching a given level). A third feature, &quot;Knock In Knock Out&quot; is really two of these and is represented as such in the Option terms i.e. there may be two of this Option Feature Terms term. The term &quot;Barrier Option&quot; applies to both of these, i.e. Knock In and Knock Out are types of Barrier Option. An option contract may or may not have a barrier option. If it does not, none of this applies. Others: knock in a knock out, knock in a digitale, if it exceeds one barrier you get a call; for another you get a put, and so on.</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Barrier features include any terms related to exercising the option ahead of the expiry date.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;OptionBinaryPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;BinaryPayoutCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option binary payout terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing a binary payout commitment.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;OptionConditionalPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionPayoutTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;ConditionalPayoutCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option conditional payout terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing a conditional payment commitment on an option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;OptionFeature">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
-		<rdfs:label xml:lang="en">option feature</rdfs:label>
-		<skos:definition xml:lang="en">Types of feature for an option. This itemizes whether the option comes into force (Knock In) or ceases being in force (Knock Out) when the stated event occurs.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;OptionPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-exo;enteredIntoBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">Commitment by the issuer to pay out on an option should the holder choose to exercise this.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This commitment is set out in formal Exercise Terms.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;OptionPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ParametricCashflowTerms"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;OptionTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option payout terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing the payout on an option. These formally define the commitment(s) entered into by the writing party to the option.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;OptionPremiumFormula">
@@ -696,12 +553,24 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option terms</rdfs:label>
+		<skos:definition xml:lang="en">derivative terms specific to an option contract, including but not limited to exercise terms</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-exo;PayoffAssetsList">
-		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;SecurityUnderlier"/>
-		<rdfs:label xml:lang="en">payoff assets list</rdfs:label>
-		<skos:definition xml:lang="en">The list of n assets which are used to determine a best or worst value in determining conditional payoff commitments.</skos:definition>
+	<owl:Class rdf:about="&fibo-der-drc-exo;RainbowOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-bsk;MixedBasket"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">rainbow option</rdfs:label>
+		<skos:definition xml:lang="en">exotic option linked to the performances of two or more underlying assets</skos:definition>
+		<skos:example xml:lang="en">A best of assets plus cash rainbow effectively has n + 1 payoff possibilities. If we consider a 2 asset &quot;best of plus cash&quot;, the payoff at expiry is a choice between Asset 1, Asset 2, or the predetermined cash amount. There is no strike price and the payoff is given as: Rainbow = max(S1, S2, Cash;T)</skos:example>
+		<skos:example xml:lang="en">An asset maximum or minimum payout rainbow is similar to the best of n assets plus cash, with the exception that no cash payoff is possible and there is a strike price for this type of option. The payoff of a call and put are given as: Rainbow-Call = max[0, max(S1, S2) - X] Rainbow-Put = max[0, X - max(S1, S2)] Minimum of n Assets. The counterpart to a maximum of n assets, this rainbow pays out the value of the underperformer of the n assets. The payoff for minimum of 2 asset rainbow calls and puts are given as: Rainbow-Call = max[0, mainS1, S2) - X] Rainbow-Put = max[0, X - min(S1, S2)]</skos:example>
+		<skos:example xml:lang="en">Better of n Assets This type of rainbow is similar to the best of n assets plus cash but with the exception that there is no possible cash payoff, and X is set to 0. With this in mind, a better of 2 assets rainbow is essentially a two-asset call option, with a payoff being: Rainbow = max[0, max(S1, S2)] Worse of n Assets Essentially the opposite to the better of n assets, with the payoff being on the asset with the lower value. We can give the payoff for this option on 2 assets as: Rainbow = max[0, min(S1, S2)]</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Rainbbow options can speculate on the best performer in the group or minimum performances of all the underlying assets at one time. Each underlying may be called a color so the sum of all of these factors makes up a rainbow. These structures can be rather exotic and made for institutional clients when referring to financial assets. Rainbow options can be structured in many ways depending on how the performances of each underlying asset are considered. Some pay off based on the best or worst performance among the underlying assets. In other words, it looks at the top or bottom performance and pays off based on that single asset. These are sometimes called &apos;best of&apos; or &apos;worst of&apos; rainbow options.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Rainbow options are usually calls or puts on the best or worst of n underlying assets. Like a basket option, which is written on a group of assets and pays out on a weighted-average gain on the basket as a whole, a rainbow option also considers a group of assets, but usually pays out on the level of one of them. A simple example is a call rainbow option written on FTSE 100, Nikkei and S&amp;P 500 which will pay out the difference between the strike price and the level of the index that has risen by the largest amount of the three.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;ResettableStrikeTerms">
@@ -735,16 +604,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<fibo-fnd-utl-av:synonym xml:lang="en">swap option</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-exo;UpOrDown">
-		<rdfs:label xml:lang="en">up or down</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;enteredIntoBy">
-		<rdfs:label xml:lang="en">entered into by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionPayoutCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;exerciseDateOffset">
 		<rdfs:label xml:lang="en">exercise date offset</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripContract"/>
@@ -757,12 +616,6 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:domain rdf:resource="&fibo-der-drc-exo;FixedStrikeAmount"/>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasDirection">
-		<rdfs:label xml:lang="en">has direction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionBarrierFeatureEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-exo;UpOrDown"/>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasOptionTypeElectionDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
@@ -839,7 +692,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-exo;threshold">
 		<rdfs:label xml:lang="en">threshold</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionBarrierFeatureEvent"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;BarrierFeatureEvent"/>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">The price or other variable (as a number) which has to be met for the event to be deemed to have occurred.</skos:definition>
 	</owl:DatatypeProperty>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -113,10 +113,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220101/DerivativesContracts/Options/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220701/DerivativesContracts/Options/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20210601/DerivativesContracts/Options.rdf version of this ontology was revised to add an expiration date as an important property of an option.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20210901/DerivativesContracts/Options.rdf version of this ontology was revised to correct a restriction on an option with respect to an optional option premium which was not well-formed, and modified the definition of interest rate option to reflect a benchmark, and to be a specialization of vanilla option.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20211201/DerivativesContracts/Options.rdf version of this ontology was revised to make certain values subclasses of MonetaryAmount instead of MonetaryMeasure.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20220101/DerivativesContracts/Options.rdf version of this ontology was revised to add an explanatory note to basket option and make it a kind of exotic option.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -133,15 +134,28 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;BasketOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-bsk;MixedBasket"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasPriceDeterminationMethod"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractDuration"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDuration"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">basket option</rdfs:label>
 		<skos:definition xml:lang="en">option whose underlying asset is a group, or basket, of commodities, securities, indices, or currencies</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As with other options, a basket option gives the holder the right, but not the obligation, to buy or sell the basket at a specific price, on or before a certain date.  This exotic option has all the characteristics of a standard option, but with the basis of the strike price on the weighted value of its components. Currency baskets are the most popular type of basket option, and they will settle in the holder&apos;s home currency. Because it involves just one transaction, a basket option often costs less than multiple single options as it saves on commissions and fees.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;BondOption">

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -120,7 +120,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20210601/DerivativesContracts/Options.rdf version of this ontology was revised to add an expiration date as an important property of an option.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20210901/DerivativesContracts/Options.rdf version of this ontology was revised to correct a restriction on an option with respect to an optional option premium which was not well-formed, and modified the definition of interest rate option to reflect a benchmark, and to be a specialization of vanilla option.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20211201/DerivativesContracts/Options.rdf version of this ontology was revised to make certain values subclasses of MonetaryAmount instead of MonetaryMeasure.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20220101/DerivativesContracts/Options.rdf version of this ontology was revised to add an explanatory note to basket option and make it a kind of exotic option and added interest rate derivative as the parent of interest rate option.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20220101/DerivativesContracts/Options.rdf version of this ontology was revised to add an explanatory note to basket option and make it a kind of exotic option and added interest rate derivative as the parent of interest rate option; added capped option as a kind of vanilla option.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -181,6 +181,19 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller (issuer) of the call option assumes the obligation of delivering the assets specified should the buyer exercise the option.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-opt;CappedOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasCapPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">capped option</rdfs:label>
+		<skos:definition xml:lang="en">option with an established profit cap or cap price</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The cap price is equal to the option&apos;s strike price plus a cap interval for a call option or the strike price minus a cap interval for a put option. A capped option is automatically exercised when the underlying security closes at or above (for a call) or at or below (for a put) the option&apos;s cap price.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-opt;EquityOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
@@ -197,6 +210,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;ExoticOption">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OverTheCounterInstrument"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:label xml:lang="en">exotic option</rdfs:label>
 		<skos:definition xml:lang="en">option that has a non-standard payout structure or other feature</skos:definition>
@@ -451,6 +465,14 @@
 		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionPremium"/>
 		<skos:definition xml:lang="en">indicates a calculated price as of some relative date considered the market value of the option at that point in time</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en">has premium</fibo-fnd-utl-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasCapPrice">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
+		<rdfs:label xml:lang="en">has cap price</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+		<skos:definition xml:lang="en">price at which the contract may be exercised</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasExercisePrice">

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
+	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -40,6 +41,7 @@
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
+	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -89,6 +91,7 @@
 		<sm:filename>Options.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
@@ -117,7 +120,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20210601/DerivativesContracts/Options.rdf version of this ontology was revised to add an expiration date as an important property of an option.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20210901/DerivativesContracts/Options.rdf version of this ontology was revised to correct a restriction on an option with respect to an optional option premium which was not well-formed, and modified the definition of interest rate option to reflect a benchmark, and to be a specialization of vanilla option.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20211201/DerivativesContracts/Options.rdf version of this ontology was revised to make certain values subclasses of MonetaryAmount instead of MonetaryMeasure.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20220101/DerivativesContracts/Options.rdf version of this ontology was revised to add an explanatory note to basket option and make it a kind of exotic option.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20220101/DerivativesContracts/Options.rdf version of this ontology was revised to add an explanatory note to basket option and make it a kind of exotic option and added interest rate derivative as the parent of interest rate option.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -229,6 +232,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;InterestRateOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;InterestRateDerivativeInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

1. Modified the ontology prefix from fibo-der-der-exo to fibo-der-drc-exo in line with the released ontologies in this module; 
2.  Added a number of exotic options, including barrier option, knock-in option, knock-out option, double barrier option, forward start option and cliquet option; 
3. Added details to the definition of Asian option and chooser option per the notes in the JIRA issue
4. Revised the definition of basket option in the main options ontology to make it an exotic option
5. Added several additional exotic options, including digital, commodore, compound, and lookback options

Fixes: #1780 / DER-122


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


