### PR TITLE
SEC-175 - Augment the definition of an ADR to describe Chinese ADRs

### DIFF
--- a/BE/LegalEntities/LegalPersons.rdf
+++ b/BE/LegalEntities/LegalPersons.rdf
@@ -68,7 +68,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20220801/LegalEntities/LegalPersons/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20221001/LegalEntities/LegalPersons/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/LegalEntities/LegalPersons.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/LegalEntities/LegalPersons.rdf version of this ontology was modified per the FIBO 2.0 RFC to normalize restrictions on business license.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/LegalEntities/LegalPersons.rdf version of this ontology was modified to rationalize natural person and legally capable person in a new concept, namely legally competent natural person, simplify / merge the legal person and formal organization class hierarchies, and correct certain definitions, including power of attorney.</skos:changeNote>
@@ -82,6 +82,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210401/LegalEntities/LegalPersons.rdf version of this ontology was modified to fix spelling errors.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20211201/LegalEntities/LegalPersons.rdf version of this ontology was modified to incorporate the concept of employment, required to support regulatory reporting, and add the concept of a special purpose vehicle.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220101/LegalEntities/LegalPersons.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220801/LegalEntities/LegalPersons.rdf version of this ontology was modified to add the definition of a variable interest entity.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -254,6 +255,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:label>statutory body</rdfs:label>
 		<skos:definition>legal entity established by a government to consider evidence and make judgements in some field of activity</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-le-lp;VariableInterestEntity">
+		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:label xml:lang="en">variable interest entity</rdfs:label>
+		<skos:definition xml:lang="en">legal entity whose shareholders are entitled to a percentage of a named company&apos;s profits via a private contract</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">VIE</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Variable interest entity (VIE) is a term used by the Financial Accounting Standards Board (FASB) to refer to a legal entity with certain characteristics such that a public company with a financial interest in the entity is subject to certain financial reporting requirements. Examples include certain Chinese companies, such as Alibaba, that leverage VIEs to gain access to foreign capital that would otherwise not be available due to Chinese government regulations.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">shell company</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lp;isOrganizedIn">

--- a/SEC/Equities/DepositaryReceipts.rdf
+++ b/SEC/Equities/DepositaryReceipts.rdf
@@ -74,10 +74,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/DepositaryReceipts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20221001/Equities/DepositaryReceipts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Equities/DepositaryReceipts.rdf version of this ontology was modified to expand the definition of a depositary receipt to cover a broader range of securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211101/Equities/DepositaryReceipts.rdf version of this ontology was modified to further refine the definition of a depositary receipt, add participatory notes, and broaden explanatory notes to allow for coverage of Chinese ADRs.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Equities/DepositaryReceipts.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/DepositaryReceipts.rdf version of this ontology was modified to add the concept of a Chinese depositary receipt.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -135,6 +136,20 @@
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">ADR level</fibo-fnd-utl-av:abbreviation>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-dr;ChineseDepositaryReceipt">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-dr;GlobalDepositaryReceipt"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;isLegallyRecordedIn"/>
+				<owl:hasValue rdf:resource="&fibo-be-ge-easj;JurisdictionOfTheRepublicOfChina"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">Chinese depositary receipt</rdfs:label>
+		<skos:definition xml:lang="en">global depositary receipt that represents ownership in the securities of a non-Chinese company that trades on a public exchange in China</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">CDR</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It refers to shares in non-Chinese companies that trade in China the same way that American depositary receipts (ADRs) allow non-U.S. company shares to trade on American exchanges.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;DepositaryReceipt">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
 		<rdfs:subClassOf>
@@ -156,11 +171,11 @@
 		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Depositary receipts are widely used in order to allow the trading of securities in jurisdictions other than
 the one where the original securities were issued, such as in a local market. Depositary receipts facilitate buying securities in foreign companies, because the securities do not have to leave the home country. They enable domestic investors to buy securities of foreign companies without the accompanying risks or inconveniences of cross-border and cross-currency transactions.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">depository receipt</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym xml:lang="en">depositary receipt</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;EuropeanDepositaryReceipt">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-dr;DepositaryReceipt"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-dr;GlobalDepositaryReceipt"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;isLegallyRecordedIn"/>
@@ -168,7 +183,7 @@ the one where the original securities were issued, such as in a local market. De
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">European depositary receipt</rdfs:label>
-		<skos:definition xml:lang="en">depositary receipt that represents ownership in the securities of a non-European company that trades in European financial markets</skos:definition>
+		<skos:definition xml:lang="en">global depositary receipt that represents ownership in the securities of a non-European company that trades in European financial markets</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">EDR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A European depositary receipt is a European equivalent of the original American depositary receipt (ADR). The EDR is issued by a bank in Europe representing securities traded on an exchange outside of the bank&apos;s home country.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -176,7 +191,7 @@ the one where the original securities were issued, such as in a local market. De
 	<owl:Class rdf:about="&fibo-sec-eq-dr;GlobalDepositaryReceipt">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-dr;DepositaryReceipt"/>
 		<rdfs:label xml:lang="en">global depositary receipt</rdfs:label>
-		<skos:definition xml:lang="en">depositary receipt where a certificate issued by a depository bank, which purchases securities of foreign companies, creates a security on a local exchange backed by those securities</skos:definition>
+		<skos:definition xml:lang="en">depositary receipt where a certificate issued by a depositary bank, which purchases securities of foreign companies, creates a security on a local exchange backed by those securities</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">GDR</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Global depositary receipts are the global equivalent of the original American depositary receipts (ADR) on which they are based. GDRs represent ownership of an underlying number of securities of a foreign company and are commonly used to invest in companies from developing or emerging markets by investors in developed markets.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en">international depositary receipt</fibo-fnd-utl-av:synonym>
@@ -204,11 +219,11 @@ the one where the original securities were issued, such as in a local market. De
 				<owl:hasValue rdf:resource="&fibo-be-ge-sasj;JurisdictionOfIndia"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">Indian depository receipt</rdfs:label>
+		<rdfs:label xml:lang="en">Indian depositary receipt</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Indian_Depository_Receipt"/>
 		<skos:definition xml:lang="en">global depositary receipt that represents the purchase, or ownership, of foreign assets which are deposited in a Indian account managed by the Domestic Depository in India</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">IDR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An Indian Depository Receipt (IDR) is an instrument denominated in Indian Rupees in the form of a depository receipt created by a Domestic Depository (custodian of securities registered with the Securities and Exchange Board of India) against the underlying securities of issuing company to enable foreign companies to raise funds from the Indian securities Markets.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An Indian Depository Receipt (IDR) is an instrument denominated in Indian Rupees in the form of a depositary receipt created by a Domestic Depository (custodian of securities registered with the Securities and Exchange Board of India) against the underlying securities of issuing company to enable foreign companies to raise funds from the Indian securities Markets.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;JapaneseDepositaryReceipt">
@@ -259,7 +274,7 @@ the one where the original securities were issued, such as in a local market. De
 		<rdfs:label xml:lang="en">Luxembourg depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">global depositary receipt that represents the purchase, or ownership, of foreign assets which are deposited in a Luxembourg-based account</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">LDR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Luxembourg Depositary Receipt (LDR) is a certificate which represents the purchase, or ownership, of foreign assets which are deposited in a Luxembourg-based account. An LDR functions in much the same way as a global depository receipt (GDR). LDRs may represent ownership of either an underlying number of shares or a notional amount of bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Luxembourg Depositary Receipt (LDR) is a certificate which represents the purchase, or ownership, of foreign assets which are deposited in a Luxembourg-based account. An LDR functions in much the same way as a global depositary receipt (GDR). LDRs may represent ownership of either an underlying number of shares or a notional amount of bonds.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;OffshoreDepositaryReceipt">
@@ -327,7 +342,7 @@ jurisdictions other than the one where the original debt instruments were issued
 		<rdfs:label xml:lang="en">unsponsored depositary receipt</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-eq-dr;SponsoredDepositaryReceipt"/>
 		<skos:definition xml:lang="en">depositary receipt that is established without the company&apos;s cooperation</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For an unsponsored ADR, a depository entity can issue certificates when there&apos;s heavy demand from investors for ownership in a specific company from abroad. The issuing entity is normally a broker-dealer that owns common stock in the company. Because they&apos;re issued without the consent or cooperation of the foreign company, unsponsored ADRs generally trade over-the-counter (OTC)—rather than on a stock exchange. Also, shareholder benefits and voting rights may not be extended to the holders of these particular securities. Many large global corporations use unsponsored ADRs to attract American capital. For example, American investors can invest in Royal Mail PLC, a postal and delivery service company from the United Kingdom that was founded by Henry VIII. The company&apos;s unsponsored ADR trades OTC under the ticker symbol ROYMY.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For an unsponsored ADR, a depositary entity can issue certificates when there&apos;s heavy demand from investors for ownership in a specific company from abroad. The issuing entity is normally a broker-dealer that owns common stock in the company. Because they&apos;re issued without the consent or cooperation of the foreign company, unsponsored ADRs generally trade over-the-counter (OTC)—rather than on a stock exchange. Also, shareholder benefits and voting rights may not be extended to the holders of these particular securities. Many large global corporations use unsponsored ADRs to attract American capital. For example, American investors can invest in Royal Mail PLC, a postal and delivery service company from the United Kingdom that was founded by Henry VIII. The company&apos;s unsponsored ADR trades OTC under the ticker symbol ROYMY.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-dr;hasMultiplier">

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
+	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
 	<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -42,6 +43,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
+	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
 	xmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -96,8 +98,8 @@
 		<sm:fileAbbreviation>fibo-sec-eq-eq</sm:fileAbbreviation>
 		<sm:filename>EquityInstruments.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -126,7 +128,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20221001/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
@@ -139,6 +141,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Equities/EquityInstruments.rdf version of this ontology was revised to deprecate the notion of a securities restriction specific to a limited partnership fund unit, which required import of unnecessary content and would not be used in practice.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220301/Equities/EquityInstruments.rdf version of this ontology was revised to clean up deprecated elements, most of which had been in the ontology for awhile.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220501/Equities/EquityInstruments.rdf version of this ontology was revised to address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityInstruments.rdf version of this ontology was revised to add the notion of a VIE share.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -1019,6 +1022,25 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:label xml:lang="en">unrestricted share</rdfs:label>
 		<skos:definition xml:lang="en">share whose ownership/transfer/sale is not subject to special conditions including country-specific restrictions</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;VariableInterestEntityShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+						<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;VariableInterestEntity"/>
+					</owl:Restriction>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">variable interest entity share</rdfs:label>
+		<skos:definition>share that certifies ownership of a contractual right to a percentage of a company&apos;s profits</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Unlike a traditional stock certificate, the VIE share provides a legal proprietary interest in a completely separate company&apos;s assets, sometimes referred to as a shell company. The contractual right certified by the VIE share is derived from a contract between (1) the company named on the VIE share and (2) the shell company. In other words, VIE shareholders only have a traditional stock certificate in the completely separate shell company, which is entitled to a percentage of the named company&apos;s profits via a private contract.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en-GB">VIE share</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;VotingRight">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

1. Added the concept of a variable interest entity (VIE) to legal entities and of a VIE share to equity instruments, required to define a Chinese DR
2. Added the concept of a generic Chinese DR without necessarily tying it to a VIE, but now those kinds of CDRs can be represented as appropriate


Fixes: #1838 / SEC-175


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


