### PR TITLE
Extension to CMNS AV ontology added to hygiene tests

### DIFF
--- a/etc/testing/hygiene_parameterized/testHygiene0005.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene0005.sparql
@@ -1,11 +1,9 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
-prefix spin:  <http://spinrdf.org/spin#> 
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#> 
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
 prefix sm: <http://www.omg.org/techprocess/ab/SpecificationMetadata/>
 prefix cmns-av: <https://www.omg.org/spec/Commons/AnnotationVocabulary/>
-
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
 prefix dct: <http://purl.org/dc/terms/>
 
@@ -18,9 +16,9 @@ WHERE {
   FILTER NOT EXISTS {?ont owl:deprecated "true"^^xsd:boolean} .
   FILTER regex(str(?ont), <HYGIENE_TESTS_FILTER_PARAMETER>)	
   FILTER NOT EXISTS {
-	?ont rdfs:label ?l  ;
-	{sm:copyright ?cr } UNION ;{cmns-av:copyright ?cr }
-	dct:license ?lic ;
-	dct:abstract ?abs .}
+	?ont rdfs:label ?l  .
+	{?ont sm:copyright ?cr } UNION {?ont cmns-av:copyright ?cr } .
+	?ont dct:license ?lic .
+	?ont dct:abstract ?abs .}
 BIND (concat ("PRODERROR: ", xsd:string(?ont), " has to have appropriate metadata.") AS ?error)
 }

--- a/etc/testing/hygiene_parameterized/testHygiene0005.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene0005.sparql
@@ -4,11 +4,13 @@ prefix spin:  <http://spinrdf.org/spin#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#> 
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
 prefix sm: <http://www.omg.org/techprocess/ab/SpecificationMetadata/>
+prefix cmns-av: <https://www.omg.org/spec/Commons/AnnotationVocabulary/>
+
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
 prefix dct: <http://purl.org/dc/terms/>
 
 ##
-# banner Every Ontology defined in FIBO must have a rdfs:label,  sm:copyright, dct:license, dct:abstract
+# banner Every Ontology defined in FIBO must have a rdfs:label,  copyright, dct:license, dct:abstract
 
 SELECT DISTINCT ?error
 WHERE {
@@ -17,7 +19,7 @@ WHERE {
   FILTER regex(str(?ont), <HYGIENE_TESTS_FILTER_PARAMETER>)	
   FILTER NOT EXISTS {
 	?ont rdfs:label ?l  ;
-	sm:copyright ?cr ;
+	{sm:copyright ?cr } UNION ;{cmns-av:copyright ?cr }
 	dct:license ?lic ;
 	dct:abstract ?abs .}
 BIND (concat ("PRODERROR: ", xsd:string(?ont), " has to have appropriate metadata.") AS ?error)

--- a/etc/testing/hygiene_parameterized/testHygiene0268.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene0268.sparql
@@ -3,7 +3,6 @@ prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#> 
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
 prefix afn: <http://jena.apache.org/ARQ/function#>
-prefix sm: <http://www.omg.org/techprocess/ab/SpecificationMetadata/>
 prefix dct: <http://purl.org/dc/terms/> 
 
 ##


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

## Description

This temporarily allows for "duplicated" properties be used in hygiene tests - it is needed to move towards usage of OMG common libraries.

Fixes: #1860 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


