### PR TITLE
DER-136 - Restructure and clean up the Credit Default Swaps ontology

### DIFF
--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -92,6 +92,14 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
+	<owl:Class rdf:about="&fibo-der-cr-cds;AssetBackedCreditDefaultSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
+		<rdfs:label xml:lang="en">asset-backed credit default swap contract</rdfs:label>
+		<skos:definition xml:lang="en">credit default swap whose underlying reference obligation is an asset-backed security rather than corporate credit</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">ABCDS</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the case of an ABCDS, the buyer receives protection for defaults on asset-backed securities or tranches of securities, rather than protecting against the default of a particular issuer. Asset-backed securities are securities backed by a pool of loans or receivables, such as auto loans, home equity loans or credit cards loans.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementDealer">
 		<rdfs:label xml:lang="en">credit default swap cash settlement dealer</rdfs:label>
 		<skos:definition xml:lang="en">A party from whom quotations are obtained by the calculation agent on the reference obligation for purposes of cash settlement of a CDS.</skos:definition>
@@ -203,77 +211,12 @@
 		<rdfs:label xml:lang="en">credit default swap credit event reference</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSFeeLegStream">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;singlePayment"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;definesPeriodicPayments"/>
-				<owl:onClass rdf:resource="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;initialPayment"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;protectionSellerPayment"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;initialPoints"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;marketFixedRate"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap fee leg stream</rdfs:label>
-		<skos:definition xml:lang="en">Terms defining the fee leg in a CDS contract</skos:definition>
-		<skos:editorialNote xml:lang="en">Review session notes: See &quot;Fee Payment Leg&quot; for notes on this structure. Now separated the Leg (as a side of the transaction) and the formal terms for payment of the CDS fee, as a set of Contract Terms.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSFeePaymentCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;definedAs.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap fee payment commitment</rdfs:label>
-		<skos:definition xml:lang="en">The commitment in a Credit Default Swap, to pay the fee or fees for the credit protection.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is embodied in a Fee Leg.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSFeePaymentScheduleSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-		<rdfs:label xml:lang="en">credit default swap fee payment schedule specification</rdfs:label>
-		<skos:definition xml:lang="en">A schedule expressing payment events and dates.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">credit default swap periodic payment schedule</rdfs:label>
-		<skos:definition xml:lang="en">The schedule of fixed amounts to be paid on specified payment dates.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The amount can be specified in terms of a known currency amount or as an amount calculated on a formula basis by reference to a per annum fixed rate. The applicable business day convention and business day for adjusting any fixed rate payer payment date if it would otherwise fall on a day that is not a business day are to be specified. Review notes: Note that both of the above possibilities refer to the amount, not the determination of dates. It is assumed that this is always a specification of how to determine the dates (a schedule specification) and not an explicit list of dates and amounts on each date. If the latter is applicable, a term for this needs to be added as a type of &quot;Explicit Schedule&quot;.</fibo-fnd-utl-av:explanatoryNote>
+	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentCreditDefaultSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
+		<rdfs:label xml:lang="en">contingent credit default swap contract</rdfs:label>
+		<skos:definition xml:lang="en">credit default swap in which an additional triggering event is required</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">CCDS</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In a contingent credit default swap, the trigger requires both a credit event (as in a traditional credit default swap) and another specified event. The additional specified event is usually a significant movement in an index covering equities, commodities, interest rates, or some other overall measure of the economy or relevant industry.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentLeg">
@@ -304,14 +247,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasReferenceObligation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
+				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasContractPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
+				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasReferenceObligation"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -334,20 +277,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit default swap contract</rdfs:label>
 		<skos:definition xml:lang="en">bilateral contract in which one party (protection seller) agrees to provide payment to the other party (protection buyer) should a credit event occur against the underlying, which could be a specified debt (the reference obligation), a specific debt issuer (reference entity), a basket of reference entities and/or reference obligations, or a credit index (reference index)</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">CDS</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The protection seller is typically paid a fee and/or premium, expressed as an annualized percent of the notional in basis points, regularly over the life of the transaction or otherwise as agreed by the parties.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwapTransaction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasFeeLeg"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;FeePaymentLeg"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap transaction</rdfs:label>
-		<skos:definition xml:lang="en">The transaction in which one party pay a fee or fees for credit protection and another commits to enter into the contingent transaction if the credit event takes place.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is embodied in a Fee Leg.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditEventNotice">
@@ -451,16 +383,11 @@
 		<skos:editorialNote xml:lang="en">Identified at SME Review as being one possible mechanism which may be used in some cases, and specified as such in the CDS contract, for delivery of the Deliverable Obligation. Deifnition Origin:SMER</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;FeePaymentLeg">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fee payment leg</rdfs:label>
-		<skos:definition xml:lang="en">The fee leg in a CDS contract</skos:definition>
-		<skos:editorialNote xml:lang="en">Review session notes: Q: whether this is any different to a regular Payment Leg. Answers: This is the &quot;other&quot; side of the swap from credit protection, i.e. the payment side. You are going to pay a set of fixed payments in return for a payment that occurs in the event of the credit event. So this is not incorrect but not a useful name for it. Swap is swap of a set of payments that equates the credit margin in return for the payments that apply in the case of the credit event. Conclusions: A good name for it might be the Credit Margin, at least from the point of view of the protection buyer, as this is the margin they are paying for the credit protection.</skos:editorialNote>
+	<owl:Class rdf:about="&fibo-der-cr-cds;LoanCreditDefaultSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
+		<rdfs:label xml:lang="en">loan credit default swap contract</rdfs:label>
+		<skos:definition xml:lang="en">credit default swap whose underlying reference obligation is limited strictly to syndicated secured loans, rather than any type of corporate debt</skos:definition>
+		<fibo-fnd-utl-av:abbreviation xml:lang="en">LCDS</fibo-fnd-utl-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;LocallyDefinedCreditBasket">
@@ -507,21 +434,6 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML adds &quot;Furthermore the Reference Obligation is ALWAYS deliverable and establishes the Pari Passu ranking (as the deliverable bonds must rank equal to the reference&quot; however this is not borne out in all cases (sometimes the Deliverable Obligation is NOT the Reference Obligation. This term is what we are referrring to when we refer to the credit event. This is what you are referencing to determine whether or not a default has occurred. Note: Loans as Reference Obligation: If the Ref Ob is a loan you can&apos;t establish that a default event has occurred but would have to specify some other event that can be obvserved to objectively determine that there has been a default. For example, you might have a loan for a company but monitor a bond issued by that company. If the bond defaults, the deliverable obligation may be the loan or some cash settlement based on the value of that loan (more typically). Detailed Review Notes: Q: Where does it go from here: thing or event? A: Commonly refers to an instrument, i.e. &quot;This is the instrument we are looking at; if this instrument defaults then we are going to pay out on the protection leg. FpML Full Definition: &apos;The underlying obligations of the reference entity on which you are buying or selling protection. The credit events Failure to Pay, Obligation Acceleration, Obligation Default, Restructuring, Repudiation/Moratorium are defined with respect to these obligations. ISDA 2003 Term:&apos; Also FpML referenceObligtion choice entry: &apos;The Reference Obligation is a financial instrument that is either issued or guaranteed by the reference entity. It serves to clarify the precise reference entity protection is being offered upon, and its legal position with regard to other related firms (parents/subsidiaries). Furthermore the Reference Obligation is ALWAYS deliverable and establishes the Pari Passu ranking (as the deliverable bonds must rank equal to the reference obligation). ISDA 2003 Term: Reference Obligation&apos; Deifnition Origin:FpML adapted</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;accruedInterestApplicable">
-		<rdfs:label xml:lang="en">accrued interest applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether accrued interest is included.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;additionalTerm">
-		<rdfs:label xml:lang="en">additional term</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">Information conveying additional contractual terms for the contract.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;calculationAmount">
 		<rdfs:label xml:lang="en">calculation amount</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
@@ -556,22 +468,10 @@
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs.1">
-		<rdfs:label xml:lang="en">defined as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs.2">
 		<rdfs:label xml:lang="en">defined as</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionCommitment"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definesPeriodicPayments">
-		<rdfs:label xml:lang="en">defines periodic payments</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;dependentOn">
@@ -607,17 +507,18 @@
 		<skos:definition xml:lang="en">Events which... [definition needed, the FpML text doesn&apos;t define it]</skos:definition>
 	</owl:DatatypeProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasContractPrice">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasNotionalAmount"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
+		<rdfs:label xml:lang="en">has contract price</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+		<skos:definition xml:lang="en">specifies a predetermined price at which the buyer purchases the credit default swap contract</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasDeliverySide">
 		<rdfs:label xml:lang="en">has delivery side</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasFeeLeg">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-drc-swp;hasLeg"/>
-		<rdfs:label xml:lang="en">has fee leg</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;FeePaymentLeg"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasReferenceObligation">
@@ -637,27 +538,6 @@
 		<rdfs:label xml:lang="en">has subject</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;initialPayment">
-		<rdfs:label xml:lang="en">initial payment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A single fixed payment that is payable by the payer to the receiver on the initial payment date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;initialPoints">
-		<rdfs:label xml:lang="en">initial points</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
-		<skos:definition xml:lang="en">The up-front points expressed as a percentage of the notional.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;marketFixedRate">
-		<rdfs:label xml:lang="en">market fixed rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
-		<skos:definition xml:lang="en">The credit spread (&quot;fair value&quot;) at which the trade was executed.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;mayBe">
@@ -699,25 +579,11 @@
 		<skos:definition xml:lang="en">The notional amount is the price at which the protection seller agrees to buy the bond in the event of a default.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;paymentDelay">
-		<rdfs:label xml:lang="en">payment delay</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether payment delays are applicable to the fixed Amount.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;physicalSettlementPeriod">
 		<rdfs:label xml:lang="en">physical settlement period</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDuration"/>
 		<skos:definition xml:lang="en">The number of business days used in the determination of the physical settlement date. Further Notes The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply then it should be flagged that &quot;Business Days Not Specified&quot;. If a specified number of business days are to apply these should be specified. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified. ISDA 2003 Term: Physical Settlement Period Note that although this is described as a period, it is not a period of time from one date/time to another, but a duration i.e. a length of time (in business days). FpML: &apos;The number of business days used in the determination of the physical settlement date. The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply the businessDaysNotSpecified element should be included. If a specified number of business days are to apply these should be specified in the businessDays element. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified in the maximumBusinessDays element. ISDA 2003 Term: Physical Settlement Period&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;protectionSellerPayment">
-		<rdfs:label xml:lang="en">protection seller payment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A payment on a CDS trade where there is a payment from Seller to Buyer.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;quotationAmount">
@@ -733,13 +599,6 @@
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementQuotationMethod"/>
 		<skos:definition xml:lang="en">The type of price quotations to be requested from dealers when determining the market value of the reference obligation for purposes of cash settlement.</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;quotationStyle">
-		<rdfs:label xml:lang="en">quotation style</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">The type of quotation that was used between the trading desks in setting up the deal.</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;scheduledTerminationDate">
 		<rdfs:label xml:lang="en">scheduled termination date</rdfs:label>
@@ -759,13 +618,6 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<skos:definition xml:lang="en">The currency in which the deal is to be settled.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;singlePayment">
-		<rdfs:label xml:lang="en">single payment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A single fixed amount that is payable by the buyer to the seller on the fixed rate payer payment date. The fixed amount to be paid is specified in terms of a known currency amount.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;sixtyBusinessDaySettlementCap">

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -14,12 +14,10 @@
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
-	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -43,12 +41,10 @@
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
-	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
-	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -76,12 +72,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -93,36 +87,6 @@
 		<skos:definition xml:lang="en">credit default swap whose underlying reference obligation is an asset-backed security rather than corporate credit</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">ABCDS</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the case of an ABCDS, the buyer receives protection for defaults on asset-backed securities or tranches of securities, rather than protecting against the default of a particular issuer. Asset-backed securities are securities backed by a pool of loans or receivables, such as auto loans, home equity loans or credit cards loans.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSubject"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap contingent transaction</rdfs:label>
-		<skos:definition xml:lang="en">The transaction which takes place in the event that the specified Credit Event in a Credit default Swap takes place. Deifnition Origin:SMER</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CashSettlementQuotationMethod">
@@ -210,14 +174,40 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasScheduledTerminationDate"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-cr-cds;allowsSubstitution"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit protection terms</rdfs:label>
@@ -299,25 +289,11 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A triggering event is typically a credit event, but could be anything that happens in the marketplace. For example, a weather-specific contract could be triggered by a hurricane - which wouldn&apos;t be considered a credit event per se.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;defaultRequirement">
-		<rdfs:label xml:lang="en">default requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;ObligationAcceleration"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The threshold for Obligation Acceleration</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;defaultRequirement.1">
-		<rdfs:label xml:lang="en">default requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;ObligationDefault"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The threshold for Obligation Default</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;escrowApplicable">
-		<rdfs:label xml:lang="en">escrow applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
+	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;allowsSubstitution">
+		<rdfs:label xml:lang="en">allows substitution</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether physical settlement must take place through the use of an escrow agent.</skos:definition>
+		<skos:definition xml:lang="en">indicates whether it is possible to substitute other obligations in place of the specified deliverable obligation</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasContractPrice">
@@ -337,44 +313,19 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasQuotationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;hasPriceDeterminationMethod"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-fi-ip;hasPriceDeterminationMethod"/>
 		<rdfs:label xml:lang="en">has quotation method</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;CashSettlementQuotationMethod"/>
 		<skos:definition xml:lang="en">indicates the nature of the pricing quotations to be requested from dealers when determining the market value of the reference obligation for purposes of cash settlement</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSubject">
-		<rdfs:label xml:lang="en">has subject</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;mayRequire">
-		<rdfs:label xml:lang="en">may require</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;modifiedEquityDelivery">
-		<rdfs:label xml:lang="en">modified equity delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">no-one knows what this means. Equity? It is not considered a default if the coupon on a Preferred Share is not paid. There are provisions in preference shares, since a company may be legally restrited from paying dividends other than from its reserves (e.g. in Aus law) so therefore this can&apos;t be a default. FpML: &apos;Value of this element set to \&apos;true\&apos; indicates that modified equity delivery is applicable.&apos;</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;physicalSettlementPeriod">
-		<rdfs:label xml:lang="en">physical settlement period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDuration"/>
-		<skos:definition xml:lang="en">The number of business days used in the determination of the physical settlement date. Further Notes The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply then it should be flagged that &quot;Business Days Not Specified&quot;. If a specified number of business days are to apply these should be specified. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified. ISDA 2003 Term: Physical Settlement Period Note that although this is described as a period, it is not a period of time from one date/time to another, but a duration i.e. a length of time (in business days). FpML: &apos;The number of business days used in the determination of the physical settlement date. The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply the businessDaysNotSpecified element should be included. If a specified number of business days are to apply these should be specified in the businessDays element. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified in the maximumBusinessDays element. ISDA 2003 Term: Physical Settlement Period&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;scheduledTerminationDate">
+	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasScheduledTerminationDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-arr-doc;hasTerminationDate"/>
 		<rdfs:label xml:lang="en">scheduled termination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date at which the contract for credit protection is due to expire as agreed by both parties.</skos:definition>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionTerms"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<skos:definition xml:lang="en">date on which credit protection is due to expire as agreed by both parties</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;sixtyBusinessDaySettlementCap">
@@ -384,21 +335,8 @@
 		<skos:definition xml:lang="en">Whether the legal terms set forth in the following language are deemed part of the confirmation (the section references are to the 2003 ISDA Credit Derivatives Definitions): &apos;Notwithstanding Section 1.7 or any provisions of Sections 9.9 or 9.10 to the contrary, but without prejudice to Section 9.3 and (where applicable) Sections 9.4, 9.5 and 9.6, if the Termination Date has not occurred on or prior to the date that is 60 Business Days following the Physical Settlement Date, such 60th Business Day shall be deemed to be the Termination Date with respect to this Transaction except in relation to any portion of the Transaction (an &quot;Affected Portion&quot;) in respect of which: (1) a valid notice of Buy-in Price has been delivered that is effective fewer than three Business Days prior to such 60th Business Day, in which case the Termination Date for that Affected Portion shall be the third Business Day following the date on which such notice is effective; or (2) Buyer has purchased but not Delivered Deliverable Obligations validly specified by Seller pursuant to Section 9.10(b), in which case the Termination Date for that Affected Portion shall be the tenth Business Day following the date on which Seller validly specified such Deliverable Obligations to Buyer.&apos;</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;substitution">
-		<rdfs:label xml:lang="en">substitution</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether it is possible to substitute other obligations in place of the specified Deliverable Obligation.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationAcceleration">
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationSpecificCreditEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Preferred by the market over Obligation Default, because more definitive and encompasses the definition of Obligation Default - this is more favorable to the Seller. Subject to the default requirement amount. FpML full definition: &apos;A credit event. One or more of the obligations have been declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay (preferred by the market over Obligation Default, because more definitive and encompasses the definition of Obligation Default - this is more favorable to the Seller). Subject to the default requirement amount. ISDA 2003 Term: Obligation Acceleration.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationDefault">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML full definition: &apos;A credit event. One or more of the obligations have become capable of being declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay. ISDA 2003 Term: Obligation Default.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-stl;CashSettlementTerms">
@@ -424,6 +362,16 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that the valuation determined via the appraisal of the underlying asset may include a quotation that is either an upper limit to the outstanding principal balance of the reference obligation for which the quote should be obtained, or a floating rate payer calculation amount.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fi-stl;PhysicalSettlementTerms">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+				<owl:onClass rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 	</owl:Class>
 
 </rdf:RDF>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
+	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 	<!ENTITY fibo-fbc-fi-stl "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -19,7 +20,6 @@
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/">
-	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -35,6 +35,7 @@
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
+	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:fibo-fbc-fi-stl="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -48,7 +49,6 @@
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"
-	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -67,6 +67,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -81,7 +82,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -95,50 +95,8 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the case of an ABCDS, the buyer receives protection for defaults on asset-backed securities or tranches of securities, rather than protecting against the default of a particular issuer. Asset-backed securities are securities backed by a pool of loans or receivables, such as auto loans, home equity loans or credit cards loans.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementQuotationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
-		<rdfs:label xml:lang="en">credit default swap cash settlement quotation method</rdfs:label>
-		<skos:definition xml:lang="en">The specification of the type of quotation rate to be obtained from each cash settlement reference bank. Further notes: For example, Bid, Offer or Mid-market. FpML Definition: The specification of the type of quotation rate to be obtained from each cash settlement reference bank.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliveryCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
-		<rdfs:label xml:lang="en">credit default swap contingent delivery commitment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliverySide">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;definedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap contingent delivery side</rdfs:label>
-		<skos:definition xml:lang="en">The settlement of a CDS deal in the event that the events specified in the Contingent Leg of the deal take place.</skos:definition>
-		<skos:editorialNote xml:lang="en">Need to establish whether this is the delivery side or the settlement side of the Contingent transaction. The label Settlement seems to be misapplied. Deifnition Origin:SMER</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliveryTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeSettlementTerms"/>
-		<rdfs:label xml:lang="en">credit default swap contingent delivery terms</rdfs:label>
-		<skos:definition xml:lang="en">The settlement of a CDS deal in the event that the events specified in the Contingent Leg of the deal take place.</skos:definition>
-		<skos:editorialNote xml:lang="en">Need to establish whether this is the delivery side or the settlement side of the Contingent transaction. The label Settlement seems to be misapplied. Deifnition Origin:SMER</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentTransaction">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasDeliverySide"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSettlementSide"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentTransactionSettlement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSubject"/>
@@ -167,10 +125,11 @@
 		<skos:definition xml:lang="en">The transaction which takes place in the event that the specified Credit Event in a Credit default Swap takes place. Deifnition Origin:SMER</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentTransactionSettlement">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
-		<rdfs:label xml:lang="en">credit default swap contingent transaction settlement</rdfs:label>
-		<skos:definition xml:lang="en">Settlement for the transaction agreed in the CDS, which takes place if the Credit Event takes place. This is the payment as agreed by the Protection Seller, who becomes the buyer of the Deliverable Obligation. Deifnition Origin:SMER</skos:definition>
+	<owl:Class rdf:about="&fibo-der-cr-cds;CashSettlementQuotationMethod">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
+		<rdfs:label xml:lang="en">cash settlement quotation method</rdfs:label>
+		<skos:definition xml:lang="en">specification of the nature of the quotation rate to be obtained from each cash settlement reference bank</skos:definition>
+		<skos:example xml:lang="en">For example, Bid, Offer or Mid-market.</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentCreditDefaultSwap">
@@ -181,32 +140,8 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In a contingent credit default swap, the trigger requires both a credit event (as in a traditional credit default swap) and another specified event. The additional specified event is usually a significant movement in an index covering equities, commodities, interest rates, or some other overall measure of the economy or relevant industry.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentLeg">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLeg"/>
-		<rdfs:label xml:lang="en">contingent leg</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentTransactionCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label xml:lang="en">contingent transaction commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment which is agreed in advance but which only comes into force on the occurrence of some pre-agreed event.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditBasketReferenceConstituent">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;BasketConstituent"/>
-		<rdfs:label xml:lang="en">credit basket reference constituent</rdfs:label>
-		<skos:definition xml:lang="en">A constituent of the credit basket.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This amounts to a legal entity which is the reference entity and a security issued by that entity, as a means of measuring the credit performance of that legal entity.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CreditDerivative"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;establishes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasContractPrice"/>
@@ -215,8 +150,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionCommitment"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -235,6 +176,7 @@
 		<skos:definition xml:lang="en">bilateral contract in which one party (protection seller) agrees to provide payment to the other party (protection buyer) should a credit event occur against the underlying, which could be a specified debt (the reference obligation), a specific debt issuer (reference entity), a basket of reference entities and/or reference obligations, or a credit index (reference index)</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">CDS</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that the effective date of the contract indicates the starting date of the credit protection defined therein.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The protection seller is typically paid a fee and/or premium, expressed as an annualized percent of the notional in basis points, regularly over the life of the transaction or otherwise as agreed by the parties.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -257,19 +199,15 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A specified condition to settlement. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice. FpML full definition: &apos;A specified condition to settlement. An irrevocable written or verbal notice that describes a credit event that has occurred. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionCommitment">
+	<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionTerms">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;definedAs.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasNotionalAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit protection commitment</rdfs:label>
-		<skos:definition xml:lang="en">The commitment in a Credit Defualt Swap, to protect against specified credit events.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Terms are defined as &quot;Contingent Leg&quot;; in FpML these are defined as &quot;Protection Terms&quot;. They are terms of the CDS contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionContingentLegTerms">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
@@ -282,9 +220,10 @@
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit protection contingent leg terms</rdfs:label>
+		<rdfs:label xml:lang="en">credit protection terms</rdfs:label>
 		<skos:definition xml:lang="en">The leg of the swap which represents the credit protection.</skos:definition>
 		<skos:editorialNote xml:lang="en">Review notes 31 March: For a protection leg the commitment is a conditional commitment to pay out in the event of the credit event. Typically this would be a default. Contingent Leg is another name for this, because it is contingent on the credit event. Contents: 1. The payment to be made in the event of the credit event occurring 2. the Credit Event itself. This is called the calculation amount as it is the notional amount minus the recovery, to get a final calculation amount. There is a formula behind this. The Calculation Amount is how the calculation is driven not what the actual payment amount is. Do we model the formula? Depends whether there is physical or cash settlement. Modeler notes: FpML terms for &quot;CDS Protection Terms&quot; are equivalent to this structure. Formal Definition for CDS Protection Terms: The legal terms relevant to defining the applicable floating rate payer calculation amount, credit events and associated conditions to settlement, and reference obligations. FpML: &apos;This element contains all the terms relevant to defining the applicable floating rate payer calculation amount, credit events and associated conditions to settlement, and reference obligations.&apos; Deifnition Origin:SMER</skos:editorialNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The notional amount is the price at which the protection seller agrees to pay out in the event that a triggering event occurs. Note that there may be additional payment schedules or a more complex calculation formula required depending on the terms of the contract.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligation">
@@ -360,20 +299,6 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A triggering event is typically a credit event, but could be anything that happens in the marketplace. For example, a weather-specific contract could be triggered by a hurricane - which wouldn&apos;t be considered a credit event per se.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;calculationAmount">
-		<rdfs:label xml:lang="en">calculation amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The notional amount of protection coverage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;cashSettlementBusinessDays">
-		<rdfs:label xml:lang="en">cash settlement business days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:range rdf:resource="&xsd;integer"/>
-		<skos:definition xml:lang="en">The number of business days used in the determination of the cash settlement payment date.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;defaultRequirement">
 		<rdfs:label xml:lang="en">default requirement</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;ObligationAcceleration"/>
@@ -388,49 +313,11 @@
 		<skos:definition xml:lang="en">The threshold for Obligation Default</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs">
-		<rdfs:label xml:lang="en">defined as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs.2">
-		<rdfs:label xml:lang="en">defined as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;dependentOn">
-		<rdfs:label xml:lang="en">dependent on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;effectiveDate">
-		<rdfs:label xml:lang="en">effective date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The effective starting date of the credit protection defined in the contract.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;escrowApplicable">
 		<rdfs:label xml:lang="en">escrow applicable</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether physical settlement must take place through the use of an escrow agent.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;establishes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;confers"/>
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;floatingAmountEvent">
-		<rdfs:label xml:lang="en">floating amount event</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">Events which... [definition needed, the FpML text doesn&apos;t define it]</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasContractPrice">
@@ -441,16 +328,20 @@
 		<skos:definition xml:lang="en">specifies a predetermined price at which the buyer purchases the credit default swap contract</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasDeliverySide">
-		<rdfs:label xml:lang="en">has delivery side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
+	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasMinimumQuotationAmount">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
+		<rdfs:label xml:lang="en">has minimum quotation amount</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+		<skos:definition xml:lang="en">indicates a minimum intended threshold amount of outstanding principal balance of the reference obligation for which the quote should be obtained</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSettlementSide">
-		<rdfs:label xml:lang="en">has settlement side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentTransactionSettlement"/>
+	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasQuotationMethod">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;hasPriceDeterminationMethod"/>
+		<rdfs:label xml:lang="en">has quotation method</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
+		<rdfs:range rdf:resource="&fibo-der-cr-cds;CashSettlementQuotationMethod"/>
+		<skos:definition xml:lang="en">indicates the nature of the pricing quotations to be requested from dealers when determining the market value of the reference obligation for purposes of cash settlement</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSubject">
@@ -465,26 +356,12 @@
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;minimumQuotationAmount">
-		<rdfs:label xml:lang="en">minimum quotation amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The minimum intended threshold amount of outstanding principal balance of the reference obligation for which the quote should be obtained.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;modifiedEquityDelivery">
 		<rdfs:label xml:lang="en">modified equity delivery</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">no-one knows what this means. Equity? It is not considered a default if the coupon on a Preferred Share is not paid. There are provisions in preference shares, since a company may be legally restrited from paying dividends other than from its reserves (e.g. in Aus law) so therefore this can&apos;t be a default. FpML: &apos;Value of this element set to \&apos;true\&apos; indicates that modified equity delivery is applicable.&apos;</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;notionalAmount">
-		<rdfs:label xml:lang="en">notional amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The notional amount is the price at which the protection seller agrees to buy the bond in the event of a default.</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;physicalSettlementPeriod">
 		<rdfs:label xml:lang="en">physical settlement period</rdfs:label>
@@ -493,32 +370,11 @@
 		<skos:definition xml:lang="en">The number of business days used in the determination of the physical settlement date. Further Notes The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply then it should be flagged that &quot;Business Days Not Specified&quot;. If a specified number of business days are to apply these should be specified. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified. ISDA 2003 Term: Physical Settlement Period Note that although this is described as a period, it is not a period of time from one date/time to another, but a duration i.e. a length of time (in business days). FpML: &apos;The number of business days used in the determination of the physical settlement date. The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply the businessDaysNotSpecified element should be included. If a specified number of business days are to apply these should be specified in the businessDays element. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified in the maximumBusinessDays element. ISDA 2003 Term: Physical Settlement Period&apos;</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;quotationAmount">
-		<rdfs:label xml:lang="en">quotation amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">An amount quoted, which is either an upper limit to the outstanding principal balance of the reference obligation for which the quote should be obtained, or the floating rate payer calculation amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;quotationMethod">
-		<rdfs:label xml:lang="en">quotation method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementQuotationMethod"/>
-		<skos:definition xml:lang="en">The type of price quotations to be requested from dealers when determining the market value of the reference obligation for purposes of cash settlement.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;scheduledTerminationDate">
 		<rdfs:label xml:lang="en">scheduled termination date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The date at which the contract for credit protection is due to expire as agreed by both parties.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;settlementCurrency">
-		<rdfs:label xml:lang="en">settlement currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the deal is to be settled.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;sixtyBusinessDaySettlementCap">
@@ -543,6 +399,31 @@
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationDefault">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML full definition: &apos;A credit event. One or more of the obligations have become capable of being declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay. ISDA 2003 Term: Obligation Default.&apos;</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fi-stl;CashSettlementTerms">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasQuotationMethod"/>
+				<owl:onClass rdf:resource="&fibo-der-cr-cds;CashSettlementQuotationMethod"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-bsc;ValuationTerms"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasMinimumQuotationAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that the valuation determined via the appraisal of the underlying asset may include a quotation that is either an upper limit to the outstanding principal balance of the reference obligation for which the quote should be obtained, or a floating rate payer calculation amount.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -6,7 +6,9 @@
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
+	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-fi-stl "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -34,7 +36,9 @@
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
+	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-fi-stl="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -68,6 +72,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -85,18 +91,6 @@
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifiesDealer"/>
-				<owl:allValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCashSettlementDealer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap cash settlement</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
-	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementDealer">
 		<rdfs:label xml:lang="en">credit default swap cash settlement dealer</rdfs:label>
@@ -175,7 +169,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit default swap contingent transaction</rdfs:label>
@@ -282,25 +276,6 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The amount can be specified in terms of a known currency amount or as an amount calculated on a formula basis by reference to a per annum fixed rate. The applicable business day convention and business day for adjusting any fixed rate payer payment date if it would otherwise fall on a day that is not a business day are to be specified. Review notes: Note that both of the above possibilities refer to the amount, not the determination of dates. It is assumed that this is always a specification of how to determine the dates (a schedule specification) and not an explicit list of dates and amounts on each date. If the latter is applicable, a term for this needs to be added as a type of &quot;Explicit Schedule&quot;.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSPhysicalSettlement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;mayRequire"/>
-				<owl:onClass rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap physical settlement</rdfs:label>
-		<skos:definition xml:lang="en">Physical settlement is where you deliver the reference obligation (e.g.a bond) itself. Deifnition Origin:SMER</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentLeg">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLeg"/>
 		<rdfs:label xml:lang="en">contingent leg</rdfs:label>
@@ -319,23 +294,8 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This amounts to a legal entity which is the reference entity and a security issued by that entity, as a means of measuring the credit performance of that legal entity.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwapContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDerivative"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
-				<owl:onClass rdf:resource="&fibo-der-drc-swp;SwapPayingParty"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
-				<owl:onClass rdf:resource="&fibo-der-drc-swp;SwapReceivingParty"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CreditDerivative"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;establishes"/>
@@ -373,8 +333,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit default swap contract</rdfs:label>
-		<skos:definition xml:lang="en">In a credit default swap one party (the protection seller) agrees to compensate another party (the protection buyer) if a specified company or Sovereign (the reference entity) experiences a credit event, indicating it is or may be unable to service its debts. The protection seller is typically paid a fee and/or premium, expressed as an annualized percent of the notional in basis points, regularly over the life of the transaction or otherwise as agreed by the parties.</skos:definition>
-		<skos:editorialNote xml:lang="en">Earlier draft definition: A swap instrument in which one party underwrites the risk of credit default of the other party or of an identified third party.</skos:editorialNote>
+		<skos:definition xml:lang="en">bilateral contract in which one party (protection seller) agrees to provide payment to the other party (protection buyer) should a credit event occur against the underlying, which could be a specified debt (the reference obligation), a specific debt issuer (reference entity), a basket of reference entities and/or reference obligations, or a credit index (reference index)</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The protection seller is typically paid a fee and/or premium, expressed as an annualized percent of the notional in basis points, regularly over the life of the transaction or otherwise as agreed by the parties.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwapTransaction">
@@ -387,17 +348,6 @@
 		<rdfs:label xml:lang="en">credit default swap transaction</rdfs:label>
 		<skos:definition xml:lang="en">The transaction in which one party pay a fee or fees for credit protection and another commits to enter into the contingent transaction if the credit event takes place.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is embodied in a Fee Leg.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDerivative">
-		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;DebtInstrumentDerivative"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditEventUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit derivative</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditEventNotice">
@@ -445,19 +395,19 @@
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionContingentLegTerms">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifies.1"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifies.2"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifiesObligation"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -559,15 +509,15 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;accruedInterestApplicable">
 		<rdfs:label xml:lang="en">accrued interest applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether accrued interest is included.</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;additionalTerm">
 		<rdfs:label xml:lang="en">additional term</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition xml:lang="en">Information conveying additional contractual terms for the contract.</skos:definition>
 	</owl:DatatypeProperty>
@@ -581,7 +531,7 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;cashSettlementBusinessDays">
 		<rdfs:label xml:lang="en">cash settlement business days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&xsd;integer"/>
 		<skos:definition xml:lang="en">The number of business days used in the determination of the cash settlement payment date.</skos:definition>
 	</owl:DatatypeProperty>
@@ -631,14 +581,14 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;effectiveDate">
 		<rdfs:label xml:lang="en">effective date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The effective starting date of the credit protection defined in the contract.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;escrowApplicable">
 		<rdfs:label xml:lang="en">escrow applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether physical settlement must take place through the use of an escrow agent.</skos:definition>
 	</owl:DatatypeProperty>
@@ -646,7 +596,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;establishes">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;confers"/>
 		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
 	</owl:ObjectProperty>
 	
@@ -673,7 +623,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasReferenceObligation">
 		<rdfs:subPropertyOf rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
 		<rdfs:label xml:lang="en">has reference obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
 	</owl:ObjectProperty>
 	
@@ -718,20 +668,20 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;mayRequire">
 		<rdfs:label xml:lang="en">may require</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;minimumQuotationAmount">
 		<rdfs:label xml:lang="en">minimum quotation amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">The minimum intended threshold amount of outstanding principal balance of the reference obligation for which the quote should be obtained.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;modifiedEquityDelivery">
 		<rdfs:label xml:lang="en">modified equity delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">no-one knows what this means. Equity? It is not considered a default if the coupon on a Preferred Share is not paid. There are provisions in preference shares, since a company may be legally restrited from paying dividends other than from its reserves (e.g. in Aus law) so therefore this can&apos;t be a default. FpML: &apos;Value of this element set to \&apos;true\&apos; indicates that modified equity delivery is applicable.&apos;</skos:definition>
 	</owl:DatatypeProperty>
@@ -744,7 +694,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;notionalAmount">
 		<rdfs:label xml:lang="en">notional amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">The notional amount is the price at which the protection seller agrees to buy the bond in the event of a default.</skos:definition>
 	</owl:ObjectProperty>
@@ -758,7 +708,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;physicalSettlementPeriod">
 		<rdfs:label xml:lang="en">physical settlement period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDuration"/>
 		<skos:definition xml:lang="en">The number of business days used in the determination of the physical settlement date. Further Notes The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply then it should be flagged that &quot;Business Days Not Specified&quot;. If a specified number of business days are to apply these should be specified. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified. ISDA 2003 Term: Physical Settlement Period Note that although this is described as a period, it is not a period of time from one date/time to another, but a duration i.e. a length of time (in business days). FpML: &apos;The number of business days used in the determination of the physical settlement date. The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply the businessDaysNotSpecified element should be included. If a specified number of business days are to apply these should be specified in the businessDays element. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified in the maximumBusinessDays element. ISDA 2003 Term: Physical Settlement Period&apos;</skos:definition>
 	</owl:ObjectProperty>
@@ -772,14 +722,14 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;quotationAmount">
 		<rdfs:label xml:lang="en">quotation amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">An amount quoted, which is either an upper limit to the outstanding principal balance of the reference obligation for which the quote should be obtained, or the floating rate payer calculation amount.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;quotationMethod">
 		<rdfs:label xml:lang="en">quotation method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementQuotationMethod"/>
 		<skos:definition xml:lang="en">The type of price quotations to be requested from dealers when determining the market value of the reference obligation for purposes of cash settlement.</skos:definition>
 	</owl:ObjectProperty>
@@ -793,7 +743,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;scheduledTerminationDate">
 		<rdfs:label xml:lang="en">scheduled termination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The date at which the contract for credit protection is due to expire as agreed by both parties.</skos:definition>
 	</owl:ObjectProperty>
@@ -806,7 +756,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;settlementCurrency">
 		<rdfs:label xml:lang="en">settlement currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<skos:definition xml:lang="en">The currency in which the deal is to be settled.</skos:definition>
 	</owl:ObjectProperty>
@@ -820,44 +770,14 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;sixtyBusinessDaySettlementCap">
 		<rdfs:label xml:lang="en">sixty business day settlement cap</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether the legal terms set forth in the following language are deemed part of the confirmation (the section references are to the 2003 ISDA Credit Derivatives Definitions): &apos;Notwithstanding Section 1.7 or any provisions of Sections 9.9 or 9.10 to the contrary, but without prejudice to Section 9.3 and (where applicable) Sections 9.4, 9.5 and 9.6, if the Termination Date has not occurred on or prior to the date that is 60 Business Days following the Physical Settlement Date, such 60th Business Day shall be deemed to be the Termination Date with respect to this Transaction except in relation to any portion of the Transaction (an &quot;Affected Portion&quot;) in respect of which: (1) a valid notice of Buy-in Price has been delivered that is effective fewer than three Business Days prior to such 60th Business Day, in which case the Termination Date for that Affected Portion shall be the third Business Day following the date on which such notice is effective; or (2) Buyer has purchased but not Delivered Deliverable Obligations validly specified by Seller pursuant to Section 9.10(b), in which case the Termination Date for that Affected Portion shall be the tenth Business Day following the date on which Seller validly specified such Deliverable Obligations to Buyer.&apos;</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifies">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifies.1">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifies.2">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifiesDealer">
-		<rdfs:label xml:lang="en">specifies dealer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementDealer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifiesObligation">
-		<rdfs:label xml:lang="en">specifies obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;substitution">
 		<rdfs:label xml:lang="en">substitution</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether it is possible to substitute other obligations in place of the specified Deliverable Obligation.</skos:definition>
 	</owl:DatatypeProperty>
@@ -865,14 +785,14 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
 		<rdfs:label xml:lang="en">valuation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The date (however specified) after conditions to settlement have been satisfied, when the calculation agent obtains a price quotation on the Reference Obligation for purposes of cash settlement.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationMethod">
 		<rdfs:label xml:lang="en">valuation method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementValuationMethod"/>
 		<skos:definition xml:lang="en">The methodology for determining the final price of the reference obligation for purposes of cash settlement.</skos:definition>
 	</owl:ObjectProperty>
@@ -880,7 +800,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationTime">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDateTime"/>
 		<rdfs:label xml:lang="en">valuation time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DateTime"/>
 		<skos:definition xml:lang="en">The time of day in the specified business center when the calculation agent seeks quotations for an amount of the reference obligation for purposes of cash settlement.</skos:definition>
 	</owl:ObjectProperty>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -4,18 +4,17 @@
 	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
-	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-fi-stl "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
-	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
+	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -34,18 +33,17 @@
 	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
-	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-fi-stl="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
-	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
+	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -64,14 +62,11 @@
 		<dct:abstract>A transaction and contract in which one leg is the conditional commitment to pay out on some debt in the event that a pre-defined credit event takes place. The contract may make reference to a specific debt instrument or loan, or take effect in the event of one of a range of events that happen to the business entity that is the debtor in that debt. Includes terms for different kinds of settlement arrangement. Note that these are a swap in name only, since under normal conditions there is only one stream of payment, the fee payment leg.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-cr-cds</sm:fileAbbreviation>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -79,15 +74,15 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
@@ -190,27 +185,6 @@
 		<skos:definition xml:lang="en">Settlement for the transaction agreed in the CDS, which takes place if the Credit Event takes place. This is the payment as agreed by the Protection Seller, who becomes the buyer of the Deliverable Obligation. Deifnition Origin:SMER</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCreditEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;notifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap credit event</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCreditEventReference">
-		<rdfs:label xml:lang="en">credit default swap credit event reference</rdfs:label>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentCreditDefaultSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:label xml:lang="en">contingent credit default swap contract</rdfs:label>
@@ -253,12 +227,6 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasReferenceObligation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionCommitment"/>
 			</owl:Restriction>
@@ -286,30 +254,19 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;servedBy"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-doc;isAbout"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arr-doc;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit event notice</rdfs:label>
-		<skos:definition xml:lang="en">An irrevocable written or verbal notice that describes a credit event that has occurred.</skos:definition>
+		<skos:definition xml:lang="en">irrevocable written or verbal notice that states that a triggering event has occurred</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A specified condition to settlement. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice. FpML full definition: &apos;A specified condition to settlement. An irrevocable written or verbal notice that describes a credit event that has occurred. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditEventUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit event underlying</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionCommitment">
@@ -334,13 +291,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit protection contingent leg terms</rdfs:label>
@@ -349,29 +300,29 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LegalObligation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;mayBe"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">deliverable obligation</rdfs:label>
-		<skos:definition xml:lang="en">An asset which is to be delivered as settlement of a CDS deal.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the RO is a bond, the DO may be a different bond. Detailed Review Notes: Would see this more often in less deep markets. If it is a Loan, the DO may be assigment of a loan. FpML Full Definition: &apos;This element contains all the ISDA terms relevant to defining the deliverable obligations.&apos; Deifnition Origin:SMER</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
+		<rdfs:label xml:lang="en">deliverable asset</rdfs:label>
+		<skos:definition xml:lang="en">asset that must be delivered as a part of the process of settling a credit default swap</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the reference obligation is a bond, the deliverable asset (obligation) may be a different bond. If it is a loan, the deliverable asset may involve assigment of a loan.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligationBuyer">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
 		<rdfs:label xml:lang="en">deliverable obligation buyer</rdfs:label>
-		<skos:definition xml:lang="en">The party which is obligated to purchase the Deliverable Obligation in the event that the CDS Contingent Transaction takes place. Deifnition Origin:SMER</skos:definition>
+		<skos:definition xml:lang="en">contract party that is obliged to purchase a deliverable obligation (asset) if a triggering event occurs, depending on the event and the contract</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligationSeller">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Seller"/>
 		<rdfs:label xml:lang="en">deliverable obligation seller</rdfs:label>
-		<skos:definition xml:lang="en">The party which is obligated to sell the Deliverable Obligation in the event that the CDS Contingent Transaction takes place. Deifnition Origin:SMER</skos:definition>
+		<skos:definition xml:lang="en">contract party that is obliged to sell a deliverable obligation (asset) if a triggering event occurs, depending on the event and the contract</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;EscrowAgent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;RegisteredAgent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
@@ -379,8 +330,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">escrow agent</rdfs:label>
-		<skos:definition xml:lang="en">An agent which acts in escrow for the delivery of some Deliverable Obligation in the context of some CDS contract.</skos:definition>
-		<skos:editorialNote xml:lang="en">Identified at SME Review as being one possible mechanism which may be used in some cases, and specified as such in the CDS contract, for delivery of the Deliverable Obligation. Deifnition Origin:SMER</skos:editorialNote>
+		<skos:definition xml:lang="en">third party that holds an asset or funds before they are formally transferred from one party to another party, per the terms of a contract, within some specified time period and/or when a triggering event occurs</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Use of an escrow agent is one possible mechanism that may be used in some cases, as specified in a credit default swap contract, for delivery purposes.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;LoanCreditDefaultSwap">
@@ -400,38 +351,25 @@
 	<owl:Class rdf:about="&fibo-der-cr-cds;NotifyingParty">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
 		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-drc-swp;SwapPayingParty">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-drc-swp;SwapReceivingParty">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-fnd-agr-ctr;ContractParty">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-agr-ctr;ContractThirdParty">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">notifying party</rdfs:label>
-		<skos:definition xml:lang="en">The party which is able to issue formal notices indicating that a Credit Event has taken place, by means of a credit event notice.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If more than one party is referenced as being the notifying party (in the CDS contract) then either party may notify the other of a credit event occurring. That is, this party may be either party to the CDS Contract. ISDA 2003 Term: Notifying Party. FpML Full Definition: &apos;Pointer style references to a party identifier defined elsewhere in the document. The notifying party is the party that notifies the other party when a credit event has occurred by means of a credit event notice. If more than one party is referenced as being the notifying party then either party may notify the other of a credit event occurring. ISDA 2003 Term: Notifying Party.&apos;</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">party responsible for issuing one or more formal notices indicating that an event that is relevant to a given contract has taken place</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The notifying party is the party that notifies the other party when a credit or other triggering event has occurred by means of a credit event notice. If more than one party is referenced as being the notifying party then either party may notify the other of such an occurrence.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ReferenceEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
-		<rdfs:label xml:lang="en">credit default swap reference entity</rdfs:label>
-		<skos:definition xml:lang="en">The legal entity on which the protection buyer is buying or selling protection and any successor that assumes all or substantially all of its contractual and other obligations. This is the legal entity to which a Credit Event refers, if the event is defined in relation to some legal entity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML additional notes: It is vital to use the correct legal name of the entity and to be careful not to choose a subsidiary if you really want to trade protection on a parent company. Please note, Reference Entities cannot be senior or subordinated. It is the obligations of the Reference Entities that can be senior or subordinated. ISDA 2003 Term: Reference Entity&apos; Although the CDS is made out with reference to some security (issued by some party) or some loan to some party, the underlying purpose of the CDS is to protect that instrument in the event of some Credit Event that is to do with the issuing (debtor) party itself. Credit Events are therefore defined in relation to the Legal Entity and not in relation to the Security itself. FpML Definition: &apos;The corporate or sovereign entity on which you are buying or selling protection and any successor that assumes all or substantially all of its contractual and other obligations. It is vital to use the correct legal name of the entity and to be careful not to choose a subsidiary if you really want to trade protection on a parent company. Please note, Reference Entities cannot be senior or subordinated. It is the obligations of the Reference Entities that can be senior or subordinated. ISDA 2003 Term: Reference Entity&apos; Deifnition Origin:FpML adapted</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ReferenceObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-		<rdfs:label xml:lang="en">credit default swap reference obligation</rdfs:label>
-		<skos:definition xml:lang="en">The underlying obligation against which the CDS provides credit protection. The Reference Obligation is a financial instrument that is either issued or guaranteed by the reference entity. It serves to clarify the precise reference entity protection is being offered upon, and its legal position with regard to other related firms (parents/subsidiaries).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML adds &quot;Furthermore the Reference Obligation is ALWAYS deliverable and establishes the Pari Passu ranking (as the deliverable bonds must rank equal to the reference&quot; however this is not borne out in all cases (sometimes the Deliverable Obligation is NOT the Reference Obligation. This term is what we are referrring to when we refer to the credit event. This is what you are referencing to determine whether or not a default has occurred. Note: Loans as Reference Obligation: If the Ref Ob is a loan you can&apos;t establish that a default event has occurred but would have to specify some other event that can be obvserved to objectively determine that there has been a default. For example, you might have a loan for a company but monitor a bond issued by that company. If the bond defaults, the deliverable obligation may be the loan or some cash settlement based on the value of that loan (more typically). Detailed Review Notes: Q: Where does it go from here: thing or event? A: Commonly refers to an instrument, i.e. &quot;This is the instrument we are looking at; if this instrument defaults then we are going to pay out on the protection leg. FpML Full Definition: &apos;The underlying obligations of the reference entity on which you are buying or selling protection. The credit events Failure to Pay, Obligation Acceleration, Obligation Default, Restructuring, Repudiation/Moratorium are defined with respect to these obligations. ISDA 2003 Term:&apos; Also FpML referenceObligtion choice entry: &apos;The Reference Obligation is a financial instrument that is either issued or guaranteed by the reference entity. It serves to clarify the precise reference entity protection is being offered upon, and its legal position with regard to other related firms (parents/subsidiaries). Furthermore the Reference Obligation is ALWAYS deliverable and establishes the Pari Passu ranking (as the deliverable bonds must rank equal to the reference obligation). ISDA 2003 Term: Reference Obligation&apos; Deifnition Origin:FpML adapted</fibo-fnd-utl-av:explanatoryNote>
+	<owl:Class rdf:about="&fibo-der-cr-cds;TriggeringEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
+		<rdfs:label xml:lang="en">triggering event</rdfs:label>
+		<skos:definition xml:lang="en">event that relates to or triggers some aspect of a credit default swap</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A triggering event is typically a credit event, but could be anything that happens in the marketplace. For example, a weather-specific contract could be triggered by a hurricane - which wouldn&apos;t be considered a credit event per se.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;calculationAmount">
@@ -521,13 +459,6 @@
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasReferenceObligation">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-		<rdfs:label xml:lang="en">has reference obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSettlementSide">
 		<rdfs:label xml:lang="en">has settlement side</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
@@ -538,12 +469,6 @@
 		<rdfs:label xml:lang="en">has subject</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;mayBe">
-		<rdfs:label xml:lang="en">may be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;mayRequire">
@@ -565,12 +490,6 @@
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">no-one knows what this means. Equity? It is not considered a default if the coupon on a Preferred Share is not paid. There are provisions in preference shares, since a company may be legally restrited from paying dividends other than from its reserves (e.g. in Aus law) so therefore this can&apos;t be a default. FpML: &apos;Value of this element set to \&apos;true\&apos; indicates that modified equity delivery is applicable.&apos;</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;notifiedBy">
-		<rdfs:label xml:lang="en">notified by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;notionalAmount">
 		<rdfs:label xml:lang="en">notional amount</rdfs:label>
@@ -605,12 +524,6 @@
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The date at which the contract for credit protection is due to expire as agreed by both parties.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;servedBy">
-		<rdfs:label xml:lang="en">served by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditEventNotice"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;settlementCurrency">
@@ -658,12 +571,12 @@
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationAcceleration">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Preferred by the market over Obligation Default, because more definitive and encompasses the definition of Obligation Default - this is more favorable to the Seller. Subject to the default requirement amount. FpML full definition: &apos;A credit event. One or more of the obligations have been declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay (preferred by the market over Obligation Default, because more definitive and encompasses the definition of Obligation Default - this is more favorable to the Seller). Subject to the default requirement amount. ISDA 2003 Term: Obligation Acceleration.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationDefault">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML full definition: &apos;A credit event. One or more of the obligations have become capable of being declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay. ISDA 2003 Term: Obligation Default.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -95,22 +95,10 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the case of an ABCDS, the buyer receives protection for defaults on asset-backed securities or tranches of securities, rather than protecting against the default of a particular issuer. Asset-backed securities are securities backed by a pool of loans or receivables, such as auto loans, home equity loans or credit cards loans.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementDealer">
-		<rdfs:label xml:lang="en">credit default swap cash settlement dealer</rdfs:label>
-		<skos:definition xml:lang="en">A party from whom quotations are obtained by the calculation agent on the reference obligation for purposes of cash settlement of a CDS.</skos:definition>
-		<skos:editorialNote xml:lang="en">ACTION not sure if this is a distinct party or specification of an existing party in a wider process. Assume the latter - so define where and what.</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementQuotationMethod">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label xml:lang="en">credit default swap cash settlement quotation method</rdfs:label>
 		<skos:definition xml:lang="en">The specification of the type of quotation rate to be obtained from each cash settlement reference bank. Further notes: For example, Bid, Offer or Mid-market. FpML Definition: The specification of the type of quotation rate to be obtained from each cash settlement reference bank.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementValuationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
-		<rdfs:label xml:lang="en">credit default swap cash settlement valuation method</rdfs:label>
-		<skos:definition xml:lang="en">The defined methodology for determining the final price of the reference obligation for purposes of cash settlement. FpML: The ISDA defined methodology for determining the final price of the reference obligation for purposes of cash settlement.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliveryCommitment">
@@ -546,29 +534,6 @@
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether it is possible to substitute other obligations in place of the specified Deliverable Obligation.</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
-		<rdfs:label xml:lang="en">valuation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date (however specified) after conditions to settlement have been satisfied, when the calculation agent obtains a price quotation on the Reference Obligation for purposes of cash settlement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationMethod">
-		<rdfs:label xml:lang="en">valuation method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementValuationMethod"/>
-		<skos:definition xml:lang="en">The methodology for determining the final price of the reference obligation for purposes of cash settlement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationTime">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDateTime"/>
-		<rdfs:label xml:lang="en">valuation time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DateTime"/>
-		<skos:definition xml:lang="en">The time of day in the specified business center when the calculation agent seeks quotations for an amount of the reference obligation for purposes of cash settlement.</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationAcceleration">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -106,6 +106,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CreditDerivative"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasContractPrice"/>
@@ -140,8 +141,8 @@
 		<skos:definition xml:lang="en">bilateral contract in which one party (protection seller) agrees to provide payment to the other party (protection buyer) should a credit event occur against the underlying, which could be a specified debt (the reference obligation), a specific debt issuer (reference entity), a basket of reference entities and/or reference obligations, or a credit index (reference index)</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">CDS</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">According to a 2022 working paper from the Federal Reserve, &quot;credit default swaps (CDS) are, by far, the most common type of credit derivative. They are financial instruments that allow the transfer of credit risk among market participants, potentially facilitating greater efficiency in the pricing and distribution of credit risk. In its most basic form, a CDS is a contract where a &apos;protection buyer&apos; agrees to make periodic payments (the CDS &apos;spread&apos; or premium) over a predetermined number of years (the maturity or term of the CDS) to a &apos;protection seller&apos; in exchange for a payment from the protection seller in the event of default by a &apos;reference entity.&apos; CDS premiums tend to be paid quarterly and are set as a percentage of the total amount of protection bought (the &apos;notional amount&apos; of the contract). CDS maturities generally range from one to ten years, with the five-year maturity being particularly common.&quot; See https://www.federalreserve.gov/econres/feds/files/2022023pap.pdf for more detail.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that the effective date of the contract indicates the starting date of the credit protection defined therein.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The protection seller is typically paid a fee and/or premium, expressed as an annualized percent of the notional in basis points, regularly over the life of the transaction or otherwise as agreed by the parties.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditEventNotice">

--- a/DER/DerivativesContracts/DerivativesBasics.rdf
+++ b/DER/DerivativesContracts/DerivativesBasics.rdf
@@ -121,7 +121,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to replace hasContractSize with hasLotSize.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210501/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to move designated contract market to the markets ontology in FBC and eliminate the notion of NonPhysicalUnderlier, which was determined to add unnecessary overhead.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to address text formatting issues identified via hygiene testing.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to add the concept of a credit derivative and modify the notion of an underlying asset valuation to be a kind of value assessment.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to add the concept of a credit derivative, modify the notion of an underlying asset valuation to be a kind of value assessment, and modify the concept of valuation terms to be a subclass of derivative terms.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -321,7 +321,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;ValuationTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasDateOfAssessment"/>
@@ -397,6 +397,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-bsc;hasTickValue">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 		<rdfs:label xml:lang="en">has tick value</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>

--- a/DER/DerivativesContracts/DerivativesBasics.rdf
+++ b/DER/DerivativesContracts/DerivativesBasics.rdf
@@ -121,7 +121,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to replace hasContractSize with hasLotSize.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210501/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to move designated contract market to the markets ontology in FBC and eliminate the notion of NonPhysicalUnderlier, which was determined to add unnecessary overhead.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to address text formatting issues identified via hygiene testing.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to add the concept of a credit derivative.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to add the concept of a credit derivative and modify the notion of an underlying asset valuation to be a kind of value assessment.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -302,7 +302,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;UnderlyingAssetValuation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentActivity"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;ValueAssessment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasCalculationAgent"/>

--- a/DER/DerivativesContracts/DerivativesBasics.rdf
+++ b/DER/DerivativesContracts/DerivativesBasics.rdf
@@ -114,13 +114,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/DerivativesBasics/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20221001/DerivativesContracts/DerivativesBasics/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and eliminate a redundant subclass declaration in observable value.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200401/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to loosen the domain of the hasUnderlier property, which could be either an instrument or leg, refine the definition of Underlier and hasUnderlier based on recent work on swaps, add the definition of a contract for difference (CFD), simplify the contract party hierarchy where the subclasses of contract party do not add semantics, add the concepts of underlying asset valuation and calculation agent, which are needed for various derivatives (moved from forwards) and eliminate the language related to transactions as well as the distinction between an OTC contract and exchange-traded contract / listed security, given how blurry the lines are today, across derivatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to eliminate hasThirdParty as a superproperty of hasCalculationAgent, which led to unintended reasoning consequences, added concepts and properties specific to settlement and valuation required for futures, forwards, and options, and moved general properties from forwards and swaps up to derivatives basics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to replace hasContractSize with hasLotSize.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210501/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to move designated contract market to the markets ontology in FBC and eliminate the notion of NonPhysicalUnderlier, which was determined to add unnecessary overhead.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to address text formatting issues identified via hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to add the concept of a credit derivative.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -167,6 +168,14 @@
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.nasdaq.com/glossary/c/contract-for-difference</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These contracts can also be on the difference of two assets&apos; prices. They can also be on the difference of a single asset of different maturities (like a bond or futures contracts).</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en">spread trading</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-bsc;CreditDerivative">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
+		<rdfs:label xml:lang="en">credit derivative</rdfs:label>
+		<skos:definition xml:lang="en">derivative instrument that is a privately held, negotiable bilateral contract traded over-the-counter (OTC) between two parties in a creditor/debtor relationship, enabling the creditor to effectively transfer some or all of the risk of a debtor defaulting to a third party</skos:definition>
+		<skos:example xml:lang="en">Examples include credit default swaps (CDS), collateralized debt obligations (CDO), total return swaps, and credit spread options and forwards.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The third party accepts the risk in return for payment, known as the premium.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;DerivativeSettlementTerms">

--- a/DER/DerivativesContracts/FuturesAndForwards.rdf
+++ b/DER/DerivativesContracts/FuturesAndForwards.rdf
@@ -108,10 +108,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220901/DerivativesContracts/FuturesAndForwards/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20221001/DerivativesContracts/FuturesAndForwards/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to eliminate references to hasContractSize, clean up unnecessary restrictions on Future and Forward, and eliminate the redundant listing class.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210601/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to move designated contract market to the markets ontology in FBC and revise the definition of a CurrencyFuture to eliminate an unnecessary superclass and restriction due to the release of CurrencyContracts and to revise the definition of a dividend future to reference the listed share that it tracks rather than the dividend itself.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to to incorporate the concepts that were originally in a separate, very small equity forwards ontology.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to incorporate the concepts that were originally in a separate, very small equity forwards ontology.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220901/DerivativesContracts/FuturesAndForwards.rdf version of this ontology was modified to better integrate adjustment method.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -420,6 +421,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ff;hasMethodOfAdjustment">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
 		<rdfs:label xml:lang="en">has method of adjustment</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-ff;EquityForward"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-ff;ForwardContractAdjustmentMethod"/>

--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -93,7 +93,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/Swaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20221001/DerivativesContracts/Swaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/Swaps/ version of this ontology was modified to refine the concept of a unique swap identifier (USI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20190201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate the property &apos;hasPaymentSchedule&apos; from this ontology in favor of the equivalent property with the same name from FND, adding concepts related to statistical swaps, and revising definitions to be ISO 704 compliant.</skos:changeNote>
@@ -102,6 +102,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210301/DerivativesContracts/Swaps/ version of this ontology was modified to move swap execution facility to the markets ontology in FBC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210701/DerivativesContracts/Swaps/ version of this ontology was modified to add the concept of a rates swap and the corresponding rate-based leg to facilitate mapping to the CFI standard.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220201/DerivativesContracts/Swaps/ version of this ontology was modified to address text formatting issues identified through hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/Swaps/ version of this ontology was modified to make a total return swap a kind of credit derivative.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -582,6 +583,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;TotalReturnSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CreditDerivative"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;ReturnSwap"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>

--- a/FBC/DebtAndEquities/CreditEvents.rdf
+++ b/FBC/DebtAndEquities/CreditEvents.rdf
@@ -55,9 +55,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/CreditEvents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20221001/DebtAndEquities/CreditEvents/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to move a restriction involving breach of covenant from credit event, since not all credit events involve breaches, to default event, and loosen the constraint since a breach depends on the contract.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220401/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to augment the definition of obligation-specific event with an optional default threshold to better support credit default swaps.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -196,6 +197,13 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-cre;hasDefaultThresholdAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 			</owl:Restriction>
@@ -227,7 +235,6 @@
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-cre;hasDefaultThresholdAmount">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 		<rdfs:label xml:lang="en">has default threshold amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">specifies an amount of money that triggers a failure to pay, repudiation/moratorium or restructuring event</skos:definition>
 	</owl:ObjectProperty>

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -91,7 +91,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to change one of the subclasses of price determination method to a named individual and correct the definition of mean price determination. Note that there may be multiple individuals of type &apos;closing price determination method&apos;, depending on the exchange and other factors. Also revised the lot size properties to have a range of xsd:decimal to allow for fractional shares or number of elements, revised the explanatory note, and added examples.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to eliminate a redundant restriction on CollectionOfSecurityPrices.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to eliminate a redundant restriction on CollectionOfSecurityPrices and better integrate pricing methods.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -569,6 +569,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-ip;hasPriceDeterminationMethod">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
 		<rdfs:label xml:lang="en">has price determination method</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
 		<skos:definition xml:lang="en">indicates a strategy by which a given price is determined</skos:definition>

--- a/FBC/FinancialInstruments/Settlement.rdf
+++ b/FBC/FinancialInstruments/Settlement.rdf
@@ -190,7 +190,7 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">settlement</rdfs:label>
+		<rdfs:label xml:lang="en">settlement event</rdfs:label>
 		<skos:definition>specific event involving the finalization a transaction or portion thereof, including but not limited to finalizing accounting, exchanging consideration, and/or legally recording documents, as applicable</skos:definition>
 	</owl:Class>
 	

--- a/FBC/FinancialInstruments/Settlement.rdf
+++ b/FBC/FinancialInstruments/Settlement.rdf
@@ -195,7 +195,7 @@
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-stl;hasDeliveryMethod">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
 		<rdfs:label xml:lang="en">has settlement method</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fbc-fi-stl;DeliveryMethod"/>

--- a/FBC/FinancialInstruments/Settlement.rdf
+++ b/FBC/FinancialInstruments/Settlement.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
@@ -28,6 +29,7 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
@@ -65,7 +67,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220901/FinancialInstruments/Settlement/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20221001/FinancialInstruments/Settlement/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220901/FinancialInstruments/Settlement.rdf version of this ontology was revised to integrate the notion of a value assessment with a settlement event.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -162,6 +165,33 @@
 		<rdfs:label>settlement convention</rdfs:label>
 		<skos:definition>convention employed to determine the closing date (from the stated settlement date) in the process of settling a transaction on which securities or interests in securities are delivered, usually against (in simultaneous exchange for) payment of some consideration</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>This is often stated in the form &apos;T+n&apos; where n is the number of business days from the specified settlement date (T).</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fi-stl;SettlementEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
+				<owl:onClass rdf:resource="&fibo-fnd-arr-asmt;ValueAssessment"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;exemplifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fi-stl;Settlement"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">settlement</rdfs:label>
+		<skos:definition>specific event involving the finalization a transaction or portion thereof, including but not limited to finalizing accounting, exchanging consideration, and/or legally recording documents, as applicable</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-stl;hasDeliveryMethod">

--- a/FND/Arrangements/Assessments.rdf
+++ b/FND/Arrangements/Assessments.rdf
@@ -13,7 +13,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -35,7 +34,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -73,7 +71,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20221001/Arrangements/Assessments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190601/Arrangements/Assessments.rdf version of this ontology was revised to integrate concepts related to value assessments / appraisals.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Assessments.rdf version of this ontology was revised to augment the definition of appraisal with an estimated value and correct a bug in the definition of hasAppraiser.</skos:changeNote>
@@ -252,7 +249,7 @@
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-asmt;appliesMethodology">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;uses"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
 		<rdfs:label>applies methodology</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-arr-asmt;ValuationMethod"/>
 		<skos:definition>indicates the strategy used for the purposes of determining the fair market or present value of something</skos:definition>

--- a/FND/Arrangements/Assessments.rdf
+++ b/FND/Arrangements/Assessments.rdf
@@ -6,12 +6,14 @@
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -26,12 +28,14 @@
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -44,8 +48,8 @@
 		<dct:abstract>This ontology defines abstract concepts for assessments, evaluations, and outcomes, as the basis for various analysis, such as for business performance, compliance and risk.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2019-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2019-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2019-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2019-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/</sm:dependsOn>
@@ -62,15 +66,18 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20211201/Arrangements/Assessments/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20221001/Arrangements/Assessments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190601/Arrangements/Assessments.rdf version of this ontology was revised to integrate concepts related to value assessments / appraisals.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Assessments.rdf version of this ontology was revised to augment the definition of appraisal with an estimated value and correct a bug in the definition of hasAppraiser.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20211201/Arrangements/Assessments.rdf version of this ontology was revised to add the concept of a valuation method, which is then applied in the context of a value assessment.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -146,6 +153,12 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
+				<owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOutput"/>
 				<owl:onClass rdf:resource="&fibo-fnd-arr-asmt;AssessmentReport"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -204,12 +217,26 @@
 		<skos:definition>judgement, appraisal, or view about something</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fnd-arr-asmt;ValuationMethod">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
+		<rdfs:label xml:lang="en">valuation method</rdfs:label>
+		<skos:definition xml:lang="en">method used to determine the present or expected worth of an asset</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Asset valuation is the process of determining the fair market or present value of assets, using book values, absolute valuation models like discounted cash flow analysis, option pricing models or comparables. Such assets include investments in marketable securities such as stocks, bonds and options; tangible assets like buildings and equipment; or intangible assets such as brands, patents and trademarks.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fnd-arr-asmt;ValueAssessment">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOutput"/>
 				<owl:onClass rdf:resource="&fibo-fnd-arr-asmt;Appraisal"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;appliesMethodology"/>
+				<owl:onClass rdf:resource="&fibo-fnd-arr-asmt;ValuationMethod"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -223,6 +250,13 @@
 		<skos:definition>assessment event to estimate the value of something</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Note that an appraiser in this context may be a licensed appraiser, such as a real estate appraiser or auction house, or a calculation agent, depending on the circumstances.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-asmt;appliesMethodology">
+		<rdfs:subPropertyOf rdf:resource="&lcc-cr;uses"/>
+		<rdfs:label>applies methodology</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-arr-asmt;ValuationMethod"/>
+		<skos:definition>indicates the strategy used for the purposes of determining the fair market or present value of something</skos:definition>
+	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-asmt;estimatesValueAt">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>

--- a/FND/GoalsAndObjectives/Objectives.rdf
+++ b/FND/GoalsAndObjectives/Objectives.rdf
@@ -44,7 +44,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20220701/GoalsAndObjectives/Objectives/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20221001/GoalsAndObjectives/Objectives/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/GoalsAndObjectives/Objectives.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
 	(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -57,6 +57,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190401/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to integrate concepts such as distribution and sales strategy, and to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to add the concept of a program, required for IND but also to represent compliance, and other kinds of programs.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201101/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to address hygiene issues with respect to text formatting.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to add the property &apos;has strategy&apos; for use in linking to pricing, quotation, distribution, delivery, and other strategies or methods.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -177,6 +178,13 @@
 		<rdfs:label>has objective</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-gao-obj;Objective"/>
 		<skos:definition>relates something to a specific objective (result) that it aims to achieve within a time frame and with available resources</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-gao-obj;hasStrategy">
+		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
+		<rdfs:label>has strategy</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
+		<skos:definition>relates something to a plan or method for achieving a specific goal, objective, solution or outcome</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/SEC/Debt/CollateralizedDebtObligations.rdf
+++ b/SEC/Debt/CollateralizedDebtObligations.rdf
@@ -339,19 +339,6 @@
 		<skos:definition xml:lang="en">The portfolio manager for a managed CDO or arbitrage CDO (also called an asset manager). This assumes that the role is the same in both cases.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-cdo;CDOReferenceObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-cdo;becomesConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-syn;SyntheticCDOPortfolioConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d o reference obligation</rdfs:label>
-		<skos:definition xml:lang="en">A CDS Reference Obligation specifically defined for and referenced in a Synthectic CDO.</skos:definition>
-		<skos:editorialNote xml:lang="en">Facts that distinguish this from Reference Obligation in general: This is basically the same concept but the reference obligation is subsequently used to define the constituents of a synthetic CDO portfolio. That is, the instrument which is the Reference Obligation becomes a member of that portfolio (REVIEW this - isn&apos;t it that sometimes different instruments are used instead? Need to clarify on this. What then is the relationship between the CDS Reference Obligation and the Synthetic CDO Pool constituent</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;CDOSquaredDeal">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-cdo;CDODeal"/>
 		<rdfs:subClassOf>
@@ -806,12 +793,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-cdo;CDOOriginationObjective"/>
 		<rdfs:label xml:lang="en">true p s objective</rdfs:label>
 	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-cdo;becomesConstituent">
-		<rdfs:label xml:lang="en">becomes constituent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-cdo;CDOReferenceObligation"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-syn;SyntheticCDOPortfolioConstituent"/>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-cdo;confersOwnershipOf">
 		<rdfs:label xml:lang="en">confers ownership of</rdfs:label>

--- a/SEC/Debt/SyntheticCDOs.rdf
+++ b/SEC/Debt/SyntheticCDOs.rdf
@@ -162,7 +162,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-syn;hasUnderlyingContract"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -205,7 +205,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-syn;simulatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">synthetic pool asset</rdfs:label>
@@ -243,7 +243,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-syn;hasUnderlyingContract">
 		<rdfs:label xml:lang="en">has underlying contract</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-syn;SyntheticDebtInstrumentPool"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<skos:definition xml:lang="en">The underlying CDS which is created to mechanise the cash flows in the synthetic portfolio.</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -294,7 +294,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-syn;simulatedBy">
 		<rdfs:label xml:lang="en">simulated by</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-syn;SyntheticPoolAsset"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<skos:definition xml:lang="en">The underlying CDS which is created to mechanise the cash flows in the synthetic portfolio.</skos:definition>
 	</owl:ObjectProperty>
 	

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -18,6 +18,7 @@
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
@@ -59,6 +60,7 @@
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
@@ -141,7 +143,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Equities/EquityInstruments.rdf version of this ontology was revised to deprecate the notion of a securities restriction specific to a limited partnership fund unit, which required import of unnecessary content and would not be used in practice.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220301/Equities/EquityInstruments.rdf version of this ontology was revised to clean up deprecated elements, most of which had been in the ontology for awhile.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220501/Equities/EquityInstruments.rdf version of this ontology was revised to address text formatting hygiene issues.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityInstruments.rdf version of this ontology was revised to add the notion of a VIE share.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityInstruments.rdf version of this ontology was revised to add the notion of a VIE share and integrate dividend distribution method with strategy.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -271,6 +273,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;DividendDistributionMethod">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-bd;Convention"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label>dividend distribution method</rdfs:label>
 		<skos:definition>convention by which dividends are provided to shareholders</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Distribution may be by payment of a monetary amount or by reinvestment, as specified by the board of directors at the time a decision to issue a dividend is made.</fibo-fnd-utl-av:explanatoryNote>
@@ -1080,7 +1083,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasDistributionMethod">
-		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
 		<rdfs:label>has distribution method</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Dividend"/>
 		<rdfs:range rdf:resource="&fibo-sec-eq-eq;DividendDistributionMethod"/>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -646,7 +646,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasDefaultSettlementConvention"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundUnitsSettlementTermsConvention"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-stl;SettlementConvention"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund processing terms</rdfs:label>
@@ -785,13 +785,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund unit holding</rdfs:label>
 		<skos:definition xml:lang="en">A holding of a unit in another fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;FundUnitsSettlementTermsConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-stl;SettlementConvention"/>
-		<rdfs:label xml:lang="en">fund units settlement terms convention</rdfs:label>
-		<skos:definition xml:lang="en">Default settlement terms which may apply to a fund, trading of for units in the fund and for redemption of fund units.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From EFAMA DD Review Notes: Default settlement terms. Related to the Unit. Usually the terms are set already at the fund level, and won&apos;t vary at share class level between different share classes, but they are facts about the share classes / Notes / Bonds i.e. what you can trade. In fact this happens already - different kinds of investors may have different settlement dates. In this example you announce it earlier - not the same. This may be a separate fact. Conesnsus:Review</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundsCashDistribution">
@@ -1240,7 +1233,7 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;clearFundsRequired">
 		<rdfs:label xml:lang="en">clear funds required</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundUnitsSettlementTermsConvention"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether cleared funds may be required before a subscription order can be executed.</skos:definition>
 	</owl:DatatypeProperty>
@@ -1465,7 +1458,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasDefaultSettlementConvention">
 		<rdfs:label xml:lang="en">has default settlement convention</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundProcessingTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundUnitsSettlementTermsConvention"/>
+		<rdfs:range rdf:resource="&fibo-fbc-fi-stl;SettlementConvention"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasDepository">
@@ -2049,7 +2042,7 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;redemptionCycleInBusinessDays">
 		<rdfs:label xml:lang="en">redemption cycle in business days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundUnitsSettlementTermsConvention"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;SettlementConvention"/>
 		<rdfs:range rdf:resource="&xsd;integer"/>
 		<skos:definition xml:lang="en">The last business day following the day on which a redemption order is priced (T) by which settlement will be due for orders placed with the main Fund Order Desk. Alternatively, if proceeds will be paid following receipt of written renunciation, the last business day following receipt of the relevant renunciation documentation by the main Fund Order Desk (R) by which the proceeds will be sent.</skos:definition>
 	</owl:DatatypeProperty>
@@ -2101,13 +2094,6 @@
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RecurrenceInterval"/>
 		<skos:definition xml:lang="en">For units where there is Reinvestment distribution, the frequency with which the reinvestment takes place (this will be the same or less frequently than the Dividend Payment Frequency), otherwise this fact does not apply.</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;settlementPeriodInBusinessDays">
-		<rdfs:label xml:lang="en">settlement period in business days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundUnitsSettlementTermsConvention"/>
-		<rdfs:range rdf:resource="&xsd;integer"/>
-		<skos:definition xml:lang="en">The last business day following the day on which a subscription order is priced (T) by which settlement will be due for orders placed with the main Fund Order Desk, eg. T+3.</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;signatureRequired">
 		<rdfs:label xml:lang="en">signature required</rdfs:label>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

1. Created the concept of a credit derivative in derivatives basics, added a subclass relation between credit derivative and total return swap, and made some preliminary changes to credit default swaps per FCT discussion on 10/11/2022
2. Simplified the model by eliminating the notion of a fee leg per discussion in the SEC FCT on 10/14
3. Replaced CDSCreditEvent with TriggeringEvent, eliminated the redundant notion of a reference obligation, which is the underlier, cleaned up definitions and eliminated additional duplication per discussion on 10/18 in the DER FCT
4. Moved the notion of a valuation method to assessments and integrated it with settlement, the valuation of an underlier in general, and eliminated redundancies in CDS as a consequence on 10/21 in the SEC FCT
5. Eliminated additional redundancies and better integrated cash settlement terms with the extensions needed for CDS, including remaining hygiene issues

Fixes: #1843 / DER-136


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


