### PR TITLE
DER-131 - Augment the exotic options ontology with properties for Barrier and Asian Options

### DIFF
--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -22,6 +22,8 @@
 	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
 	<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/">
+	<!ENTITY fibo-sec-sec-cls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -52,6 +54,8 @@
 	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
 	xmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"
+	xmlns:fibo-sec-sec-cls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -80,6 +84,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
@@ -90,16 +95,59 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-drc-exo;ArithmeticCalculationStrategy">
+		<rdf:type rdf:resource="&fibo-der-drc-exo;AveragingStrategy"/>
+		<rdfs:label>arithmetic calculation strategy</rdfs:label>
+		<rdfs:seeAlso rdf:resource="&fibo-fnd-utl-alx;ArithmeticMean"/>
+		<skos:definition>strategy that uses an arithmetic mean calculation</skos:definition>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;AsianOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-exo;AsianOptionClassifier"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-exo;AveragingStrategy"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;usesCurrencyInAveraging"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasAsianTailPeriod"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-ex;hasExerciseDate"/>
 				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;usesWeightedAverage"/>
+				<owl:onDataRange rdf:resource="&xsd;boolean"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -111,17 +159,40 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These options allow the buyer to purchase (or sell) the underlying asset at the average price instead of the spot price. There are various ways to interpret the word &apos;average,&apos; and that needs to be specified in the options contract. Typically, the average price is a geometric or arithmetic average of the price of the underlying asset at discreet intervals, which are also specified in the options contract. Because of the averaging feature, Asian options reduce the volatility inherent in the option; therefore, Asian options are typically cheaper than European or American options. They are used by traders who are exposed to the underlying asset over some time, such as consumers and suppliers of commodities, etc.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-exo;BarrierFeatureEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
+	<owl:Class rdf:about="&fibo-der-drc-exo;AsianOptionClassifier">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:onClass rdf:resource="&fibo-ind-ind-ind;MarketRate"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;AsianOption"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">barrier feature event</rdfs:label>
-		<skos:definition xml:lang="en">event that defines when an option feature comes into effect</skos:definition>
+		<rdfs:label>Asian option classifier</rdfs:label>
+		<skos:definition>financial instrument classifier that classifies Asian options based on whether they are rate-based or price based</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-drc-exo;AverageRate">
+		<rdf:type rdf:resource="&fibo-der-drc-exo;AsianOptionClassifier"/>
+		<rdfs:label>average rate classification</rdfs:label>
+		<skos:definition>Asian option classifier indicating that the payoff is based on the difference between a fixed strike price and the calculated average price of the underlying</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-drc-exo;AverageStrike">
+		<rdf:type rdf:resource="&fibo-der-drc-exo;AsianOptionClassifier"/>
+		<rdfs:label>average strike classification</rdfs:label>
+		<skos:definition>Asian option classifier indicating that the payoff is based on the difference between the price of the underlying at expiration and a strike price equal to the calculated average price of the underlying issue</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-der-drc-exo;AveragingStrategy">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;AsianOption"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">averaging strategy</rdfs:label>
+		<skos:definition xml:lang="en">method used for calculating the average rate or price</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;BarrierOption">
@@ -142,12 +213,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-exo;isAboveStrikePrice"/>
 				<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;BarrierFeatureEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">barrier option</rdfs:label>
@@ -336,6 +401,13 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Forward start options typically attempt to keep future strike prices at the money or near the money. In this way, the holder will have the right, but not the obligation, to buy (call) or sell (put) the underlying asset in the future at or near the then-current market price. Knowing where the strike price will be in relation to the underlying&apos;s price makes it easier to come up with the premium (cost) of the option, which is also typically determined and paid at the initiation of the contract prior to the activation date. If, at the expiration date, the underlying trades below the strike price of the option (for a call), then it expires worthless. If the underlying is above the strike (for a call), then the holder exercises it and owns the underlying at the strike price. For a put option, if the underlying is below the strike price, the option has value and will be sold or exercised to realize a gain. If the underlying is above the strike price, the option will expire worthless. Typically, as with most options, the holder may sell the option if it is in the money and take the cash instead of exercising the option. Since it is an exotic option, the seller and buyer of the option may also agree to settle the option with cash instead of delivering the underlying. Once a forward start option becomes active (strike price is set), then the option is valued like a vanilla option.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The only unknown for the contract is the strike price. In terms of pricing the contract, the future price of the underlying asset is also unknown. The contract typically stipulates some parameters for where the strike price will be in relation to the underlying asset&apos;s price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-drc-exo;GeometricCalculationStrategy">
+		<rdf:type rdf:resource="&fibo-der-drc-exo;AveragingStrategy"/>
+		<rdfs:label>geometric calculation strategy</rdfs:label>
+		<rdfs:seeAlso rdf:resource="&fibo-fnd-utl-alx;GeometricMean"/>
+		<skos:definition>strategy that uses an geometric mean calculation</skos:definition>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;InterestRateCapOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;InterestRateOption"/>
@@ -533,6 +605,14 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en">swap option</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasAsianTailPeriod">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDatePeriod"/>
+		<rdfs:label xml:lang="en">has Asian tail period</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;AsianOption"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
+		<skos:definition xml:lang="en">window of time during which averaging of the price of the underlying contract is effective</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasExerciseDateOffset">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
 		<rdfs:label xml:lang="en">has exercise date offset</rdfs:label>
@@ -632,11 +712,18 @@
 		<skos:definition xml:lang="en">indicates whether the barrier is crossed when the price of the underlier is above (or below, if not) the strike price (threshold)</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-exo;threshold">
-		<rdfs:label xml:lang="en">threshold</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-exo;BarrierFeatureEvent"/>
-		<rdfs:range rdf:resource="&xsd;decimal"/>
-		<skos:definition xml:lang="en">The price or other variable (as a number) which has to be met for the event to be deemed to have occurred.</skos:definition>
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;usesCurrencyInAveraging">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
+		<rdfs:label xml:lang="en">uses currency in averaging</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+		<skos:definition xml:lang="en">indicates the currency used in averaging calculation</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-exo;usesWeightedAverage">
+		<rdfs:label xml:lang="en">uses weighted average</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;AsianOption"/>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition xml:lang="en">indicates whether a weighted average is being used to calculate the average rate or strike price</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;OptionPremium">

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -685,7 +685,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasSecondRebateAmount">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
-		<rdfs:label xml:lang="en">has first rebate amount</rdfs:label>
+		<rdfs:label xml:lang="en">has second rebate amount</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
 		<skos:definition xml:lang="en">indicates the percentage of the premium paid by the holder in the case of a double barrier option</skos:definition>
 	</owl:ObjectProperty>

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -128,6 +128,24 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasMonitoringFrequency"/>
+				<owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasMonitoringPeriod"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;DatePeriod"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;isAboveStrikePrice"/>
+				<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;BarrierFeatureEvent"/>
 			</owl:Restriction>
@@ -227,6 +245,32 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;DoubleBarrierOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasFirstRebateAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasSecondRebateAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasFirstBarrierPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasSecondBarrierPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">double barrier option</rdfs:label>
 		<skos:definition xml:lang="en">barrier option applied to currencies or over the counter stocks that works as a binary, or digital option in that it pays out only under defined circumstances, or it is worthless, at expiration</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Considered an exotic option, a double barrier option is a combination of two single barrier options, with one barrier above and one barrier below the current price of the underlying. It is a bet by the holder that the underlying asset will move significantly, in the case of a knock-in barrier option, or will move by a very small amount, in the case of a knock-out barrier option, over the life of the contract. Traders use these options when they have an opinion on volatility but not on the direction of the underlying asset&apos;s next price move. A barrier option is a type of option where the payoff, and the very existence of the option, depends on whether or not the underlying asset reaches a predetermined price.</fibo-fnd-utl-av:explanatoryNote>
@@ -311,6 +355,19 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;KnockInOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasFirstRebateAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasFirstBarrierPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">knock-in option</rdfs:label>
 		<skos:definition xml:lang="en">barrier option is not an option until a certain price is met</skos:definition>
 		<skos:example xml:lang="en">Assume an investor purchases a knock-in put option with a down Direction, with a barrier price of $90 and a strike price of $100. The underlying security is trading at $110, and the option expires in three months. If the price of the underlying security reaches $90, the option comes into existence and becomes a vanilla option with a strike price of $100. Thereafter, the holder of the option has the right to sell the underlying asset at the strike price of $100, even though it is trading below $90. It is this right that gives the option value. The put option remains active until the expiration date, even if the underlying security rebounds back above $90. However, if the underlying asset does not fall below the barrier price during the life of the contract, the down-and-in option expires worthless. Just because the barrier is reached does not assure a profit on the trade since the underlying would need to stay below $100 (after triggering the barrier) in order for the option to have value.</skos:example>
@@ -319,6 +376,19 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;KnockOutOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasFirstRebateAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasFirstBarrierPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">knock-out option</rdfs:label>
 		<skos:definition xml:lang="en">barrier option with a built-in mechanism to expire worthless if a specified price level in the underlying asset is reached</skos:definition>
 		<skos:example xml:lang="en">Assume an investor purchases a Knock-Out call option with a down Direction, also called a &apos;Down and Out Option&apos;, on a stock that is trading at $60 with a strike price of $55 and a barrier of $50. Assume the stock trades below $50, at any time, before the call option expires. Therefore, the down-and-out call option promptly ceases to exist.</skos:example>
@@ -471,6 +541,22 @@
 		<skos:definition xml:lang="en">indicates the period in days between the reset date and the exercise date</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasFirstBarrierPrice">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
+		<rdfs:label xml:lang="en">has first barrier price</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+		<skos:definition xml:lang="en">has price (or level) that activates or deactivates the option</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For a double barrier option, this is the level of the first barrier. Otherwise it is the only barrier price.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasFirstRebateAmount">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
+		<rdfs:label xml:lang="en">has first rebate amount</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
+		<skos:definition xml:lang="en">indicates the percentage of the premium paid by the holder for the option</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Both knock-out and knock-in barrier options can contain a provision to provide rebates to holders, if the option does not reach the barrier price and becomes worthless.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasInterestAccrualDateOffset">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
 		<rdfs:label xml:lang="en">has interest accrual date offset</rdfs:label>
@@ -487,12 +573,41 @@
 		<skos:definition xml:lang="en">window of time during which the lookback is effective</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-exo;hasMonitoringFrequency">
+		<rdfs:label xml:lang="en">has monitoring frequency</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:range rdf:resource="&xsd;positiveInteger"/>
+		<skos:definition xml:lang="en">has frequency with respect to how often, in days, the asset price is checked to see if the barrier has been breached</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasMonitoringPeriod">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDatePeriod"/>
+		<rdfs:label xml:lang="en">has monitoring period</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
+		<skos:definition xml:lang="en">window of time during which pricing is monitored</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasOptionTypeElectionDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label xml:lang="en">has option type election date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-exo;ChooserOption"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition xml:lang="en">indicates the date on which the holder of the chooser option contract determines a choice of either a call or a put</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasSecondBarrierPrice">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
+		<rdfs:label xml:lang="en">has second barrier price</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+		<skos:definition xml:lang="en">has price (or level) that the second barrier activates or deactivates in the case of a double barrier option</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasSecondRebateAmount">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
+		<rdfs:label xml:lang="en">has first rebate amount</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
+		<skos:definition xml:lang="en">indicates the percentage of the premium paid by the holder in the case of a double barrier option</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasSettlementDateOffset">
@@ -509,6 +624,13 @@
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
 		<skos:definition xml:lang="en">strike price or level expressed as a percentage of the value of the underlying asset</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-der-drc-exo;isAboveStrikePrice">
+		<rdfs:label xml:lang="en">is above strike price</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition xml:lang="en">indicates whether the barrier is crossed when the price of the underlier is above (or below, if not) the strike price (threshold)</skos:definition>
+	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-exo;threshold">
 		<rdfs:label xml:lang="en">threshold</rdfs:label>

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -135,7 +135,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-exo;hasMonitoringPeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;DatePeriod"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

1. Augmented the definition of a barrier option with a number of properties, including those that apply specifically to knock-in, knock-out, and double barrier options
2. Augmented the definition of an Asian option with a couple of classifiers and several properties to complete coverage

Fixes: #1807 / DER-131


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


