### PR TITLE
DER-123 - We need to add Option Trading Strategies under Options

### DIFF
--- a/DER/DerivativesContracts/DerivativesBasics.rdf
+++ b/DER/DerivativesContracts/DerivativesBasics.rdf
@@ -78,8 +78,8 @@
 		<dct:abstract>This ontology defines basic terminology common to derivative and over-the-counter (OTC) contracts.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
@@ -114,12 +114,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20210801/DerivativesContracts/DerivativesBasics/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/DerivativesBasics/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and eliminate a redundant subclass declaration in observable value.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200401/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to loosen the domain of the hasUnderlier property, which could be either an instrument or leg, refine the definition of Underlier and hasUnderlier based on recent work on swaps, add the definition of a contract for difference (CFD), simplify the contract party hierarchy where the subclasses of contract party do not add semantics, add the concepts of underlying asset valuation and calculation agent, which are needed for various derivatives (moved from forwards) and eliminate the language related to transactions as well as the distinction between an OTC contract and exchange-traded contract / listed security, given how blurry the lines are today, across derivatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to eliminate hasThirdParty as a superproperty of hasCalculationAgent, which led to unintended reasoning consequences, added concepts and properties specific to settlement and valuation required for futures, forwards, and options, and moved general properties from forwards and swaps up to derivatives basics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to replace hasContractSize with hasLotSize.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210501/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to move designated contract market to the markets ontology in FBC and eliminate the notion of NonPhysicalUnderlier, which was determined to add unnecessary overhead.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to address text formatting issues identified via hygiene testing.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -201,7 +202,7 @@
 		<skos:definition>clearing house that enables parties to substitute the credit of the DCO for the credit of the parties</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>DCO</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.cftc.gov/IndustryOversight/ClearingOrganizations/index.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Substitution may be done through contract novation, for example.  A derivatives clearing organization (DCO) also arranges or provides, on a multilateral basis, for the settlement or netting of obligations, or otherwise provides clearing services or arrangements that mutualize or transfer credit risk among participants.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Substitution may be done through contract novation, for example. A derivatives clearing organization (DCO) also arranges or provides, on a multilateral basis, for the settlement or netting of obligations, or otherwise provides clearing services or arrangements that mutualize or transfer credit risk among participants.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;IntroducingBroker">
@@ -219,7 +220,7 @@
 		<rdfs:label>observable value</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Fair_value"/>
 		<skos:definition>value for something discernible and for which evidence can be obtained</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Derivatives, such as certain exotics, can be based on values ascribed to virtually anything, including weather.  Typically, however, an observable value refers to something that can be readily observed in the marketplace, such as a quoted rate (e.g., interest rate, exchange rate), index value, commodity price, stock price, economic indicator, or something similar as of some point in time.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Derivatives, such as certain exotics, can be based on values ascribed to virtually anything, including weather. Typically, however, an observable value refers to something that can be readily observed in the marketplace, such as a quoted rate (e.g., interest rate, exchange rate), index value, commodity price, stock price, economic indicator, or something similar as of some point in time.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;OverTheCounterInstrument">

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -192,7 +192,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">averaging strategy</rdfs:label>
-		<skos:definition xml:lang="en">method used for calculating the average rate or price</skos:definition>
+		<skos:definition xml:lang="en">method used for calculating the average rate or price of an Asian option</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-exo;BarrierOption">
@@ -543,25 +543,6 @@
 		<skos:definition xml:lang="en">observed value of the underlying asset as of some date during the lookback period that is considered the best value from the perspective of the option holder during the lookback period (depending on whether the option is a call or put)</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-exo;OptionPremiumFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
-		<rdfs:label xml:lang="en">option premium formula</rdfs:label>
-		<skos:definition xml:lang="en">expression used to calculate the premium based either on the price per option or percentage of the notional amount</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-exo;OptionStripStrategy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option strip strategy</rdfs:label>
-		<skos:definition xml:lang="en">A strip or sequential set of options with periodic reset dates, such that each period between resets behaves like an individual option (known as a Caplet or Floorlet).</skos:definition>
-		<skos:editorialNote xml:lang="en">The defining fact is that it is a set of sequential options. So in principal this is a strip of any kind of option. Can you strip forwards? In principal, but usually you would have a Commodity Swap which would be a strip of Forwards. Other strips? Don&apos;t always buy a string of caplets and floorlets but buy an individual cap or floor. for IR Options These are always Caps or Floors, that is the option settlement takes the form of the difference between the Strike rate and the designated underlying (observable) rate on the stated dates. Review notes: caps and floors are always strips, but there are strips for other assets as well. SO: There are strips besides Options; There are Option Strips besides IR (Cap and Floor) ones. See eg. in France where you may have a strip of options where the strike is set at each rollover. Details to come by email. In this case it would be an asset option, specifically Equity.</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-exo;ProjectedValueAtMaturity">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;CalculatedPrice"/>
 		<rdfs:subClassOf>
@@ -613,14 +594,6 @@
 		<skos:definition xml:lang="en">window of time during which averaging of the price of the underlying contract is effective</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasExerciseDateOffset">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
-		<rdfs:label xml:lang="en">has exercise date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
-		<skos:definition xml:lang="en">indicates the period in days between the reset date and the exercise date</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasFirstBarrierPrice">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
 		<rdfs:label xml:lang="en">has first barrier price</rdfs:label>
@@ -635,14 +608,6 @@
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
 		<skos:definition xml:lang="en">indicates the percentage of the premium paid by the holder for the option</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Both knock-out and knock-in barrier options can contain a provision to provide rebates to holders, if the option does not reach the barrier price and becomes worthless.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasInterestAccrualDateOffset">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
-		<rdfs:label xml:lang="en">has interest accrual date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
-		<skos:definition xml:lang="en">indicates the period in days between each reset date and the commencement of interest accrual for the next period</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasLookbackPeriod">
@@ -690,14 +655,6 @@
 		<skos:definition xml:lang="en">indicates the percentage of the premium paid by the holder in the case of a double barrier option</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasSettlementDateOffset">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
-		<rdfs:label xml:lang="en">has settlement date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-exo;OptionStripStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
-		<skos:definition xml:lang="en">indicats the period in days between each reset date and the corresponding settlement date</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-exo;hasStrikePercentageAmount">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
 		<rdfs:label xml:lang="en">has strike percentage amount</rdfs:label>
@@ -725,15 +682,5 @@
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">indicates whether a weighted average is being used to calculate the average rate or strike price</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:Class rdf:about="&fibo-der-drc-opt;OptionPremium">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasExpression"/>
-				<owl:onClass rdf:resource="&fibo-der-drc-exo;OptionPremiumFormula"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -216,6 +216,26 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The cap price is equal to the option&apos;s strike price plus a cap interval for a call option or the strike price minus a cap interval for a put option. A capped option is automatically exercised when the underlying security closes at or above (for a call) or at or below (for a put) the option&apos;s cap price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-opt;Collar">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;CallOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;PutOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">collar</rdfs:label>
+		<skos:definition xml:lang="en">option trading strategy that involves buying a downside put and selling an upside call that is implemented to protect against large losses, but which also limits large upside gains</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-opt;CondorSpread">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
 		<rdfs:label xml:lang="en">condor spread</rdfs:label>
@@ -301,7 +321,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;IronButterfly">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;Butterfly"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
@@ -470,7 +490,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option trading strategy</rdfs:label>
 		<skos:definition xml:lang="en">trading tactic involving more than one option type, strike price, or expiration date on the same underlying asset</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that some trading strategies, such as a protective put, may be considered financial instruments in their own right, but most strategies are not. The critical differentiators include whether the strategy itself can be traded, whether it has a financial instrument identifier independently from the identifier(s) of the embedded instrument(s), such as a FIGI or ISIN, and so forth.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that some trading strategies may be considered financial instruments in their own right, but most strategies are not. The critical differentiators include whether the strategy itself can be traded, whether it has a financial instrument identifier independently from the identifier(s) of the embedded instrument(s), such as a FIGI or ISIN, and so forth.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Option trading strategies refer to buying calls or put options or selling calls or put options or both together for the purpose of limiting losses and/or optimizing profits. Basically, these strategies utilize one or more combinations for the best outcome possible based on defined parameters. Simple combinations include option spread trades such as vertical spreads, calendar (or horizontal) spreads, and diagonal spreads. More involved combinations include trades such as condor or butterfly spreads which are actually combinations of two vertical spreads.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -542,7 +562,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">stradle</rdfs:label>
-		<skos:definition xml:lang="en">neutral options strategy that involves simultaneously buying both a put option and a call option for the underlying security with the same strike price and the same expiration date</skos:definition>
+		<skos:definition xml:lang="en">neutral option trading strategy that involves simultaneously buying both a put option and a call option for the underlying security with the same strike price and the same expiration date</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The strategy is profitable only when the value of the underlier varies (rises or falls) from the strike price by more than the total premium paid.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -563,7 +583,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">strangle</rdfs:label>
-		<skos:definition xml:lang="en">strategy in which the investor holds a position in both a call and a put option with different strike prices, but with the same expiration date and underlying asset</skos:definition>
+		<skos:definition xml:lang="en">option trading strategy in which the investor holds a position in both a call and a put option with different strike prices, but with the same expiration date and underlying asset</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A strangle is a good strategy if you think the underlying security will experience a large price movement in the near future but are unsure of the direction. However, it is profitable mainly if the asset swings sharply in price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -582,9 +602,9 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option strip strategy</rdfs:label>
-		<skos:definition xml:lang="en">trading strategy that involves a sequential set of options with periodic reset dates, such that each period between resets behaves like an individual option</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The period between resets may be called a Caplet or Floorlet.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label xml:lang="en">strip strategy</rdfs:label>
+		<skos:definition xml:lang="en">option trading strategy that involves a sequential set of options with periodic reset dates, such that each period between resets behaves like an individual option</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically, a strip is a strategy that involves being long in one call position and two put options, all with the same strike price on a single underlying stock. The investor who adopts this strategy believes that the underlying price of the stock will plummet in the near-term future. All three of the options will have the same expiration date and the same strike price. If the investor is correct and the price drastically decreases, the puts will pay out substantially. If the investor is wrong and the price of the underlying asset increases, the call option will mitigate the loss. The period between resets may be called a Caplet or Floorlet.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;VanillaOption">

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -550,7 +550,7 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">collar</rdfs:label>
+		<rdfs:label xml:lang="en">protective collar</rdfs:label>
 		<skos:definition xml:lang="en">collar that consists of a covered call and protective put</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A protective collar consists of a long position in the underlying security, a put option purchased to hedge the downside risk on a stock, a call option written on the stock to finance the put purchase.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -243,6 +243,12 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are two types of condor spreads. A long condor seeks to profit from low volatility and little to no movement in the underlying asset. A short condor seeks to profit from high volatility and a sizable move in the underlying asset in either direction. A Condor Spread uses either all calls or all puts.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-opt;CoveredCall">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;CallOption"/>
+		<rdfs:label xml:lang="en">covered call</rdfs:label>
+		<skos:definition xml:lang="en">call option in which the seller (investor) owns an equivalent amount of the underlying security</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-opt;EquityOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
@@ -274,6 +280,32 @@
 		<skos:definition xml:lang="en">measure of the difference between the market price of an option, called the premium, and its intrinsic value</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Extrinsic value is also the portion of the worth that has been assigned to an option by factors other than the underlying asset&apos;s price. The opposite of extrinsic value is intrinsic value, which is the inherent worth of an option.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en">option time value</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-opt;Fence">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;CallOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;PutOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">fence</rdfs:label>
+		<skos:definition xml:lang="en">option trading strategy that uses options to limit the range of possible returns on a financial instrument</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A fence consists of the following elements:
+- long position in a financial instrument (e.g., a share, index or currency)
+- long put (normally with a strike price close to or at the current spot price of the financial instrument)
+- short put (with a strike price lower than the bought put - e.g., 80% of the current spot price)
+- short call (with a strike price higher than the current spot price).</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The expiration dates of all the options are usually the same. The call strike is normally chosen in such a way that the sum total of the three option premiums is equal to zero. This investment strategy will ensure that the value of the investment at expiry will be between the strike price on the short call and the strike price on the long put. Thus, possible gains and losses (the value of the financial instrument minus the cost of acquiring it) are confined to a specified range. However, if the price of the financial instrument falls below the strike level of the sold put the investor will start participating in any further price declines of the financial instrument.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;FixedIncomeOption">
@@ -502,12 +534,68 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An OTM call option will have a strike price that is higher than the market price of the underlying asset. Alternatively, an OTM put option has a strike price that is lower than the market price of the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
+	<owl:Class rdf:about="&fibo-der-drc-opt;ProtectiveCollar">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;Collar"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;CoveredCall"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;ProtectivePut"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">collar</rdfs:label>
+		<skos:definition xml:lang="en">collar that consists of a covered call and protective put</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A protective collar consists of a long position in the underlying security, a put option purchased to hedge the downside risk on a stock, a call option written on the stock to finance the put purchase.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-opt;ProtectivePut">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;PutOption"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasCalculatedMarketValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-opt;OptionPremium"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">protective put</rdfs:label>
+		<skos:definition xml:lang="en">put option giving the buyer (holder) the right, but not the obligation, to sell the assets specified at with a strike price equal or close to the current price of the underlying asset, on or before a specified date</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A protective put is a risk management and options strategy that involves holding a long position in the underlying asset (e.g., stock). A protective put strategy is analogous to the nature of insurance. The main goal of a protective put is to limit potential losses that may result from an unexpected price drop of the underlying asset</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">synthetic call</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-opt;PutOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:label xml:lang="en">put option</rdfs:label>
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to sell the assets specified at a fixed price or formula, on or before a specified date</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The seller of the put option assumes the obligation of buying the assets specified should the buyer exercise the option.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-opt;RiskReversal">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;CallOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;PutOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">risk reversal</rdfs:label>
+		<skos:definition xml:lang="en">option trading strategy that consists of being short (selling) an out of the money put and being long (i.e., buying) an out of the money call, both with the same maturity</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A risk reversal is a position which simulates profit and loss behavior of owning an underlying security; therefore, it is sometimes called a synthetic long. This is an investment strategy that amounts to both buying and selling out-of-money options simultaneously. In this strategy, the investor will first make a market hunch; if that hunch is bullish, he will want to go long. However, instead of going long on the stock, he will buy an out of the money call option, and simultaneously sell an out of the money put option. Presumably he will use the money from the sale of the put option to purchase the call option. Then as the stock goes up in price, the call option will be worth more, and the put option will be worth less.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;StandardizedOptionsTerms">
@@ -596,6 +684,20 @@
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;StripStrategy">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;CallOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;PutOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -395,6 +395,13 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasExpression"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;OptionPremiumFormula"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -412,6 +419,12 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The option premium is the income received by the seller (writer) of an option contract to another party. In-the-money option premiums are composed of two factors: intrinsic and extrinsic value. Out-of-the-money options&apos; premiums consist solely of extrinsic value. For stock options, the premium is quoted as a dollar amount per share, and most contracts represent the commitment of 100 shares.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-opt;OptionPremiumFormula">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+		<rdfs:label xml:lang="en">option premium formula</rdfs:label>
+		<skos:definition xml:lang="en">expression used to calculate the premium based either on the price per option or percentage of the notional amount</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-opt;OptionTradingStrategy">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;TradingStrategy"/>
 		<rdfs:subClassOf>
@@ -422,7 +435,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option trading strategy</rdfs:label>
 		<skos:definition xml:lang="en">trading tactic involving more than one option type, strike price, or expiration date on the same underlying asset</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that some trading strategies are considered financial instruments in their own right, but others are not. Those that are actual financial instruments are modeled as both strategies and options. The critical differentiators include whether the strategy itself can be traded, whether it has a financial instrument identifier independently from the identifier(s) of the embedded instrument(s), such as a FIGI or ISIN, and so forth.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that some trading strategies, such as a protective put, may be considered financial instruments in their own right, but most strategies are not. The critical differentiators include whether the strategy itself can be traded, whether it has a financial instrument identifier independently from the identifier(s) of the embedded instrument(s), such as a FIGI or ISIN, and so forth.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Option trading strategies refer to buying calls or put options or selling calls or put options or both together for the purpose of limiting losses and/or optimizing profits. Basically, these strategies utilize one or more combinations for the best outcome possible based on defined parameters. Simple combinations include option spread trades such as vertical spreads, calendar (or horizontal) spreads, and diagonal spreads. More involved combinations include trades such as condor or butterfly spreads which are actually combinations of two vertical spreads.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -526,6 +539,19 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For call options, the strike price is the price at which the security may be purchased by the option holder; for put options, the strike price is the price at which the security may be sold.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-opt;StripStrategy">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">option strip strategy</rdfs:label>
+		<skos:definition xml:lang="en">trading strategy that involves a sequential set of options with periodic reset dates, such that each period between resets behaves like an individual option (known as a Caplet or Floorlet).</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The period between resets may be called a Caplet or Floorlet.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-opt;VanillaOption">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:subClassOf>
@@ -562,6 +588,14 @@
 		<skos:definition xml:lang="en">price at which the contract may be exercised</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasExerciseDateOffset">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
+		<rdfs:label xml:lang="en">has exercise date offset</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-drc-opt;StripStrategy"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
+		<skos:definition xml:lang="en">indicates the period in days between the reset date and the exercise date</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasExercisePrice">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
 		<rdfs:label xml:lang="en">has exercise price</rdfs:label>
@@ -587,6 +621,14 @@
 		<skos:definition>indicates the exercise convention specified for the option</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasInterestAccrualDateOffset">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
+		<rdfs:label xml:lang="en">has interest accrual date offset</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-drc-opt;StripStrategy"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
+		<skos:definition xml:lang="en">indicates the period in days between each reset date and the commencement of interest accrual for the next period</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasOptionHolder">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
 		<rdfs:label>has option holder</rdfs:label>
@@ -602,6 +644,21 @@
 		<rdfs:range rdf:resource="&fibo-der-drc-opt;OptionIssuer"/>
 		<skos:definition>indicates the issuer of the option</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically, the option writer collects the premium when the option is initially sold.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasSettlementDateOffset">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
+		<rdfs:label xml:lang="en">has settlement date offset</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-drc-opt;StripStrategy"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
+		<skos:definition xml:lang="en">indicats the period in days between each reset date and the corresponding settlement date</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasStrikePercentageAmount">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
+		<rdfs:label xml:lang="en">has strike percentage amount</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
+		<skos:definition xml:lang="en">indicates a strike price or level expressed as a percentage of the value of the underlying asset</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasStrikeRate">

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -216,6 +216,13 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The cap price is equal to the option&apos;s strike price plus a cap interval for a call option or the strike price minus a cap interval for a put option. A capped option is automatically exercised when the underlying security closes at or above (for a call) or at or below (for a put) the option&apos;s cap price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-opt;CondorSpread">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:label xml:lang="en">condor spread</rdfs:label>
+		<skos:definition xml:lang="en">non-directional options strategy that limits both gains and losses while seeking to profit from either low or high volatility</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are two types of condor spreads. A long condor seeks to profit from low volatility and little to no movement in the underlying asset. A short condor seeks to profit from high volatility and a sizable move in the underlying asset in either direction. A Condor Spread uses either all calls or all puts.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-opt;EquityOption">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;VanillaOption"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
@@ -313,6 +320,34 @@
 		<skos:definition xml:lang="en">butterfly strategy that consists of two call options and two put options, three strike prices and the same expiration date</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The key to using this trade as part of a successful trading strategy is to forecast a time when option prices are likely to decline in value generally. This usually occurs during periods of sideways movement or a mild upward trend.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en">iron fly</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-opt;IronCondor">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;CondorSpread"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;CallOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;PutOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasExercisePrice"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;StrikePrice"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">4</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">iron condor</rdfs:label>
+		<skos:definition xml:lang="en">condor strategy consisting of two puts (one long and one short) and two calls (one long and one short), and four strike prices, all with the same expiration date</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The iron condor earns the maximum profit when the underlying asset closes between the middle strike prices at expiration. In other words, the goal is to profit from low volatility in the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;LongTermEquityAnticipationSecurity">
@@ -548,7 +583,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option strip strategy</rdfs:label>
-		<skos:definition xml:lang="en">trading strategy that involves a sequential set of options with periodic reset dates, such that each period between resets behaves like an individual option (known as a Caplet or Floorlet).</skos:definition>
+		<skos:definition xml:lang="en">trading strategy that involves a sequential set of options with periodic reset dates, such that each period between resets behaves like an individual option</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The period between resets may be called a Caplet or Floorlet.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -514,7 +514,7 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">stradle</rdfs:label>
+		<rdfs:label xml:lang="en">strangle</rdfs:label>
 		<skos:definition xml:lang="en">strategy in which the investor holds a position in both a call and a put option with different strike prices, but with the same expiration date and underlying asset</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A strangle is a good strategy if you think the underlying security will experience a large price movement in the near future but are unsure of the direction. However, it is profitable mainly if the asset swings sharply in price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -116,11 +116,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220701/DerivativesContracts/Options/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/Options/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20210601/DerivativesContracts/Options.rdf version of this ontology was revised to add an expiration date as an important property of an option.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20210901/DerivativesContracts/Options.rdf version of this ontology was revised to correct a restriction on an option with respect to an optional option premium which was not well-formed, and modified the definition of interest rate option to reflect a benchmark, and to be a specialization of vanilla option.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20211201/DerivativesContracts/Options.rdf version of this ontology was revised to make certain values subclasses of MonetaryAmount instead of MonetaryMeasure.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20220101/DerivativesContracts/Options.rdf version of this ontology was revised to add an explanatory note to basket option and make it a kind of exotic option and added interest rate derivative as the parent of interest rate option; added capped option as a kind of vanilla option.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/DER/20220701/DerivativesContracts/Options.rdf version of this ontology was revised to add the most common options trading strategies.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -158,7 +159,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">basket option</rdfs:label>
 		<skos:definition xml:lang="en">option whose underlying asset is a group, or basket, of commodities, securities, indices, or currencies</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As with other options, a basket option gives the holder the right, but not the obligation, to buy or sell the basket at a specific price, on or before a certain date.  This exotic option has all the characteristics of a standard option, but with the basis of the strike price on the weighted value of its components. Currency baskets are the most popular type of basket option, and they will settle in the holder&apos;s home currency. Because it involves just one transaction, a basket option often costs less than multiple single options as it saves on commissions and fees.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As with other options, a basket option gives the holder the right, but not the obligation, to buy or sell the basket at a specific price, on or before a certain date. This exotic option has all the characteristics of a standard option, but with the basis of the strike price on the weighted value of its components. Currency baskets are the most popular type of basket option, and they will settle in the holder&apos;s home currency. Because it involves just one transaction, a basket option often costs less than multiple single options as it saves on commissions and fees.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;BondOption">
@@ -171,6 +172,27 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bond option</rdfs:label>
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to buy or sell (depending on whether it is a call or a put) a bond at a certain price on or before a specified date</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-opt;Butterfly">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-opt;hasExercisePrice"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;StrikePrice"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">3</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Option"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">4</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">butterfly</rdfs:label>
+		<skos:definition xml:lang="en">strategy that combines bull and bear spreads with a fixed risk and capped profit</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These spreads are intended as a market-neutral strategy and pay off the most if the underlying asset does not move prior to option expiration. They involve either four calls, four puts, or a combination of puts and calls with three strike prices. Butterfly spreads pay off the most if the underlying asset price doesn&apos;t change before the option expires. The upper and lower strike prices are equal distance from the middle, or at-the-money, strike price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;CallOption">
@@ -206,7 +228,7 @@
 		<rdfs:label xml:lang="en">equity option</rdfs:label>
 		<skos:definition xml:lang="en">option giving the buyer (holder) the right, but not the obligation, to buy (via a call option) or sell (via a put option) the underlying equity assets specified at a pre-determined price (i.e., the strike price, fixed or calculated), on or before a specified date (the expiration date)</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For an Equity Option, one contract represents 100 shares of stock.  Equity options settle in &apos;American style&apos;.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For an Equity Option, one contract represents 100 shares of stock. Equity options settle in &apos;American style&apos;.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;ExoticOption">
@@ -269,6 +291,28 @@
 		<rdfs:label xml:lang="en">intrinsic value</rdfs:label>
 		<skos:definition xml:lang="en">measure of what an asset is worth, i.e. with respect to its current price</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This measure is arrived at by means of an objective calculation or complex financial model. In financial analysis this term is used in conjunction with the work of identifying, as nearly as possible, the underlying value of a company and its cash flow. In options pricing it refers to the difference between the strike price of the option and the current price of the underlying asset.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-opt;IronButterfly">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;CallOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;PutOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">iron butterfly</rdfs:label>
+		<skos:definition xml:lang="en">butterfly strategy that consists of two call options and two put options, three strike prices and the same expiration date</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The key to using this trade as part of a successful trading strategy is to forecast a time when option prices are likely to decline in value generally. This usually occurs during periods of sideways movement or a mild upward trend.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">iron fly</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;LongTermEquityAnticipationSecurity">
@@ -372,13 +416,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;TradingStrategy"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option trading strategy</rdfs:label>
 		<skos:definition xml:lang="en">trading tactic involving more than one option type, strike price, or expiration date on the same underlying asset</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Simple combinations include option spread trades such as vertical spreads, calendar (or horizontal) spreads, and diagonal spreads. More involved combinations include trades such as Condor or Butterfly spreads which are actually combinations of two vertical spreads.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that some trading strategies are considered financial instruments in their own right, but others are not. Those that are actual financial instruments are modeled as both strategies and options. The critical differentiators include whether the strategy itself can be traded, whether it has a financial instrument identifier independently from the identifier(s) of the embedded instrument(s), such as a FIGI or ISIN, and so forth.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Option trading strategies refer to buying calls or put options or selling calls or put options or both together for the purpose of limiting losses and/or optimizing profits. Basically, these strategies utilize one or more combinations for the best outcome possible based on defined parameters. Simple combinations include option spread trades such as vertical spreads, calendar (or horizontal) spreads, and diagonal spreads. More involved combinations include trades such as condor or butterfly spreads which are actually combinations of two vertical spreads.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-der-drc-opt;OutOfTheMoney">
@@ -430,6 +475,48 @@
 		<skos:definition xml:lang="en">standardized contract terms established by a securities or options exchange or by an options clearing entity</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such terms may relate to the underlying instruments, exercise price, expiration date, and contract size, for example.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-opt;Stradle">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;CallOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;PutOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">stradle</rdfs:label>
+		<skos:definition xml:lang="en">neutral options strategy that involves simultaneously buying both a put option and a call option for the underlying security with the same strike price and the same expiration date</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The strategy is profitable only when the value of the underlier varies (rises or falls) from the strike price by more than the total premium paid.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-opt;Strangle">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;CallOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-opt;PutOption"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">stradle</rdfs:label>
+		<skos:definition xml:lang="en">strategy in which the investor holds a position in both a call and a put option with different strike prices, but with the same expiration date and underlying asset</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A strangle is a good strategy if you think the underlying security will experience a large price movement in the near future but are unsure of the direction. However, it is profitable mainly if the asset swings sharply in price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;StrikePrice">

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -545,7 +545,7 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such terms may relate to the underlying instruments, exercise price, expiration date, and contract size, for example.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-opt;Stradle">
+	<owl:Class rdf:about="&fibo-der-drc-opt;Straddle">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;OptionTradingStrategy"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -561,7 +561,7 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">stradle</rdfs:label>
+		<rdfs:label xml:lang="en">straddle</rdfs:label>
 		<skos:definition xml:lang="en">neutral option trading strategy that involves simultaneously buying both a put option and a call option for the underlying security with the same strike price and the same expiration date</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The strategy is profitable only when the value of the underlier varies (rises or falls) from the strike price by more than the total premium paid.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>

--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -93,7 +93,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220201/DerivativesContracts/Swaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/Swaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/Swaps/ version of this ontology was modified to refine the concept of a unique swap identifier (USI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20190201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate the property &apos;hasPaymentSchedule&apos; from this ontology in favor of the equivalent property with the same name from FND, adding concepts related to statistical swaps, and revising definitions to be ISO 704 compliant.</skos:changeNote>
@@ -101,6 +101,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/DerivativesContracts/Swaps/ version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only, facilitate the elimination of the property &apos;mayBeTradedIn&apos;, which was only used in one place and was redundant with the concept of a ListedSecurity / Listing in SEC, and move two properties, hasPayingParty and hasReceivingParty to DerivativesBasics to facilitate wider use.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/Swaps/ version of this ontology was modified to move swap execution facility to the markets ontology in FBC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/Swaps/ version of this ontology was modified to add the concept of a rates swap and the corresponding rate-based leg to facilitate mapping to the CFI standard.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220201/DerivativesContracts/Swaps/ version of this ontology was modified to address text formatting issues identified through hygiene testing.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -219,7 +220,7 @@
 		<rdfs:label xml:lang="en">index return swap</rdfs:label>
 		<skos:definition xml:lang="en">return swap in which payments are based on a fee paid to the seller of the swap and on a floating reference price based on changes in the level of an index from an initial level to a level observed on some valuation date(s)</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISDA Disclosure Annex for Commodity Derivative Transactions. See https://globalmarkets.bnpparibas.com/gm/features/docs/dfdisclosures/ISDA_Commodity_Derivatives_Disclosure_Annex_04_2013.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Payments to the parties may be made either on a periodic basis or on termination of the transaction.  One party will receive a payment based upon the change in the level of the index between two valuation dates (multiplied by the notional amount of the swap), as modified by the fee paid to the seller of the swap. If the level of the index increases, the buyer of the swap will be entitled to a payment based on this performance, as such payment may be reduced (or negated) by the fee paid to the seller of the swap. If the level of the index decreases, the seller of the swap will be entitled to a payment based on this performance, as such payment may be increased by the fee paid to the seller of the swap.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Payments to the parties may be made either on a periodic basis or on termination of the transaction. One party will receive a payment based upon the change in the level of the index between two valuation dates (multiplied by the notional amount of the swap), as modified by the fee paid to the seller of the swap. If the level of the index increases, the buyer of the swap will be entitled to a payment based on this performance, as such payment may be reduced (or negated) by the fee paid to the seller of the swap. If the level of the index decreases, the seller of the swap will be entitled to a payment based on this performance, as such payment may be increased by the fee paid to the seller of the swap.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;MajorSwapParticipant">
@@ -279,7 +280,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;PerformanceBasedVariableLeg"/>
 		<rdfs:label>realized variable leg</rdfs:label>
 		<skos:definition>performance-based leg wherein the payment is netted at maturity rather than periodically</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In this case there is a single payment at maturity/settlement and so there is no stream of cashflows either way.  The other leg of these swaps is implied, and is simply the strike price.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>In this case there is a single payment at maturity/settlement and so there is no stream of cashflows either way. The other leg of these swaps is implied, and is simply the strike price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;ReturnLeg">
@@ -358,7 +359,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;FixedLeg"/>
 		<rdfs:label xml:lang="en">strike leg</rdfs:label>
 		<skos:definition xml:lang="en">swap leg that specifies a fixed amount, &apos;the strike&apos;, quoted at the time of execution</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The fixed amount may be with respect to some variable or a monetary amount.  The realization of a strike leg is not a cashflow per se, but a netting out against the terms defined in the other leg of a statistical swap.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The fixed amount may be with respect to some variable or a monetary amount. The realization of a strike leg is not a cashflow per se, but a netting out against the terms defined in the other leg of a statistical swap.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;Swap">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Augment the options ontology to include well-known trading strategies and integrate strategies that are currently in the exotic options ontology

Fixes: #1811 / DER-123


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


