### PR TITLE
DER-137 - Revise the CDS ontology to include concepts defined in the Fed overview and CFI standard

### DIFF
--- a/AboutFIBOProd-IncludingReferenceData.rdf
+++ b/AboutFIBOProd-IncludingReferenceData.rdf
@@ -194,6 +194,8 @@
 	///////////////////////////////////////////////////////////////////////////////////////
 	-->		
 		
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
+		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
@@ -375,7 +377,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20220801/AboutFIBOProd-IncludingReferenceData/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20221201/AboutFIBOProd-IncludingReferenceData/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBOProd-TBoxOnly.rdf
+++ b/AboutFIBOProd-TBoxOnly.rdf
@@ -85,6 +85,8 @@
 	//
 	///////////////////////////////////////////////////////////////////////////////////////
 	-->		
+	
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
@@ -246,7 +248,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20220901/AboutFIBOProd-TBoxOnly/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20221201/AboutFIBOProd-TBoxOnly/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -24,7 +24,7 @@
  <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/">
  		<rdfs:label>About FIBO Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-09-30T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-12-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
@@ -103,6 +103,8 @@
 	//
 	///////////////////////////////////////////////////////////////////////////////////////
 	-->		
+			
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
@@ -289,7 +291,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20220901/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20221201/AboutFIBOProd/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/DER/AllDER.rdf
+++ b/DER/AllDER.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-all "https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/">
+	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-comm "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/">
 	<!ENTITY fibo-der-drc-cur "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/">
@@ -25,6 +26,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-all="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/"
+	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-comm="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"
 	xmlns:fibo-der-drc-cur="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"
@@ -48,7 +50,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/">
 		<rdfs:label>Derivatives Domain</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-28T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-12-30T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain</dct:title>
 		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
@@ -72,19 +74,13 @@
 		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
 		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-der-all</sm:fileAbbreviation>
 		<sm:filename>AllDER.rdf</sm:filename>
 		<sm:keyword>derivative instruments</sm:keyword>
 		<sm:keyword>options, futures, rights instruments, swaps</sm:keyword>
 		<sm:moduleAbbreviation>fibo-der</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
+	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 	<!ENTITY fibo-fbc-fi-stl "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/">
@@ -28,10 +30,12 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
+	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:fibo-fbc-fi-stl="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"
@@ -61,11 +65,13 @@
 		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-cr-cds</sm:fileAbbreviation>
 		<sm:filename>CreditDefaultSwaps.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -98,26 +104,12 @@
 		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CashSettlementQuotationMethod">
+	<owl:Class rdf:about="&fibo-der-cr-cds;CashSettlementMethod">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasPricingSource"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;Dealer">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash settlement quotation method</rdfs:label>
-		<skos:definition xml:lang="en">specification of the nature of the quotation rate to be obtained from each cash settlement reference bank</skos:definition>
-		<skos:example xml:lang="en">For example, Bid, Offer or Mid-market.</skos:example>
+		<rdfs:label xml:lang="en">cash settlement method</rdfs:label>
+		<skos:definition xml:lang="en">strategy for calculating or otherwise establishing a reference final price for the contract</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The method may include an independently administered synthetic auction process that sets the reference final price.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentCreditDefaultSwap">
@@ -131,6 +123,13 @@
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CreditDerivative"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOccurrence"/>
+				<owl:onClass rdf:resource="&fibo-der-cr-cds;SettlementAuction"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasContractPrice"/>
@@ -180,13 +179,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasNotionalAmount"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasScheduledTerminationDate"/>
 				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -224,9 +216,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit protection terms</rdfs:label>
-		<skos:definition xml:lang="en">The leg of the swap which represents the credit protection.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review notes 31 March: For a protection leg the commitment is a conditional commitment to pay out in the event of the credit event. Typically this would be a default. Contingent Leg is another name for this, because it is contingent on the credit event. Contents: 1. The payment to be made in the event of the credit event occurring 2. the Credit Event itself. This is called the calculation amount as it is the notional amount minus the recovery, to get a final calculation amount. There is a formula behind this. The Calculation Amount is how the calculation is driven not what the actual payment amount is. Do we model the formula? Depends whether there is physical or cash settlement. Modeler notes: FpML terms for &quot;CDS Protection Terms&quot; are equivalent to this structure. Formal Definition for CDS Protection Terms: The legal terms relevant to defining the applicable floating rate payer calculation amount, credit events and associated conditions to settlement, and reference obligations. FpML: &apos;This element contains all the terms relevant to defining the applicable floating rate payer calculation amount, credit events and associated conditions to settlement, and reference obligations.&apos; Deifnition Origin:SMER</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The notional amount is the price at which the protection seller agrees to pay out in the event that a triggering event occurs. Note that there may be additional payment schedules or a more complex calculation formula required depending on the terms of the contract.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">legal terms that define triggering events and associated conditions related to settlement</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that there may be additional payment schedules or a more complex calculation formula required depending on the terms of the contract.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym xml:lang="en">contingent leg</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligation">
@@ -291,8 +283,8 @@
 	<owl:Class rdf:about="&fibo-der-cr-cds;LocallyDefinedCreditBasket">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;Basket"/>
 		<rdfs:label xml:lang="en">locally defined credit basket</rdfs:label>
-		<skos:definition xml:lang="en">A basket of securities and/or reference entities monitored for credit purposes.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This would be the underlying of a non single-name Credit Default Swap. Review session notes: Basket is not just a basket of securities but a basket of securities and/or reference entities. The basket has terms about the nth entity to default and so on. So it works like a locally defined credit index, which (we assume) works in a similar way. Modeling note: Credit Index now modeled using information from OTPP, where each constituent is one Reference Entity and one corresponding instrument. Assume this arrangement works the same way. Modeled accordingly. See Indices and Indicators section for equivalent terms for published Credit Index.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">basket of securities and/or reference entities monitored for credit purposes</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The basket works like a locally defined credit index, which (we assume) works in a similar way. Modeling note: Credit Index now modeled using information from OTPP, where each constituent is one Reference Entity and one corresponding instrument. See Indices and Indicators section for equivalent terms for published Credit Index.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;MultiNameCreditDefaultSwap">
@@ -320,6 +312,13 @@
 		<rdfs:label xml:lang="en">notifying party</rdfs:label>
 		<skos:definition xml:lang="en">party responsible for issuing one or more formal notices indicating that an event that is relevant to a given contract has taken place</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The notifying party is the party that notifies the other party when a credit or other triggering event has occurred by means of a credit event notice. If more than one party is referenced as being the notifying party then either party may notify the other of such an occurrence.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-cr-cds;SettlementAuction">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-stl;SettlementEvent"/>
+		<rdfs:label xml:lang="en">settlement auction</rdfs:label>
+		<skos:definition xml:lang="en">independently administered synthetic auction process on a set of defined deliverable obligations that sets the reference final price that can be used to facilitate cash settlement of all covered transactions following a credit event</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;SingleNameCreditDefaultSwap">
@@ -364,8 +363,8 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-fi-ip;hasPriceDeterminationMethod"/>
 		<rdfs:label xml:lang="en">has quotation method</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;CashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CashSettlementQuotationMethod"/>
-		<skos:definition xml:lang="en">indicates the nature of the pricing quotations to be requested from dealers when determining the market value of the reference obligation for purposes of cash settlement</skos:definition>
+		<rdfs:range rdf:resource="&fibo-der-cr-cds;CashSettlementMethod"/>
+		<skos:definition xml:lang="en">indicates the nature of the pricing quotations to be requested from banks and/or dealers when determining the market value of the reference obligation for purposes of cash settlement</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasScheduledTerminationDate">
@@ -387,11 +386,17 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-ip;AuctionMethod">
+		<rdf:type rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
+		<rdfs:label xml:lang="en">auction method</rdfs:label>
+		<skos:definition xml:lang="en">method for determining a price that represents use of an independently administered synthetic auction in order to set a price</skos:definition>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&fibo-fbc-fi-stl;CashSettlementTerms">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasQuotationMethod"/>
-				<owl:onClass rdf:resource="&fibo-der-cr-cds;CashSettlementQuotationMethod"/>
+				<owl:onClass rdf:resource="&fibo-der-cr-cds;CashSettlementMethod"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -407,6 +412,29 @@
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasMinimumQuotationAmount"/>
 				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasPricingSource"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-be-fct-pub;Publisher">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;Dealer">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-fi-ip;PricingModel">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-fct-mkt;Exchange">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-fi-ip;CompositeMarket">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that the valuation determined via the appraisal of the underlying asset may include a quotation that is either an upper limit to the outstanding principal balance of the reference obligation for which the quote should be obtained, or a floating rate payer calculation amount.</fibo-fnd-utl-av:explanatoryNote>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -63,6 +63,7 @@
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-cr-cds</sm:fileAbbreviation>
 		<sm:filename>CreditDefaultSwaps.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
@@ -85,7 +86,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;AssetBackedCreditDefaultSwap">

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -83,10 +83,18 @@
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;AssetBackedCreditDefaultSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:label xml:lang="en">asset-backed credit default swap contract</rdfs:label>
+		<rdfs:label xml:lang="en">asset-backed credit default swap</rdfs:label>
 		<skos:definition xml:lang="en">credit default swap whose underlying reference obligation is an asset-backed security rather than corporate credit</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">ABCDS</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the case of an ABCDS, the buyer receives protection for defaults on asset-backed securities or tranches of securities, rather than protecting against the default of a particular issuer. Asset-backed securities are securities backed by a pool of loans or receivables, such as auto loans, home equity loans or credit cards loans.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-cr-cds;BasketCreditDefaultSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;MultiNameCreditDefaultSwap"/>
+		<rdfs:label xml:lang="en">basket credit default swap</rdfs:label>
+		<skos:definition xml:lang="en">credit default swap that references a bespoke, synthetic portfolio of underlying assets whose components have been agreed to for a specific OTC derivative by the parties to the transaction</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Draft paper on Credit Default Swaps from the Federal Reserve Board, available at https://www.federalreserve.gov/econres/feds/files/2022023pap.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CashSettlementQuotationMethod">
@@ -98,7 +106,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentCreditDefaultSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:label xml:lang="en">contingent credit default swap contract</rdfs:label>
+		<rdfs:label xml:lang="en">contingent credit default swap</rdfs:label>
 		<skos:definition xml:lang="en">credit default swap in which an additional triggering event is required</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">CCDS</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In a contingent credit default swap, the trigger requires both a credit event (as in a traditional credit default swap) and another specified event. The additional specified event is usually a significant movement in an index covering equities, commodities, interest rates, or some other overall measure of the economy or relevant industry.</fibo-fnd-utl-av:explanatoryNote>
@@ -137,7 +145,7 @@
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapReceivingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap contract</rdfs:label>
+		<rdfs:label xml:lang="en">credit default swap</rdfs:label>
 		<skos:definition xml:lang="en">bilateral contract in which one party (protection seller) agrees to provide payment to the other party (protection buyer) should a credit event occur against the underlying, which could be a specified debt (the reference obligation), a specific debt issuer (reference entity), a basket of reference entities and/or reference obligations, or a credit index (reference index)</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">CDS</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
@@ -252,9 +260,26 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Use of an escrow agent is one possible mechanism that may be used in some cases, as specified in a credit default swap contract, for delivery purposes.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-cr-cds;IndexCreditDefaultSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;MultiNameCreditDefaultSwap"/>
+		<rdfs:label xml:lang="en">index credit default swap</rdfs:label>
+		<skos:definition xml:lang="en">credit default swap that references a family of standardized credit derivative indices, where the underlying reference entities are a defined basket of credit from a particular geographic region (e.g. Asia, North America, Europe), and/or credit rating level (e.g. emerging markets, high yield, investment grade)</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Draft paper on Credit Default Swaps from the Federal Reserve Board, available at https://www.federalreserve.gov/econres/feds/files/2022023pap.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Credit default indices trade in standard maturities, and the reference entities are typically the most liquid; the reference portfolio is reassessed periodically to maintain this.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-cr-cds;IndexTrancheCreditDefaultSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;MultiNameCreditDefaultSwap"/>
+		<rdfs:label xml:lang="en">index tranche credit default swap</rdfs:label>
+		<skos:definition xml:lang="en">credit default swap that references a synthetic collateralized debt obligation (CDO) based on a credit index where each tranche references a different segment of the loss distribution of the underlying index</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Each tranche has a different priority of claims on the principal and interest flows from the collateral pool, and is traditionally portioned into rising levels of seniority.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-cr-cds;LoanCreditDefaultSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
-		<rdfs:label xml:lang="en">loan credit default swap contract</rdfs:label>
+		<rdfs:label xml:lang="en">loan credit default swap</rdfs:label>
 		<skos:definition xml:lang="en">credit default swap whose underlying reference obligation is limited strictly to syndicated secured loans, rather than any type of corporate debt</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">LCDS</fibo-fnd-utl-av:abbreviation>
 	</owl:Class>
@@ -264,6 +289,16 @@
 		<rdfs:label xml:lang="en">locally defined credit basket</rdfs:label>
 		<skos:definition xml:lang="en">A basket of securities and/or reference entities monitored for credit purposes.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This would be the underlying of a non single-name Credit Default Swap. Review session notes: Basket is not just a basket of securities but a basket of securities and/or reference entities. The basket has terms about the nth entity to default and so on. So it works like a locally defined credit index, which (we assume) works in a similar way. Modeling note: Credit Index now modeled using information from OTPP, where each constituent is one Reference Entity and one corresponding instrument. Assume this arrangement works the same way. Modeled accordingly. See Indices and Indicators section for equivalent terms for published Credit Index.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-cr-cds;MultiNameCreditDefaultSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
+		<rdfs:label xml:lang="en">multi-name credit default swap</rdfs:label>
+		<skos:definition xml:lang="en">credit default swap that references more than one obligation or borrower</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Draft paper on Credit Default Swaps from the Federal Reserve Board, available at https://www.federalreserve.gov/econres/feds/files/2022023pap.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For instance, a multiname contract could be written to cover defaults in a reference portfolio (such as in the case of a basket credit default swap) or, as has been increasingly common over the past couple of decades,be based on an index of commonly negotiated single-name CDS. The latter are generally called CDS indexes.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>multiname credit default swap</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;NotifyingParty">
@@ -281,6 +316,14 @@
 		<rdfs:label xml:lang="en">notifying party</rdfs:label>
 		<skos:definition xml:lang="en">party responsible for issuing one or more formal notices indicating that an event that is relevant to a given contract has taken place</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The notifying party is the party that notifies the other party when a credit or other triggering event has occurred by means of a credit event notice. If more than one party is referenced as being the notifying party then either party may notify the other of such an occurrence.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-cr-cds;SingleNameCreditDefaultSwap">
+		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
+		<rdfs:label xml:lang="en">single name credit default swap</rdfs:label>
+		<skos:definition xml:lang="en">credit default swap whose underlying risk is a single reference obligation, or a single reference entity, such as a corporation or a sovereign borrower</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Draft paper on Credit Default Swaps from the Federal Reserve Board, available at https://www.federalreserve.gov/econres/feds/files/2022023pap.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 10962:2019, Securities and related financial instruments - Classification of financial instruments (CFI) code</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;TriggeringEvent">

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -280,13 +280,6 @@
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">LCDS</fibo-fnd-utl-av:abbreviation>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-cr-cds;LocallyDefinedCreditBasket">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;Basket"/>
-		<rdfs:label xml:lang="en">locally defined credit basket</rdfs:label>
-		<skos:definition xml:lang="en">basket of securities and/or reference entities monitored for credit purposes</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The basket works like a locally defined credit index, which (we assume) works in a similar way. Modeling note: Credit Index now modeled using information from OTPP, where each constituent is one Reference Entity and one corresponding instrument. See Indices and Indicators section for equivalent terms for published Credit Index.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-cr-cds;MultiNameCreditDefaultSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDefaultSwap"/>
 		<rdfs:label xml:lang="en">multi-name credit default swap</rdfs:label>
@@ -374,13 +367,6 @@
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition xml:lang="en">date on which credit protection is due to expire as agreed by both parties</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;sixtyBusinessDaySettlementCap">
-		<rdfs:label xml:lang="en">sixty business day settlement cap</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-stl;PhysicalSettlementTerms"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether the legal terms set forth in the following language are deemed part of the confirmation (the section references are to the 2003 ISDA Credit Derivatives Definitions): &apos;Notwithstanding Section 1.7 or any provisions of Sections 9.9 or 9.10 to the contrary, but without prejudice to Section 9.3 and (where applicable) Sections 9.4, 9.5 and 9.6, if the Termination Date has not occurred on or prior to the date that is 60 Business Days following the Physical Settlement Date, such 60th Business Day shall be deemed to be the Termination Date with respect to this Transaction except in relation to any portion of the Transaction (an &quot;Affected Portion&quot;) in respect of which: (1) a valid notice of Buy-in Price has been delivered that is effective fewer than three Business Days prior to such 60th Business Day, in which case the Termination Date for that Affected Portion shall be the third Business Day following the date on which such notice is effective; or (2) Buyer has purchased but not Delivered Deliverable Obligations validly specified by Seller pursuant to Section 9.10(b), in which case the Termination Date for that Affected Portion shall be the tenth Business Day following the date on which Seller validly specified such Deliverable Obligations to Buyer.&apos;</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationSpecificCreditEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -133,18 +133,6 @@
 				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapPayingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapReceivingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit default swap</rdfs:label>
 		<skos:definition xml:lang="en">bilateral contract in which one party (protection seller) agrees to provide payment to the other party (protection buyer) should a credit event occur against the underlying, which could be a specified debt (the reference obligation), a specific debt issuer (reference entity), a basket of reference entities and/or reference obligations, or a credit index (reference index)</skos:definition>
 		<fibo-fnd-utl-av:abbreviation xml:lang="en">CDS</fibo-fnd-utl-av:abbreviation>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -54,12 +54,13 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
-		<rdfs:label xml:lang="en">CreditDefaultSwaps</rdfs:label>
-		<dct:abstract>A transaction and contract in which one leg is the conditional commitment to pay out on some debt in the event that a pre-defined credit event takes place. The contract may make reference to a specific debt instrument or loan, or take effect in the event of one of a range of events that happen to the business entity that is the debtor in that debt. Includes terms for different kinds of settlement arrangement. Note that these are a swap in name only, since under normal conditions there is only one stream of payment, the fee payment leg.</dct:abstract>
+		<rdfs:label xml:lang="en">Credit Default Swaps Ontology</rdfs:label>
+		<dct:abstract>Credit default swaps are financial instruments that allow the transfer of credit risk among market participants, potentially facilitating greater efficiency in the pricing and distribution/offset of credit risk. They are bilateral contracts in which one party (the protection seller) agrees to provide payment(s) to the other party (the protection buyer) should a credit event occur against the underlying. The underlier for a CDS may be a specified debt (the reference obligation), a specific debt issuer (reference entity), in which case the credit events involving the entity is what triggers the payment, a basket of reference entities and/or reference obligations, or a credit index (reference index). This ontology defines the concept of a basic credit default swap as well as more specific kinds of CDS and specifies related details.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-cr-cds</sm:fileAbbreviation>
+		<sm:filename>CreditDefaultSwaps.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
@@ -172,7 +173,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit event notice</rdfs:label>
 		<skos:definition xml:lang="en">irrevocable written or verbal notice that states that a triggering event has occurred</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A specified condition to settlement. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice. FpML full definition: &apos;A specified condition to settlement. An irrevocable written or verbal notice that describes a credit event that has occurred. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice.&apos;</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notices of certain kinds of credit events are required as a condition of a credit default swap. Such notices are sent from a notifying party (either the buyer or the seller) to the counterparty. They provide information that assists the contract parties in determining whether a triggering credit event has occurred.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionTerms">

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -99,6 +99,21 @@
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CashSettlementQuotationMethod">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-ip;hasPricingSource"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;Dealer">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">cash settlement quotation method</rdfs:label>
 		<skos:definition xml:lang="en">specification of the nature of the quotation rate to be obtained from each cash settlement reference bank</skos:definition>
 		<skos:example xml:lang="en">For example, Bid, Offer or Mid-market.</skos:example>

--- a/DER/CreditDerivatives/MetadataDERCreditDerivatives.rdf
+++ b/DER/CreditDerivatives/MetadataDERCreditDerivatives.rdf
@@ -24,15 +24,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/MetadataDERCreditDerivatives/">
 		<rdfs:label>Metadata about the EDMC-FIBO Derivatives (DER) Credit Derivatives Module</rdfs:label>
 		<dct:abstract>The credit derivatives module covers derivatives that allow either the lender or borrower to transfer the credit risk, or risk of default, to another party other than the lender or debtholder.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2022-12-30T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018 EDM Council, Inc.</sm:copyright>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-cr-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataDERCreditDerivatives.rdf</sm:filename>
 		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20180801/CreditDerivatives/MetadataDERCreditDerivatives/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20221201/CreditDerivatives/MetadataDERCreditDerivatives/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-der-cr-mod;CreditDerivativesModule">
@@ -42,7 +43,8 @@
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Credit Derivatives Module</dct:title>
-		<sm:copyright>Copyright (c) 2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-der-cr</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 	</owl:NamedIndividual>

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -91,7 +91,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to change one of the subclasses of price determination method to a named individual and correct the definition of mean price determination. Note that there may be multiple individuals of type &apos;closing price determination method&apos;, depending on the exchange and other factors. Also revised the lot size properties to have a range of xsd:decimal to allow for fractional shares or number of elements, revised the explanatory note, and added examples.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to eliminate a redundant restriction on CollectionOfSecurityPrices, better integrate pricing methods, and loosen the domain restriction on hasPricingSource.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to eliminate a redundant restriction on CollectionOfSecurityPrices, better integrate pricing methods, loosen the domain restriction on hasPricingSource and add dealer to the set of possible sources for prices.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -236,6 +236,8 @@
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&fibo-be-fct-pub;Publisher">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;Dealer">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
 							</rdf:Description>
@@ -405,6 +407,8 @@
 							<rdf:Description rdf:about="&fibo-be-fct-pub;Publisher">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;Dealer">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-fbc-fi-ip;PricingModel">
 							</rdf:Description>

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -85,13 +85,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20221001/FinancialInstruments/InstrumentPricing/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FinancialInstruments/InstrumentPricing/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, to add adjusted price and to create a more general hasLotSize property that can be used in various contexts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to change one of the subclasses of price determination method to a named individual and correct the definition of mean price determination. Note that there may be multiple individuals of type &apos;closing price determination method&apos;, depending on the exchange and other factors. Also revised the lot size properties to have a range of xsd:decimal to allow for fractional shares or number of elements, revised the explanatory note, and added examples.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to eliminate a redundant restriction on CollectionOfSecurityPrices and better integrate pricing methods.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to eliminate a redundant restriction on CollectionOfSecurityPrices, better integrate pricing methods, and loosen the domain restriction on hasPricingSource.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -578,8 +578,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-ip;hasPricingSource">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
 		<rdfs:label xml:lang="en">has pricing source</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
-		<skos:definition xml:lang="en">indicates the origin of a given price for a financial instrument</skos:definition>
+		<skos:definition xml:lang="en">indicates the origin of a given quote or price for a financial instrument</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fi-ip;hasQuoteLotSize">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

1. Augmented the CDS ontology to include single and multi-name CDS including subclasses of multi-name
2. Eliminated unnecessary restrictions on various concepts
3. Revised the definition of cash settlement method to address the potential for ad hoc auctions
4. Added 'dealers' to the possible pricing sources
5. Cleaned up a few lingering / dangling concepts to enable it to be released
6. Updated metadata files and released the CDS ontology for inclusion in production in the Q4 2022 release

Fixes: #1848 / DER-137


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


