### PR TITLE
FBC-305 - Replace specification metadata-related annotations with annotations from the Commons Ontology Library in the FIBO Financial Business and Commerce (FBC) Domain

### DIFF
--- a/FBC/AllFBC-Europe.rdf
+++ b/FBC/AllFBC-Europe.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-eufse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fct-eufseind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/">
@@ -10,10 +11,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-Europe/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-eufse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"
 	xmlns:fibo-fbc-fct-eufseind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"
@@ -24,59 +25,45 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-Europe/">
 		<rdfs:label>Financial Business and Commerce Domain, European Extension</rdfs:label>
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Capacity Post, Inc.</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain, European Extension</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbceu-all</sm:fileAbbreviation>
-		<sm:filename>AllFBC-Europe.rdf</sm:filename>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>financial products</sm:keyword>
-		<sm:keyword>financial services, service providers, and accounts</sm:keyword>
-		<sm:keyword>markets</sm:keyword>
-		<sm:keyword>registration authorities</sm:keyword>
-		<sm:keyword>regulatory agencies</sm:keyword>
-		<sm:moduleAbbreviation>fibo-fbc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-Europe/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceMarkets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/AllFBC-Europe/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for the European Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND but excluding individuals for North American governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/AllFBC-Europe/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for the European Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND but excluding individuals for North American governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/FBC/AllFBC-EuropeAndNorthAmerica.rdf
+++ b/FBC/AllFBC-EuropeAndNorthAmerica.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbceuna-all "https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-EuropeAndNorthAmerica/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-EuropeAndNorthAmerica/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbceuna-all="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-EuropeAndNorthAmerica/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -18,55 +19,42 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-EuropeAndNorthAmerica/">
 		<rdfs:label>Financial Business and Commerce (FBC) Domain, European and North American Extension</rdfs:label>
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Capacity Post, Inc.</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain, European and North American Extensions</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbceuna-all</sm:fileAbbreviation>
-		<sm:filename>AllFBC-EuropeAndNorthAmerica.rdf</sm:filename>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>financial products</sm:keyword>
-		<sm:keyword>financial services, service providers, and accounts</sm:keyword>
-		<sm:keyword>markets</sm:keyword>
-		<sm:keyword>registration authorities</sm:keyword>
-		<sm:keyword>regulatory agencies</sm:keyword>
-		<sm:moduleAbbreviation>fibo-fbc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-Europe/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmerica/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/AllFBC-EuropeAndNorthAmerica/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for the European and North American Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND as well as individuals for European and North American governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/AllFBC-EuropeAndNorthAmerica/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for the European and North American Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND as well as individuals for European and North American governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/FBC/AllFBC-ExampleIndividuals.rdf
+++ b/FBC/AllFBC-ExampleIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbcexind-all "https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ExampleIndividuals/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ExampleIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbcexind-all="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ExampleIndividuals/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -18,7 +19,6 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ExampleIndividuals/">
@@ -26,50 +26,38 @@
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.
 	
 	This ontology is provided for the convenience of FIBO users, and enables loading of all of FBC, including all EU and NA reference individuals as well as example government and business entities that are used in FIBO use cases and training.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Capacity Post, Inc.</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain, European and North American Extensions with Examples</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg L.P.</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>No Magic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbcexind-all</sm:fileAbbreviation>
-		<sm:filename>AllFBC-ExampleIndividuals.rdf</sm:filename>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>financial products</sm:keyword>
-		<sm:keyword>financial services, service providers, and accounts</sm:keyword>
-		<sm:keyword>markets</sm:keyword>
-		<sm:keyword>registration authorities</sm:keyword>
-		<sm:keyword>regulatory agencies</sm:keyword>
-		<sm:moduleAbbreviation>fibo-fbc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-ExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-EuropeAndNorthAmerica/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/AllFBC-ExampleIndividuals/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for the European and North American Extension of FBC with examples is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND as well as individuals for European and North American governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies, together with examples that are used in many fibo use cases and for training purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/AllFBC-ExampleIndividuals/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for the European and North American Extension of FBC with examples is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND as well as individuals for European and North American governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies, together with examples that are used in many fibo use cases and for training purposes.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/FBC/AllFBC-NorthAmerica.rdf
+++ b/FBC/AllFBC-NorthAmerica.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-cafse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fct-cajrga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/">
@@ -13,10 +14,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmerica/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-cafse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/"
 	xmlns:fibo-fbc-fct-cajrga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"
@@ -30,52 +31,36 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmerica/">
 		<rdfs:label>Financial Business and Commerce Domain, North American Extension</rdfs:label>
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Capacity Post, Inc.</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain, North American Extension</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbcna-all</sm:fileAbbreviation>
-		<sm:filename>AllFBC-NorthAmerica.rdf</sm:filename>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>financial products</sm:keyword>
-		<sm:keyword>financial services, service providers, and accounts</sm:keyword>
-		<sm:keyword>markets</sm:keyword>
-		<sm:keyword>registration authorities</sm:keyword>
-		<sm:keyword>regulatory agencies</sm:keyword>
-		<sm:moduleAbbreviation>fibo-fbc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-NorthAmerica/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceMarkets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/"/>
@@ -84,8 +69,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/AllFBC-NorthAmerica/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for the North American Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) Version 2.0 domains, including all of FND but excluding individuals for European governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/AllFBC-NorthAmerica/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for the North American Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) Version 2.0 domains, including all of FND but excluding individuals for European governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/FBC/AllFBC-NorthAmericanExamples.rdf
+++ b/FBC/AllFBC-NorthAmericanExamples.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-usind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/">
 	<!ENTITY fibo-fbcnaex-all "https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmericanExamples/">
@@ -8,10 +9,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmericanExamples/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-usind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"
 	xmlns:fibo-fbcnaex-all="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmericanExamples/"
@@ -20,57 +21,43 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmericanExamples/">
 		<rdfs:label>Financial Business and Commerce Domain, North American Extensions and Examples</rdfs:label>
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Capacity Post, Inc.</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain, North American Extension and Examples</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbcnaex-all</sm:fileAbbreviation>
-		<sm:filename>AllFBC-NorthAmericanExamples.rdf</sm:filename>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>financial products</sm:keyword>
-		<sm:keyword>financial services, service providers, and accounts</sm:keyword>
-		<sm:keyword>markets</sm:keyword>
-		<sm:keyword>registration authorities</sm:keyword>
-		<sm:keyword>regulatory agencies</sm:keyword>
-		<sm:moduleAbbreviation>fibo-fbc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-NorthAmericanExamples/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmerica/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/AllFBC-NorthAmericanExamples/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for the North American Extension of FBC with Examples is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND) and Business Entities (BE) domains, including all of FND but excluding individuals for European government entities, jurisdictions, financial services entities, regulatory agencies, and the like, with the anticipation that additional examples will be added over time.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/AllFBC-NorthAmericanExamples/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for the North American Extension of FBC with Examples is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND) and Business Entities (BE) domains, including all of FND but excluding individuals for European government entities, jurisdictions, financial services entities, regulatory agencies, and the like, with the anticipation that additional examples will be added over time.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/FBC/AllFBC-ReferenceIndividuals.rdf
+++ b/FBC/AllFBC-ReferenceIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbcri-all "https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceIndividuals/">
 	<!ENTITY fibo-fbcrm-all "https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceMarkets/">
@@ -8,10 +9,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbcri-all="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceIndividuals/"
 	xmlns:fibo-fbcrm-all="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceMarkets/"
@@ -20,57 +21,43 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceIndividuals/">
 		<rdfs:label>Financial Business and Commerce Domain, Reference Individuals Extension</rdfs:label>
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products. This extension includes all reference data from FND, BE, and FBC combined, rather than limiting that content to Europe and North America.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Capacity Post, Inc.</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain, Reference Individuals Extension</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbcri-all</sm:fileAbbreviation>
-		<sm:filename>AllFBC-ReferenceIndividuals.rdf</sm:filename>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>financial products</sm:keyword>
-		<sm:keyword>financial services, service providers, and accounts</sm:keyword>
-		<sm:keyword>markets</sm:keyword>
-		<sm:keyword>registration authorities</sm:keyword>
-		<sm:keyword>regulatory agencies</sm:keyword>
-		<sm:moduleAbbreviation>fibo-fbc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-ReferenceIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-Europe/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmerica/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/AllFBC-ReferenceIndividuals/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for the Reference Individuals Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND, and all of BE excluding example individuals, as well as all of FBC excluding examples.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/AllFBC-ReferenceIndividuals/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for the Reference Individuals Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND, and all of BE excluding example individuals, as well as all of FBC excluding examples.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/FBC/AllFBC-ReferenceMarkets.rdf
+++ b/FBC/AllFBC-ReferenceMarkets.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-bci "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/">
 	<!ENTITY fibo-fbc-fct-ireg "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities/">
@@ -10,10 +11,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceMarkets/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-bci="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"
 	xmlns:fibo-fbc-fct-ireg="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities/"
@@ -24,58 +25,44 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceMarkets/">
 		<rdfs:label>Financial Business and Commerce Domain, Reference Markets Extension</rdfs:label>
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Capacity Post, Inc.</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain, Reference Markets Extension</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbcrm-all</sm:fileAbbreviation>
-		<sm:filename>AllFBC-ReferenceMarkets.rdf</sm:filename>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>financial products</sm:keyword>
-		<sm:keyword>financial services, service providers, and accounts</sm:keyword>
-		<sm:keyword>markets</sm:keyword>
-		<sm:keyword>registration authorities</sm:keyword>
-		<sm:keyword>regulatory agencies</sm:keyword>
-		<sm:moduleAbbreviation>fibo-fbc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MarketsIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/AllFBC-ReferenceMarkets/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for the Reference Markets Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND but excluding individuals for governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/AllFBC-ReferenceMarkets/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for the Reference Markets Extension of FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, including all of FND but excluding individuals for governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/FBC/AllFBC.rdf
+++ b/FBC/AllFBC.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-all "https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
@@ -21,10 +22,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-all="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
@@ -46,51 +47,35 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/">
 		<rdfs:label>Financial Business and Commerce Domain</rdfs:label>
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-09-30T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Capacity Post, Inc.</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Capacity Post, Inc.</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Dassault Systemes / No Magic</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-all</sm:fileAbbreviation>
-		<sm:filename>AllFBC.rdf</sm:filename>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>financial products</sm:keyword>
-		<sm:keyword>financial services, service providers, and accounts</sm:keyword>
-		<sm:keyword>markets</sm:keyword>
-		<sm:keyword>registration authorities</sm:keyword>
-		<sm:keyword>regulatory agencies</sm:keyword>
-		<sm:moduleAbbreviation>fibo-fbc</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
@@ -107,8 +92,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220901/AllFBC/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, excluding individuals for governments and jurisdictions, financial services and most regulatory organizations and related registries, as well as the LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/AllFBC/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for FBC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE) and Financial Business and Commerce (FBC) domains, excluding individuals for governments and jurisdictions, financial services and most regulatory organizations and related registries, as well as the LCC region-specific ontologies.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/FBC/DebtAndEquities/CreditEvents.rdf
+++ b/FBC/DebtAndEquities/CreditEvents.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
@@ -14,10 +15,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
@@ -32,7 +33,6 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
@@ -40,14 +40,6 @@
 		<dct:abstract>This ontology defines a range of credit events, that is events in which some payment or payments are not made. These include credit events relating to a specific debt obligation and events relating to the business entity as a whole. 
 		Note: the events defined herein are primarily business rather than consumer oriented, and are specified fairly generally. Many credit events are jurisdiction-specific, such as Chapter 11 restructuring and Chapter 7 bankruptcy in the United States. This ontology is designed to facilitate jurisdiction and instrument-specific extensions as needed.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:fileAbbreviation>fibo-fbc-dae-cre</sm:fileAbbreviation>
-		<sm:filename>CreditEvents.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -55,19 +47,23 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20221001/DebtAndEquities/CreditEvents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/DebtAndEquities/CreditEvents/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to move a restriction involving breach of covenant from credit event, since not all credit events involve breaches, to default event, and loosen the constraint since a breach depends on the contract.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220401/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to augment the definition of obligation-specific event with an optional default threshold to better support credit default swaps.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221001/DebtAndEquities/CreditEvents.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;Bankruptcy">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
 		<rdfs:label xml:lang="en">bankruptcy</rdfs:label>
 		<skos:definition xml:lang="en">credit event involving a change in state or condition in which a party becomes insolvent</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://thelawdictionary.org/bankruptcy/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://thelawdictionary.org/bankruptcy/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;CreditEvent">
@@ -87,7 +83,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">default event</rdfs:label>
 		<skos:definition xml:lang="en">credit event representing a failure to meet a contractual obligation, such as failure to repay a debt including interest or principal on a loan or security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A default can occur when a borrower is unable to make timely payments, misses payments, or avoids or stops making payments, typically with respect to a single transaction. A default has adverse effects on the borrower&apos;s credit and ability to borrow in the future, and allows the creditor to demand immediate repayment of the obligation in full.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A default can occur when a borrower is unable to make timely payments, misses payments, or avoids or stops making payments, typically with respect to a single transaction. A default has adverse effects on the borrower&apos;s credit and ability to borrow in the future, and allows the creditor to demand immediate repayment of the obligation in full.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;DistressedRatingsDowngrade">
@@ -144,7 +140,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
 		<rdfs:label xml:lang="en">filing for bankruptcy</rdfs:label>
 		<skos:definition xml:lang="en">credit event that involves a request to a court to be recognized as bankrupt</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The bankruptcy process is initiated via a petition filed by the debtor or on behalf of creditors. The debtor&apos;s assets may be used to repay a portion of outstanding debt as specified by the court or a court-appointed individual.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The bankruptcy process is initiated via a petition filed by the debtor or on behalf of creditors. The debtor&apos;s assets may be used to repay a portion of outstanding debt as specified by the court or a court-appointed individual.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;HardCreditEvent">
@@ -157,21 +153,21 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;DefaultEvent"/>
 		<rdfs:label xml:lang="en">installment default</rdfs:label>
 		<skos:definition xml:lang="en">default event involving non-payment of several installment payments as scheduled in the terms of the agreement, or non-payment of a call by the beneficial owner</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The latter may result in a court action by the issuer or the sale of the securities to recover costs and/or a forfeit of partially paid securities.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The latter may result in a court action by the issuer or the sale of the securities to recover costs and/or a forfeit of partially paid securities.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;MaturityExtension">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationSpecificCreditEvent"/>
 		<rdfs:label xml:lang="en">maturity extension</rdfs:label>
 		<skos:definition xml:lang="en">credit event involving extension of payments beyond the original maturity date of the obligation</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As stipulated in the terms and conditions for a bond, for example, the issuer or the bondholder may prolong the maturity date. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">As stipulated in the terms and conditions for a bond, for example, the issuer or the bondholder may prolong the maturity date. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;Moratorium">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
 		<rdfs:label xml:lang="en">moratorium</rdfs:label>
 		<skos:definition xml:lang="en">entity-specific credit event involving a temporary suspension of payments until related issues are resolved</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A moratorium may be a legally-mandated hiatus in debt collection as a part of a bankruptcy process.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A moratorium may be a legally-mandated hiatus in debt collection as a part of a bankruptcy process.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationAcceleration">
@@ -223,7 +219,7 @@
 		<rdfs:label xml:lang="en">soft credit event</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-dae-cre;HardCreditEvent"/>
 		<skos:definition xml:lang="en">default event that is repairable</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the default is not repaired within a grace period, then a failure to repair (failure to pay) credit event is triggered, potentially as a hard default.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">If the default is not repaired within a grace period, then a failure to repair (failure to pay) credit event is triggered, potentially as a hard default.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;WriteDown">
@@ -244,7 +240,7 @@
 		<rdfs:label xml:lang="en">has grace period</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
 		<skos:definition xml:lang="en">window following any payment due date during which a party must fulfill its obligations before a failure to pay credit event occurs</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that this may be a period denominated in business days or calendar days.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Note that this may be a period denominated in business days or calendar days.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-cre;involvesMultipleEvents">

--- a/FBC/DebtAndEquities/CreditRatings.rdf
+++ b/FBC/DebtAndEquities/CreditRatings.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-crt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -26,10 +27,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-crt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -56,7 +57,6 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/">
@@ -64,13 +64,6 @@
 		<dct:abstract>This ontology defines the concept of a credit rating, along with credit watch and outlook qualifying terms. There are credit ratings for individuals, for organizations and for instruments. 
 		These are referenced extensively in the securities models but are also applicable to business entities generally and in the context of lending and account maintenance.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:resource="https://www.omg.org/spec/LCC/"/>
-		<sm:fileAbbreviation>fibo-fbc-dae-crt</sm:fileAbbreviation>
-		<sm:filename>CreditRatings.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -90,10 +83,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-crt;AlertCreditMessage">
@@ -105,9 +100,9 @@
 		<rdf:type rdf:resource="&fibo-fbc-dae-crt;CreditQuality"/>
 		<rdfs:label>alternative-A quality</rdfs:label>
 		<skos:definition>classifier for mortgages that are considered to be riskier than prime quality but less risky than subprime quality</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>Alt-A</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Typically Alt-A mortgages are characterized by borrowers with less than full documentation, average credit scores, higher loan-to-values, and more investment properties and secondary homes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>Alternative A-paper</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>Alt-A</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Typically Alt-A mortgages are characterized by borrowers with less than full documentation, average credit scores, higher loan-to-values, and more investment properties and secondary homes.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>Alternative A-paper</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditInquiry">
@@ -181,7 +176,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit rating</rdfs:label>
 		<skos:definition xml:lang="en">assessment of creditworthiness of a borrower generally or with respect to a particular debt or financial obligation</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically, a credit rating is provided as a detailed report based on the financial history of borrowing or lending and creditworthiness of the entity or person derived from income statements, historical records related to borrowing, etc. with an aim to determine their ability to meet debt obligations.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Typically, a credit rating is provided as a detailed report based on the financial history of borrowing or lending and creditworthiness of the entity or person derived from income statements, historical records related to borrowing, etc. with an aim to determine their ability to meet debt obligations.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditRatingAgency">
@@ -225,7 +220,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>credit rating model</rdfs:label>
 		<skos:definition>algorithm for computing a credit rating</skos:definition>
-		<fibo-fnd-utl-av:usageNote>Use dct:hasVersion to specify a version for the credit score model.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>Use dct:hasVersion to specify a version for the credit score model.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditRatingModelType">
@@ -330,7 +325,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>credit report</rdfs:label>
 		<skos:definition>report describing the creditworthiness and related credit attributes of a borrower</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is typically provided by a credit rating agency but could be produced by an internal proprietary model as well.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is typically provided by a credit rating agency but could be produced by an internal proprietary model as well.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditReportCategory">
@@ -368,7 +363,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>credit tradeline</rdfs:label>
 		<skos:definition>report derived from the transaction history of a credit account</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A tradeline on a credit report refers to a specific credit account. Tradelines report snapshot details derived from a combination of account features and payment history, and are used by credit reporting agencies as inputs to the analysis process that determines a party&apos;s credit rating.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A tradeline on a credit report refers to a specific credit account. Tradelines report snapshot details derived from a combination of account features and payment history, and are used by credit reporting agencies as inputs to the analysis process that determines a party&apos;s credit rating.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditWatchDirection">
@@ -424,14 +419,14 @@
 		<rdf:type rdf:resource="&fibo-fbc-dae-crt;CreditQuality"/>
 		<rdfs:label>investment grade quality</rdfs:label>
 		<skos:definition>classifier for debt instruments that are considered to be of high quality and have a low risk of default</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Bond rating firms use different designations, often consisting of the upper- and lower-case letters to identify a bond&apos;s credit quality rating. &apos;AAA&apos; and &apos;AA&apos; (high credit quality) and &apos;A&apos; and &apos;BBB&apos; (medium credit quality) are considered investment grade. Credit ratings for bonds below these designations (&apos;BB,&apos; &apos;B,&apos; &apos;CCC,&apos; etc.) are considered low credit quality, and are commonly referred to as &apos;junk bonds.&apos;</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Bond rating firms use different designations, often consisting of the upper- and lower-case letters to identify a bond&apos;s credit quality rating. &apos;AAA&apos; and &apos;AA&apos; (high credit quality) and &apos;A&apos; and &apos;BBB&apos; (medium credit quality) are considered investment grade. Credit ratings for bonds below these designations (&apos;BB,&apos; &apos;B,&apos; &apos;CCC,&apos; etc.) are considered low credit quality, and are commonly referred to as &apos;junk bonds.&apos;</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-crt;NonprimeQuality">
 		<rdf:type rdf:resource="&fibo-fbc-dae-crt;CreditQuality"/>
 		<rdfs:label>nonprime quality</rdfs:label>
 		<skos:definition>classifier for borrowers, rates, or holdings that have poor quality, such as borrowers with poor credit history due to a short sale, bankruptcy, foreclosure and/or other negative credit events within the last several years</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Nonprime loans may be offered to individuals who are unable to qualify for a conventional loan.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Nonprime loans may be offered to individuals who are unable to qualify for a conventional loan.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-crt;OnWatchOutlook">
@@ -455,8 +450,8 @@
 		<rdf:type rdf:resource="&fibo-fbc-dae-crt;CreditQuality"/>
 		<rdfs:label>prime quality</rdfs:label>
 		<skos:definition>classifier for borrowers, rates, or holdings that are considered to be of high quality</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This classification often refers to loans made to high-quality borrowers that are offered prime or relatively low interest rates. Prime loans have low default risk.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>A-paper</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>This classification often refers to loans made to high-quality borrowers that are offered prime or relatively low interest rates. Prime loans have low default risk.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>A-paper</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;ShortTermCreditRating">
@@ -479,7 +474,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-dae-crt;CreditQuality"/>
 		<rdfs:label>subprime quality</rdfs:label>
 		<skos:definition>classifier for borrowers, rates, or holdings that are considered below-average quality, such as borrowers with a tarnished or limited credit history, and may be subject to higher than average interest rates</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Subprime refers to borrowers or loans, usually offered at rates well above the prime rate. Subprime lending is higher risk, given the lower credit rating of borrowers.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Subprime refers to borrowers or loans, usually offered at rates well above the prime rate. Subprime lending is higher risk, given the lower credit rating of borrowers.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crt;concernsParty">

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -27,10 +28,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -58,21 +59,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 		<rdfs:label>Debt Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts that are common to all debt instruments, such as debt, borrower, lender, debtor, creditor, interest, principal, and the like. It is designed to be used by various other FIBO specifications, including but not limited to SEC/Debt and LOAN.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:fileAbbreviation>fibo-fbc-dae-dbt</sm:fileAbbreviation>
-		<sm:filename>Debt.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
@@ -93,8 +85,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away, to support collateral agreements such as deeds of trust, UCC filings and the like, to add the concept of a rate reset time of day, to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations.</skos:changeNote>
@@ -103,7 +96,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/DebtAndEquities/Debt/ version of this ontology was modified to (1) add concepts including credit agreement whose principal is repaid at maturity and those whose principal is repaid over the course of the agreement, (2) move properties related to maturity to this ontology from FinancialInstruments and restructure the relationship between these two ontologies, (3) add the concept of a borrower identifier and the related scheme, (4) add the concept of an interest rate cap as a potential provision with respect to interest rate terms, and (5) clarified the definition of promissory note.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220301/DebtAndEquities/Debt/ version of this ontology was modified to add more detailed schedule information to support management of the various kinds of events that can impact a given contract as well as the concept of a revolving line of credit.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220601/DebtAndEquities/Debt/ version of this ontology was modified to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/Debt.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Accrual">
@@ -118,7 +114,7 @@
 		<rdfs:label>accrual</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>the process of accumulating interest or other income that has been earned but not paid</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>There are legal contractual terms for the accrual of interest, as distinct from the payment of interest.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>There are legal contractual terms for the accrual of interest, as distinct from the payment of interest.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Amortization">
@@ -147,7 +143,7 @@
 		<rdfs:label>amortization schedule</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>schedule of periodic payments (repayment installments) that specify changes in the balance of the debt over time</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Payments are divided into equal amounts for the duration of the loan or debt instrument, making it the simplest repayment model. A greater amount of the payment is applied to interest at the beginning of the amortization schedule, while more money is applied to principal at the end.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Payments are divided into equal amounts for the duration of the loan or debt instrument, making it the simplest repayment model. A greater amount of the payment is applied to interest at the beginning of the amortization schedule, while more money is applied to principal at the end.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Borrower">
@@ -181,7 +177,7 @@
 		<rdfs:label>borrower identification scheme</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.fincen.gov/resources/statutes-regulations/guidance/guidance-customer-identification-regulations-financial"/>
 		<skos:definition>system for allocating identifiers to borrowers</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Many banks and other financial institutions have internal systems for assigning identifiers to borrowers. In the United States, larger banks may use a Customer Information File (CIF) number, assigned as a part of their federally mandated Customer Information Program (CIP).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Many banks and other financial institutions have internal systems for assigning identifiers to borrowers. In the United States, larger banks may use a Customer Information File (CIF) number, assigned as a part of their federally mandated Customer Information Program (CIP).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;BorrowerIdentifier">
@@ -203,7 +199,7 @@
 		<rdfs:label>borrower identifier</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.fdic.gov/news/financial-institution-letters/1997/fil9786.pdf"/>
 		<skos:definition>sequence of characters, capable of uniquely identifying a borrower</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A given identifier identifies a particular borrower with respect to at least some number of notes/facilities inside a particular institution according to some policy for minting identifiers. Optimally, there would be a single identifier for a given borrower, but due to operational issues, this is often not the case. A CIF number, or Customer Information File number, is used to link accounts across an institution to all notes/facilities owed by a given borrower.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A given identifier identifies a particular borrower with respect to at least some number of notes/facilities inside a particular institution according to some policy for minting identifiers. Optimally, there would be a single identifier for a given borrower, but due to operational issues, this is often not the case. A CIF number, or Customer Information File number, is used to link accounts across an institution to all notes/facilities owed by a given borrower.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;BorrowingCapacity">
@@ -229,7 +225,7 @@
 		<rdfs:label>borrowing capacity</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>upper bound on the total amount of money that a lender believes a party has the ability to repay an obligation when due, as of some point in time</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The notion of borrowing capacity is related to management decisions pertaining to credit, i.e., the creditworthiness of the borrower, loan amount, risk tolerance, and so forth, and may be reassessed from time to time depending on the type of credit agreement and regulatory requirements. Determining borrowing capacity is typically done as a part of loan origination, especially for residential mortgages.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The notion of borrowing capacity is related to management decisions pertaining to credit, i.e., the creditworthiness of the borrower, loan amount, risk tolerance, and so forth, and may be reassessed from time to time depending on the type of credit agreement and regulatory requirements. Determining borrowing capacity is typically done as a part of loan origination, especially for residential mortgages.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Collateral">
@@ -378,8 +374,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit facility</rdfs:label>
 		<skos:definition xml:lang="en">credit agreement that allows the borrower to periodically take out money over an extended period of time rather than reapplying for a loan every time they need funds</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Credit facilities include revolving loans/lines of credit, committed facilities, letters of credit, and most retail credit accounts. They may define sub-facilities to which the lender is prepared to commit for specific purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">master commitment</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">Credit facilities include revolving loans/lines of credit, committed facilities, letters of credit, and most retail credit accounts. They may define sub-facilities to which the lender is prepared to commit for specific purposes.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">master commitment</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Creditor">
@@ -407,24 +403,24 @@
 		<rdfs:label>day-count convention</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>a business recurrence interval convention that is used to calculate the number of days in an interest payment, which applies to the amount of accrued interest or the present value for debt instruments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Day-count conventions apply to swaps, mortgages and forward rate agreements as well as bonds, each of which has its own day-count convention, which varies depending on the type of instrument, whether the interest rate is fixed or floating, and the country of issuance. Among the most common conventions are 30/360 or 365, actual/360 or 365, and actual/actual. A 30/360 convention assumes 30 days in a month and 360 days in a year. An actual/360 convention assumes the actual number of days in the given month and 360 days in the year. An actual/ actual convention uses the actual number of days in the given interest period and year.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Day-count conventions apply to swaps, mortgages and forward rate agreements as well as bonds, each of which has its own day-count convention, which varies depending on the type of instrument, whether the interest rate is fixed or floating, and the country of issuance. Among the most common conventions are 30/360 or 365, actual/360 or 365, and actual/actual. A 30/360 convention assumes 30 days in a month and 360 days in a year. An actual/360 convention assumes the actual number of days in the given month and 360 days in the year. An actual/ actual convention uses the actual number of days in the given interest period and year.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30360BondBasis">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention 30/360 bond basis</rdfs:label>
 		<skos:definition>day-count convention that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(f), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>30A/360</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>See ISDA 2006 Section 4.16(f), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>30A/360</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30360US">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention 30/360 US</rdfs:label>
 		<skos:definition>day-count convention that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(f), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>This convention is used for US corporate bonds and many US agency issues. It is most commonly referred to as &apos;30/360&apos;, but the term &apos;30/360&apos; may also refer to any of the other conventions of this class, depending on the context. See ISDA 2006 Section 4.16(f), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>30/360</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>See ISDA 2006 Section 4.16(f), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This convention is used for US corporate bonds and many US agency issues. It is most commonly referred to as &apos;30/360&apos;, but the term &apos;30/360&apos; may also refer to any of the other conventions of this class, depending on the context. See ISDA 2006 Section 4.16(f), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation</cmns-av:explanatoryNote>
+		<cmns-av:synonym>30/360</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30365">
@@ -437,67 +433,67 @@
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention 30E/360</rdfs:label>
 		<skos:definition>day-count convention that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>See ICMA Rule 251.1(ii), 251.2, and ISDA 2006 Section 4.16(g), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>30/360 ICMA</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>30S/360</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>Eurobond basis (ISDA 2006)</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>Special German</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>See ICMA Rule 251.1(ii), 251.2, and ISDA 2006 Section 4.16(g), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>30/360 ICMA</cmns-av:synonym>
+		<cmns-av:synonym>30S/360</cmns-av:synonym>
+		<cmns-av:synonym>Eurobond basis (ISDA 2006)</cmns-av:synonym>
+		<cmns-av:synonym>Special German</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30E360ISDA">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention 30E/360 ISDA</rdfs:label>
 		<skos:definition>day-count convention that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(h), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>30/360 ICMA</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>Eurobond basis (ISDA 2006)</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>German</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>See ISDA 2006 Section 4.16(h), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>30/360 ICMA</cmns-av:synonym>
+		<cmns-av:synonym>Eurobond basis (ISDA 2006)</cmns-av:synonym>
+		<cmns-av:synonym>German</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-Actual360">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention actual/360</rdfs:label>
 		<skos:definition>day-count convention that uses the actual number of days in each month and 360 days in a year for calculating interest payments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>See ICMA Rule 251.1(i) (not sterling), ISDA 2006 Section 4.16(e), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>This convention is used in money markets for short-term lending of currencies, including the US dollar and Euro, and is applied in ESCB monetary policy operations. It is the convention used with repurchase agreements.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>French</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>a/360</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>act/360</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>See ICMA Rule 251.1(i) (not sterling), ISDA 2006 Section 4.16(e), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This convention is used in money markets for short-term lending of currencies, including the US dollar and Euro, and is applied in ESCB monetary policy operations. It is the convention used with repurchase agreements.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>French</cmns-av:synonym>
+		<cmns-av:synonym>a/360</cmns-av:synonym>
+		<cmns-av:synonym>act/360</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-Actual365Fixed">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention actual/365 fixed</rdfs:label>
 		<skos:definition>day-count convention that uses the actual number of days in each month and 365 days in a year for calculating interest payments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(d), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>English</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>a/365 fixed</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>a/365f</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>act/365 fixed</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>See ISDA 2006 Section 4.16(d), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>English</cmns-av:synonym>
+		<cmns-av:synonym>a/365 fixed</cmns-av:synonym>
+		<cmns-av:synonym>a/365f</cmns-av:synonym>
+		<cmns-av:synonym>act/365 fixed</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-ActualActualICMA">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention actual/actual ICMA</rdfs:label>
 		<skos:definition>day-count convention that uses the actual number of days in each month and actual number of days in that year for calculating interest payments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>See ICMA Rule 251.1(iii), ISDA 2006 Section 4.16(c), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>This method ensures that all coupon payments are always for the same amount. It also ensures that all days in a coupon period are valued equally. This is the convention used for US Treasury bonds and notes, among other securities.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>ISMA-99</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>act/act ICMA</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>act/act ISMA</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>actual/actual</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>See ICMA Rule 251.1(iii), ISDA 2006 Section 4.16(c), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This method ensures that all coupon payments are always for the same amount. It also ensures that all days in a coupon period are valued equally. This is the convention used for US Treasury bonds and notes, among other securities.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>ISMA-99</cmns-av:synonym>
+		<cmns-av:synonym>act/act ICMA</cmns-av:synonym>
+		<cmns-av:synonym>act/act ISMA</cmns-av:synonym>
+		<cmns-av:synonym>actual/actual</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-ActualActualISDA">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention actual/actual ISDA</rdfs:label>
 		<skos:definition>day-count convention that uses the actual number of days in each month and actual number of days in that year for calculating interest payments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(b), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>This convention accounts for days in the period based on the portion in a leap year and the portion in a non-leap year.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>act/365</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>act/act</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>actual/365</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>actual/actual</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>See ISDA 2006 Section 4.16(b), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This convention accounts for days in the period based on the portion in a leap year and the portion in a non-leap year.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>act/365</cmns-av:synonym>
+		<cmns-av:synonym>act/act</cmns-av:synonym>
+		<cmns-av:synonym>actual/365</cmns-av:synonym>
+		<cmns-av:synonym>actual/actual</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Debt">
@@ -517,7 +513,7 @@
 		<rdfs:label>debt</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>an obligation to pay something, such as an amount of money, good, service, or instrument</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In cases where the debtor and payer are the same legal person, then a debt is equivalent to a payment obligation.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In cases where the debtor and payer are the same legal person, then a debt is equivalent to a payment obligation.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;DebtTerms">
@@ -525,7 +521,7 @@
 		<rdfs:label>debt terms</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>contract terms that specify the formal rights and obligations of borrower and lender under a contract in which funds are lent from the one party to the other</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>These may be terms in a loan contract (including for example a mortgage contract) or they may be the contractual terms of a debt security.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>These may be terms in a loan contract (including for example a mortgage contract) or they may be the contractual terms of a debt security.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Debtor">
@@ -558,7 +554,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>explicit contract event schedule</rdfs:label>
 		<skos:definition>schedule of events, including but not limited to payment events, rate reset events and others that will occur over the lifetime of the credit agreement</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is a schedule of actual dates and events that are terms of the contract.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is a schedule of actual dates and events that are terms of the contract.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;FixedInterestRate">
@@ -575,7 +571,7 @@
 		<rdfs:seeAlso rdf:resource="http://recomparison.com/comparisons/100975/floating-vs-variable-vs-adjustable-interest-rate/"/>
 		<skos:definition>a variable interest rate that is based on a specific index or benchmark rate</skos:definition>
 		<skos:example>Certain revolving credit, such as credit-card related debt, may adjust after a specified period of time to an absolute rate stated in the agreement (variable but not floating) rather than based on a benchmark rate (variable, floating).</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote>The index used to determine the specific interest rate is generally included in the terms of the loan. In most cases, lenders will also charge a spread, or added percentage points on top of the established index rate. If a loan is billed as prime plus 2.5 percent, for a prime rate of 3.5 percent, the terms of the loan will require the borrower to pay off a 6 percent interest. Floating interest rates typically involve periodic reset dates for the loan, particularly when the index rate changes. Resets may also occur online at market predetermined intervals, with yearly adjustments being a common arrangement.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The index used to determine the specific interest rate is generally included in the terms of the loan. In most cases, lenders will also charge a spread, or added percentage points on top of the established index rate. If a loan is billed as prime plus 2.5 percent, for a prime rate of 3.5 percent, the terms of the loan will require the borrower to pay off a 6 percent interest. Floating interest rates typically involve periodic reset dates for the loan, particularly when the index rate changes. Resets may also occur online at market predetermined intervals, with yearly adjustments being a common arrangement.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;FullAmortization">
@@ -677,8 +673,8 @@
 		<rdfs:label>interest payment terms</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>contract terms for payment of interest on a debt</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Interest is usually payable on any outstanding principal amount, therefore interest relates to the amount of debt outstanding at any given point of time, not to the principal amount advanced at the time that the loan was advanced or the debt security issued (aside from the initial payment).</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Note that in most cases, the dates and payment frequencies for interest will coincide with the dates and payment frequencies related to the principal.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Interest is usually payable on any outstanding principal amount, therefore interest relates to the amount of debt outstanding at any given point of time, not to the principal amount advanced at the time that the loan was advanced or the debt security issued (aside from the initial payment).</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that in most cases, the dates and payment frequencies for interest will coincide with the dates and payment frequencies related to the principal.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Lender">
@@ -837,14 +833,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>projected contract event schedule</rdfs:label>
 		<skos:definition>schedule of events, including but not limited to anticipated payment events, rate reset events and others that are expected to occur over the lifetime of the credit agreement</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is a regular schedule that provides a way of documenting the anchor dates and frequency of occurrences, using rules, rather than an explicit list of dates, that are terms of the contract. This method will project future event dates (transaction event dates), based on the frequencies specified and would be adjusted due to calendar restrictions and other rules to deal with holidays, weekends, and so forth.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is a regular schedule that provides a way of documenting the anchor dates and frequency of occurrences, using rules, rather than an explicit list of dates, that are terms of the contract. This method will project future event dates (transaction event dates), based on the frequencies specified and would be adjusted due to calendar restrictions and other rules to deal with holidays, weekends, and so forth.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PromissoryNote">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 		<rdfs:label>promissory note</rdfs:label>
 		<skos:definition>negotiable instrument that is a written promise by one party to another that commits that party to pay a specified sum on demand or within a specified time frame under specified terms</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Promissory notes are generally fully fungible.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Promissory notes are generally fully fungible.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;RateResetTimeOfDay">
@@ -880,7 +876,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">revolving line of credit</rdfs:label>
 		<skos:definition xml:lang="en">credit facility that enables the borrower to withdraw funds, repay, and withdraw again</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Revolving credit facilities are essentially lines of credit with variable interest rates.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Revolving credit facilities are essentially lines of credit with variable interest rates.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;SubFacility">
@@ -900,7 +896,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">sub-facility</rdfs:label>
 		<skos:definition xml:lang="en">portion of a credit facility extended to the borrower for some purpose, possibly per some schedule specified in the facility</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Each sub-facility may have separate terms, and may be or include individual promissory notes, depending on the facility. The amount of associated with the individual sub-facilities sums to the total credit facility amount. Sub-facilities may, individually, have a stated purpose, such as to cover inventory, equipment, accounts receivable, working capital, letters of credit, and so forth.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Each sub-facility may have separate terms, and may be or include individual promissory notes, depending on the facility. The amount of associated with the individual sub-facilities sums to the total credit facility amount. Sub-facilities may, individually, have a stated purpose, such as to cover inventory, equipment, accounts receivable, working capital, letters of credit, and so forth.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;UncommittedCreditFacility">
@@ -921,7 +917,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:disjointWith rdf:resource="&fibo-fbc-dae-dbt;FixedInterestRate"/>
 		<skos:definition>an interest rate that is allowed to vary over the maturity of a loan or other debt instrument</skos:definition>
-		<fibo-fnd-utl-av:synonym>adjustable rate</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>adjustable rate</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;governsPaymentOf">
@@ -970,7 +966,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition>indicates the monetary amount of the debt</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Represents the total debt amount including principal and interest</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Represents the total debt amount including principal and interest</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasDenomination">
@@ -1052,7 +1048,7 @@
 		<rdfs:label>has maturity date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>indicates the date on which the principal amount of an instrument is due to be repaid to the investor and interest or coupon payments stop, and/or the date on which the instrument may be redeemed</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Maturity dates typically apply to debt instruments, such as notes, drafts, bonds, and other loans, but may also apply to preferred shares and other financial instruments.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Maturity dates typically apply to debt instruments, such as notes, drafts, bonds, and other loans, but may also apply to preferred shares and other financial instruments.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasOriginalTimeToMaturity">
@@ -1060,7 +1056,7 @@
 		<rdfs:label>has time to maturity</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDuration"/>
 		<skos:definition>indicates the lifespan of credit agreement or offering, from the date of issuance to the scheduled maturity date</skos:definition>
-		<fibo-fnd-utl-av:synonym>has term to maturity</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>has term to maturity</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasOutstandingAmount">
@@ -1101,7 +1097,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition>relates an instrument to the date by which the principal must be repaid in full</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Depending on the terms of the instrument (debt security, such as a bond, loan, etc.), this may be the date of a single payment of the debt principal or of the completion of scheduled partial redemption payments.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Depending on the terms of the instrument (debt security, such as a bond, loan, etc.), this may be the date of a single payment of the debt principal or of the completion of scheduled partial redemption payments.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;isAmortizationOf">

--- a/FBC/DebtAndEquities/Guaranty.rdf
+++ b/FBC/DebtAndEquities/Guaranty.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -25,10 +26,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -54,20 +55,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
 		<rdfs:label>Guaranty Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts related to contractual guaranty.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:fileAbbreviation>fibo-fbc-dae-gty</sm:fileAbbreviation>
-		<sm:filename>Guaranty.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
@@ -86,8 +79,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/Guaranty/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/DebtAndEquities/Guaranty/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Guaranty/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181001/DebtAndEquities/Guaranty/ version of this ontology revised to add financial asset as a parent of letter of credit.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181001/DebtAndEquities/Guaranty/ version of this ontology revised to incorporate refinement of the concept of a guaranty as needed for debt securities and loans.</skos:changeNote>
@@ -95,7 +89,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/DebtAndEquities/Guaranty/ version of this ontology revised to simplify the contract party hierarchy, add properties linking controlled parties to their guarantor, and clean up definitions to eliminate ambiguity, etc.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/DebtAndEquities/Guaranty/ version of this ontology revised to make letter of credit a subclass of committed credit facility, and to differentiate financial collateral from physical collateral.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/DebtAndEquities/Guaranty/ version of this ontology revised to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/Guaranty.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;CollateralizedGuaranty">
@@ -108,7 +105,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>collateralized guaranty</rdfs:label>
 		<skos:definition>guaranty that takes the form of some asset that is pledged by a borrower to a lender (usually in return for a loan)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In some cases, the lender may require the borrower to place pledged assets such as cash or securities in a separate account that the lender controls.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In some cases, the lender may require the borrower to place pledged assets such as cash or securities in a separate account that the lender controls.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;GovernmentGuaranty">
@@ -151,8 +148,8 @@
 		<rdfs:label>guarantor</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
 		<skos:definition>party that guarantees, endorses, or provides indemnity for some obligation on behalf of some other party</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In some cases, the party acting as guarantor may also be a party to the contract, such as in the case of Fannie Mae or Freddie Mac. In such cases, the same individual would be modeled as having both roles.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In some cases, the party acting as guarantor may also be a party to the contract, such as in the case of Fannie Mae or Freddie Mac. In such cases, the same individual would be modeled as having both roles.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;Guaranty">
@@ -190,8 +187,8 @@
 		<rdfs:label>guaranty</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
 		<skos:definition>commitment whereby something is formally assured if a party with primary liability fails to perform</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The commitment may cover a debt, cash flows on a debt instrument (such as interest payments), or performance of some obligation.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The commitment may cover a debt, cash flows on a debt instrument (such as interest payments), or performance of some obligation.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;InsuranceBackedGuaranty">
@@ -255,9 +252,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>letter of credit</rdfs:label>
 		<skos:definition>letter from a bank or other creditworthy institution guaranteeing that a buyer&apos;s payment to a seller will be received on time and for the correct amount</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>L/C</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>In some states in the U.S., the issuer is not limited to financial institutions -- it is simply a written instrument, addressed by one person to another, requesting the latter to give credit to the person in whose favor it is drawn.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>In the event that the buyer is unable to make payment, the bank or other issuer is required to cover the full or remaining amount.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>L/C</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>In some states in the U.S., the issuer is not limited to financial institutions -- it is simply a written instrument, addressed by one person to another, requesting the latter to give credit to the person in whose favor it is drawn.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In the event that the buyer is unable to make payment, the bank or other issuer is required to cover the full or remaining amount.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;LetterOfCreditGuaranty">
@@ -282,7 +279,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
 		<rdfs:label>policyholder</rdfs:label>
 		<skos:definition>counterparty to and typically owner of an insurance policy</skos:definition>
-		<fibo-fnd-utl-av:synonym>insured party</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>insured party</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;PriorityLevel">

--- a/FBC/DebtAndEquities/MetadataFBCDebtAndEquities.rdf
+++ b/FBC/DebtAndEquities/MetadataFBCDebtAndEquities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-mod "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/MetadataFBCDebtAndEquities/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/MetadataFBCDebtAndEquities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-mod="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/MetadataFBCDebtAndEquities/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -18,36 +19,34 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/MetadataFBCDebtAndEquities/">
 		<rdfs:label>Metadata about the EDMC-FIBO Financial Business and Commerce(FBC) Debt and Equities Module</rdfs:label>
 		<dct:abstract>The debt and equities module includes ontologies describing concepts that are common to debt and equity instruments, as well as across debt instruments, such as loans, bonds, asset-backed securities, and so forth.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2017-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-fbc-dae-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataFBCDebtAndEquities.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/MetadataFBCDebtAndEquities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/DebtAndEquities/MetadataFBCDebtAndEquities/"/>
+		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-mod;DebtAndEquitiesModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO FBC Debt and Equities Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>debt and equities module</rdfs:label>
 		<dct:abstract>The debt and equities module includes ontologies describing concepts that are common to debt and equity instruments, as well as across debt instruments, such as loans, bonds, asset-backed securities, and so forth.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-FBC-DAE</sm:moduleAbbreviation>
+		<dct:title>FIBO FBC Debt and Equities Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Debt and Equities Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -22,10 +23,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -48,22 +49,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 		<rdfs:label>Financial Instruments Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for financial instruments in general, providing the high-level hooks for build-out in more detail in the relevant domain areas. These include, but are not limited to, equities, options, debt instruments, and so forth, some of which may be negotiable.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fi-fi</sm:fileAbbreviation>
-		<sm:filename>FinancialInstruments.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
@@ -80,8 +71,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/FinancialInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FinancialInstruments/FinancialInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified for the FIBO 2.0 RFC, including minor bug fixes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified as a part of organizational hierarchy simplification, to add maturity-related properties, and to add exempt security.</skos:changeNote>
@@ -96,7 +88,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to move properties and restrictions related to maturity to the Debt ontology, on credit agreement, and deprecate them here as well as to restructure the relationship between the two ontologies.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220101/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to eliminate deprecated content, i.e., properties related to maturity that are now in the Debt ontology and revise the definition of a securities transaction identifier to align with ISO 23897.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220601/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to address dead links and text formatting issues uncovered by hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PromissoryNote">
@@ -128,7 +123,7 @@
 		<skos:definition>financial instrument used for the purposes of currency trading</skos:definition>
 		<skos:example>Example currencies include UK pounds, US dollars, Euro. An example currency instrument is spot currency instrument.</skos:example>
 		<skos:scopeNote>Each instance of a currency instrument has a one to one relationship with its associated currency.</skos:scopeNote>
-		<fibo-fnd-utl-av:adaptedFrom>Parameswaran, Sunil. Fundamentals of Financial Instruments: An Introduction to Stocks, Bonds, Foreign Exchange, and Derivatives. John Wiley and Sons (Asia) Pte. Lte., Singapore, 2011.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Parameswaran, Sunil. Fundamentals of Financial Instruments: An Introduction to Stocks, Bonds, Foreign Exchange, and Derivatives. John Wiley and Sons (Asia) Pte. Lte., Singapore, 2011.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;DebtInstrument">
@@ -148,7 +143,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>debt instrument</rdfs:label>
 		<skos:definition>financial instrument and credit agreement evidencing monies owed by the issuer to the holder on terms as specified</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;DerivativeInstrument">
@@ -158,9 +153,9 @@
 		<skos:definition>financial instrument that confers on its holders certain rights or obligations, whose value is derived from one or more underlying assets</skos:definition>
 		<skos:example>The three major categories of derivatives are (1) forward and future contracts, (2) options contracts, and (3) swaps. The most common underlying assets include stocks, bonds, commodities, currencies, interest rates and market indexes.</skos:example>
 		<skos:scopeNote>Derivatives can be characterized by whether they are exchange-traded or traded over-the-counter (OTC).</skos:scopeNote>
-		<fibo-fnd-utl-av:adaptedFrom>Parameswaran, Sunil. Fundamentals of Financial Instruments: An Introduction to Stocks, Bonds, Foreign Exchange, and Derivatives. John Wiley and Sons (Asia) Pte. Lte., Singapore, 2011.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Derivative contracts owe their availability to the existence of markets for an underlying asset or a portfolio of assets on which such agreements are written. The derivative itself is merely a contract between two or more parties. Its value is determined by fluctuations in the underlying asset. Most derivatives are characterized by high leverage.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>derivative contract</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>Parameswaran, Sunil. Fundamentals of Financial Instruments: An Introduction to Stocks, Bonds, Foreign Exchange, and Derivatives. John Wiley and Sons (Asia) Pte. Lte., Singapore, 2011.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Derivative contracts owe their availability to the existence of markets for an underlying asset or a portfolio of assets on which such agreements are written. The derivative itself is merely a contract between two or more parties. Its value is determined by fluctuations in the underlying asset. Most derivatives are characterized by high leverage.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>derivative contract</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Entitlement">
@@ -168,15 +163,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
 		<rdfs:label>entitlement</rdfs:label>
 		<skos:definition>financial instrument that provides the holder the privilege to subscribe to or to receive specific assets on terms specified</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>right</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</cmns-av:adaptedFrom>
+		<cmns-av:synonym>right</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;EquityInstrument">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
 		<rdfs:label>equity instrument</rdfs:label>
 		<skos:definition>financial instrument representing an ownership interest in an entity or pool of assets</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;ExemptSecurity">
@@ -184,8 +179,8 @@
 		<rdfs:label>exempt security</rdfs:label>
 		<skos:definition>security that is exempt from certain regulatory rules</skos:definition>
 		<skos:example>Some exemptions from the registration requirement include: private offerings to a limited number of persons or institutions; offerings of limited size; intrastate offerings; and securities of municipal, state, and federal governments.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>Securities Act of 1933</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Generally, securities must be filed with the appropriate regulatory agencies in the jurisdiction in which they are sold. The registration forms companies file provide essential facts while minimizing the burden and expense of complying with the law. Not all securities must be registered, however. By exempting many small offerings from the registration process, regulators seek to foster capital formation by lowering the cost of offering securities to the public.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Securities Act of 1933</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Generally, securities must be filed with the appropriate regulatory agencies in the jurisdiction in which they are sold. The registration forms companies file provide essential facts while minimizing the burden and expense of complying with the law. Not all securities must be registered, however. By exempting many small offerings from the registration process, regulators seek to foster capital formation by lowering the cost of offering securities to the public.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
@@ -234,8 +229,8 @@
 		<rdfs:label>financial instrument</rdfs:label>
 		<skos:definition>written contract that gives rise to both a financial asset of one entity and a financial liability of another entity</skos:definition>
 		<skos:example>Examples of financial instruments include: cash, evidence of an ownership interest in an entity, or a contractual right to receive (or deliver) cash, or another financial instrument.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.ifrs.org/content/dam/ifrs/publications/pdf-standards/english/2021/issued/part-a/ias-32-financial-instruments-presentation.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A financial instrument can be thought of as a template that defines an arrangement structure that remains to be fleshed out with terms and parameters in order to establish a specific instance of the contract.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.ifrs.org/content/dam/ifrs/publications/pdf-standards/english/2021/issued/part-a/ias-32-financial-instruments-presentation.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A financial instrument can be thought of as a template that defines an arrangement structure that remains to be fleshed out with terms and parameters in order to establish a specific instance of the contract.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;FinancialInstrumentIdentifier">
@@ -256,7 +251,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:label>future</rdfs:label>
 		<skos:definition>derivative instrument that obligates the buyer to receive and the seller to deliver the assets specified at an agreed price, at some later point in time</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Issuer">
@@ -274,9 +269,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>issuer</rdfs:label>
 		<skos:definition>party that issues (or proposes to issue in a formal filing) a financial instrument</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Securities Exchange Act of 1934, as amended 12 August 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An issuer can be any legal person, including a legally competent natural person, company, government, or political subdivision, agency, or instrumentality of a government, depending on the nature of the instrument. A person might provide a loan directly to another party, but most instruments are issued by legal entities.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>With respect to certificates of deposit for securities, voting-trust certificates, or collateral- trust certificates, or with respect to certificates of interest or shares in an unincorporated investment trust not having a board of directors or of the fixed, restricted management, or unit type, the term issuer means the person or persons performing the acts and assuming the duties of depositor or manager pursuant to the provisions of the trust or other agreement or instrument under which such securities are issued; and except that with respect to equipment-trust certificates or like securities, the term issuer means the person by whom the equipment or property is, or is to be, used.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Securities Exchange Act of 1934, as amended 12 August 2012</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An issuer can be any legal person, including a legally competent natural person, company, government, or political subdivision, agency, or instrumentality of a government, depending on the nature of the instrument. A person might provide a loan directly to another party, but most instruments are issued by legal entities.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>With respect to certificates of deposit for securities, voting-trust certificates, or collateral- trust certificates, or with respect to certificates of interest or shares in an unincorporated investment trust not having a board of directors or of the fixed, restricted management, or unit type, the term issuer means the person or persons performing the acts and assuming the duties of depositor or manager pursuant to the provisions of the trust or other agreement or instrument under which such securities are issued; and except that with respect to equipment-trust certificates or like securities, the term issuer means the person by whom the equipment or property is, or is to be, used.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;NegotiableSecurity">
@@ -297,14 +292,14 @@
 		<rdfs:label>non-negotiable security</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fi-fi;NegotiableSecurity"/>
 		<skos:definition>security that is not transferable to another party</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Certain securities that can be redeemed by the issuer may not be &apos;negotiable&apos;, such as savings bonds and certificates of deposit.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Certain securities that can be redeemed by the issuer may not be &apos;negotiable&apos;, such as savings bonds and certificates of deposit.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Option">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:label>option</rdfs:label>
 		<skos:definition>derivative instrument that grants to the holder either the privilege to purchase or the privilege to sell the assets specified at a predetermined price or formula at or within a time period in the future</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Second edition, 2001-05-01.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;PackagedFinancialProduct">
@@ -336,18 +331,18 @@
 		<rdfs:seeAlso rdf:resource="https://www.sec.gov/Archives/edgar/data/36995/000121465907002234/c101872fwp.htm"/>
 		<skos:definition>financial product that acts as a container for at least one financial instrument, including other financial products, and whose value is derived from, or based on a reference asset, market measure, or investment strategy</skos:definition>
 		<skos:scopeNote>Packaged products are typically included in an institution&apos;s approved product catalog, i.e., pre-approved by compliance organizations for sale to clients. Not all institutions maintain such a catalog, with internal identifiers for such products, but many do. Such core products may have as attributes: Type (product and possibly asset class), product identifier, status and approval date, product family approval (as appropriate), and so forth.</skos:scopeNote>
-		<fibo-fnd-utl-av:explanatoryNote>Certain properties of the instruments, such as their term, interest rate, eligibility of the client, etc., may be set as a part of the product specification. Some of these are intrinsic but variable properties of the instrument, for example the exact interest rate, whereas others are extrinsic, such as client eligibility. Product offerings have prices, which may build in various fees, that are components of the cost of carry on a trader&apos;s books.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Reference assets and market measures may include single equity or debt securities, indexes, commodities, interest rates and/or foreign currencies, as well as baskets of these reference assets or market measures. Like other well-known market instruments such as convertible bonds, many structured products are hybrid securities. Structured products typically have two components - a debt instrument and a derivative, which is often an option. The debt instrument, in some instances, may pay interest at a specified rate and interval. The derivative component establishes payment at maturity, which may give the issuer the right to buy from you, or sell you, the referenced security or securities at a predetermined price. For example, structured products may combine characteristics of debt and equity or of debt and commodities.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>SEC Rule 434 defines structured securities as &apos;securities whose cash flow characteristics depend upon one or more indices or that have embedded forwards or options or securities where an investor&apos;s investment return and the issuer&apos;s payment obligations are contingent on, or highly sensitive to, changes in the value of underlying assets, indices, interest rates or cash flows&apos;.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>market-linked investment</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>structured product</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Certain properties of the instruments, such as their term, interest rate, eligibility of the client, etc., may be set as a part of the product specification. Some of these are intrinsic but variable properties of the instrument, for example the exact interest rate, whereas others are extrinsic, such as client eligibility. Product offerings have prices, which may build in various fees, that are components of the cost of carry on a trader&apos;s books.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Reference assets and market measures may include single equity or debt securities, indexes, commodities, interest rates and/or foreign currencies, as well as baskets of these reference assets or market measures. Like other well-known market instruments such as convertible bonds, many structured products are hybrid securities. Structured products typically have two components - a debt instrument and a derivative, which is often an option. The debt instrument, in some instances, may pay interest at a specified rate and interval. The derivative component establishes payment at maturity, which may give the issuer the right to buy from you, or sell you, the referenced security or securities at a predetermined price. For example, structured products may combine characteristics of debt and equity or of debt and commodities.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>SEC Rule 434 defines structured securities as &apos;securities whose cash flow characteristics depend upon one or more indices or that have embedded forwards or options or securities where an investor&apos;s investment return and the issuer&apos;s payment obligations are contingent on, or highly sensitive to, changes in the value of underlying assets, indices, interest rates or cash flows&apos;.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>market-linked investment</cmns-av:synonym>
+		<cmns-av:synonym>structured product</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;RedemptionProvision">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:label>redemption provision</rdfs:label>
 		<skos:definition>contract provision enabling the issuer (writer) to regain possession through repayment of some stipulated price</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In general, redemption is synonymous with &apos;buy back&apos; or &apos;cash in&apos;, depending on the kind of instrument. Redemption provisions are commonly applicable to the process of annulling a defeasible title, such as for a mortgage or tax sale, by paying the debt or fulfilling an obligation.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In general, redemption is synonymous with &apos;buy back&apos; or &apos;cash in&apos;, depending on the kind of instrument. Redemption provisions are commonly applicable to the process of annulling a defeasible title, such as for a mortgage or tax sale, by paying the debt or fulfilling an obligation.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;SecuritiesTransaction">
@@ -360,8 +355,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>securities transaction</rdfs:label>
 		<skos:definition>transaction between two or more parties involving the exchange of commonly defined financial products</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 23897:2020, Financial services - Unique transaction identifier (UTI), clause 3.3</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>financial transaction</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>ISO 23897:2020, Financial services - Unique transaction identifier (UTI), clause 3.3</cmns-av:adaptedFrom>
+		<cmns-av:synonym>financial transaction</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;SecuritiesTransactionIdentifier">
@@ -380,18 +375,18 @@
 		</rdfs:subClassOf>
 		<rdfs:label>security</rdfs:label>
 		<skos:definition>financial instrument that can be bought or sold</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Securities Exchange Act of 1934, as amended 12 August 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A security can be any note, stock, treasury stock, security future, security-based swap, bond, debenture,certificate of interest or participation in any profit-sharing agreement or in any oil, gas, or other mineral royalty or lease, any collateral-trust certificate, preorganization certificate or subscription, transferable share, investment contract, voting-trust certificate, certificate of deposit for a security, any put, call, straddle, option, or privilege on any security, certificate of deposit, or group or index of securities (including any interest therein or based on the value thereof), or any put, call, straddle, option, or privilege entered into on a national securities exchange relating to foreign currency, or in general, any instrument commonly known as a security, or any certificate of interest or participation in, temporary or interim certificate for, receipt for, or warrant or right to subscribe to or purchase, any of the foregoing; but shall not include currency or any note, draft, bill of exchange, or bankers&apos; acceptance which has a maturity at the time of issuance of not exceeding nine months, exclusive of days of grace, or any renewal thereof the maturity of which is likewise limited.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>In the U.S., the Supreme Court has adopted a flexible and liberal approach in determining what constitutes a security. In its famous decision of SEC v. W.J. Howey Co., 328 U.S. 293, 90 L.Ed. 1244, 66 S.Ct. 1100 (1946), the Court held that land sales contracts for citrus groves in Florida, coupled with warranty deeds for the land and a contract to service the land, were &apos;investment contracts&apos; and thus securities. The Court stated that [a]n investment contract for purposes of the Securities Act means a contract, transaction or scheme whereby a person invests his money in a common enterprise and is led to expect profits solely from the efforts of the promoter or a third party. 66 S.Ct. at 1103. According to the Court, it is immaterial whether the shares in the enterprise are evidenced by formal certificates or by nominal interests in the physical assets employed in the enterprise. 66 S.Ct. at 1104.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Some securities may be traded over the counter, or through an exchange, or via some other trading venue such as an electronic trading platform.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Whether a contract or other economic right is a security essentially depends on whether the holder of the contract is acting as an investor who seeks financial benefits based on the work of a promoter or a third party.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Securities Exchange Act of 1934, as amended 12 August 2012</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A security can be any note, stock, treasury stock, security future, security-based swap, bond, debenture,certificate of interest or participation in any profit-sharing agreement or in any oil, gas, or other mineral royalty or lease, any collateral-trust certificate, preorganization certificate or subscription, transferable share, investment contract, voting-trust certificate, certificate of deposit for a security, any put, call, straddle, option, or privilege on any security, certificate of deposit, or group or index of securities (including any interest therein or based on the value thereof), or any put, call, straddle, option, or privilege entered into on a national securities exchange relating to foreign currency, or in general, any instrument commonly known as a security, or any certificate of interest or participation in, temporary or interim certificate for, receipt for, or warrant or right to subscribe to or purchase, any of the foregoing; but shall not include currency or any note, draft, bill of exchange, or bankers&apos; acceptance which has a maturity at the time of issuance of not exceeding nine months, exclusive of days of grace, or any renewal thereof the maturity of which is likewise limited.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In the U.S., the Supreme Court has adopted a flexible and liberal approach in determining what constitutes a security. In its famous decision of SEC v. W.J. Howey Co., 328 U.S. 293, 90 L.Ed. 1244, 66 S.Ct. 1100 (1946), the Court held that land sales contracts for citrus groves in Florida, coupled with warranty deeds for the land and a contract to service the land, were &apos;investment contracts&apos; and thus securities. The Court stated that [a]n investment contract for purposes of the Securities Act means a contract, transaction or scheme whereby a person invests his money in a common enterprise and is led to expect profits solely from the efforts of the promoter or a third party. 66 S.Ct. at 1103. According to the Court, it is immaterial whether the shares in the enterprise are evidenced by formal certificates or by nominal interests in the physical assets employed in the enterprise. 66 S.Ct. at 1104.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Some securities may be traded over the counter, or through an exchange, or via some other trading venue such as an electronic trading platform.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Whether a contract or other economic right is a security essentially depends on whether the holder of the contract is acting as an investor who seeks financial benefits based on the work of a promoter or a third party.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;SpotContract">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
 		<rdfs:label xml:lang="en">spot contract</rdfs:label>
 		<skos:definition xml:lang="en">financial instrument that settles for immediate delivery on a specified date</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A spot transaction is a transaction in which some goods or instrument(s) are exchanged for some other goods or instruments, including currency, with no future delivery provision, i.e., within the minimum number of days possible. Examples include currency spots and commodity spot transactions, whose settlement convention is determined by the relevant market.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A spot transaction is a transaction in which some goods or instrument(s) are exchanged for some other goods or instruments, including currency, with no future delivery provision, i.e., within the minimum number of days possible. Examples include currency spots and commodity spot transactions, whose settlement convention is determined by the relevant market.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;StandardizedTerms">
@@ -406,8 +401,8 @@
 		<rdfs:label>has nominal value</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition>indicates the face value of something</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Nominal value of a security is its redemption price and will vary from its market value. A preferred stock&apos;s nominal (par) value is important in that it is used to calculate its dividend while the nominal value of common stock is an arbitrary value assigned for balance sheet purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>face value</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Nominal value of a security is its redemption price and will vary from its market value. A preferred stock&apos;s nominal (par) value is important in that it is used to calculate its dividend while the nominal value of common stock is an arbitrary value assigned for balance sheet purposes.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>face value</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;hasPrincipalExecutiveOfficeAddress">
@@ -416,7 +411,7 @@
 		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalPerson"/>
 		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
 		<skos:definition>relates an organization, specifically the issuer of a financial instrument, to its principal executive address, as required for issuance of that instrument</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Note that in most cases, the principal executive office address is also the headquarters address for a company.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that in most cases, the principal executive office address is also the headquarters address for a company.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;hasRedemptionProvision">
@@ -439,7 +434,7 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<skos:definition>relates an instrument to the currency its value is typically expressed in</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This should be the same currency that was declared at the time of issuance.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This should be the same currency that was declared at the time of issuance.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;holdsSharesIn">

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
@@ -23,10 +24,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
@@ -50,24 +51,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 		<rdfs:label xml:lang="en">Instrument Pricing Ontology</rdfs:label>
 		<dct:abstract>This ontology provides a basic set of definitions related to pricing, yield, and spread that are extended in other instrument-specific ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fi-ip</sm:fileAbbreviation>
-		<sm:filename>InstrumentPricing.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"/>
@@ -83,23 +72,27 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FinancialInstruments/InstrumentPricing/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FinancialInstruments/InstrumentPricing/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, to add adjusted price and to create a more general hasLotSize property that can be used in various contexts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to change one of the subclasses of price determination method to a named individual and correct the definition of mean price determination. Note that there may be multiple individuals of type &apos;closing price determination method&apos;, depending on the exchange and other factors. Also revised the lot size properties to have a range of xsd:decimal to allow for fractional shares or number of elements, revised the explanatory note, and added examples.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to eliminate a redundant restriction on CollectionOfSecurityPrices, better integrate pricing methods, loosen the domain restriction on hasPricingSource and add dealer to the set of possible sources for prices.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FinancialInstruments/InstrumentPricing.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;AdjustedClosingPrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;ClosingPrice"/>
 		<rdfs:label xml:lang="en">adjusted closing price</rdfs:label>
 		<skos:definition xml:lang="en">amended closing price to reflect a security&apos;s value after accounting for any corporate actions, such as stock splits, dividends, and rights offerings</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A particularly dramatic change in price occurs when a company announces a stock split. When the change is made, the price displayed will immediately reflect the split. For example, if a company splits its stock 2-for-1, the last closing price will be cut in half. That&apos;s the adjusted closing price.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A particularly dramatic change in price occurs when a company announces a stock split. When the change is made, the price displayed will immediately reflect the split. For example, if a company splits its stock 2-for-1, the last closing price will be cut in half. That&apos;s the adjusted closing price.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;BestBid">
@@ -149,7 +142,7 @@
 		<rdfs:label xml:lang="en">bid price</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fi-ip;OfferPrice"/>
 		<skos:definition xml:lang="en">price a prospective buyer is willing to pay</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The term &apos;bid price&apos; is used by traders / market makers with respect to a given security, and that are prepared to buy or sell round lots at publicly quoted prices, and by specialists in certain instruments that perform similar functions on an exchange.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The term &apos;bid price&apos; is used by traders / market makers with respect to a given security, and that are prepared to buy or sell round lots at publicly quoted prices, and by specialists in certain instruments that perform similar functions on an exchange.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;ClosingPrice">
@@ -162,7 +155,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
 		<rdfs:label xml:lang="en">closing price determination method</rdfs:label>
 		<skos:definition xml:lang="en">strategy for calculating or otherwise determining an official closing price</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The official closing price is typically the final price at which something trades during regular market hours on an exchange or trading venue. Because of the evolving nature of online trading in a 24 hour world, every exchange has a method of calculating its official closing price, although that methodology changes from time to time. They may also publish an adjusted closing price, which reflects changes to the price that reflect corporate actions and after hours trading that occur before the opening of the exchange on the following day. Understanding how the closing price is determined is important to ensure price comparability for a given security across exchanges.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The official closing price is typically the final price at which something trades during regular market hours on an exchange or trading venue. Because of the evolving nature of online trading in a 24 hour world, every exchange has a method of calculating its official closing price, although that methodology changes from time to time. They may also publish an adjusted closing price, which reflects changes to the price that reflect corporate actions and after hours trading that occur before the opening of the exchange on the following day. Understanding how the closing price is determined is important to ensure price comparability for a given security across exchanges.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;CollectionOfSecurityPrices">
@@ -175,7 +168,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">collection of security prices</rdfs:label>
 		<skos:definition xml:lang="en">collection consisting of a series of prices, each of which has a specific date and time associated with it, for some security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that such a collection is of prices that may be quoted or may be established through analysis, such as an average over a number of markets (composite market) or developed via some pricing model (e.g., matrix pricing).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Note that such a collection is of prices that may be quoted or may be established through analysis, such as an average over a number of markets (composite market) or developed via some pricing model (e.g., matrix pricing).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;CompositeMarket">
@@ -206,7 +199,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;RateOfReturn"/>
 		<rdfs:label xml:lang="en">internal rate of return</rdfs:label>
 		<skos:definition xml:lang="en">discount rate that results in a net present value (NPV) of zero for a series of future cash flows</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This concept is central to many definitions of debt instrument analytics, and is the inverse of net present value.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This concept is central to many definitions of debt instrument analytics, and is the inverse of net present value.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;IntraDayPrice">
@@ -296,9 +289,9 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:label xml:lang="en">offer price</rdfs:label>
 		<skos:definition xml:lang="en">price suggested by a prospective seller at a particular time for a given security</skos:definition>
-		<fibo-fnd-utl-av:synonym xml:lang="en">ask price</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">asking price</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">offering price</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym xml:lang="en">ask price</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">asking price</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">offering price</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;OfficialClosingPrice">
@@ -311,15 +304,15 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">official closing price</rdfs:label>
 		<skos:definition xml:lang="en">price of the final trade of a security at the end of a trading day on a given exchange</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A stock&apos;s closing price is the standard benchmark used by investors to track its performance over time.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">end-of-day price</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">A stock&apos;s closing price is the standard benchmark used by investors to track its performance over time.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">end-of-day price</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;OpeningPrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
 		<rdfs:label xml:lang="en">opening price</rdfs:label>
 		<skos:definition xml:lang="en">price at which something first trades at the start of a trading day</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Investors that want to buy or sell as soon as the market opens will put in an order at the opening price. Depending on how the closing price for the prior day is determined, and if there is no after hours trading (AFT), the opening price will be the same as the prior trading day&apos;s closing price. Otherwise, the opening price may differ from the prior trading day&apos;s official closing price.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Investors that want to buy or sell as soon as the market opens will put in an order at the opening price. Depending on how the closing price for the prior day is determined, and if there is no after hours trading (AFT), the opening price will be the same as the prior trading day&apos;s closing price. Otherwise, the opening price may differ from the prior trading day&apos;s official closing price.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;PriceAnalytic">
@@ -393,7 +386,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">rate of return</rdfs:label>
 		<skos:definition xml:lang="en">net gain or loss on an investment over a specified time period, expressed as a percentage of the investment&apos;s initial cost or value as of a specific point in time</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">RoR</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation xml:lang="en">RoR</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;SecurityPrice">
@@ -437,7 +430,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">security price</rdfs:label>
 		<skos:definition xml:lang="en">monetary price for a financial instrument at some point in time</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A security price may be the price that some party is willing to pay, has recently paid, or would like to be paid, depending on the circumstances.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A security price may be the price that some party is willing to pay, has recently paid, or would like to be paid, depending on the circumstances.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;TradingDay">
@@ -464,11 +457,11 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">trading day</rdfs:label>
 		<skos:definition xml:lang="en">time span that a particular trading venue is open</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">RTH</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.lawinsider.com/dictionary/trading-day</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the United States, and with respect to common stock in particular, trading day means any day on which the stock is traded on the principal market, or, if the principal market is not the principal trading market for the common stock, then on the principal securities exchange or securities market on which the common stock is then traded, provided that &apos;Trading Day&apos; shall not include any day on which the common stock is scheduled to trade on such exchange or market for less than 4.5 hours or any day that the common stock is suspended from trading during the final hour of trading on such exchange or market (or if such exchange or market does not designate in advance the closing time of trading on such exchange or market, then during the hour ending at 4:00:00 p.m., New York time) unless such day is otherwise designated as a trading day in writing by the holder.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">regular trading hours</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:usageNote xml:lang="en">By convention it is sufficient to provide a value for hasOpeningDateTime, with hasClosingDateTime being optional.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:abbreviation xml:lang="en">RTH</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.lawinsider.com/dictionary/trading-day</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">In the United States, and with respect to common stock in particular, trading day means any day on which the stock is traded on the principal market, or, if the principal market is not the principal trading market for the common stock, then on the principal securities exchange or securities market on which the common stock is then traded, provided that &apos;Trading Day&apos; shall not include any day on which the common stock is scheduled to trade on such exchange or market for less than 4.5 hours or any day that the common stock is suspended from trading during the final hour of trading on such exchange or market (or if such exchange or market does not designate in advance the closing time of trading on such exchange or market, then during the hour ending at 4:00:00 p.m., New York time) unless such day is otherwise designated as a trading day in writing by the holder.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">regular trading hours</cmns-av:synonym>
+		<cmns-av:usageNote xml:lang="en">By convention it is sufficient to provide a value for hasOpeningDateTime, with hasClosingDateTime being optional.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;TradingSession">
@@ -489,22 +482,22 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">trading session</rdfs:label>
 		<skos:definition xml:lang="en">window of time within a trading day in which orders may be placed and filled</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://financial-dictionary.thefreedictionary.com/Trading+Sessions</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An exchange may have several trading sessions during a day. For example, the exchange may be open from 9 a.m. until 10:30 a.m., from 11:30 a.m. until 1 p.m., and from 2 p.m. to 3:30 p.m. Holding several trading sessions gives the market more time to digest information rationally without having to respond immediately.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://financial-dictionary.thefreedictionary.com/Trading+Sessions</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">An exchange may have several trading sessions during a day. For example, the exchange may be open from 9 a.m. until 10:30 a.m., from 11:30 a.m. until 1 p.m., and from 2 p.m. to 3:30 p.m. Holding several trading sessions gives the market more time to digest information rationally without having to respond immediately.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;VolumeWeightedAveragePrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;PriceAnalytic"/>
 		<rdfs:label xml:lang="en">volume-weighted average price</rdfs:label>
 		<skos:definition xml:lang="en">average price at which a given security has traded throughout a trading day, determined by multiplying each trade by its volume, adding the results, then dividing by the volume traded for the day</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">VWAP</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation xml:lang="en">VWAP</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;VolumeWeightedOpenPrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;PriceAnalytic"/>
 		<rdfs:label xml:lang="en">volume-weighted open price</rdfs:label>
 		<skos:definition xml:lang="en">price determined by multiplying each trade by its volume, adding the results, then dividing by the volume over a certain period during the trading day (rather than over the course of the entire day)</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">VWOP</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation xml:lang="en">VWOP</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;Yield">
@@ -530,8 +523,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">yield</rdfs:label>
 		<skos:definition xml:lang="en">return on the investor&apos;s capital investment</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Yield must be based on a price, and must be in reference to some event or duration of time. It has a calculation method, and may have other qualifying terms such as for compounded yield.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Yield reflects income over some period of time which is then annualized, and typically projected into the future, assuming that conditions and rates remain the same, whereas return on investment is retrospective.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A Yield must be based on a price, and must be in reference to some event or duration of time. It has a calculation method, and may have other qualifying terms such as for compounded yield.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Yield reflects income over some period of time which is then annualized, and typically projected into the future, assuming that conditions and rates remain the same, whereas return on investment is retrospective.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;YieldSpread">
@@ -552,7 +545,7 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:range rdf:resource="&xsd;integer"/>
 		<skos:definition xml:lang="en">indicates depth of the order book to which the price refers</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An order book is the list of orders (manual or electronic) that a trading venue (in particular stock exchanges) uses to record the interest of buyers and sellers in a particular financial instrument. The book depth refers to the number of price levels available at a particular time in the book. Sometimes the book is represented to a fixed depth, and orders beyond that depth are ignored or rejected, and in other cases the book can contain unlimited levels.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">An order book is the list of orders (manual or electronic) that a trading venue (in particular stock exchanges) uses to record the interest of buyers and sellers in a particular financial instrument. The book depth refers to the number of price levels available at a particular time in the book. Sometimes the book is represented to a fixed depth, and orders beyond that depth are ignored or rejected, and in other cases the book can contain unlimited levels.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-ip;hasClosingPriceDeterminationMethod">
@@ -560,7 +553,7 @@
 		<rdfs:label xml:lang="en">has closing price determination method</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fbc-fi-ip;ClosingPriceDeterminationMethod"/>
 		<skos:definition xml:lang="en">indicates a strategy by which the official closing price is determined</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This method itself changes quite frequently i.e. the exchange may change the way it computes closing prices.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This method itself changes quite frequently i.e. the exchange may change the way it computes closing prices.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fi-ip;hasLotSize">
@@ -569,7 +562,7 @@
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">magnitude of an item (i.e., total quantity)</skos:definition>
 		<skos:example xml:lang="en">For example, with respect to corn, 5000 bushels is a typical contract size. For some oil commodities trades, 1000 barrels is considered a single contract. For equity options, the lot size is typically 100 shares of the underlying.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The lot size, referenced in offerings, listings, orders, and trades, typically refers to the number of shares or units in a single contract.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The lot size, referenced in offerings, listings, orders, and trades, typically refers to the number of shares or units in a single contract.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-ip;hasPriceDeterminationMethod">
@@ -606,9 +599,9 @@
 		<rdfs:label xml:lang="en">has round lot size</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">standard number of securities traded on an exchange</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In stocks, a round lot is considered 100 shares or a larger number that can be evenly divided by 100. In bonds, a round lot is usually $100,000 worth. Odd lots and smaller lots have become increasingly common due to technology advances and small investor demand.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">normal trading unit</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">unit of trading</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">In stocks, a round lot is considered 100 shares or a larger number that can be evenly divided by 100. In bonds, a round lot is usually $100,000 worth. Odd lots and smaller lots have become increasingly common due to technology advances and small investor demand.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">normal trading unit</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">unit of trading</cmns-av:synonym>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-ip;hasTradingDateTime">

--- a/FBC/FinancialInstruments/MetadataFBCFinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/MetadataFBCFinancialInstruments.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fi-mod "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/MetadataFBCFinancialInstruments/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/MetadataFBCFinancialInstruments/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fi-mod="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/MetadataFBCFinancialInstruments/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -18,35 +19,34 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/MetadataFBCFinancialInstruments/">
 		<rdfs:label>Metadata about the EDMC-FIBO Financial Business and Commerce(FBC) Financial Instruments Module</rdfs:label>
 		<dct:abstract>The financial instruments module includes ontologies defining general purpose financial instruments, i.e., agreements, contracts, notes, equities, options, debt instruments, and so forth, some of which may be negotiable.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-fbc-fi-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataFBCFinancialInstruments.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/MetadataFBCFinancialInstruments/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FinancialInstruments/MetadataFBCFinancialInstruments/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-mod;FinancialInstrumentsModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO FBC Financial Instruments Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>financial instruments module</rdfs:label>
 		<dct:abstract>The financial instruments module includes ontologies defining general purpose financial instruments, i.e., agreements, contracts, notes, equities, options, debt instruments, and so forth, some of which may be negotiable.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-FBC-FI</sm:moduleAbbreviation>
+		<dct:title>FIBO FBC Financial Instruments Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Financial Instruments Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FBC/FinancialInstruments/Settlement.rdf
+++ b/FBC/FinancialInstruments/Settlement.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
@@ -18,10 +19,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
@@ -40,22 +41,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/Settlement/">
 		<rdfs:label xml:lang="en">Settlement Ontology</rdfs:label>
 		<dct:abstract>This ontology defines high-level concepts for settlement that are applicable across FIBO domain areas, such as for loans, securities, and derivatives.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fi-stl</sm:fileAbbreviation>
-		<sm:filename>Settlement.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -67,9 +58,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20221001/FinancialInstruments/Settlement/"/>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220901/FinancialInstruments/Settlement.rdf version of this ontology was revised to integrate the notion of a value assessment with a settlement event.</skos:changeNote>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FinancialInstruments/Settlement/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221001/FinancialInstruments/Settlement.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FinancialInstruments/Settlement.rdf version of this ontology was revised to integrate the notion of a value assessment with a settlement event.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-stl;CashSettlementTerms">
@@ -95,14 +90,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">cash settlement terms</rdfs:label>
 		<skos:definition>contractual commitment to settle in cash</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Note that the security price represents a price per share or per lot, whereas the settlement amount represents a total.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that the security price represents a price per share or per lot, whereas the settlement amount represents a total.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-stl;DeliveryInCash">
 		<rdf:type rdf:resource="&fibo-fbc-fi-stl;DeliveryMethod"/>
 		<rdfs:label>delivery in cash</rdfs:label>
 		<skos:definition>commitment to deliver an amount of money at the earliest available date as per settlement convention</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<rdf:Description rdf:about="&fibo-fbc-fi-stl;DeliveryMethod">
@@ -117,21 +112,21 @@
 		<rdf:type rdf:resource="&fibo-fbc-fi-stl;DeliveryMethod"/>
 		<rdfs:label xml:lang="en">elect at exercise method</rdfs:label>
 		<skos:definition xml:lang="en">commitment to determine the delivery strategy at the time of exercise</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-stl;NonDeliverableMethod">
 		<rdf:type rdf:resource="&fibo-fbc-fi-stl;DeliveryMethod"/>
 		<rdfs:label xml:lang="en">non-deliverable method</rdfs:label>
 		<skos:definition xml:lang="en">commitment with respect to synthetic options on foreign exchange forwards that are based on non-convertible or thinly traded currencies</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-stl;PhysicalDeliveryMethod">
 		<rdf:type rdf:resource="&fibo-fbc-fi-stl;DeliveryMethod"/>
 		<rdfs:label xml:lang="en">physical delivery method</rdfs:label>
 		<skos:definition xml:lang="en">commitment to settle an obligation through the receipt or delivery of the actual underlying instrument(s) or other asset, such as a commodity, instead of through cash settlement</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-stl;PhysicalSettlementTerms">
@@ -144,8 +139,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">physical settlement terms</rdfs:label>
 		<skos:definition xml:lang="en">commitment to deliver the actual underlying asset on the specified delivery date, rather than cash</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If you sell a gold futures contract of say 100 troy ounces then you have to deliver real gold to the buyer on the mutually agreed date. Most derivatives are not actually exercised, but are traded out before their delivery date. However, physical delivery still occurs with some trades: it is most common with commodities, but can also occur with other financial instruments.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">If you sell a gold futures contract of say 100 troy ounces then you have to deliver real gold to the buyer on the mutually agreed date. Most derivatives are not actually exercised, but are traded out before their delivery date. However, physical delivery still occurs with some trades: it is most common with commodities, but can also occur with other financial instruments.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-stl;Settlement">
@@ -164,7 +159,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>settlement convention</rdfs:label>
 		<skos:definition>convention employed to determine the closing date (from the stated settlement date) in the process of settling a transaction on which securities or interests in securities are delivered, usually against (in simultaneous exchange for) payment of some consideration</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is often stated in the form &apos;T+n&apos; where n is the number of business days from the specified settlement date (T).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is often stated in the form &apos;T+n&apos; where n is the number of business days from the specified settlement date (T).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-stl;SettlementEvent">
@@ -208,7 +203,7 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<skos:definition>indicates the preferred currency for settlement purposes</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This property should only be used in cases where the settlement currency is distinct from the currency in which the instrument is denominated.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This property should only be used in cases where the settlement currency is distinct from the currency in which the instrument is denominated.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-stl;hasSettlementAmount">
@@ -231,8 +226,8 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether the security is to be held at the transfer agent as part of the FAST (Fully Automated Securities Transfer) program</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>is FAST applicable</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The Fast Automated Securities Transfer Program (FAST) is a contract between DTC (and its subsidiaries) and transfer agents whereby FAST agents act as custodians for DTC.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>is FAST applicable</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The Fast Automated Securities Transfer Program (FAST) is a contract between DTC (and its subsidiaries) and transfer agents whereby FAST agents act as custodians for DTC.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;SettlementTerms">

--- a/FBC/FunctionalEntities/BusinessCenters.rdf
+++ b/FBC/FunctionalEntities/BusinessCenters.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-bc "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
@@ -11,10 +12,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-bc="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
@@ -26,30 +27,26 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/">
 		<rdfs:label>Business Centers Ontology</rdfs:label>
 		<dct:abstract>This ontology refines the notion of a business center for reference in defining markets and exchanges, clearing houses, and other functional entities as appropriate. The ontology covers the concept of an FpML business center (excluding those that are business day adjustments), with a focus on a physical place where business is transacted, where relevant.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:resource="https://www.omg.org/spec/LCC/"/>
-		<sm:fileAbbreviation>fibo-fbc-fct-bc</sm:fileAbbreviation>
-		<sm:filename>BusinessCenters.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/BusinessCenters/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/BusinessCenters/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180901/FunctionalEntities/BusinessCenters.rdf version of this ontology was revised to eliminate duplication with concepts in LCC and to merge countries with locations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/BusinessCenters.rdf version of this ontology was revised to eliminate circular imports and make definitions ISO 704 compliant.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/FunctionalEntities/BusinessCenters.rdf version of this ontology was revised to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/BusinessCenters.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-bc;BusinessCenterCode">
@@ -68,15 +65,15 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business center code</rdfs:label>
 		<skos:definition>code used to denote a metropolitan area where business is conducted</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The codes for business centers and municipalities defined herein are largely those identified either as FpML business centers or are locations where there is an exchange, as noted in the ISO 10962 MIC code standard.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The codes for business centers and municipalities defined herein are largely those identified either as FpML business centers or are locations where there is an exchange, as noted in the ISO 10962 MIC code standard.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-bc;BusinessCenterCodeScheme">
 		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeSet"/>
 		<rdfs:label>business center code set</rdfs:label>
 		<skos:definition>coding scheme used to define a set of codes for municipalities or business centers</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-bc;BusinessDayAdjustmentCode">
@@ -95,12 +92,12 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business day adjustment code</rdfs:label>
 		<skos:definition>code used to denote a convention for specifying what happens when a date falls on a day that is weekend or holiday in some municipality or business center</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;BusinessCenter">
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Note that business centers, as defined in FpML, are intended for use in specifying the business calendar used by that municipality, or by certain organizations located in that municipality.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Note that business centers, as defined in FpML, are intended for use in specifying the business calendar used by that municipality, or by certain organizations located in that municipality.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;Municipality">

--- a/FBC/FunctionalEntities/BusinessCentersIndividuals.rdf
+++ b/FBC/FunctionalEntities/BusinessCentersIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-bc "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/">
 	<!ENTITY fibo-fbc-fct-bci "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/">
@@ -16,10 +17,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-bc="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/"
 	xmlns:fibo-fbc-fct-bci="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"
@@ -36,25 +37,20 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/">
 		<rdfs:label>Business Centers Individuals</rdfs:label>
 		<dct:abstract>This ontology includes individuals representing the set of international business centers corresponding to those identified in FpML as well as additional municipalities called out in the ISO 10383 Codes for exchanges and market identification (MIC) standard.
 		This set of business centers is current with respect to the FpML published XML data as of Q2 2022. Note that we have deviated from the standard FIBO naming convention of strict use of camel case to add underscores in certain city names for readability purposes.</dct:abstract>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-fbc-fct-bci</sm:fileAbbreviation>
-		<sm:filename>BusinessCentersIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/"/>
@@ -76,11 +72,11 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220601/FunctionalEntities/BusinessCentersIndividuals/ version of this ontology was modified to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/BusinessCentersIndividuals/ version of this ontology was modified to equate Almaty and Alma-ata, which are the same city (Alma-ata is the old name, no longer in use).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220901/FunctionalEntities/BusinessCentersIndividuals/ version of this ontology was modified to add a number of new municipalities that were included in the December 2022 MIC codes.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FunctionalEntities/BusinessCentersIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
-	
-	<owl:AnnotationProperty rdf:about="&dct;description">
-	</owl:AnnotationProperty>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;AEAD">
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
@@ -1366,7 +1362,7 @@
 		<rdfs:label>ESAS Settlement Day</rdfs:label>
 		<dct:description>the business day adjustment convention for the ESAS Settlement Day (as defined in 2006 ISDA Definitions Section 7.1 and Supplement Number 15 to the 2000 ISDA Definitions)</dct:description>
 		<fibo-fnd-plc-loc:hasBusinessCenter rdf:resource="&fibo-fbc-fct-bci;Wellington"/>
-		<fibo-fnd-utl-av:explanatoryNote>ESAS is the Reserve Bank of New Zealand&apos;s Exchange Settlement Account System which is used by banks and other approved financial institutions to settle their obligations on a Real-Time Gross Settlement (RTGS) basis.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>ESAS is the Reserve Bank of New Zealand&apos;s Exchange Settlement Account System which is used by banks and other approved financial institutions to settle their obligations on a Real-Time Gross Settlement (RTGS) basis.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;ESBA">
@@ -1412,8 +1408,8 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Ebene">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Ebene</rdfs:label>
-		<fibo-fnd-utl-av:synonym>Cybercity</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>Ebene Cybercity</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>Cybercity</cmns-av:synonym>
+		<cmns-av:synonym>Ebene Cybercity</cmns-av:synonym>
 		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Mauritius"/>
 	</owl:NamedIndividual>
 	
@@ -1514,7 +1510,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCodeScheme"/>
 		<rdfs:label>FpML Business Center Code Scheme</rdfs:label>
 		<dct:description>the coding scheme used to define a set of codes for municipalities, or business centers, or business day adjustments for FpML</dct:description>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/business-center</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Frankfurt">
@@ -1583,7 +1579,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;GIFT_City">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>GIFT City</rdfs:label>
-		<fibo-fnd-utl-av:synonym>Gujarat International Finance Tec-City</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>Gujarat International Finance Tec-City</cmns-av:synonym>
 		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
@@ -2974,7 +2970,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>New York</rdfs:label>
 		<dct:description>the international business center of New York</dct:description>
-		<fibo-fnd-utl-av:synonym>New York City</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>New York City</cmns-av:synonym>
 		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
@@ -3540,7 +3536,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Saint-Petersburg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Saint Petersburg</rdfs:label>
-		<fibo-fnd-utl-av:synonym>St. Petersburg</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>St. Petersburg</cmns-av:synonym>
 		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
@@ -3548,7 +3544,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Saint Peter Port</rdfs:label>
 		<dct:description>the international business center of Saint Peter Port</dct:description>
-		<fibo-fnd-utl-av:synonym>St. Peter Port</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>St. Peter Port</cmns-av:synonym>
 		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Guernsey"/>
 	</owl:NamedIndividual>
 	
@@ -3822,7 +3818,7 @@
 		<fibo-fnd-plc-loc:hasBusinessCenter rdf:resource="&fibo-fbc-fct-bci;Paris"/>
 		<fibo-fnd-plc-loc:hasBusinessCenter rdf:resource="&fibo-fbc-fct-bci;Rome"/>
 		<fibo-fnd-plc-loc:hasBusinessCenter rdf:resource="&fibo-fbc-fct-bci;Vienna"/>
-		<fibo-fnd-utl-av:explanatoryNote>TARGET, which stands for the Trans-European Automated Real-time Gross settlement adjustment Express Transfer system, is the real-time gross settlement (RTGS) system for the euro. TARGET operating days are the settlement days for the financial markets in euro, as well as foreign exchange transactions involving the euro.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>TARGET, which stands for the Trans-European Automated Real-time Gross settlement adjustment Express Transfer system, is the real-time gross settlement (RTGS) system for the euro. TARGET operating days are the settlement days for the financial markets in euro, as well as foreign exchange transactions involving the euro.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;THBA">

--- a/FBC/FunctionalEntities/BusinessRegistries.rdf
+++ b/FBC/FunctionalEntities/BusinessRegistries.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
@@ -25,10 +26,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
@@ -54,24 +55,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/">
 		<rdfs:label>Business Registries Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the Registration Authorities ontology to define specific kinds of registries, such as business entity registries, registries for identifiers and codes of various sorts, and registries for financial institutions and intermediaries based on jurisdiction, who regulates them, and the services they provide.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-breg</sm:fileAbbreviation>
-		<sm:filename>BusinessRegistries.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
@@ -89,9 +78,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/BusinessRegistries/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/BusinessRegistries/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.1 RTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified per FIBO 2.0 RFC primarily to loosen the constraints on address properties and better support standards including ISO 9362 (BIC codes), ISO 13616 (IBAN and BBAN codes), and ISO 17442 (the GLIEF LEI standard).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified to generalize certain unions where they were no longer required, use the composite date datatype where appropriate, add individuals for entity expiration reason and validation level to better align with the GLEIF LEI data, and move international registration authorities, such as SWIFT, to a separate ontology for better modularity.</skos:changeNote>
@@ -104,8 +94,11 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210901/FunctionalEntities/BusinessRegistries.rdf version of this ontology was revised to clarify the definition of registry identifier and augment the definitions of certain identifiers, such as an LEI, to make them registry identifiers, as well as to modify the definition of an LOU to be a Registrar rather than RegistrationAuthority, and deprecate the redundant LOU identifier.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/BusinessRegistries.rdf version of this ontology was revised to eliminate deprecated content.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220501/FunctionalEntities/BusinessRegistries.rdf version of this ontology was revised to eliminate dead links and address text formatting issues uncovered by hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/BusinessRegistries.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was revised to refine the definitions of certain date properties to allow for broader usage, such as for market-related content.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-le-fbo;ValueAddedTaxIdentificationNumber">
@@ -172,7 +165,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityStatus"/>
 		<rdfs:label>active status</rdfs:label>
 		<skos:definition>status indicating that as of the last report or update, the entity was legally registered and operating</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>ACTIVE</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -180,7 +173,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>annulled status</rdfs:label>
 		<skos:definition>status indicating that the registration was determined to be erroneous or invalid after issuance</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>ANNULLED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -201,7 +194,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business register identifier</rdfs:label>
 		<skos:definition>identifier that uniquely identifies a business register, such as a register identified by the Global Legal Entity Identifier Foundation (GLEIF) registration authorities list</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/gleif-registration-authorities-list</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/gleif-registration-authorities-list</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;BusinessRegistrationAuthority">
@@ -220,8 +213,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business registration authority</rdfs:label>
 		<skos:definition>registration authority that is responsible for maintaining a registry of business entities</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/gleif-registration-authorities-list</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A business registry may include any government-managed registry for registering a business, such as a state department of corporations in the US, as well as other registries such as a local operating unit (LOU) for registration of legal entity identifiers (LEIs). Any sanctioned registration authority as defined by the Registration Authorities List, published by GLEIF, is a business registration authority in this sense.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/gleif-registration-authorities-list</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A business registry may include any government-managed registry for registering a business, such as a state department of corporations in the US, as well as other registries such as a local operating unit (LOU) for registration of legal entity identifiers (LEIs). Any sanctioned registration authority as defined by the Registration Authorities List, published by GLEIF, is a business registration authority in this sense.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;BusinessRegistry">
@@ -248,7 +241,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business registry</rdfs:label>
 		<skos:definition>registry for registering and maintaining information about business entities</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/gleif-registration-authorities-list</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/gleif-registration-authorities-list</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;BusinessRegistryEntry">
@@ -280,7 +273,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>cancelled status</rdfs:label>
 		<skos:definition>status indicating that the registration was abandoned prior to issuance</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>CANCELLED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -288,7 +281,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>duplicate status</rdfs:label>
 		<skos:definition>status indicating that the registration was determined to be a duplicate registration of the same entity as another registration; duplicate status is assigned to the non-surviving registration (i.e. the identifier that should no longer be used)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>DUPLICATE</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -303,14 +296,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>entity expiration reason</rdfs:label>
 		<skos:definition>code for the reason that a legal entity ceased to exist and/or operate</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityExpirationReasonCorporateAction">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<rdfs:label>entity expiration reason - corporate action</rdfs:label>
 		<skos:definition>expiration reason indicating that an entity was acquired or merged with another entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>CORPORATE_ACTION</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -318,7 +311,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<rdfs:label>entity expiration reason - disolved</rdfs:label>
 		<skos:definition>expiration reason indicating that an entity ceased to operate</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>DISSOLVED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -326,7 +319,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<rdfs:label>entity expiration reason - other</rdfs:label>
 		<skos:definition>expiration reason indicating something that is neither due to disolution nor corporate action</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>OTHER</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -340,8 +333,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>entity legal form registry</rdfs:label>
 		<skos:definition>registry for registering and maintaining information about the legal forms that are valid for business entities for a particular jurisdiction following the ISO 20275 standard</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ELF registry</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/code-lists/iso-20275-entity-legal-forms-code-list</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>ELF registry</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/code-lists/iso-20275-entity-legal-forms-code-list</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;EntityLegalFormRegistryEntry">
@@ -354,16 +347,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label>entity legal form registry entry</rdfs:label>
 		<skos:definition>entry in an entity legal form registry that conforms to ISO 20275</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ELF registry entry</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/code-lists/iso-20275-entity-legal-forms-code-list</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>ELF registry entry</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/code-lists/iso-20275-entity-legal-forms-code-list</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;EntityStatus">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStage"/>
 		<rdfs:label>entity status</rdfs:label>
 		<skos:definition>lifecycle stage indicating the operational and/or legal status of an entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In some jurisdictions, there may be other possible values for entity status, such as suspended in the State of California, thus the individuals provided herein are not intended to be exhaustive.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In some jurisdictions, there may be other possible values for entity status, such as suspended in the State of California, thus the individuals provided herein are not intended to be exhaustive.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;EntityValidationLevel">
@@ -377,14 +370,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>entity validation level</rdfs:label>
 		<skos:definition>code for the level of validation performed by the GLEIF or LOU with respect to the reference data provided by the registrant</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityValidationLevelEntitySuppliedOnly">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevel"/>
 		<rdfs:label>entity validation level - entity-supplied only</rdfs:label>
 		<skos:definition>Based on the validation procedures in use by the LOU responsible for the record, the information associated with this record has significant reliance on the information that a submitter provided due to the unavailability of corroborating information.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>ENTITY_SUPPLIED_ONLY</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -392,7 +385,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevel"/>
 		<rdfs:label>entity validation level - fully corroborated</rdfs:label>
 		<skos:definition>Based on the validation procedures in use by the LOU responsible for the record, there is sufficient information contained in authoritative public sources to corroborate the information that the submitter has provided for the record.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>FULLY_CORROBORATED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -400,7 +393,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevel"/>
 		<rdfs:label>entity validation level - partially corroborated</rdfs:label>
 		<skos:definition>Based on the validation procedures in use by the LOU responsible for the record, the information supplied by the registrant can be partially corroborated by public authoritative sources, while some of the record is dependent upon the information that the registrant submitted, either due to conflicts with authoritative information, or due to data unavailability.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>PARTIALLY_CORROBORATED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -408,7 +401,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityStatus"/>
 		<rdfs:label>inactive status</rdfs:label>
 		<skos:definition>status indicating that the entity is no longer legally registered and/or operating, whether as a result of business closure, acquisition by or merger with another (or new) entity, or determination of illegitimacy</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>INACTIVE</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -416,7 +409,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>issued status</rdfs:label>
 		<skos:definition>status indicating that the registration has been validated and issued, and which identifies an entity that was operating legally as of the last update</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>ISSUED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -424,7 +417,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>lapsed status</rdfs:label>
 		<skos:definition>status indicating that the registration that has not been renewed by the specified renewal date and is not known by public sources to have ceased operation as of the last update</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>LAPSED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -438,8 +431,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>legal entity identifier registry</rdfs:label>
 		<skos:definition>registry for registering and maintaining information about business entities for a particular jurisdiction</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>LEI registry</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>LEI registry</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry">
@@ -471,8 +464,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>legal entity identifier registry entry</rdfs:label>
 		<skos:definition>entry in a legal entity identifier registry that conforms to ISO 17442 and the Global Legal Entity Identifier Foundation (GLEIF) Common Data Format (CDF)</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>LEI registry entry</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>LEI registry entry</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;LocalOperatingUnit">
@@ -491,16 +484,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label>local operating unit</rdfs:label>
 		<skos:definition>registrar that is authorized by the Global LEI Foundation to issue legal entity identifiers</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>LOU</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>LOUs supply registration, renewal and other services, and act as the primary interface for legal entities wishing to obtain an LEI.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>LOU</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>LOUs supply registration, renewal and other services, and act as the primary interface for legal entities wishing to obtain an LEI.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;MergedStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>merged status</rdfs:label>
 		<skos:definition>status indicating that the registration is for an entity that has been merged into another legal entity, such that this legal entity no longer exists as an independently operating entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>MERGED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -529,7 +522,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>North American Industry Classification System code</rdfs:label>
 		<skos:definition>the North American Industry Classification System (NAICS) code representing an industry</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NAICS code</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>NAICS code</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;NorthAmericanIndustryClassificationSystemScheme">
@@ -544,16 +537,16 @@
 		<rdfs:label>North American Industry Classification System scheme</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.census.gov/naics/"/>
 		<skos:definition>the scheme defining the North American Industry Classification System (NAICS) Codes</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The North American Industry Classification System (NAICS) is the standard used by Federal statistical agencies in classifying business establishments for the purpose of collecting, analyzing, and publishing statistical data related to the U.S. business economy.
+		<cmns-av:explanatoryNote>The North American Industry Classification System (NAICS) is the standard used by Federal statistical agencies in classifying business establishments for the purpose of collecting, analyzing, and publishing statistical data related to the U.S. business economy.
 
-NAICS was developed under the auspices of the Office of Management and Budget (OMB), and adopted in 1997 to replace the Standard Industrial Classification (SIC) system. It was developed jointly by the U.S. Economic Classification Policy Committee (ECPC), Statistics Canada and Mexico&apos;s Instituto Nacional Estadistica y Geografia, to allow for a high level of comparability in business statistics among the North American countries.</fibo-fnd-utl-av:explanatoryNote>
+NAICS was developed under the auspices of the Office of Management and Budget (OMB), and adopted in 1997 to replace the Standard Industrial Classification (SIC) system. It was developed jointly by the U.S. Economic Classification Policy Committee (ECPC), Statistics Canada and Mexico&apos;s Instituto Nacional Estadistica y Geografia, to allow for a high level of comparability in business statistics among the North American countries.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;PendingArchivalStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>pending archival status</rdfs:label>
 		<skos:definition>status indicating that the registration is about to be transferred to a different registration authority, after which its registration status will revert to a non-pending status</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>PENDING_ARCHIVAL</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -561,7 +554,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>pending transfer status</rdfs:label>
 		<skos:definition>status indicating that the registration has requested transfer to a different registration authority, and for which transfer is in progress</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>PENDING_TRANSFER</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -569,7 +562,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>pending validation status</rdfs:label>
 		<skos:definition>status indicating that an application for registration has been submitted and is in process, pending validation</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>PENDING_VALIDATION</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -585,22 +578,22 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		</rdfs:subClassOf>
 		<rdfs:label>registration authority code</rdfs:label>
 		<skos:definition>identifier that uniquely identifies a business registry, and is associated with a registration authority and jurisdiction, issued by the Global Legal Entity Identifier Foundation (GLEIF)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/gleif-registration-authorities-list</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/gleif-registration-authorities-list</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;RegistrationStatus">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStage"/>
 		<rdfs:label>registration status</rdfs:label>
 		<skos:definition>lifecycle stage indicating the status of a given registration of something, such as a business or legal entity, as specified by the registration authority</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>There may be other possible values for registration status, depending on the registry, thus the individuals provided herein are not intended to be exhaustive.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>There may be other possible values for registration status, depending on the registry, thus the individuals provided herein are not intended to be exhaustive.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;RetiredStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>retired status</rdfs:label>
 		<skos:definition>status indicating that the registration is for an entity that has ceased operation, without having been merged into another entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>RETIRED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -629,7 +622,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		</rdfs:subClassOf>
 		<rdfs:label>standard industrial classification code</rdfs:label>
 		<skos:definition>the SIC code representing an industry</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SIC code</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>SIC code</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;StandardIndustrialClassificationScheme">
@@ -644,14 +637,14 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>standard industrial classification scheme</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.osha.gov/pls/imis/sic_manual.html/"/>
 		<skos:definition>the scheme defining the Standard Industrial Classification (SIC) Code List</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Standard Industrial Classifications are four-digit codes that categorize companies by the type of business activities they engage in. These codes were created by the U.S. government in 1937 to facilitate analysis of economic activity across government agencies and within industries. They were mostly replaced in 1997 by a new system of six-digit codes called the North American Industry Classification System (NAICS). The new codes were adopted in part to standardize industry data collection and analysis in between Canada, the United States and Mexico which had entered into the North American Free Trade Agreement. Note that certain organizations, such as the Securities and Exchange Commission (SEC) still use SIC codes for some purposes.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Standard Industrial Classifications are four-digit codes that categorize companies by the type of business activities they engage in. These codes were created by the U.S. government in 1937 to facilitate analysis of economic activity across government agencies and within industries. They were mostly replaced in 1997 by a new system of six-digit codes called the North American Industry Classification System (NAICS). The new codes were adopted in part to standardize industry data collection and analysis in between Canada, the United States and Mexico which had entered into the North American Free Trade Agreement. Note that certain organizations, such as the Securities and Exchange Commission (SEC) still use SIC codes for some purposes.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;TransferredStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>transferred status</rdfs:label>
 		<skos:definition>status indicating that the registration that has been transferred to a different registration authority</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>TRANSFERRED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -659,14 +652,14 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasLegalName"/>
 		<rdfs:label>has alternative language legal name</rdfs:label>
 		<skos:definition>denotes a registered legal name for the entity in an alternative language used in the legal jurisdiction in which the entity is registered</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasAutomaticallyTransliteratedLegalName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-fct-breg;hasTransliteratedLegalName"/>
 		<rdfs:label>has automatically transliterated legal name</rdfs:label>
 		<skos:definition>denotes an auto-generated ASCII-transliterated representation of the legal name for the entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasEntityExpirationDate">
@@ -674,7 +667,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>has entity expiration date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition>indicates the date on which an entity ceases(d) to exist</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-breg;hasEntityExpirationReason">
@@ -682,7 +675,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>has entity expiration reason</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<skos:definition>indicates the reason that an entity ceased to exist (i.e., disolved, merged with another entity, etc.)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-breg;hasEntityStatus">
@@ -690,14 +683,14 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>has entity status</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-breg;EntityStatus"/>
 		<skos:definition>indicates the status of the entity (i.e., active, inactive)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasExpiryDate">
 		<rdfs:label>has expiry date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition>indicates the date on which something ceases(d) to exist</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasInitialRegistrationDate">
@@ -705,14 +698,14 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>has initial registration date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition>indicates the date on which an identifier or other registered item was created and/or first registered</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasPreferredTransliteratedLegalName">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-fct-breg;hasTransliteratedLegalName"/>
 		<rdfs:label>has preferred transliterated legal name</rdfs:label>
 		<skos:definition>denotes a preferred ASCII-transliterated representation of the legal name for the entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasPriorLegalName">
@@ -720,7 +713,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;wasFormerlyKnownAs"/>
 		<rdfs:label>has prior legal name</rdfs:label>
 		<skos:definition>denotes a primary legal name that was used previously for the entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasRegistrationRevisionDate">
@@ -728,7 +721,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>has registration status revision date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition>indicates the date that the status of a specific registration in the registry was revised</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-breg;hasRegistrationStatus">
@@ -748,7 +741,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>has registry name</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fct-ra;Registry"/>
 		<skos:definition>denotes a name for the registry, for example, for a business registry in which a business registration identifier for the legal entity is registered</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasRenewalDate">
@@ -756,16 +749,16 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>has renewal date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition>indicates the date by which a specific registration in the registry must be renewed or updated</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic?tl=en#BICPolicyandDatarecord</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:usageNote>This property is equivalent to the date of expiry in some registries, such as the BIC registry.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic?tl=en#BICPolicyandDatarecord</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>This property is equivalent to the date of expiry in some registries, such as the BIC registry.</cmns-av:usageNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasTradingOrOperationalName">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
 		<rdfs:label>has trading or operational name</rdfs:label>
 		<skos:definition>denotes a &apos;trading as&apos;, &apos;brand name&apos;, &apos;doing business as&apos;, or &apos;operating under&apos; name currently used by the entity in addition to, but not replacing, the (primary) legal, official registered name</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasTransliteratedLegalName">
@@ -773,7 +766,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasLegalName"/>
 		<rdfs:label>has transliterated legal name</rdfs:label>
 		<skos:definition>denotes an optional ASCII-transliterated (i.e. Latin- or Romanized) representation of the legal name for the entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-breg;hasValidationAuthority">
@@ -781,7 +774,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>has validation authority</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-breg;BusinessRegistrationAuthority"/>
 		<skos:definition>identifies the business registration authority for the legal entity, used by the Local Operating Unit (LOU) as the basis for validation, as defined in the GLEIF Registration Authorities List</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasValidationDate">
@@ -789,7 +782,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>has validation date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 		<skos:definition>indicates the date that a specific registration in the registry was most recently reviewed and validated</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic?tl=en#BICPolicyandDatarecord</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic?tl=en#BICPolicyandDatarecord</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-breg;hasValidationLevel">
@@ -802,7 +795,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:label>is self-maintained</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition>indicates whether the information about the entity is maintained internally or by a third-party</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic?tl=en#BICPolicyandDatarecord</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic?tl=en#BICPolicyandDatarecord</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-fnd-aap-ppl;PassportNumber">

--- a/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-eufse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
@@ -10,10 +11,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-eufse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
@@ -24,31 +25,25 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/">
 		<rdfs:label>European Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with additional kinds of entities that that provide services in Europe, across national boundaries, such as European market data providers, organizations that provide exchanges in multiple countries, organizations that support the European Union, and so forth.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-eufse</sm:fileAbbreviation>
-		<sm:filename>EUFinancialServicesEntities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf version of this ontology was revised to adjust the name of the CreditInstitutionOrInvestmentFirm classification to eliminate the &apos;or&apos; in the name to address hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;CRDCreditInstitution">
@@ -64,15 +59,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionInvestmentFirm"/>
 		<rdfs:label>credit institution</rdfs:label>
 		<skos:definition>an undertaking the business of which is to take deposits or other repayable funds from the public and to grant credits for its own account, and to which authorisation has been granted to operate within the European Union and European Economic Area countries (EEA)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32013R0575&amp;from=EN#page=18</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32013R0575&amp;from=EN#page=18</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;CreditInstitutionInvestmentFirm">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label>credit institution / investment firm</rdfs:label>
 		<skos:definition>classification specific to European financial institutions that designates them as credit institutions / investment firms as defined by the European Banking Authority (EBA)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32013R0575&amp;from=EN#page=18</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32013R0575&amp;from=EN#page=18</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;EuropeanEconomicAreaBranch">
@@ -81,7 +76,7 @@
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-eufse;NonEuropeanEconomicAreaBranch"/>
 		<skos:definition>a branch of a credit institution authorised in another European Economic Area (EEA) country that has the right to passport its activities</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:synonym>EEA branch</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>EEA branch</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;InvestmentFirm">
@@ -104,7 +99,7 @@
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-eufse;CreditInstitution"/>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-eufse;LocalFirm"/>
 		<skos:definition>any legal person whose regular occupation or business is the provision of one or more investment services to third parties and/or the performance of one or more investment activities on a professional basis</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32004L0039&amp;from=en#page=9</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32004L0039&amp;from=en#page=9</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;LocalFirm">
@@ -112,7 +107,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;BrokerageFirm"/>
 		<rdfs:label>local firm</rdfs:label>
 		<skos:definition>a firm dealing for its own account on markets in financial futures or options or other derivatives and on cash markets for the sole purpose of hedging positions on derivatives markets, or dealing for the accounts of other members of those markets and being guaranteed by clearing members of the same markets, where responsibility for ensuring the performance of contracts entered into by such a firm is assumed by clearing members of the same markets</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32013R0575&amp;from=EN#page=18</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32013R0575&amp;from=EN#page=18</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;NonEuropeanEconomicAreaBranch">
@@ -120,7 +115,7 @@
 		<rdfs:label>non European Economic Area branch</rdfs:label>
 		<skos:definition>a branch of a credit institution whose Head Office is in a third country</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:synonym>non-EEA branch</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>non-EEA branch</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;PaymentInstitution">
@@ -133,7 +128,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>payment institution</rdfs:label>
 		<skos:definition>a legal person that has been granted authorisation in accordance with Article 10 to provide and execute payment services throughout the European community</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32007L0064&amp;from=EN#page=18</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32007L0064&amp;from=EN#page=18</cmns-av:adaptedFrom>
 	</owl:Class>
 
 </rdf:RDF>

--- a/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
@@ -24,10 +25,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
@@ -52,28 +53,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/">
 		<rdfs:label>European Regulatory Agencies Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary regulatory agencies ontology in FBC with additional agencies and registries that regulate and provide services in Europe, across national boundaries, such as agencies that support the European Union.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-eurga</sm:fileAbbreviation>
-		<sm:filename>EURegulatoryAgencies.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
@@ -89,17 +74,21 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI information for the European Central Bank, eliminate duplication with concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was revised to update the LEI data for all LEIs to correspond to the content published by the GLEIF and clean up individual definitions as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-549300DTUYXVMJXZNY75-LEI">
@@ -116,7 +105,7 @@
 		<rdfs:label>Credit Institution Register</rdfs:label>
 		<skos:definition>registry of credit institutions to which authorisation has been granted to operate within the European Union and European Economic Area countries (EEA), a repository of financial data and institution characteristics for covered institutions collected by the the European Banking Authority (EBA)</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-eurga;EuropeanBankingAuthorityRegulator"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eurga;CreditInstitutionRegisterEntry">
@@ -141,16 +130,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label>Credit Institution Register entry</rdfs:label>
 		<skos:definition>entry in the Credit Institution Register, a repository of credit institutions collected by the European Banking Authority (EBA) as provided by the various national banking authorities for those institutions that qualify</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eurga;EuropeanBankingAuthority">
 		<rdf:type rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
 		<rdfs:label>European Banking Authority</rdfs:label>
 		<skos:definition>European Banking Authority legal entity, whose main task is to contribute, through the adoption of binding Technical Standards (BTS) and Guidelines, to the creation of the European Single Rulebook in banking</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>EBA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/about-us/missions-and-tasks</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The Authority also plays an important role in promoting convergence of supervisory practices to ensure a harmonised application of prudential rules. Finally, the EBA is mandated to assess risks and vulnerabilities in the EU banking sector through, in particular, regular risk assessment reports and pan-European stress tests. To perform these tasks, the EBA can produce a number of regulatory and non regulatory documents including binding Technical Standards, Guidelines, Recommendations, Opinions and ad-hoc or regular reports.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>EBA</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/about-us/missions-and-tasks</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The Authority also plays an important role in promoting convergence of supervisory practices to ensure a harmonised application of prudential rules. Finally, the EBA is mandated to assess risks and vulnerabilities in the EU banking sector through, in particular, regular risk assessment reports and pan-European stress tests. To perform these tasks, the EBA can produce a number of regulatory and non regulatory documents including binding Technical Standards, Guidelines, Recommendations, Opinions and ad-hoc or regular reports.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eurga;EuropeanBankingAuthorityRegulator">
@@ -160,7 +149,7 @@
 		<skos:definition>European Banking Authority (EBA) regulator and registration authority</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-eurga;EuropeanBankingAuthority"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-eurga;CreditInstitutionRegister"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/about-us/missions-and-tasks</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/about-us/missions-and-tasks</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eurga;EuropeanBankingRegulatoryAgencyAndCentralBank">
@@ -170,7 +159,7 @@
 		<rdfs:label>European banking regulatory agency and central bank</rdfs:label>
 		<skos:definition>regulatory agency, registration authority and central banking role of the European Central Bank</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-eurga;EuropeanCentralBank"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.ecb.europa.eu/home/html/index.en.html</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.ecb.europa.eu/home/html/index.en.html</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eurga;EuropeanCentralBank">
@@ -180,9 +169,9 @@
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-eurga;EuropeanCentralBankHeadquartersAndLegalAddress"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ecb.europa.eu/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>European Central Bank</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:abbreviation>ECB</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.ecb.europa.eu/ecb/orga/escb/ecb-mission/html/index.en.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The European Central Bank is responsible for the prudential supervision of credit institutions located in the euro area and participating non-euro area Member States, within the Single Supervisory Mechanism, which also comprises the national competent authorities. It thereby contributes to the safety and soundness of the banking system and the stability of the financial system within the EU and each participating Member State.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>ECB</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.ecb.europa.eu/ecb/orga/escb/ecb-mission/html/index.en.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The European Central Bank is responsible for the prudential supervision of credit institutions located in the euro area and participating non-euro area Member States, within the Single Supervisory Mechanism, which also comprises the national competent authorities. It thereby contributes to the safety and soundness of the banking system and the stability of the financial system within the EU and each participating Member State.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eurga;EuropeanCentralBankHeadquartersAndLegalAddress">

--- a/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
@@ -25,10 +26,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
@@ -54,27 +55,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/">
 		<rdfs:label>International Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with additional kinds of entities that provide services internationally, such as international market data providers, organizations that provide exchanges in multiple countries, etc.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-eufseind</sm:fileAbbreviation>
-		<sm:filename>EuropeanFinancialServicesEntitiesIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
@@ -91,9 +77,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to eliminate usage of deprecated elements.</skos:changeNote>
@@ -102,7 +89,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to add the SIX Group and SIX Financial Information, which owns and operates a number of exchanges and issues the valoren, which is a commonly used financial instrument identifier, as well as to update the LEI data for all LEIs to correspond to the content published by the GLEIF on data.world.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to clarify the definitions of various LOUs as well as to update the LEI data for all LEIs to correspond to the content published by the GLEIF and clean up individual definitions as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to clean up dead links.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-213800D1EI4B9WTWWD28-LEI">
@@ -212,7 +202,7 @@
 		<skos:definition>individual representing Business Entity Data (BED) B.V.</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-eufseind;BusinessEntityData-NL"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-utl-av:explanatoryNote>wholly-owned subsidiary of DTCC that owns and operates the Global Market Entity Identifier Utility (GMEI) legal entity identifier (LEI) solution in the federated Global LEI system (GLEIS)</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>wholly-owned subsidiary of DTCC that owns and operates the Global Market Entity Identifier Utility (GMEI) legal entity identifier (LEI) solution in the federated Global LEI system (GLEIS)</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;BusinessEntityData-NL">
@@ -310,7 +300,7 @@
 		<fibo-be-oac-cctl:hasSubsidiary rdf:resource="&fibo-fbc-fct-eufseind;LuxCSD"/>
 		<fibo-fbc-fct-breg:hasPriorLegalName>Cedel Bank S.A.</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fnd-rel-rel:hasLegalName>Clearstream Banking S.A.</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:explanatoryNote>The company offers asset services, cash and banking services, connectivity, global securities financing, investment fund services, issuance, IT solutions, settlement, and market coverage services. It also provides post-trade infrastructure services for the German securities industry; and manages, safe keeps, and administers the securities that it holds on behalf of its customers. Clearstream Banking S.A was formerly known as Cedel Bank S.A. and changed its name to Clearstream Banking S.A. in March 2002. The company was founded in 1970 and is based in Luxembourg.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The company offers asset services, cash and banking services, connectivity, global securities financing, investment fund services, issuance, IT solutions, settlement, and market coverage services. It also provides post-trade infrastructure services for the German securities industry; and manages, safe keeps, and administers the securities that it holds on behalf of its customers. Clearstream Banking S.A was formerly known as Cedel Bank S.A. and changed its name to Clearstream Banking S.A. in March 2002. The company was founded in 1970 and is based in Luxembourg.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;Euroclear">
@@ -371,17 +361,17 @@
 		<rdf:type rdf:resource="&fibo-be-le-fbo;NotForProfitOrganization"/>
 		<rdfs:label>European Banking Federation</rdfs:label>
 		<skos:definition>international non-profit association founded in 1960 that is the voice of the European banking sector, uniting 32 national banking associations in Europe that together represent some 4,500 banks - large and small, wholesale and retail, local and international - employing about 2.1 million people</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>EBF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ebf.eu/about-us/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>EBF</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ebf.eu/about-us/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;EuropeanMoneyMarketsInstitute">
 		<rdf:type rdf:resource="&fibo-be-le-fbo;NotForProfitOrganization"/>
 		<rdfs:label>European Money Markets Institute</rdfs:label>
 		<skos:definition>international non-profit association under Belgian law founded in 1999 with the launch of the Euro and based in Brussels (56, Ave des Arts, 1000 Brussels)</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>EMMI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.emmi-benchmarks.eu/</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Its members are national banking associations in the Member States of the European Union which are involved in the Eurozone.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>EMMI</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.emmi-benchmarks.eu/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Its members are national banking associations in the Member States of the European Union which are involved in the Eurozone.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmann">
@@ -412,7 +402,7 @@
 		<rdfs:seeAlso rdf:resource="http://www.londonstockexchange.com/home/homepage.htm"/>
 		<skos:definition>London Stock Exchange functional entity, which is a global business and financial information services and news provider, a securities exchange, and the SEDOL code issuer and registration authority</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangePlc"/>
-		<fibo-fnd-utl-av:abbreviation>LSE</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>LSE</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;LondonStockExchangeAsLocalOperatingUnit">
@@ -519,7 +509,7 @@
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-eufseind;ClearstreamBankingLegalAddress"/>
 		<fibo-be-le-lei:hasLegalFormAbbreviation>Societe Anonyme</fibo-be-le-lei:hasLegalFormAbbreviation>
 		<fibo-fnd-rel-rel:hasLegalName>LuxCSD S.A.</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:explanatoryNote>The European Central Bank (ECB) approved LuxCSD for its Securities Settlement System (SSS).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The European Central Bank (ECB) approved LuxCSD for its Securities Settlement System (SSS).</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;NasdaqOMXGroup">
@@ -553,7 +543,7 @@
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>SIX Financial Information Ltd</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>SIX SIX Financial Information SA</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fnd-rel-rel:hasLegalName>SIX Financial Information AG</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:explanatoryNote>The company name SIX is an abbreviation and stands for Swiss Infrastructure and Exchange.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The company name SIX is an abbreviation and stands for Swiss Infrastructure and Exchange.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXFinancialInformationAGLegalEntityIdentifierRegistryEntry">
@@ -580,7 +570,7 @@
 		<rdfs:label>SIX Group</rdfs:label>
 		<skos:definition>SIX Group functional entity, which offers exchange services, financial information and banking services with the aim of increasing efficiency, quality and innovative capacity along the entire Swiss banking value chain</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-eufseind;SIXGroupAG"/>
-		<fibo-fnd-utl-av:abbreviation>SIX</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>SIX</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXGroupAG">
@@ -594,7 +584,7 @@
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>SIX Group Ltd</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>SIX Group SA</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fnd-rel-rel:hasLegalName>SIX Group AG</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:explanatoryNote>The company name SIX is an abbreviation and stands for Swiss Infrastructure and Exchange.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The company name SIX is an abbreviation and stands for Swiss Infrastructure and Exchange.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SIXGroupAGHeadquartersAddress">
@@ -623,7 +613,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
 		<rdfs:label>Swedish Bankers&apos; Association</rdfs:label>
 		<skos:definition>association that represents banks and financial institutions established in Sweden that contributes to a sound and efficient regulatory framework that facilitates for banks to help create economic wealth for customers and society</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swedishbankers.se/en-us/about/about-us/about-us/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swedishbankers.se/en-us/about/about-us/about-us/</cmns-av:adaptedFrom>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fbc-fct-eufseind;EuropeanBankingFederation"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/FinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/FinancialServicesEntities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
@@ -30,10 +31,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
@@ -64,24 +65,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 		<rdfs:label>Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines basic financial service providers, such as holding companies, financial institutions (both depository and non-depository institutions), and clearing houses at a relatively general level. Nuances specific to the institutions located in a specific country are defined in jurisdiction specific dependent ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-fse</sm:fileAbbreviation>
-		<sm:filename>FinancialServicesEntities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
@@ -104,13 +93,15 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/FinancialServicesEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/FinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified per the FIBO 2.0 RFC, including, but not limited to, the addition of trade settlement concepts and generalizing the concept of a credit union.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified to refine the concept of a credit union and generalize the definition of an underwriter.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181201/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified to generalize certain unions where they were no longer required and incorporate a new financial service provider identifier that is assigned functionally rather than to a legal entity.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/FinancialServicesEntities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190101/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to leverage the new party identifier and replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to enable merging business and functional business entity in BE.</skos:changeNote>
@@ -120,6 +111,8 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20211001/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to apply the new composite identifier definition to BIC codes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220401/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to clean up dead links and address text formatting issues uncovered by hygiene testing.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;Bank">
@@ -127,7 +120,7 @@
 		<rdfs:label>bank</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.sec.gov/about/laws/ica40.pdf"/>
 		<skos:definition>a depository institution, usually a corporation, that accepts deposits, makes loans, pays checks, and performs related services, for individual members of the public, businesses or other organizations</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BankHoldingCompany">
@@ -142,8 +135,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>bank holding company</rdfs:label>
 		<skos:definition>any company that owns and/or has direct or indirect control of one or more banks; BHCs may also own nonbanking subsidiaries such as broker-dealers and asset managers</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A bank holding company may also own another bank holding company, which in turn owns or controls a bank; the company at the top of the ownership chain is called the top holder.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A bank holding company may also own another bank holding company, which in turn owns or controls a bank; the company at the top of the ownership chain is called the top holder.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BankingProduct">
@@ -176,7 +169,7 @@
 		<rdfs:label>brokerage firm</rdfs:label>
 		<skos:definition>a firm in the business of buying and selling securities, operating as both a broker and a dealer, depending on the transaction</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>The term broker-dealer is used in U.S. securities regulation parlance to describe stock brokerages, because most of them act as both agents and principals. A brokerage acts as a broker (or agent) when it executes orders on behalf of clients, whereas it acts as a dealer (or principal) when it trades for its own account.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The term broker-dealer is used in U.S. securities regulation parlance to describe stock brokerages, because most of them act as both agents and principals. A brokerage acts as a broker (or agent) when it executes orders on behalf of clients, whereas it acts as a dealer (or principal) when it trades for its own account.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BusinessIdentifierCode">
@@ -226,14 +219,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business identifier code</rdfs:label>
 		<skos:definition>international identifier for financial and non-financial institutions used to facilitate automated processing of information for financial services</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>BIC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The BIC is used for addressing messages, routing business transactions and identifying business parties. Note that the use of OrganizationPartIdentifier in FIBO corresponds to the Branch Code in the SWIFT scheme.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>SWIFT ID</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>SWIFT code</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>SWIFT-BIC</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>bank identifier code</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>business entity identifier</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>BIC</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The BIC is used for addressing messages, routing business transactions and identifying business parties. Note that the use of OrganizationPartIdentifier in FIBO corresponds to the Branch Code in the SWIFT scheme.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>SWIFT ID</cmns-av:synonym>
+		<cmns-av:synonym>SWIFT code</cmns-av:synonym>
+		<cmns-av:synonym>SWIFT-BIC</cmns-av:synonym>
+		<cmns-av:synonym>bank identifier code</cmns-av:synonym>
+		<cmns-av:synonym>business entity identifier</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BusinessIdentifierCodeScheme">
@@ -247,8 +240,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business identifier code scheme</rdfs:label>
 		<skos:definition>a scheme that specifies the elements of a unique business identifier code (BIC) scheme to identify financial and non-financial institutions used to facilitate automated processing of information for financial services</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/60390.html</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/60390.html</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BusinessPartyPrefix">
@@ -269,11 +262,11 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business party prefix</rdfs:label>
 		<skos:definition>a four-character (4 alphanumeric) code associated with the organization</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>For new BIC registration by an organization already identified with a BIC or an affiliated organization [after the transition period ending November 2018], SWIFT will still reserve the usage of an existing party prefix to these organizations. This legacy rule will be reserved to existing BIC owners. If they wish to preserve this value, no other organization will be allowed to use the same code</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>For new BIC registration from an organization not yet identified by a BIC, the party prefix will be allocated at the discretion of the RA. The code will not have a mnemonic or acronym value anymore.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>bank code</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>institution code</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>For new BIC registration by an organization already identified with a BIC or an affiliated organization [after the transition period ending November 2018], SWIFT will still reserve the usage of an existing party prefix to these organizations. This legacy rule will be reserved to existing BIC owners. If they wish to preserve this value, no other organization will be allowed to use the same code</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>For new BIC registration from an organization not yet identified by a BIC, the party prefix will be allocated at the discretion of the RA. The code will not have a mnemonic or acronym value anymore.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>bank code</cmns-av:synonym>
+		<cmns-av:synonym>institution code</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BusinessPartySuffix">
@@ -292,9 +285,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business party suffix</rdfs:label>
 		<skos:definition>a two-character (2 alphanumeric) code associated with the organization</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In the prior version of the standard, position 7 of the BIC determined the location of the BIC in a particular country. In a country spanning over multiple time zones, each character may have been used to define a different time zone. If an organization moved location to a different time zone within the same country, the existing BIC would normally have been deleted and replaced by a new BIC with the appropriate location code.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>With the revision of the standard [and transition period ending November 2018], the location code has been re-defined as a &apos;party suffix&apos; without any specific meaning. A new reference data attribute has been introduced in the SWIFTRef directories to indicate where the institution is located and to which time zone it refers.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In the prior version of the standard, position 7 of the BIC determined the location of the BIC in a particular country. In a country spanning over multiple time zones, each character may have been used to define a different time zone. If an organization moved location to a different time zone within the same country, the existing BIC would normally have been deleted and replaced by a new BIC with the appropriate location code.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>With the revision of the standard [and transition period ending November 2018], the location code has been re-defined as a &apos;party suffix&apos; without any specific meaning. A new reference data attribute has been introduced in the SWIFTRef directories to indicate where the institution is located and to which time zone it refers.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;CentralBank">
@@ -308,7 +301,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>central bank</rdfs:label>
 		<skos:definition>a financial institution that is the monetary authority and major regulatory bank for a country (or group of countries)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Its functions include issuing and managing the country&apos;s currency, controlling monetary policy and supervising money market operations, managing exchange and gold reserves, acting as lender of last resort to commercial banks, and providing banking services to the government. Central banks are state-controlled but are increasingly being given an independent status to insulate them from partisan politics.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Its functions include issuing and managing the country&apos;s currency, controlling monetary policy and supervising money market operations, managing exchange and gold reserves, acting as lender of last resort to commercial banks, and providing banking services to the government. Central banks are state-controlled but are increasingly being given an independent status to insulate them from partisan politics.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;CentralCounterpartyClearingHouse">
@@ -316,21 +309,21 @@
 		<rdfs:label>central counterparty clearing house</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.esma.europa.eu/sites/default/files/EACH2.pdf"/>
 		<skos:definition>a clearing house that helps facilitate trading in derivatives and equities markets</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CCP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>These clearing houses are often operated by the major banks in the country. The house&apos;s prime responsibility is to provide efficiency and stability to the financial markets that they operate in.
+		<cmns-av:abbreviation>CCP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>These clearing houses are often operated by the major banks in the country. The house&apos;s prime responsibility is to provide efficiency and stability to the financial markets that they operate in.
 
 There are two main processes that are carried out by CCPs: clearing and settlement of market transactions. Clearing relates to identifying the obligations of both parties on either side of a transaction. Settlement occurs when the final transfer of securities and funds occur.
 
-CCPs benefit both parties in a transaction because they bear most of the credit risk. If two individuals deal with one another, the buyer bears the credit risk of the seller, and vice versa. When a CCP is used the credit risk that is held against both buyer and seller is coming from the CCP, which in all likelihood is much less than in the previous situation.</fibo-fnd-utl-av:explanatoryNote>
+CCPs benefit both parties in a transaction because they bear most of the credit risk. If two individuals deal with one another, the buyer bears the credit risk of the seller, and vice versa. When a CCP is used the credit risk that is held against both buyer and seller is coming from the CCP, which in all likelihood is much less than in the previous situation.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;CentralSecuritiesDepository">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:label>central securities depository</rdfs:label>
 		<skos:definition>a functional entity that provides a central point for depositing financial instruments (&apos;securities&apos;), for example bonds and shares</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CSD</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://ecsda.eu/facts/faq</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>CSDs&apos; clients are typically financial institutions themselves (such as custodian banks and brokers) rather than individual investors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>CSD</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://ecsda.eu/facts/faq</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>CSDs&apos; clients are typically financial institutions themselves (such as custodian banks and brokers) rather than individual investors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;ClearingBank">
@@ -352,7 +345,7 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		</rdfs:subClassOf>
 		<rdfs:label>clearing corporation</rdfs:label>
 		<skos:definition>a clearing house that is organized as a corporation</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;ClearingHouse">
@@ -365,7 +358,7 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		</rdfs:subClassOf>
 		<rdfs:label>clearing house</rdfs:label>
 		<skos:definition>a financial service provider that is exchange affiliated and provides clearing services, including the validation, delivery, and settlement of financial transactions, for financial intermediaries</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;ClearingService">
@@ -373,7 +366,7 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<rdfs:label>clearing service</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://dtcclearning.com/helpfiles/cross_bus/glossary/Content/Topics/gloss.htm"/>
 		<skos:definition>a set of activities provided on behalf of an institutional market participant by a clearing services provider following a trade that finalizes the transfer of security ownership</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council / Quarule</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>EDM Council / Quarule</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;CommercialBank">
@@ -388,34 +381,34 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<rdfs:label>commercial bank</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm"/>
 		<skos:definition>a bank that provides services, such as accepting deposits, giving business loans and auto loans, mortgage lending, and basic investment products like savings accounts and certificates of deposit</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A commercial bank is a financial institution that is owned by stockholders, operates for a profit, and engages in various lending activities.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The traditional commercial bank is a brick and mortar institution with tellers, safe deposit boxes, vaults and ATMs. However, some commercial banks do not have any physical branches and require consumers to complete all transactions by phone or Internet. In exchange, they generally pay higher interest rates on investments and deposits, and charge lower fees.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A commercial bank is a financial institution that is owned by stockholders, operates for a profit, and engages in various lending activities.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The traditional commercial bank is a brick and mortar institution with tellers, safe deposit boxes, vaults and ATMs. However, some commercial banks do not have any physical branches and require consumers to complete all transactions by phone or Internet. In exchange, they generally pay higher interest rates on investments and deposits, and charge lower fees.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;CommercialFinanceCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinanceCompany"/>
 		<rdfs:label>commercial finance company</rdfs:label>
 		<skos:definition>a finance company that makes loans to manufacturers and wholesalers, secured by accounts receivable, inventories, and equipment</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>commercial credit company</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
+		<cmns-av:synonym>commercial credit company</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;CommodityTradingAdvisor">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
 		<rdfs:label>commodity trading advisor</rdfs:label>
 		<skos:definition>an individual or organization that directly or indirectly advises others as to the value or advisability of buying or selling futures contracts or options</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CTA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Indirect advice includes exercising trading authority over a customer&apos;s account. In the U.S., registered CTAs are registered with the Commodities Futures Trading Commission (CFTC) and are generally required to be members of the National Futures Association (NFA).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>CTA</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Indirect advice includes exercising trading authority over a customer&apos;s account. In the U.S., registered CTAs are registered with the Commodities Futures Trading Commission (CFTC) and are generally required to be members of the National Futures Association (NFA).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;ConsumerFinanceCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinanceCompany"/>
 		<rdfs:label>consumer finance company</rdfs:label>
 		<skos:definition>a finance company that lends to individuals under the small loans laws of the jurisdiction in which they operate</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>direct loan company</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>small loan company</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
+		<cmns-av:synonym>direct loan company</cmns-av:synonym>
+		<cmns-av:synonym>small loan company</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;CreditUnion">
@@ -436,8 +429,8 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label>depository institution</rdfs:label>
 		<skos:definition>any financial institution engaged in the business of receiving demand deposits from the public or other institutions</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>12 U.S. Code Section 1813 - Definitions, see, for example, http://www.law.cornell.edu/uscode/text/12/1813</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>12 U.S. Code Section 1813 - Definitions, see, for example, http://www.law.cornell.edu/uscode/text/12/1813</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;DevelopmentBank">
@@ -452,9 +445,9 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<rdfs:seeAlso rdf:resource="https://www.federalreserve.gov/boarddocs/caletters/2008/0807/08-07_attachment.pdf"/>
 		<skos:definition>a service involving any transfer of funds other than a transaction involving a paper instrument, that is initiated through an electronic terminal, telephone, or computer and that orders or authorizes a financial institution to debit or credit an account</skos:definition>
 		<skos:example>EFT services include transfers through automated teller machines, point-of-sale terminals, automated clearinghouse systems, telephone bill-payment plans in which periodic or recurring transfers are contemplated, and remote banking programs.</skos:example>
-		<fibo-fnd-utl-av:abbreviation>EFT</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>wire transfer service</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>EFT</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
+		<cmns-av:synonym>wire transfer service</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;FaceAmountCertificateCompany">
@@ -463,14 +456,14 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-fse;ManagementCompany"/>
 		<skos:definition>an investment company which is engaged or proposes to engage in the business of issuing face-amount certificates of the installment type, or which has been engaged in such business and has any such certificate outstanding</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>An investor may enter into a contract with an issuer of a face amount certificate to contract to receive a stated or fixed amount of money (the face amount) at a stated date in the future. In exchange for this future sum, the investor must deposit an agreed lump sum or make scheduled installment payments over time. Face amount certificates are rarely issued these days, as most of the tax advantages that the investment once offered have been lost through changes in the tax laws.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>An investor may enter into a contract with an issuer of a face amount certificate to contract to receive a stated or fixed amount of money (the face amount) at a stated date in the future. In exchange for this future sum, the investor must deposit an agreed lump sum or make scheduled installment payments over time. Face amount certificates are rarely issued these days, as most of the tax advantages that the investment once offered have been lost through changes in the tax laws.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;FinanceCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
 		<rdfs:label>finance company</rdfs:label>
 		<skos:definition>financial intermediary in the business of making loans that obtains its financing from banks, institutions, and other money market sources rather than from deposits</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;FinancialInstitution">
@@ -489,9 +482,9 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		</rdfs:subClassOf>
 		<rdfs:label>financial institution</rdfs:label>
 		<skos:definition>a financial service provider identified as either a government agency or privately owned entity that collects funds from the public and from other institutions, and invests those funds in financial assets, such as loans, securities, bank deposits, and income-generating property</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Financial institutions are differentiated by the way they obtain and invest funds. Depository institutions accept public deposits, which are insured by the government against loss, and channel those deposits into lending activities. Non-depository institutions, such as brokerage firms, life insurance companies, pension funds, and investment companies, fund their investment activities directly from financial markets by selling securities to the public or by selling insurance policies, in the case of insurance companies.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>financial intermediary</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Financial institutions are differentiated by the way they obtain and invest funds. Depository institutions accept public deposits, which are insured by the government against loss, and channel those deposits into lending activities. Non-depository institutions, such as brokerage firms, life insurance companies, pension funds, and investment companies, fund their investment activities directly from financial markets by selling securities to the public or by selling insurance policies, in the case of insurance companies.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>financial intermediary</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;FinancialServiceProviderIdentifier">
@@ -537,8 +530,8 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
 		<rdfs:label>futures commission merchant</rdfs:label>
 		<skos:definition>an individual or organization that which does both of the following: (1) solicits or accepts orders to buy or sell futures contracts, options on futures, retail off-exchange forex contracts, or swaps and (2) accepts money or other assets from customers to support such orders</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>FCM</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>National Futures Association</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>FCM</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>National Futures Association</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;HoldingCompany">
@@ -552,26 +545,26 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		</rdfs:subClassOf>
 		<rdfs:label>holding company</rdfs:label>
 		<skos:definition>business entity established to own stock in another company, typically to own enough voting shares to have some level of control over that company&apos;s policies and management</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Holding companies protect their owners from losses to some degree, protecting assets, for example, in case of bankruptcy. They can also be set up to own property such as real estate, patents, trademarks, stocks and other assets to limit financial and legal liability</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Holding companies protect their owners from losses to some degree, protecting assets, for example, in case of bankruptcy. They can also be set up to own property such as real estate, patents, trademarks, stocks and other assets to limit financial and legal liability</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;InsuranceCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
 		<rdfs:label>insurance company</rdfs:label>
 		<skos:definition>non-depository institution whose primary and predominant business activity is the writing of insurance or the reinsuring of risks underwritten by insurance companies, and that provides compensation based on the happening of at least one contingency</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In the US, insurance companies are subject to supervision by the insurance commissioner or a similar official or agency of a State; or any receiver or similar official or any liquidating agent for such a company, in his capacity as such. Common forms of insurance include life, property and casualty, and health insurance. In addition to insuring against hazards, many insurance companies also sell investments or investment-like products. The most prevalent investment products offered by insurers are annuities and life insurance policies that also feature investment elements.
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.sec.gov/about/laws/ica40.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In the US, insurance companies are subject to supervision by the insurance commissioner or a similar official or agency of a State; or any receiver or similar official or any liquidating agent for such a company, in his capacity as such. Common forms of insurance include life, property and casualty, and health insurance. In addition to insuring against hazards, many insurance companies also sell investments or investment-like products. The most prevalent investment products offered by insurers are annuities and life insurance policies that also feature investment elements.
 
-A number of insurance companies operate brokerage arms that trade securities on behalf of clients.</fibo-fnd-utl-av:explanatoryNote>
+A number of insurance companies operate brokerage arms that trade securities on behalf of clients.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;InsuranceService">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
 		<rdfs:label>insurance service</rdfs:label>
 		<skos:definition>a financial service in which the insurer promises to provide compensation for specific potential future losses in exchange for a periodic payment</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Insurance providers invest the compensation they receive in order to make a profit. In general, insurance transfers risk from individuals or organizations to a larger pool of individuals or organizations that are better able to mitigate that risk.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Insurance providers invest the compensation they receive in order to make a profit. In general, insurance transfers risk from individuals or organizations to a larger pool of individuals or organizations that are better able to mitigate that risk.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;InvestmentBank">
@@ -589,7 +582,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		</rdfs:subClassOf>
 		<rdfs:label>investment bank</rdfs:label>
 		<skos:definition>a financial service provider that performs a variety of services. Investment banks specialize in large and complex financial transactions such as underwriting, acting as an intermediary between a securities issuer and the investing public, facilitating mergers and other corporate reorganizations, and acting as a broker and/or financial adviser for institutional clients.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Major investment banks include Barclays, BofA Merrill Lynch, Warburgs, Goldman Sachs, Deutsche Bank, JP Morgan, Morgan Stanley, Salomon Brothers, UBS, Credit Suisse, Citibank and Lazard. Some investment banks specialize in particular industry sectors. Many investment banks also have retail operations that serve small, individual customers.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Major investment banks include Barclays, BofA Merrill Lynch, Warburgs, Goldman Sachs, Deutsche Bank, JP Morgan, Morgan Stanley, Salomon Brothers, UBS, Credit Suisse, Citibank and Lazard. Some investment banks specialize in particular industry sectors. Many investment banks also have retail operations that serve small, individual customers.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;InvestmentCompany">
@@ -597,15 +590,15 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:label>investment company</rdfs:label>
 		<skos:definition>Any issuer which: (a) is or holds itself out as being engaged primarily, or proposes to engage primarily, in the business of investing, reinvesting, or trading in securities; (b) is engaged or proposes to engage in the business of issuing face-amount certificates of the installment type, or has been engaged in such business and has any such certificate outstanding; or (c) is engaged or proposes to engage in the business of investing, reinvesting, owning, holding, or trading in securities, and owns or proposes to acquire investment securities having a value exceeding 40 per centum of the value of such issuer&amp;apos;s total assets (exclusive of Government securities and cash items) on an unconsolidated basis</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>An investment company is organized as either a corporation or as a trust. Individual investors&apos; money is then pooled together in a single account and used to purchase securities that will have the greatest chance of helping the investment company reach its objectives. All investors jointly own the portfolio that is created through these pooled funds, and each investor has an undivided interest in the securities.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>In the US, all investment company offerings are subject to the Securities Act of 1933, which requires the investment company to register with the Securities Exchange Commission (SEC) and to give all purchasers a prospectus. Investment companies are also subject to the Investment Company Act of 1940, which sets forth guidelines on how investment companies must operate.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>An investment company is organized as either a corporation or as a trust. Individual investors&apos; money is then pooled together in a single account and used to purchase securities that will have the greatest chance of helping the investment company reach its objectives. All investors jointly own the portfolio that is created through these pooled funds, and each investor has an undivided interest in the securities.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In the US, all investment company offerings are subject to the Securities Act of 1933, which requires the investment company to register with the Securities Exchange Commission (SEC) and to give all purchasers a prospectus. Investment companies are also subject to the Investment Company Act of 1940, which sets forth guidelines on how investment companies must operate.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;InvestmentService">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
 		<rdfs:label>investment service</rdfs:label>
 		<skos:definition>a financial service designed to assist investors in using capital to create more money, either through income-producing vehicles or through more risk-oriented ventures to result in capital gains, including but not limited to providing investment advice, asset and portfolio management, brokerage services, and so forth</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;ManagementCompany">
@@ -614,7 +607,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-fse;UnitInvestmentTrust"/>
 		<skos:definition>investment company that sells and manages a portfolio of securities other than a face-amount certificate company or unit investment fund</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>Management companies allow investors to pool their capital with that of other investors in order to purchase professionally-managed groups of diversified securities.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Management companies allow investors to pool their capital with that of other investors in order to purchase professionally-managed groups of diversified securities.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;MerchantService">
@@ -622,7 +615,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:label>merchant service</rdfs:label>
 		<skos:definition>a financial service provided by a financial institution to a merchant or other business, including but not limited to managing financial transactions via a secure channel</skos:definition>
 		<skos:example>Example merchant services include credit and debit card processing, check guarantee and conversion services, point of sale (PoS) systems, gift card and loyalty programs, online transaction processing, etc.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;MonetaryAuthority">
@@ -636,7 +629,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:label>monetary authority</rdfs:label>
 		<skos:definition>regulatory agency that controls the monetary policy, regulation and supply of money in some country or group of countries</skos:definition>
 		<skos:example>a central bank, the executive branch of a government, a central bank for several nations, a currency board</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investordictionary.com/definition/monetary-authority</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investordictionary.com/definition/monetary-authority</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;MoneyServicesBusiness">
@@ -644,8 +637,8 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:label>money services business</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.fincen.gov/money-services-business-definition"/>
 		<skos:definition>any person doing business, whether or not on a regular basis or as an organized business concern, in one of the following capacities: (1) currency dealer or exchanger, (2) check casher, (3) issuer of traveler&apos;s checks, money orders, or stored value, (4) seller or redeemer of traveler&apos;s checks, money orders, or stored value, (5) money transmitter, or (6) postal service</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>MSB</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>This definition excludes banks and persons registered with or examined by the Securities and Exchange Commission or the Commodities Futures Trading Commission.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>MSB</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>This definition excludes banks and persons registered with or examined by the Securities and Exchange Commission or the Commodities Futures Trading Commission.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;MortgageCompany">
@@ -659,7 +652,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label>non-depository institution</rdfs:label>
 		<skos:definition>any financial institution that acts as the middleman between two parties in a financial transaction, and that does not provide traditional depository services, such as brokerage firms, insurance companies, investment companies, etc.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;PaymentService">
@@ -679,15 +672,15 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
 		<rdfs:label>payroll service</rdfs:label>
 		<skos:definition>a financial service, typically provided to small businesses that are not large enough to have an internal finance organization, that involves managing payment of wages to employees</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Payroll services typically include printing of employee pay checks, direct deposit of wages to employee bank accounts, calculation and withholding of employee taxes, calculation and payment of corporate payroll taxes and fees with appropriate government authorities (such as Social Security in the US), filing government quarterly and annual reports, and so forth. They may also include management of retirement and savings plans, health benefits, timekeeping, automated integration with the business&apos; accounting system, etc.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Payroll services typically include printing of employee pay checks, direct deposit of wages to employee bank accounts, calculation and withholding of employee taxes, calculation and payment of corporate payroll taxes and fees with appropriate government authorities (such as Social Security in the US), filing government quarterly and annual reports, and so forth. They may also include management of retirement and savings plans, health benefits, timekeeping, automated integration with the business&apos; accounting system, etc.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;PrincipalUnderwriter">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;Underwriter"/>
 		<rdfs:label>principal underwriter</rdfs:label>
 		<skos:definition>underwriter who, as principal, purchases from an investment company, or pursuant to some contract has the right to purchase from such company, any security for distribution, or who as agent for such company sells or has the right to sell any security to a dealer or to the public, excluding any dealer who purchases from such company through sn underwriter acting as an agent for such company</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Principal underwriter of or for a closed-end company or any issuer which is not an investment company, or of any security issued by such a company or issuer, means any underwriter who, in connection with a primary distribution of securities, (a) is in privity of contract with the issuer or an affiliated person of the issuer; (b) acting alone or in concert with one or more other persons, initiates or directs the formation of an underwriting syndicate; or (c) is allowed a rate of gross commission, spread, or other profit greater than the rate allowed another underwriter participating in the distribution.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Principal underwriter of or for a closed-end company or any issuer which is not an investment company, or of any security issued by such a company or issuer, means any underwriter who, in connection with a primary distribution of securities, (a) is in privity of contract with the issuer or an affiliated person of the issuer; (b) acting alone or in concert with one or more other persons, initiates or directs the formation of an underwriting syndicate; or (c) is allowed a rate of gross commission, spread, or other profit greater than the rate allowed another underwriter participating in the distribution.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;RegisteredInvestmentAdvisor">
@@ -716,22 +709,22 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		</rdfs:subClassOf>
 		<rdfs:label>registered investment advisor</rdfs:label>
 		<skos:definition>registered agent and financial service provider that advises high net worth individuals on investments and manages their portfolios</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RIA</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>RIA</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;SalesFinanceCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinanceCompany"/>
 		<rdfs:label>sales finance company</rdfs:label>
 		<skos:definition>a finance company that purchases retail and wholesale paper from automobile and other consumer and commercial goods dealers</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>acceptance company</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
+		<cmns-av:synonym>acceptance company</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;SavingsAssociation">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
 		<rdfs:label>savings association</rdfs:label>
 		<skos:definition>depository institution that is (a) any federal savings bank or association chartered under section 1464 of the Federal Deposit Insurance Act; (b) any state chartered building and loan association, savings and loan association, or homestead association; or (c) any cooperative bank (other than a cooperative bank which is a state bank as defined in subsection (a)(2)) of the Federal Deposit Insurance Act, which is organized and operating according to the laws of the State (as defined in subsection (a)(3)) in which it is chartered or organized; and (c) any corporation (other than a bank) that the board of directors and the comptroller of the currency jointly determine to be operating in substantially the same manner as such a depository institution</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;SelfRegulatingOrganization">
@@ -744,7 +737,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		</rdfs:subClassOf>
 		<rdfs:label>self-regulating organization</rdfs:label>
 		<skos:definition>a non-governmental organization that has the power to create and exercise some degree of regulatory authority over an industry or profession in some country or group of countries</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SRO</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>SRO</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;Underwriter">
@@ -781,7 +774,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:label>unit investment trust</rdfs:label>
 		<skos:definition>an investment company which (a) is organized under a trust indenture, contract of custodianship or agency, or similar instrument, (b) does not have a board of directors, and (c) issues only redeemable securities, each of which represents an undivided interest in a unit of specified securities; but does not include a voting trust</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:synonym>unit investment company</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>unit investment company</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;WealthManagementService">

--- a/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf
+++ b/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
@@ -24,10 +25,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
@@ -52,28 +53,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities/">
 		<rdfs:label>International Registries and Authorities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the Business Registries ontology to define commonly referenced international registration authorities and related registry details, where the multi-national responsibilities for registering and/or managing various identifiers needed in banking applications occur, such as SWIFT. These individuals and in some cases, such as registry entries, are managed independently to reduce the import footprint for applications that do not require them, in other words, to support modularity needs of FIBO users.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-ireg</sm:fileAbbreviation>
-		<sm:filename>InternationalRegistriesAndAuthorities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
@@ -89,13 +74,17 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/InternationalRegistriesAndAuthorities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/InternationalRegistriesAndAuthorities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of this ontology was revised to add details for the Global LEI Foundation and fix spelling errors.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of this ontology was revised to address text formatting issues uncovered via hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-506700GE1G29325QX363-LEI">
@@ -135,9 +124,9 @@
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-ireg;BankForInternationalSettlementsAddress"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bis.org/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="de">Bank für Internationalen Zahlungsausgleich</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:abbreviation>BIS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Established in 1930, the BIS is owned by 63 central banks, representing countries from around the world that together account for about 95 percent of world GDP. Its head office is in Basel, Switzerland and it has two representative offices: in Hong Kong SAR and in Mexico City, as well as Innovation Hub Centres around the world.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>BIS</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Established in 1930, the BIS is owned by 63 central banks, representing countries from around the world that together account for about 95 percent of world GDP. Its head office is in Basel, Switzerland and it has two representative offices: in Hong Kong SAR and in Mexico City, as well as Innovation Hub Centres around the world.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;BankForInternationalSettlementsAddress">
@@ -157,8 +146,8 @@
 		<skos:definition>Bank for International Settlements role as a banking services provider to central banks and other monetary authorities</skos:definition>
 		<fibo-fbc-fct-fse:hasDateEstablished rdf:resource="&fibo-fbc-fct-ireg;BankForInternationalSettlementsDateEstablished"/>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-ireg;BankForInternationalSettlements"/>
-		<fibo-fnd-utl-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The Bank for International Settlements offers a wide range of financial services specifically designed to assist central banks and other official monetary institutions in the management of their foreign exchange reserves. BIS facilitates international financial cooperation and endeavors to make monetary policy more predictable and transparent. Its customers are central banks and international organizations; they do not accept deposits from, or provide financial services to, private individuals or corporate entities.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The Bank for International Settlements offers a wide range of financial services specifically designed to assist central banks and other official monetary institutions in the management of their foreign exchange reserves. BIS facilitates international financial cooperation and endeavors to make monetary policy more predictable and transparent. Its customers are central banks and international organizations; they do not accept deposits from, or provide financial services to, private individuals or corporate entities.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;BankForInternationalSettlementsDateEstablished">
@@ -202,8 +191,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>business identifier code data record</rdfs:label>
 		<skos:definition>entry in a registry that conforms to ISO 9362 for the management of BIC codes and related registration information</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>BIC data record</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>BIC data record</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistrationAuthority">
@@ -213,10 +202,10 @@
 		<skos:definition>registration authority and financial service provider, appointed by the International Standards Organization (ISO), that is the official registration authority (RA) for ISO 9362, Banking - Banking telecommunication messages - Business identifier code (BIC)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunication"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistry"/>
-		<fibo-fnd-utl-av:abbreviation>BIC RA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:abbreviation>BIC registration authority</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>BIC code registrar</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>BIC RA</cmns-av:abbreviation>
+		<cmns-av:abbreviation>BIC registration authority</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic</cmns-av:adaptedFrom>
+		<cmns-av:synonym>BIC code registrar</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistry">
@@ -224,8 +213,8 @@
 		<rdfs:label>business identifier code registry</rdfs:label>
 		<skos:definition>registry for registering and maintaining information about bank and other business identifier codes that conform to ISO 9362</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistrationAuthority"/>
-		<fibo-fnd-utl-av:abbreviation>BIC registry</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>BIC registry</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;GLEIFLegalEntityIdentifierRegistryEntry">
@@ -244,7 +233,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistry"/>
 		<rdfs:label>Global LEI Index</rdfs:label>
 		<skos:definition>registry that contains historical and current LEI records including related reference data in one authoritative, central repository</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The reference data provides the information on a legal entity identifiable with an LEI. The Global LEI Index is the only global online source that provides open, standardized and high quality legal entity reference data.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The reference data provides the information on a legal entity identifiable with an LEI. The Global LEI Index is the only global online source that provides open, standardized and high quality legal entity reference data.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;GlobalLegalEntityIdentifierFoundation">
@@ -255,7 +244,7 @@
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-ireg;GlobalLegalEntityIdentifierFoundationAddress"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>Global Legal Entity Identifier Foundation</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:abbreviation>GLEIF</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>GLEIF</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;GlobalLegalEntityIdentifierFoundationAddress">
@@ -275,7 +264,7 @@
 		<skos:definition>ISO 13616:2007, International Bank Account Number (IBAN) Registration Authority (RA) and financial service provider, appointed by the International Standards Organization (ISO), that is the official registration authority (RA) for ISO 13616:2007, Financial services - International bank account number (IBAN)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunication"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistry"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/iban</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/iban</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;LegalEntityIdentfierRegistrationAuthority">
@@ -293,10 +282,10 @@
 		<skos:definition>ISO 10383, Market Identifier Code (MIC) Registration Authority (RA) and financial service provider, appointed by the International Standards Organization (ISO), that is the official registration authority (RA) for ISO 10383, Codes for exchanges and market identification (MIC)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunication"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-ireg;MarketIdentifierCodeRegistry"/>
-		<fibo-fnd-utl-av:abbreviation>MIC RA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.anna-web.org/standards/mic-iso-10383/</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/10383/iso-10383-market-identifier-codes</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>ISO 10383 Registration Authority</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>MIC RA</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.anna-web.org/standards/mic-iso-10383/</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/10383/iso-10383-market-identifier-codes</cmns-av:adaptedFrom>
+		<cmns-av:synonym>ISO 10383 Registration Authority</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;MarketIdentifierCodeRegistry">
@@ -304,8 +293,8 @@
 		<rdfs:label>market identifier code registry</rdfs:label>
 		<skos:definition>registry for registering and maintaining information for market identifier codes that conform to ISO 10383</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-ireg;MICRegistrationAuthority"/>
-		<fibo-fnd-utl-av:abbreviation>MIC registry</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/10383/iso-10383-market-identifier-codes</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>MIC registry</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/10383/iso-10383-market-identifier-codes</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-ireg;MarketIdentifierCodeRegistryEntry">
@@ -345,8 +334,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>market identifier code registry entry</rdfs:label>
 		<skos:definition>entry in a market identifier code registry that conforms to ISO 10383</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>MIC registry entry</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/10383/iso-10383-market-identifier-codes</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>MIC registry entry</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/10383/iso-10383-market-identifier-codes</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;SWIFTLegalEntityIdentifierRegistryEntry">
@@ -369,7 +358,7 @@
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunicationAddress"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.swift.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>Society for Worldwide Interbank Financial Telecommunication SCRL/CVBA</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:abbreviation>SWIFT</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>SWIFT</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunicationAddress">

--- a/FBC/FunctionalEntities/Markets.rdf
+++ b/FBC/FunctionalEntities/Markets.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -25,10 +26,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -54,18 +55,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
 		<rdfs:label>Markets Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for markets, exchanges, regulated markets, and multilateral trading facilities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-fbc-fct-mkt</sm:fileAbbreviation>
-		<sm:filename>Markets.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"/>
@@ -83,9 +78,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FunctionalEntities/Markets/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/Markets/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/Markets/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 RTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20170201/FunctionalEntities/Markets/ version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/Markets/ version of this ontology was modified to generalize certain unions where they were no longer required and to move international registration authorities individuals to a separate ontology for better modularity.</skos:changeNote>
@@ -96,15 +92,18 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FunctionalEntities/Markets/ version of this ontology was modified to add the definition of an exchange participant and loosen constraints on the location in which a given exchange operates, given that there are cases when an exchange may operate in multiple locations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210601/FunctionalEntities/Markets/ version of this ontology was modified to add: &apos;off-market&apos;, with synonyms of &apos;off-facility&apos; and &apos;off-book&apos;, &apos;auction market&apos; for periodic or on-demand auction markets, &apos;dark pool&apos;, and &apos;quote-driven market&apos; for those that have QUOTE or RFQ in their name excluding QUOTED FUNDS, and other &apos;alternative trading system&apos;s; also moved &apos;designated contract market&apos; and &apos;swap execution facility&apos; from DER to the this ontology for use in generating proper classification of the ISO MIC codes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210701/FunctionalEntities/Markets/ version of this ontology was modified to revise the number and nature of &apos;market categories&apos; per the latest version of ISO 10383, including the addition of ESMA-regulated data reporting service providers and other new categories, augment the representation of a market to reference the legal entity that is the market, add their LEI and other details that correspond to the entity vs. the market and so forth.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FunctionalEntities/Markets.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;ActiveMICStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketIdentifierCodeStatus"/>
 		<rdfs:label>active MIC status</rdfs:label>
 		<skos:definition>market identifier code status that indicates that as of the last report or update, the code was registered and actively in use</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), version 2.0</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), version 2.0</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>ACTIVE</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -118,9 +117,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>alternative trading system</rdfs:label>
 		<skos:definition>trading venue that is more loosely regulated than a regulated exchange</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ATS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The SEC formally defines an alternative trading system as any organization, association, person, group of persons, or systems (1) that constitutes, maintains, or provides a market place or facilities for bringing together purchasers and sellers of securities or for otherwise performing with respect to securities the functions commonly performed by a stock exchange within the meaning of Rule 3b-16 under the Exchange Act; and (2) that does not (i) set rules governing the conduct of subscribers other than the conduct of such subscribers&apos; trading on such organization, association, person, group of persons, or system, or (ii) discipline subscribers other than by exclusion from trading.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>ATS</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The SEC formally defines an alternative trading system as any organization, association, person, group of persons, or systems (1) that constitutes, maintains, or provides a market place or facilities for bringing together purchasers and sellers of securities or for otherwise performing with respect to securities the functions commonly performed by a stock exchange within the meaning of Rule 3b-16 under the Exchange Act; and (2) that does not (i) set rules governing the conduct of subscribers other than the conduct of such subscribers&apos; trading on such organization, association, person, group of persons, or system, or (ii) discipline subscribers other than by exclusion from trading.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;ApprovedPublicationArrangement">
@@ -133,12 +132,12 @@
 		</rdfs:subClassOf>
 		<rdfs:label>approved publication arrangement</rdfs:label>
 		<skos:definition>data reporting services provider that is authorized to provide the service of publishing certain trade reports on behalf of banks, investment firms, or asset management companies</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>APA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.esma.europa.eu/press-news/esma-news/esma-identifies-data-reporting-services-providers-be-supervised-directly</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.lawinsider.com/dictionary/approved-publication-arrangement-apa</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym xml:lang="en-GB">authorised publication arrangement</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en-US">authorized publication arrangement</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>APA</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.esma.europa.eu/press-news/esma-news/esma-identifies-data-reporting-services-providers-be-supervised-directly</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.lawinsider.com/dictionary/approved-publication-arrangement-apa</cmns-av:adaptedFrom>
+		<cmns-av:synonym xml:lang="en-GB">authorised publication arrangement</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en-US">authorized publication arrangement</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;ApprovedReportingMechanism">
@@ -151,10 +150,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>approved reporting mechanism</rdfs:label>
 		<skos:definition>data reporting services provider that is authorized to provide the service of reporting details of transactions to competent authorities or ESMA (the European Securities and Markets Authority) on behalf of investment firms</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ARM</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.esma.europa.eu/press-news/esma-news/esma-identifies-data-reporting-services-providers-be-supervised-directly</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.lawinsider.com/dictionary/approved-reporting-mechanism</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>ARM</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.esma.europa.eu/press-news/esma-news/esma-identifies-data-reporting-services-providers-be-supervised-directly</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.lawinsider.com/dictionary/approved-reporting-mechanism</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;AuctionMarket">
@@ -173,11 +172,11 @@
 		</rdfs:subClassOf>
 		<rdfs:label>consolidated tape provider</rdfs:label>
 		<skos:definition>data reporting services provider that is authorized to provide the service of collecting trade reports for financial instruments from regulated markets, MTFs, OTFs and APAs and consolidating them into a continuous electronic live data stream providing price and volume data per financial instrument</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CTP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.esma.europa.eu/press-news/esma-news/esma-identifies-data-reporting-services-providers-be-supervised-directly</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.lawinsider.com/dictionary/consolidated-tape-providers-hereinafter-referred-to-as-ctp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Consolidated tape is an electronic system that collates real-time exchange-listed data, such as price and volume, and disseminates it to investors. Through the consolidated tape, various major exchanges, including the New York Stock Exchange, the NASDAQ, and the Chicago Board Options Exchange, report trades and quotes.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>CTP</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.esma.europa.eu/press-news/esma-news/esma-identifies-data-reporting-services-providers-be-supervised-directly</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.lawinsider.com/dictionary/consolidated-tape-providers-hereinafter-referred-to-as-ctp</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Consolidated tape is an electronic system that collates real-time exchange-listed data, such as price and volume, and disseminates it to investors. Through the consolidated tape, various major exchanges, including the New York Stock Exchange, the NASDAQ, and the Chicago Board Options Exchange, report trades and quotes.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;CryptoAssetServicesProvider">
@@ -223,10 +222,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>crypto asset services provider</rdfs:label>
 		<skos:definition>financial services provider that provides services for crypto assets that enable the control of crypto assets, and participate in, or provide, financial services for issuers&apos; offers, or sale, of crypto assets</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CASP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.lawinsider.com/dictionary/crypto-asset-service-provider-casp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Services related to crypto assets may include businesses that exchange crypto assets for fiat currencies, or vice versa, that conduct transactions that move crypto assets from one crypto asset address, or account, to another, and/or that provide facilities for the safekeeping, or administration, of crypto assets, or instruments.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>CASP</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.lawinsider.com/dictionary/crypto-asset-service-provider-casp</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Services related to crypto assets may include businesses that exchange crypto assets for fiat currencies, or vice versa, that conduct transactions that move crypto assets from one crypto asset address, or account, to another, and/or that provide facilities for the safekeeping, or administration, of crypto assets, or instruments.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;DarkPool">
@@ -273,9 +272,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>data reporting services provider</rdfs:label>
 		<skos:definition>market data provider and reporting party that reports and/or publishes data on securities transactions, including required regulatory reporting for such transactions, and as such is subject to regulatory supervision</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>DRSP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.esma.europa.eu/press-news/esma-news/esma-identifies-data-reporting-services-providers-be-supervised-directly</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.esma.europa.eu/supervision/supervision/data-reporting-services-providers</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>DRSP</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.esma.europa.eu/press-news/esma-news/esma-identifies-data-reporting-services-providers-be-supervised-directly</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.esma.europa.eu/supervision/supervision/data-reporting-services-providers</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;DeletedMICStatus">
@@ -293,9 +292,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>designated contract market</rdfs:label>
 		<skos:definition>exchange, trading system, or platform that enables listing for trading futures or option contracts based on any underlying commodity, index or instrument</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>DCM</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.cftc.gov/IndustryOversight/TradingOrganizations/DCMs/index.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>DCM</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.cftc.gov/IndustryOversight/TradingOrganizations/DCMs/index.htm</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;ElectronicCommunicationNetwork">
@@ -303,8 +302,8 @@
 		<rdfs:label>electronic communication network</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.cfainstitute.org/-/media/documents/issue-brief/dark-pools-internalization-and-equity-market-quality-issue-brief"/>
 		<skos:definition>alternative trading system that automatically matches buy and sell orders for securities in the market</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ECN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>ECNs allow brokerages and investors in different geographic areas to trade without a third party involved, offering privacy for investors. They also allow after-hours trading, but trading may be subject to commissions and other fees.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>ECN</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>ECNs allow brokerages and investors in different geographic areas to trade without a third party involved, offering privacy for investors. They also allow after-hours trading, but trading may be subject to commissions and other fees.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;Exchange">
@@ -351,12 +350,12 @@
 		</rdfs:subClassOf>
 		<rdfs:label>exchange</rdfs:label>
 		<skos:definition>any organization, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by such exchange</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>Securities Exchange Act of 1934, as amended 12 August 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An exchange is typically a corporation or mutual organization that provides securities trading services, where securities may be bought and sold by third parties. As a facility, an exchange is also a place of trade associated with a particular site, i.e., stock exchange, regulated market such as an Electronic Trading Platform (ECN), or unregulated market, such as an Automated Trading System (ATS), or market data provider. Stock exchanges also provide facilities for the issue and redemption of securities as well as other financial instruments and capital events including the payment of income and dividends.
+		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Securities Exchange Act of 1934, as amended 12 August 2012</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An exchange is typically a corporation or mutual organization that provides securities trading services, where securities may be bought and sold by third parties. As a facility, an exchange is also a place of trade associated with a particular site, i.e., stock exchange, regulated market such as an Electronic Trading Platform (ECN), or unregulated market, such as an Automated Trading System (ATS), or market data provider. Stock exchanges also provide facilities for the issue and redemption of securities as well as other financial instruments and capital events including the payment of income and dividends.
 
-The securities traded on a stock exchange include: shares issued by companies, unit trusts, derivatives, pooled investment products and bonds. To be able to trade a security on a certain stock exchange, it has to be listed there. Usually there is a central location at least for recordkeeping, but trade is less and less linked to such a physical place, as modern markets are electronic networks, which gives them advantages of speed and cost of transactions. Trade on an exchange is by members only.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>market</fibo-fnd-utl-av:synonym>
+The securities traded on a stock exchange include: shares issued by companies, unit trusts, derivatives, pooled investment products and bonds. To be able to trade a security on a certain stock exchange, it has to be listed there. Usually there is a central location at least for recordkeeping, but trade is less and less linked to such a physical place, as modern markets are electronic networks, which gives them advantages of speed and cost of transactions. Trade on an exchange is by members only.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>market</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;ExchangeParticipant">
@@ -393,8 +392,8 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketIdentifierCodeStatus"/>
 		<rdfs:label>expired MIC status</rdfs:label>
 		<skos:definition>as of the last report or update, the exchange code has expired</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, version 2.0</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, version 2.0</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>EXPIRED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -402,8 +401,8 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fnd-arr-cls;ClassificationScheme"/>
 		<rdfs:label>ISO 10383 classification scheme</rdfs:label>
 		<skos:definition>classification scheme for market categories and related content per the ISO 10383 standard</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/market-identifier-codes</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/market-identifier-codes</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;InterdealerQuotationSystem">
@@ -417,13 +416,13 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdfs:label>interdealer quotation system</rdfs:label>
 		<skos:definition>automated system for organizing and disseminating price quotes by brokers and dealer firms that facilitates electronic trading in securities</skos:definition>
 		<skos:example>The National Association of Securities Dealers Automatic Quotation (Nasdaq), Nasdaq SmallCap Market, and the Over-The-Counter Bulletin Board (OTCBB) exchange platforms are integrated into one IQS. By using this integrated system, investors have access to a wide range of securities, ranging from large blue-chip companies to smaller micro-caps.</skos:example>
-		<fibo-fnd-utl-av:abbreviation>IQS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.investopedia.com/terms/i/interdealerquotationsystem.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.lawinsider.com/dictionary/inter-dealer-quotation-system</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An IQS ties the price quotations of a number of exchanges together into one platform. This allows investors to more easily access security price quotations that would otherwise need to be monitored on several separate exchanges.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>In the United States, an IQS is an automated interdealer quotation system of a national securities association registered pursuant to section 15A(a) of the Exchange Act (15 U.S.C. 78o-3(a)).</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>inter-dealer quotation system</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>IQS</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.investopedia.com/terms/i/interdealerquotationsystem.asp</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.lawinsider.com/dictionary/inter-dealer-quotation-system</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An IQS ties the price quotations of a number of exchanges together into one platform. This allows investors to more easily access security price quotations that would otherwise need to be monitored on several separate exchanges.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In the United States, an IQS is an automated interdealer quotation system of a national securities association registered pursuant to section 15A(a) of the Exchange Act (15 U.S.C. 78o-3(a)).</cmns-av:explanatoryNote>
+		<cmns-av:synonym>inter-dealer quotation system</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier">
@@ -456,14 +455,14 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdfs:label>market category classifier</rdfs:label>
 		<skos:definition>classifier representing the controlled vocabulary that delineates the nature of the exchange or data reporting services provider where possible</skos:definition>
 		<skos:scopeNote>As of October 2022, the controlled vocabulary includes two codes that are not semantically useful, namely &apos;not specified&apos;, or NSPD, and &apos;other&apos;, or OTHR. These are included for the sake of completeness but ignored with respect to how the exchange or market is classified. If something has one of these two codes as a market category, they will be classified either as an operating-level or segment-level marketas appropriate with no other distinction in terms of how they are instantiated.</skos:scopeNote>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-APPA">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - APPA</rdfs:label>
 		<skos:definition>market category classifier for an approved publication arrangement</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>APPA</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -471,7 +470,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - ARMS</rdfs:label>
 		<skos:definition>market category classifier for an approved reporting mechanism</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>ARMS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -479,7 +478,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - ATSS</rdfs:label>
 		<skos:definition>market category classifier for an alternative trading system</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>ATSS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -487,7 +486,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - CASP</rdfs:label>
 		<skos:definition>market category classifier for a crypto asset services provider</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>CASP</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -495,7 +494,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - CTPS</rdfs:label>
 		<skos:definition>market category classifier for a consolidated tape provider</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>CTPS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -503,7 +502,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - DCMS</rdfs:label>
 		<skos:definition>market category classifier for a designated contract market</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>DCMS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -511,7 +510,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - IDQS</rdfs:label>
 		<skos:definition>market category classifier for an interdealer quotation system</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>IDQS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -519,7 +518,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - MLTF</rdfs:label>
 		<skos:definition>market category classifier for a multilateral trading facility</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>MLTF</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -527,7 +526,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - NSPD</rdfs:label>
 		<skos:definition>market category classifier indicating that the market category has not been specified by the reporting party</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>NSPD</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -535,7 +534,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - OTFS</rdfs:label>
 		<skos:definition>market category classifier for an organized trading facility</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>OTFS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -543,7 +542,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - OTHR</rdfs:label>
 		<skos:definition>market category classifier indicating that the reporting party believes that the market classifier is something other than any of the given market categories</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>OTHR</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -551,7 +550,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - RMKT</rdfs:label>
 		<skos:definition>market category classifier for a regulated market</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>RMKT</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -559,7 +558,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - RMOS</rdfs:label>
 		<skos:definition>market category classifier for a recognized market operator</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>RMOS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -567,7 +566,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - SEFS</rdfs:label>
 		<skos:definition>market category classifier for a swap execution facility</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>SEFS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -575,7 +574,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - SINT</rdfs:label>
 		<skos:definition>market category classifier for a systematic internalizer</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>SINT</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -583,7 +582,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - TRFS</rdfs:label>
 		<skos:definition>market category classifier for a trade reporting facility</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>TRFS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -610,22 +609,22 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		</rdfs:subClassOf>
 		<rdfs:label>market identifier</rdfs:label>
 		<skos:definition>identifier that specifies a universal method of identifying exchanges, trading platforms, regulated or non-regulated markets, and data reporting services providers as sources of prices and related information in order to facilitate automated processing</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>MIC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/market-identifier-codes</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>It is intended for use in any application and communication for identification of places
+		<cmns-av:abbreviation>MIC</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/market-identifier-codes</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>It is intended for use in any application and communication for identification of places
 - where a financial instrument is listed (place of official listing),
 - where a related trade is executed (place of trade), and
-- where trade details are reported (trade reporting facility).</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>Market Identifier Code</fibo-fnd-utl-av:synonym>
+- where trade details are reported (trade reporting facility).</cmns-av:explanatoryNote>
+		<cmns-av:synonym>Market Identifier Code</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;MarketIdentifierCodeStatus">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStage"/>
 		<rdfs:label>market indicator code status</rdfs:label>
 		<skos:definition>lifecycle stage indicating the status of the MIC code, as specified by the registration authority</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/market-identifier-codes</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/market-identifier-codes</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;MarketLevelClassifier">
@@ -657,14 +656,14 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		</rdfs:subClassOf>
 		<rdfs:label>market level classifier</rdfs:label>
 		<skos:definition>classifier that indicates whether the exchange or data reporting services provider is an operating level or market segment level facility</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketLevelClassifier-OPRT">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketLevelClassifier"/>
 		<rdfs:label>market-level classifier - OPRT</rdfs:label>
 		<skos:definition>market-level classifier for an operating-level facility</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>OPRT</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -672,7 +671,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketLevelClassifier"/>
 		<rdfs:label>market-level classifier - SGMT</rdfs:label>
 		<skos:definition>market-level classifier for a segment-level facility</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>SGMT</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -695,16 +694,16 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<skos:example>Dark pool</skos:example>
 		<skos:note>A market segment MIC can only be registered if an operating/exchange MIC already exists.</skos:note>
 		<skos:note>It is not required to have a MIC registered for all segments of a market, only for those segments that need to be identified.</skos:note>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29, clause 2.2</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29, clause 2.2</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;MarketSegmentLevelMarketIdentifier">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;MarketIdentifier"/>
 		<rdfs:label>market segment-level market identifier</rdfs:label>
 		<skos:definition>market identifier that identifies a section of an exchange/market/trade reporting facility that specialises in one or more specific instruments or that is regulated differently</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29, clause 2.2</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29, clause 2.2</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;ModifiedMICStatus">
@@ -722,18 +721,18 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		</rdfs:subClassOf>
 		<rdfs:label>multilateral trading facility</rdfs:label>
 		<skos:definition>trading system that facilitates the exchange of financial instruments between multiple parties</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>MTF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/m/multilateral_trading_facility.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Multilateral trading facilities allow eligible contract participants to gather and transfer a variety of securities, especially instruments that may not have an official market. These facilities are often electronic systems controlled by approved market operators or larger investment banks. Traders will usually submit orders electronically, where a matching software engine is used to pair buyers with sellers.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>MTF</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>http://www.investopedia.com/terms/m/multilateral_trading_facility.asp</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Multilateral trading facilities allow eligible contract participants to gather and transfer a variety of securities, especially instruments that may not have an official market. These facilities are often electronic systems controlled by approved market operators or larger investment banks. Traders will usually submit orders electronically, where a matching software engine is used to pair buyers with sellers.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;OffMarketFacility">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:label>off-market facility</rdfs:label>
 		<skos:definition>facility used for reporting over-the-counter (OTC) and other direct trades that are not executed by the exchange but are reported through the exchange</skos:definition>
-		<fibo-fnd-utl-av:synonym>off-book</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>off-facility</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>off-book</cmns-av:synonym>
+		<cmns-av:synonym>off-facility</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;OperatingLevelMarket">
@@ -753,16 +752,16 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		</rdfs:subClassOf>
 		<rdfs:label>operating-level market</rdfs:label>
 		<skos:definition>exchange/market/trade reporting facility in a specific market/country</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29, clause 2.1</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29, clause 2.1</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;OperatingLevelMarketIdentifier">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;MarketIdentifier"/>
 		<rdfs:label>operating-level market identifier</rdfs:label>
 		<skos:definition>market identifier that identifies an exchange/market/trade reporting facility in a specific market/country</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29, clause 2.1</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, 2012-10-01, confirmed 2018-03-29, clause 2.1</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;OrganizedTradingFacility">
@@ -789,21 +788,21 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdfs:label xml:lang="en-US">organized trading facility</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.financierworldwide.com/organised-trading-facilities-how-they-differ-from-mtfs"/>
 		<skos:definition>multi-lateral system which is not an RM or an MTF and in which multiple third-party buying and selling interests in bonds, structured finance products, emission allowances or derivatives are able to interact in the system in a way that results in a contract in accordance with the provisions of Title II of MiFID II</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>OTF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.marketswiki.com/mwiki/Organized_Trading_Facility</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>OTFs were introduced by the European Commission as part of MiFID II and are focused on non-equities such as derivatives and cash bond markets.
+		<cmns-av:abbreviation>OTF</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>http://www.marketswiki.com/mwiki/Organized_Trading_Facility</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>OTFs were introduced by the European Commission as part of MiFID II and are focused on non-equities such as derivatives and cash bond markets.
 
-OTFs are intended to be similar in scope to a swap execution facility (SEF), a type of entity created by the Dodd-Frank Act in the U.S. The goal of SEFs and OTFs is to bring transparency and structure to OTC derivatives trading.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Unlike RMs and MTFs, operators of OTFs will have discretion as to how to execute orders, subject to pre-transparency and best execution obligations.</fibo-fnd-utl-av:explanatoryNote>
+OTFs are intended to be similar in scope to a swap execution facility (SEF), a type of entity created by the Dodd-Frank Act in the U.S. The goal of SEFs and OTFs is to bring transparency and structure to OTC derivatives trading.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Unlike RMs and MTFs, operators of OTFs will have discretion as to how to execute orders, subject to pre-transparency and best execution obligations.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;QuoteDrivenMarket">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:label>quote-driven market</rdfs:label>
 		<skos:definition>exchange in which prices are determined from bid and ask quotations made by market makers, dealers, or specialists</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In a quote-driven market, dealers fill orders from their own inventory or by matching them with other orders. Note that this differs from a typical market, which is order-driven rather than quote-driven.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>price-driven market</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>In a quote-driven market, dealers fill orders from their own inventory or by matching them with other orders. Note that this differs from a typical market, which is order-driven rather than quote-driven.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>price-driven market</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;RecognizedMarketOperator">
@@ -817,11 +816,11 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:label xml:lang="en-GB">recognised market operator</rdfs:label>
 		<rdfs:label xml:lang="en-US">recognized market operator</rdfs:label>
 		<skos:definition>exchange that is operated or maintained by an operator registered under certain securities regulations that brings together purchasers and sellers of capital market products</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RMO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.igi-global.com/dictionary/regulating-fintech-businesses/77383</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.lawinsider.com/dictionary/recognized-market</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.mas.gov.sg/regulation/capital-markets/approved-exchange-ae-or-recognised-market-operator-rmo-licence</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>RMO</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.igi-global.com/dictionary/regulating-fintech-businesses/77383</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.lawinsider.com/dictionary/recognized-market</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.mas.gov.sg/regulation/capital-markets/approved-exchange-ae-or-recognised-market-operator-rmo-licence</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;RegisteredMultilateralTradingFacility">
@@ -870,11 +869,11 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		</rdfs:subClassOf>
 		<rdfs:label>regulated exchange</rdfs:label>
 		<skos:definition>regulated market that is operated by and/or managed by a market operator that brings together or facilitates the bringing together of multiple third-party buying and selling interests in financial instruments</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RM</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investopedia.com/terms/r/regulated-market.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In the financial community in the EU, such an exchange operates in accordance with its non-discretionary rules in a way that results in a contract, in respect of the financial instruments admitted to trading under its rules and/or systems, and which is authorised and functions regularly and in accordance with the provisions of Title III of MiFID II.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>regulated market</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>RM</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>http://www.investopedia.com/terms/r/regulated-market.asp</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In the financial community in the EU, such an exchange operates in accordance with its non-discretionary rules in a way that results in a contract, in respect of the financial instruments admitted to trading under its rules and/or systems, and which is authorised and functions regularly and in accordance with the provisions of Title III of MiFID II.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>regulated market</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;SwapExecutionFacility">
@@ -887,9 +886,9 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		</rdfs:subClassOf>
 		<rdfs:label>swap execution facility</rdfs:label>
 		<skos:definition>exchange that enables participants to execute and trade swaps</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SEF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Swap execution facilities, including trading systems and other platforms, allow for greater transparency and represent a significant shift in the way derivative trading has been done. The Dodd-Frank Act lays the foundation for this change of derivative execution.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>SEF</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Swap execution facilities, including trading systems and other platforms, allow for greater transparency and represent a significant shift in the way derivative trading has been done. The Dodd-Frank Act lays the foundation for this change of derivative execution.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;SystematicInternaliser">
@@ -903,9 +902,9 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:label xml:lang="en-GB">systematic internaliser</rdfs:label>
 		<rdfs:label xml:lang="en-US">systematic internalizer</rdfs:label>
 		<skos:definition>investment firm that, on an organised, frequent, systematic and substantial basis, deals on its own account by executing client orders outside a regulated exchange, MTF or OTF without operating a multilateral system</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.emissions-euets.com/systematic-internaliser</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>SI</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.emissions-euets.com/systematic-internaliser</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;TradeReportingFacility">
@@ -959,17 +958,17 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:label>trade reporting facility</rdfs:label>
 		<skos:definition>facility that provides a mechanism for the reporting of transactions effected otherwise than on an exchange</skos:definition>
 		<skos:example>In the United States, for example, trades by FINRA members in Nasdaq-listed and other exchange-listed securities, as approved by the Securities and Exchange Commission (SEC), executed otherwise than on an exchange may be reported to a FINRA TRF. While each FINRA TRF is affiliated with a registered national securities exchange, each FINRA TRF is a FINRA facility and is subject to FINRA&apos;s registration as a national securities association.</skos:example>
-		<fibo-fnd-utl-av:abbreviation>TRF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.finra.org/filing-reporting/trade-reporting-facility-trf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>TRF</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.finra.org/filing-reporting/trade-reporting-facility-trf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;UpdatedMICStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketIdentifierCodeStatus"/>
 		<rdfs:label>updated MIC status</rdfs:label>
 		<skos:definition>as of the last report or update, the exchange code was revised</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, version 2.0</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, version 2.0</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 		<lcc-lr:hasTag>UPDATED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
@@ -987,7 +986,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasAlias"/>
 		<rdfs:label>has facility acronym</rdfs:label>
 		<skos:definition>indicates a known acronym of the market</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-mkt;hasMarketIdentifierCodeStatus">
@@ -1006,7 +1005,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:label>operates in country</rdfs:label>
 		<rdfs:range rdf:resource="&lcc-cr;Country"/>
 		<skos:definition>indicates the ISO 3166-1 country in which an exchange, data reporting services provider, or crypto asset services provider operates</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-mkt;operatesInMunicipality">
@@ -1014,7 +1013,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:label>operates in municipality</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<skos:definition>indicates the municipality or business center in which in which an exchange, data reporting services provider, or crypto asset services provider operates</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/FBC/FunctionalEntities/MetadataFBCFunctionalEntities.rdf
+++ b/FBC/FunctionalEntities/MetadataFBCFunctionalEntities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-mod "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MetadataFBCFunctionalEntities/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MetadataFBCFunctionalEntities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-mod="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MetadataFBCFunctionalEntities/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -18,26 +19,24 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MetadataFBCFunctionalEntities/">
 		<rdfs:label>Metadata about the EDMC-FIBO Financial Business and Commerce(FBC) Functional Entities Module</rdfs:label>
 		<dct:abstract>The functional entities module includes ontologies that define business entities according to their function as opposed to their form. They include service providers such as financial institutions (e.g., banks, investment companies, and insurance companies), government regulatory and registration agencies, as well as entities described in terms of their function in some process, such as clearing houses.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-fbc-fct-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataFBCFunctionalEntities.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/MetadataFBCFunctionalEntities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/MetadataFBCFunctionalEntities/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mod;FunctionalEntitiesModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO FBC Functional Entities Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>functional entities module</rdfs:label>
 		<dct:abstract>The functional entities module includes ontologies that define business entities according to their function as opposed to their form. They include service providers such as financial institutions (e.g., banks, investment companies, and insurance companies), government regulatory and registration agencies, as well as entities described in terms of their function in some process, such as clearing houses.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"/>
@@ -59,10 +58,11 @@
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-FBC-FCT</sm:moduleAbbreviation>
+		<dct:title>FIBO FBC Functional Entities Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Functional Entities Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FBC/FunctionalEntities/MetadataFBCFunctionalEntities.rdf
+++ b/FBC/FunctionalEntities/MetadataFBCFunctionalEntities.rdf
@@ -30,8 +30,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/MetadataFBCFunctionalEntities/"/>
-		<cmns-av:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mod;FunctionalEntitiesModule">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-fbc-fct-cafse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/">
@@ -10,10 +11,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-fbc-fct-cafse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/"
@@ -24,31 +25,25 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/">
 		<rdfs:label>Canadian Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with additional kinds of entities that are specific to Canada.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2019 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2019 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-cafse</sm:fileAbbreviation>
-		<sm:filename>CAFinancialServicesEntities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities.rdf version of this ontology was modified to generalize the definition of credit union.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-cafse;CanadianCreditUnion">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-ge-caj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/">
@@ -32,10 +33,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-ge-caj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"
@@ -68,25 +69,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/">
 		<rdfs:label>Canadian Regulatory Agencies Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary regulatory agencies ontology in FBC with additional regulators that are specific to the United States and augments certain U.S. financial services entities based on who regulates them.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-cajrga</sm:fileAbbreviation>
-		<sm:filename>CARegulatoryAgencies.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"/>
@@ -108,11 +96,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgenciess.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgenciess.rdf version of this ontology was revised to update the GLEIF LEI registration information for the Bank of Canada, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
@@ -121,7 +110,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was revised to add Canadian tax identifiers and their related schemes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210501/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was revised to reflect the move of certain organization-specific concepts from BE to FND and clean up LEI data.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was revised to address text formatting issues identified through hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-549300PN6MKI0CLP4T28-LEI">
@@ -143,10 +135,10 @@
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.bankofcanada.ca/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="en">Bank of Canada</fibo-fnd-rel-rel:hasLegalName>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="fr">Banque du Canada</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bankofcanada.ca/wp-content/uploads/2010/11/regulation_canadian_financial.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The Bank of Canada&apos;s overall goal is to promote a stable and efficient financial system in Canada. The focus on the financial system as a whole parallels the Bank&apos;s approach to monetary policy, which focuses on the entire economy.
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bankofcanada.ca/wp-content/uploads/2010/11/regulation_canadian_financial.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The Bank of Canada&apos;s overall goal is to promote a stable and efficient financial system in Canada. The focus on the financial system as a whole parallels the Bank&apos;s approach to monetary policy, which focuses on the entire economy.
  
- The Bank provides liquidity to the financial system, gives policy advice to the federal government on the design and development of the system, oversees major clearing and settlement systems, and provides banking services to these systems and their participants.</fibo-fnd-utl-av:explanatoryNote>
+ The Bank provides liquidity to the financial system, gives policy advice to the federal government on the design and development of the system, oversees major clearing and settlement systems, and provides banking services to these systems and their participants.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 	</owl:NamedIndividual>
 	
@@ -192,8 +184,8 @@
 		<rdfs:label>business number</rdfs:label>
 		<skos:definition>unique, 9-digit number that is the standard identifier for legal entities in Canada which are typically a business</skos:definition>
 		<skos:example>000000000</skos:example>
-		<fibo-fnd-utl-av:abbreviation>BN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/services/taxes/business-number.html</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>BN</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/services/taxes/business-number.html</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;BusinessNumberRegistrationIdentifierScheme">
@@ -221,7 +213,7 @@
 		<skos:definition>Canada Revenue Agency business number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CanadaRevenueAgency">
@@ -235,8 +227,8 @@
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="fr">Agence du revenu du Canada</fibo-fnd-rel-rel:hasLegalName>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="en">Canada Revenue Agency</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>This agency administers tax laws for the Canadian government and for several of the provinces and territories of Canada.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>This agency administers tax laws for the Canadian government and for several of the provinces and territories of Canada.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 	</owl:NamedIndividual>
 	
@@ -260,7 +252,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>regulatory agency, registration authority and central banking role of the Bank of Canada</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-cajrga;BankOfCanada"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bankofcanada.ca/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bankofcanada.ca/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar">
@@ -298,8 +290,8 @@
 		<rdfs:label>corporation income tax number</rdfs:label>
 		<skos:definition>concatenation of an entity&apos;s business number, the &apos;RC&apos; abbreviation and a 4-digit subaccount number used for reporting corporate income tax</skos:definition>
 		<skos:example>000000000RC0001</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/corporation-income-tax-program-account.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one tax account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/corporation-income-tax-program-account.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An organization may have more than one tax account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CorporationIncomeTaxNumberIdentifierScheme">
@@ -327,7 +319,7 @@
 		<skos:definition>Canada Revenue Agency corporation income tax number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;GoodsServicesTaxHarmonizedSalesTaxNumberRegistry">
@@ -338,8 +330,8 @@
 		<skos:definition>registry that records and tracks individual GST/HST numbers for the Canada Revenue Agency</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-utl-av:abbreviation>GST/HST number registry</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Limited public access.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>GST/HST number registry</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Limited public access.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;GoodsServicesTaxHarmonizedSalesTaxRegistrationIdentifierScheme">
@@ -348,7 +340,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>registration identifier scheme for GST/HST accounts defined by the Canada Revenue Agency for the registration of a business or legal entity</skos:definition>
 		<fibo-fnd-rel-rel:refersTo rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumberRegistrationIdentifierScheme"/>
-		<fibo-fnd-utl-av:abbreviation>Canada Revenue Agency GST/HST registation number identifier scheme</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>Canada Revenue Agency GST/HST registation number identifier scheme</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;GoodsServicesTaxHarmonizedSalesTaxRegistrationNumber">
@@ -376,9 +368,9 @@
 		<rdfs:label>Goods and Services Tax / Harmonized Sales Tax registration number</rdfs:label>
 		<skos:definition>concatenation of an entity&apos;s business number, the &apos;RT&apos; abbreviation and a 4-digit subaccount number used for reporting GST/HST</skos:definition>
 		<skos:example>000000000RT0001</skos:example>
-		<fibo-fnd-utl-av:abbreviation>GST/HST registation number</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one GST/HST account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>GST/HST registation number</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An organization may have more than one GST/HST account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;GoodsServicesTaxHarmonizedSalesTaxRegistrationService">
@@ -415,8 +407,8 @@
 		<rdfs:label>import export program number</rdfs:label>
 		<skos:definition>concatenation of an entity&apos;s business number, the &apos;RM&apos; abbreviation and a 4-digit subaccount number used for customs and import/export reporting purposes</skos:definition>
 		<skos:example>000000000RM0001</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/import-export-program-account.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one import-exports account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/import-export-program-account.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An organization may have more than one import-exports account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;ImportExportProgramNumberIdentifierScheme">
@@ -444,7 +436,7 @@
 		<skos:definition>Canada Revenue Agency import export program number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;InformationReturnsIdentifierScheme">
@@ -479,8 +471,8 @@
 		<rdfs:label>information return program number</rdfs:label>
 		<skos:definition>concatenation of an entity&apos;s business number, the &apos;RZ&apos; abbreviation and a 4-digit subaccount number used for information returns</skos:definition>
 		<skos:example>000000000RZ0001</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/completing-slips-summaries/financial-slips-summaries/information-returns-program-account.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one information returns program number through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration. As opposed to other program numbers, this number is used for filing information returns and not as an account.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/completing-slips-summaries/financial-slips-summaries/information-returns-program-account.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An organization may have more than one information returns program number through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration. As opposed to other program numbers, this number is used for filing information returns and not as an account.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;InformationReturnsProgramNumberRegistrationService">
@@ -500,7 +492,7 @@
 		<skos:definition>Canada Revenue Agency information return program number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;PayrollDeductionsProgramIdentifierRegistrationService">
@@ -545,8 +537,8 @@
 		<rdfs:label>payroll deductions program number</rdfs:label>
 		<skos:definition>concatenation of an entity&apos;s business number, the &apos;RP&apos; abbreviation and a 4-digit subaccount number used for reporting payroll deductions</skos:definition>
 		<skos:example>000000000RP0001</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/what-payroll-account.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one deduction account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/what-payroll-account.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An organization may have more than one deduction account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;PayrollDeductionsProgramNumberRegistry">
@@ -556,7 +548,7 @@
 		<skos:definition>Canada Revenue Agency payroll deduction program registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-utl-av:explanatoryNote>No public access.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;RegisteredCharityProgramNumber">
@@ -583,8 +575,8 @@
 		<rdfs:label>registered charity program number</rdfs:label>
 		<skos:definition>concatenation of an entity&apos;s business number, the &apos;RR&apos; abbreviation and a 4-digit subaccount number used for registered charity contribution</skos:definition>
 		<skos:example>000000000RR0001</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/charities-giving/charities/operating-a-registered-charity/registration-number.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An organization may have more than one registered charity account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency/services/charities-giving/charities/operating-a-registered-charity/registration-number.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An organization may have more than one registered charity account through its subunits, this is handled through additional 4-digit subaccount numbers. This is used as both an account and an identifier for the registration.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;RegisteredCharityProgramNumberIdentifierScheme">
@@ -613,7 +605,7 @@
 		<skos:definition>Canada Revenue Agency registered charity program number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-utl-av:explanatoryNote>Full public access.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Full public access.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
@@ -42,10 +43,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
@@ -88,18 +89,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/">
 		<rdfs:label>US Example Individuals</rdfs:label>
 		<dct:abstract>This ontology includes example individuals for US national banks, state chartered banks, and other institutions, as well as details related to some of the larger corporations that issue stock and are represented in the Dow Jones Industrial Average and S&amp;P 500.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-fbc-fct-usind</sm:fileAbbreviation>
-		<sm:filename>USExampleIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
@@ -134,10 +129,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level and entity ownership relations.</skos:changeNote>
@@ -146,7 +142,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to make incorporation and registration dates explicit and to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to improve the representation of some of the LEI data and fix spelling errors.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-4EP6JBYBTPTQ47LZOB67-LEI">
@@ -726,7 +725,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>Citibank, N.A. FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for Citibank, N.A.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>From the NIC and FDIC records, it appears that Citibank, National Association (with RSSD of 112855 and FDIC certificate of 16100) and Citibank, N.A. have been merged into a single national bank, with the surviving FDIC certificate and RSSD as defined herein.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>From the NIC and FDIC records, it appears that Citibank, National Association (with RSSD of 112855 and FDIC certificate of 16100) and Citibank, N.A. have been merged into a single national bank, with the surviving FDIC certificate and RSSD as defined herein.</cmns-av:explanatoryNote>
 		<lcc-lr:hasTag>7213</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitibankNA"/>
 	</owl:NamedIndividual>
@@ -787,7 +786,7 @@
 		<rdfs:label>Citibank, N.A. RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Citibank, N.A.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-utl-av:explanatoryNote>From the NIC and FDIC records, it appears that Citibank, National Association (with RSSD of 112855 and FDIC certificate of 16100) and Citibank, N.A. have been merged into a single national bank, with the surviving FDIC certificate and RSSD as defined herein.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>From the NIC and FDIC records, it appears that Citibank, National Association (with RSSD of 112855 and FDIC certificate of 16100) and Citibank, N.A. have been merged into a single national bank, with the surviving FDIC certificate and RSSD as defined herein.</cmns-av:explanatoryNote>
 		<lcc-lr:hasTag>476810</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitibankNA"/>
 	</owl:NamedIndividual>
@@ -1856,7 +1855,7 @@
 		<rdfs:label>Wells Fargo &amp; Company incorporation date</rdfs:label>
 		<skos:definition>date that Wells Fargo &amp; Company was first registered as a corporation in the State of Delaware</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1966-03-02</fibo-fnd-dt-fd:hasDateValue>
-		<fibo-fnd-utl-av:explanatoryNote>Note that one of its predecessor companies was registered was first registered in Delaware in 1929, and the bank itself was founded in 1870.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that one of its predecessor companies was registered was first registered in Delaware in 1929, and the bank itself was founded in 1870.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WellsFargoAndCompanyLegalEntityIdentifierRegistryEntry">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
@@ -11,10 +12,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
@@ -26,34 +27,28 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities/">
 		<rdfs:label>US Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with additional kinds of entities that are specific to the United States.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-usfse</sm:fileAbbreviation>
-		<sm:filename>USFinancialServicesEntities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf version of this ontology was modified to generalize the definition of credit union.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf version of this ontology was modified to eliminate circular definitions and revise names such that concepts don&apos;t appear to refer to multiple things.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210201/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf version of this ontology was modified to eliminate dead links and address text formatting issues identified through hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;AgreementCorporation">
@@ -67,14 +62,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>agreement corporation</rdfs:label>
 		<skos:definition>corporation chartered by a state to engage in international banking, so named because the corporation enters into an &apos;agreement&apos; with the Fed&apos;s Board of Governors that it will limit its activities to those permitted</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;CooperativeBank">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;ThriftInstitution"/>
 		<rdfs:label>cooperative bank</rdfs:label>
 		<skos:definition>state-chartered savings association located in Massachusetts, New Hampshire, Rhode Island or Vermont</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;EdgeCorporation">
@@ -88,36 +83,36 @@
 		</rdfs:subClassOf>
 		<rdfs:label>edge corporation</rdfs:label>
 		<skos:definition>corporation chartered by the Federal Reserve to engage in international banking and financial operations</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;FarmCreditSystemInstitution">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label>farm credit system institution</rdfs:label>
 		<skos:definition>federally-chartered financial institution that is supervised, examined, and regulated by the Farm Credit Administration and operates in accordance with the Farm Credit Act of 1971, as amended, 12 U.S.C. 2001 et seq. All Farm Credit System institutions are federally-chartered instrumentalities of the United States.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;FinancialHoldingCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;USBankHoldingCompany"/>
 		<rdfs:label>financial holding company</rdfs:label>
 		<skos:definition>financial entity engaged in a broad range of banking-related activities, created by the Gramm-Leach-Bliley Act of 1999</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>These activities include: insurance underwriting, securities dealing and underwriting, financial and investment advisory services, merchant banking, issuing or selling securitized interests in bank-eligible assets, and generally engaging in any non-banking activity authorized by the Bank Holding Company Act. The Federal Reserve Board is responsible for supervising the financial condition and activities of financial holding companies. Similarly, any non-bank commercial company that is predominantly engaged in financial activities, earning 85 percent or more of its gross revenues from financial services, may choose to become a financial holding company. These companies are required to sell any non-financial (commercial) businesses within ten years.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>These activities include: insurance underwriting, securities dealing and underwriting, financial and investment advisory services, merchant banking, issuing or selling securitized interests in bank-eligible assets, and generally engaging in any non-banking activity authorized by the Bank Holding Company Act. The Federal Reserve Board is responsible for supervising the financial condition and activities of financial holding companies. Similarly, any non-bank commercial company that is predominantly engaged in financial activities, earning 85 percent or more of its gross revenues from financial services, may choose to become a financial holding company. These companies are required to sell any non-financial (commercial) businesses within ten years.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;IndustrialBank">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;Bank"/>
 		<rdfs:label>industrial bank</rdfs:label>
 		<skos:definition>limited service financial institution that raises funds by selling certificates called &apos;investment shares&apos; and by accepting deposits</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Often called Morris Plan banks or industrial loan companies, industrial banks are distinguished from commercial loan companies because industrial banks accept deposits in addition to making consumer loans. Industrial banks differ from commercial banks because they do not offer demand deposit (checking) accounts. Industrial banks are not regulated by the Federal Reserve.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Often called Morris Plan banks or industrial loan companies, industrial banks are distinguished from commercial loan companies because industrial banks accept deposits in addition to making consumer loans. Industrial banks differ from commercial banks because they do not offer demand deposit (checking) accounts. Industrial banks are not regulated by the Federal Reserve.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;MutualSavingsBank">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;SavingsBank"/>
 		<rdfs:label>mutual savings bank</rdfs:label>
 		<skos:definition>financial institution that accepts deposits primarily from individuals and places a large portion of its funds into mortgage loans</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;NationalBank">
@@ -125,30 +120,30 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;USBank"/>
 		<rdfs:label>national bank</rdfs:label>
 		<skos:definition>commercial bank whose charter is approved by the Office of the Comptroller of the Currency (OCC) rather than by a state banking department</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>National Banks are required to be members of the Federal Reserve System and belong to the Federal Deposit Insurance Corporation.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>National Banks are required to be members of the Federal Reserve System and belong to the Federal Deposit Insurance Corporation.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;NonDepositoryTrustCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
 		<rdfs:label>non-depository trust company</rdfs:label>
 		<skos:definition>trust company that accepts and executes trusts, but does not issue currency; non-depository trust companies can either be Federal Reserve Members or Federal Reserve Non-members</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;SavingsBank">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;ThriftInstitution"/>
 		<rdfs:label>savings bank</rdfs:label>
 		<skos:definition>banking institution organized to encourage thrift by paying interest dividends on savings; savings banks can have state and federal affiliations, for example, State Savings Banks and Federal Savings Banks</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;SavingsLoanAssociation">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;ThriftInstitution"/>
 		<rdfs:label>savings loan association</rdfs:label>
 		<skos:definition>financial institution that accepts deposits primarily from individuals and channels its funds primarily into residential mortgage loans</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>savings and loan association</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
+		<cmns-av:synonym>savings and loan association</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;SavingsLoanHoldingCompany">
@@ -156,8 +151,8 @@
 		<rdfs:label>savings loan holding company</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-fse;BankHoldingCompany"/>
 		<skos:definition>company that directly or indirectly controls a savings association or related holding company, and explicitly excludes any company that is also a bank holding company</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>savings and loan holding company</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
+		<cmns-av:synonym>savings and loan holding company</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;StateCharteredBank">
@@ -165,9 +160,9 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;USBank"/>
 		<rdfs:label>state-chartered bank</rdfs:label>
 		<skos:definition>commercial bank whose charter is approved by a state banking regulator</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A state bank is defined as any bank, banking association, trust company, savings bank, industrial bank (or similar depository institution operating substantially in the same manner as an industrial bank), or other banking institution which is engaged in the business of receiving deposits other than trust funds, and in the US, is incorporated under the laws of any State or which is operating under the Code of Law for the District of Columbia, including any cooperative bank or other unincorporated bank the deposits of which were insured by the Federal Deposit Insurance Corporation on the day before the date of the enactment of the Financial Institutions Reform, Recovery, and Enforcement Act of 1989.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>State-chartered banks may or may not be members of the Federal Reserve System, but typically belong to the Federal Deposit Insurance Corporation, who may be their primary federal regulator for those that are not FRS members.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A state bank is defined as any bank, banking association, trust company, savings bank, industrial bank (or similar depository institution operating substantially in the same manner as an industrial bank), or other banking institution which is engaged in the business of receiving deposits other than trust funds, and in the US, is incorporated under the laws of any State or which is operating under the Code of Law for the District of Columbia, including any cooperative bank or other unincorporated bank the deposits of which were insured by the Federal Deposit Insurance Corporation on the day before the date of the enactment of the Financial Institutions Reform, Recovery, and Enforcement Act of 1989.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>State-chartered banks may or may not be members of the Federal Reserve System, but typically belong to the Federal Deposit Insurance Corporation, who may be their primary federal regulator for those that are not FRS members.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;ThriftInstitution">
@@ -175,7 +170,7 @@
 		<rdfs:label>thrift institution</rdfs:label>
 		<skos:definition>savings association that primarily accepts savings account deposits and invests most of the proceeds in mortgages</skos:definition>
 		<skos:example>Savings banks and savings and loan associations and credit unions are examples of thrift institutions.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;USBank">
@@ -183,17 +178,17 @@
 		<rdfs:label>U.S. bank</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.sec.gov/about/laws/ica40.pdf"/>
 		<skos:definition>a bank that is licensed to conduct business in the United States</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>As defined in the Federal Deposit Insurance Act, https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A bank, as specified in the Investment Company Act of 1940, is a financial intermediary that is (a) a depository institution (as defined in section 3 of the Federal Deposit Insurance Act) or a branch or agency of a foreign bank (as such terms are defined in section 1(b) of the International Banking Act of 1978), (b) a member bank of the Federal Reserve System, (c) any other banking institution or trust company, whether incorporated or not, doing business under the laws of any State or of the United States, a substantial portion of the business of which consists of receiving deposits or exercising fiduciary powers similar to those permitted to national banks under the authority of the Comptroller of the Currency, and which is supervised and examined by State or Federal authority having supervision over banks, and which is not operated for the purpose of evading the provisions of this title, and (d) a receiver, conservator, or other liquidating agent of any institution or firm included in clause (a), (b), or (c) of this paragraph.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The Bank Holding Company Act of 1956 defines a bank as any depository financial intermediary that accepts checking accounts (checks) or makes commercial loans, and its deposits are insured by a federal deposit insurance agency. A bank acts as a middleman between suppliers of funds and users of funds, substituting its own credit judgement for that of the ultimate suppliers of funds, collecting those funds from three sources: checking accounts, savings and time deposits; short-term borrowings from other banks; and equity capital. A bank earns money by reinvesting these funds in longer-term assets.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>As defined in the Federal Deposit Insurance Act, https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A bank, as specified in the Investment Company Act of 1940, is a financial intermediary that is (a) a depository institution (as defined in section 3 of the Federal Deposit Insurance Act) or a branch or agency of a foreign bank (as such terms are defined in section 1(b) of the International Banking Act of 1978), (b) a member bank of the Federal Reserve System, (c) any other banking institution or trust company, whether incorporated or not, doing business under the laws of any State or of the United States, a substantial portion of the business of which consists of receiving deposits or exercising fiduciary powers similar to those permitted to national banks under the authority of the Comptroller of the Currency, and which is supervised and examined by State or Federal authority having supervision over banks, and which is not operated for the purpose of evading the provisions of this title, and (d) a receiver, conservator, or other liquidating agent of any institution or firm included in clause (a), (b), or (c) of this paragraph.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The Bank Holding Company Act of 1956 defines a bank as any depository financial intermediary that accepts checking accounts (checks) or makes commercial loans, and its deposits are insured by a federal deposit insurance agency. A bank acts as a middleman between suppliers of funds and users of funds, substituting its own credit judgement for that of the ultimate suppliers of funds, collecting those funds from three sources: checking accounts, savings and time deposits; short-term borrowings from other banks; and equity capital. A bank earns money by reinvesting these funds in longer-term assets.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;USBankHoldingCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;BankHoldingCompany"/>
 		<rdfs:label>U.S. bank holding company</rdfs:label>
 		<skos:definition>a bank holding company that is licensed to conduct business in the United States and is regulated and supervised by the Federal Reserve in accordance with the Bank Holding Company Act of 1956</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>According to the FFIEC, a bank holding company is a company that owns and/or controls one or more U.S. banks or one that owns, or has controlling interest in, one or more banks. A bank holding company may also own another bank holding company, which in turn owns or controls a bank; the company at the top of the ownership chain is called the top holder. The Board of Governors is responsible for regulating and supervising bank holding companies, even if the bank owned by the holding company is under the primary supervision of a different federal agency (OCC or FDIC).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>According to the FFIEC, a bank holding company is a company that owns and/or controls one or more U.S. banks or one that owns, or has controlling interest in, one or more banks. A bank holding company may also own another bank holding company, which in turn owns or controls a bank; the company at the top of the ownership chain is called the top holder. The Board of Governors is responsible for regulating and supervising bank holding companies, even if the bank owned by the holding company is under the primary supervision of a different federal agency (OCC or FDIC).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;USCreditUnion">
@@ -208,7 +203,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>U.S. credit union</rdfs:label>
 		<skos:definition>cooperative association organized for the purpose of promoting thrift among its members and creating a source of credit for provident or productive purposes</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>As soon as you deposit funds into a credit union account, you become a partial owner and participate in the union&apos;s profitability. Credit unions may be formed by large corporations and organizations for their employees and members.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>As soon as you deposit funds into a credit union account, you become a partial owner and participate in the union&apos;s profitability. Credit unions may be formed by large corporations and organizations for their employees and members.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
@@ -38,10 +39,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
@@ -80,23 +81,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/">
 		<rdfs:label>American Financial Services Entities - Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the financial services entities ontology in FBC with individual American entities that provide broad based services required by other FIBO domains, such as market data providers, instrument identifier issuers, organizations that provide exchanges in multiple countries, and so forth.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2017-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2017-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-usfsind</sm:fileAbbreviation>
-		<sm:filename>USFinancialServicesEntitiesIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
@@ -126,12 +116,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to normalize a few labels and definitions, revise GLEIF LEI registration data, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
@@ -139,7 +130,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to make incorporation and registration dates explicit and to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to improve the representation of some of the LEI data.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-254900Y8NKGV541U8Q32-LEI">
@@ -514,8 +508,8 @@
 		<rdfs:seeAlso rdf:resource="http://www.dtcc.com/about/businesses-and-subsidiaries"/>
 		<skos:definition>Depository Trust &amp; Clearing Corporation</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usfsind;DTCC-US-DE"/>
-		<fibo-fnd-utl-av:abbreviation>DTCC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>DTCC is a global financial services organization focused on developing solutions to secure today&apos;s marketplace, while shaping the future of our industry, whose mission includes risk mitigation, creation of market efficiencies, and cost reduction. They are a large financial services holding company, developing trade repositories and building global capabilities across the spectrum of asset classes.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>DTCC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>DTCC is a global financial services organization focused on developing solutions to secure today&apos;s marketplace, while shaping the future of our industry, whose mission includes risk mitigation, creation of market efficiencies, and cost reduction. They are a large financial services holding company, developing trade repositories and building global capabilities across the spectrum of asset classes.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;DepositoryTrustCompany">
@@ -529,10 +523,10 @@
 		<fibo-fbc-fct-usjrga:hasPrimaryFederalRegulator rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveRegulatoryAgencyAndCentralBank"/>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usfsind;DTC-US-NY"/>
-		<fibo-fnd-utl-av:abbreviation>DTC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>DTCC&apos;s subsidiary, The Depository Trust Company (DTC), established in 1973, was created to reduce costs and provide clearing and settlement efficiencies by immobilizing securities and making &apos;book-entry&apos; changes to ownership of the securities.
+		<cmns-av:abbreviation>DTC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>DTCC&apos;s subsidiary, The Depository Trust Company (DTC), established in 1973, was created to reduce costs and provide clearing and settlement efficiencies by immobilizing securities and making &apos;book-entry&apos; changes to ownership of the securities.
 
-DTC brings efficiency to the securities industry by retaining custody of more than 3.5 million securities issues valued at US$37.2 trillion, including securities issued in the US and more than 131 countries and territories.</fibo-fnd-utl-av:explanatoryNote>
+DTC brings efficiency to the securities industry by retaining custody of more than 3.5 million securities issues valued at US$37.2 trillion, including securities issued in the US and more than 131 countries and territories.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;DepositoryTrustCompanyOwnership">
@@ -572,7 +566,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gmeiutility.org/"/>
 		<skos:definition>Global Markets Entity Identifier (GMEI) registry. The GMEI utility is a pre-Local Operating Unit of the Global Legal Entity Identifier System (GLEIS).</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>GMEI registry</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>GMEI registry</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;ICEBenchmarkAdministration">
@@ -581,8 +575,8 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>ICE Benchmark Administration Limited (IBA) was established in July 2013 following an announcement by the Hogg Tendering Advisory Committee, an independent committee set up by the UK government to select the new administrator for the London Interbank Offered Rate (LIBOR).</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchange"/>
-		<fibo-fnd-utl-av:abbreviation>IBA</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:definitionOrigin rdf:resource="https://www.theice.com/iba.jhtml"/>
+		<cmns-av:abbreviation>IBA</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;IntercontinentalExchange">
@@ -592,7 +586,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:seeAlso rdf:resource="http://www.theice.com/"/>
 		<skos:definition>Intercontinental Exchange functional entity, which owns exchanges for financial and commodity markets, and operates 23 regulated exchanges and marketplaces</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchangeInc-US-DE"/>
-		<fibo-fnd-utl-av:abbreviation>ICE</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>ICE</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;IntercontinentalExchangeBusinessEntityIdentifier">
@@ -682,7 +676,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>date that S&amp;P Global was established</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>1925-12-29</fibo-fnd-dt-fd:hasDateValue>
-		<fibo-fnd-utl-av:explanatoryNote>The data established reflects the historical establishment of McGraw-Hill Publishing Company, Inc., including intermediate name and ownership changes.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The data established reflects the historical establishment of McGraw-Hill Publishing Company, Inc., including intermediate name and ownership changes.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;SPGlobalHeadquartersAddress">
@@ -750,7 +744,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>date that Thomson Reuters was established</skos:definition>
 		<fibo-fnd-dt-fd:hasDateValue>2008-04-17</fibo-fnd-dt-fd:hasDateValue>
-		<fibo-fnd-utl-av:explanatoryNote>The data established reflects the date that the Thomson Corporation merged with (purchased) the Reuters Group</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The data established reflects the date that the Thomson Corporation merged with (purchased) the Reuters Group</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;ThomsonReutersHeadquartersAddress-CA">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-ge-usj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/">
@@ -33,10 +34,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-ge-usj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"
@@ -70,18 +71,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/">
 		<rdfs:label>US Markets and Exchanges Individuals</rdfs:label>
 		<dct:abstract>This ontology includes extended individuals (examples that are more complete) for a sampling of markets operating in the US corresponding to the ISO 10383 Codes for exchanges and market identification (MIC).</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-fbc-fct-usmkt</sm:fileAbbreviation>
-		<sm:filename>USMarketsAndExchangesIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
@@ -105,17 +100,21 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180901/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/ version of this ontology was modified to support revisions of the MIC codes as of 11 January 2019, including the new URI strategy, and to move the registry definitions to a new international financial organizations ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/ version of this ontology was modified to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of this ontology was revised to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210301/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of this ontology was revised to restructure the various markets individuals per the changes to the markets ontology and replace references to revised individuals in the markets individuals ontology where appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;CBOEGlobalMarketsBusinessEntityIdentifier">
@@ -195,7 +194,7 @@
 		<rdfs:seeAlso rdf:resource="http://www.theice.com/"/>
 		<skos:definition>Intercontinental Exchange holding company and financial service provider that owns exchanges for financial and commodity markets, and operates 23 regulated exchanges and marketplaces</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchangeInc-US-DE"/>
-		<fibo-fnd-utl-av:abbreviation>ICE</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>ICE</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;NYSEAmericanOptions">
@@ -455,7 +454,7 @@
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>New York Stock Exchange</fibo-fnd-rel-rel:hasFormalName>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchangeAsServiceProvider"/>
-		<fibo-fnd-utl-av:explanatoryNote>The New York Stock Exchange is a leading global cash equity exchange. It is the leading equity exchange for initial public offerings, or IPOs, globally, and enables companies seeking to raise capital to become publicly listed through the IPO process upon meeting exchange listing standards. In addition to common stocks, preferred stocks and warrants, the NYSE lists structured products, such as capital securities and mandatory convertible securities. In addition, NYSE operates NYSE Bonds, an electronic trading platform with transparent pricing for debt securities, including corporate bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The New York Stock Exchange is a leading global cash equity exchange. It is the leading equity exchange for initial public offerings, or IPOs, globally, and enables companies seeking to raise capital to become publicly listed through the IPO process upon meeting exchange listing standards. In addition to common stocks, preferred stocks and warrants, the NYSE lists structured products, such as capital securities and mandatory convertible securities. In addition, NYSE operates NYSE Bonds, an electronic trading platform with transparent pricing for debt securities, including corporate bonds.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;NewYorkStockExchangeAsServiceProvider">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
@@ -39,10 +40,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
@@ -82,27 +83,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/">
 		<rdfs:label>US Regulatory Agencies Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary regulatory agencies ontology in FBC with additional regulators that are specific to the United States and augments certain U.S. financial services entities based on who regulates them.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-usjrga</sm:fileAbbreviation>
-		<sm:filename>USRegulatoryAgencies.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
@@ -132,11 +118,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified to integrate a financial services provider identifier for certain banking identifiers, add a property for secondary federal regulator, add individual registration schemes for state-specific business registries, improve on some definitions, normalize some of the labels, eliminate duplication of concepts in LCC, to simplify addresses, merge countries with locations in FND, eliminte the redundant notion of an InstitutionType, which can be determined using a SPARQL query or classification and results in a very large disjunction, and correct a couple of improperly defined annotations.</skos:changeNote>
@@ -147,7 +134,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210401/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to reflect the move of certain organization-specific concepts from BE to FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211001/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to correct a restriction defining state government entities and to make federal reserve district identifier a subclass of geographic region identifier and fix spelling errors.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to eliminate dead links and address text formatting issues identified by hygiene testing.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usfse;FinancialHoldingCompany">
@@ -305,7 +295,7 @@
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.aba.com/Pages/default.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>American Bankers Association</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:abbreviation>ABA</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>ABA</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;AmericanBankersAssociationRTNRegistrar">
@@ -316,7 +306,7 @@
 		<skos:definition>American Bankers Association (ABA) Routing Transit Number (RTN) Registrar, which is a delegated capability currently provided by Accuity</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;AccuityInc-US-DE"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;ABARTNRegistry"/>
-		<fibo-fnd-utl-av:abbreviation>ABA RTN Registrar</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>ABA RTN Registrar</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;AmericanBankersAssociationRegistrationAuthority">
@@ -327,7 +317,7 @@
 		<skos:definition>American Bankers Association (ABA) Registration Authority (RA), which is a function of the ABA for registration of issuer identification numbers in the US</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;AmericanBankersAssociation"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;ABAIINRegistry"/>
-		<fibo-fnd-utl-av:abbreviation>ABA RA</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>ABA RA</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem">
@@ -337,7 +327,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and registration authority for the overall Federal Reserve System</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveBoard"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.federalreserve.gov/faqs/about_12591.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.federalreserve.gov/faqs/about_12591.htm</cmns-av:adaptedFrom>
 		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveRegulatoryAgencyAndCentralBank"/>
 	</owl:NamedIndividual>
 	
@@ -347,7 +337,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>CFTC Industry Filings repository, a repository of organizational characteristics and financial data for Designated Contract Markets (DCM), Swap Execution Facilities (SEF), Derivatives Clearing Organizations (DCO), Swap Data Repositories (SDR), and Lists of Foreign Boards of Trade (FBOT) Registered with the Commission</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;CommoditiesFuturesAndDerivativesRegulator"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.cftc.gov/IndustryOversight/IndustryFilings/index.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.cftc.gov/IndustryOversight/IndustryFilings/index.htm</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaBankingRegulator">
@@ -418,7 +408,7 @@
 		<skos:definition>State of California&apos;s Department of Business Oversight</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://dbo.ca.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:explanatoryNote>The Department of Business Oversight (DBO) protects consumers and oversees financial service providers and products. The DBO supervises the operations of state-licensed financial institutions, including banks, credit unions and money transmitters. Additionally, the DBO licenses and regulates a variety of financial service providers, including securities brokers and dealers, investment advisers, payday lenders and other consumer finance lenders.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The Department of Business Oversight (DBO) protects consumers and oversees financial service providers and products. The DBO supervises the operations of state-licensed financial institutions, including banks, credit unions and money transmitters. Additionally, the DBO licenses and regulates a variety of financial service providers, including securities brokers and dealers, investment advisers, payday lenders and other consumer finance lenders.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaGovernment"/>
 	</owl:NamedIndividual>
 	
@@ -450,7 +440,7 @@
 		<skos:definition>Commodity Futures Trading Commission (CFTC), an independent Federal agency whose mission is to foster open, transparent, competitive, and financially sound markets, to avoid systemic risk, and to protect the market users and their funds, consumers, and the public from fraud, manipulation, and abusive practices related to derivatives and other products that are subject to the Commodity Exchange Act</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.cftc.gov/index.htm</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>CFTC</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>CFTC</cmns-av:abbreviation>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
@@ -460,7 +450,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and registration authority role of the Consumer Financial Protection Bureau (CFPB)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;ConsumerFinancialProtectionBureau"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.consumerfinance.gov/the-bureau/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.consumerfinance.gov/the-bureau/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;ConsumerFinancialProtectionBureau">
@@ -471,7 +461,7 @@
 		<skos:definition>Consumer Financial Protection Bureau (CFPB), an independent Federal agency that helps consumer finance markets work by making rules more effective, by consistently and fairly enforcing those rules, and by empowering consumers to take more control over their economic lives</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.consumerfinance.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>CFPB</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>CFPB</cmns-av:abbreviation>
 		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
 	</owl:NamedIndividual>
 	
@@ -495,7 +485,7 @@
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.cscglobal.com/cscglobal/home/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>Corporation Service Company</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:abbreviation>CSC</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>CSC</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CorporationServiceCompanyAddress">
@@ -541,7 +531,7 @@
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompanyHeadquartersAddress"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://ct.wolterskluwer.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>CT Corporation</fibo-fnd-rel-rel:hasLegalName>
-		<fibo-fnd-utl-av:abbreviation>CT</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>CT</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CorporationTrustCompanyBusinessEntityIdentifier">
@@ -634,8 +624,8 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>EDGAR repository, a repository of financial information about securities and their issuers, including but not limited to corporate quarterly and annual filings, collected by the SEC</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.sec.gov/edgar/aboutedgar.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>EDGAR, the Electronic Data Gathering, Analysis, and Retrieval system, performs automated collection, validation, indexing, acceptance, and forwarding of submissions by companies and others who are required by law to file forms with the U.S. Securities and Exchange Commission (SEC). Its primary purpose is to increase the efficiency and fairness of the securities market for the benefit of investors, corporations, and the economy by accelerating the receipt, acceptance, dissemination, and analysis of time-sensitive corporate information filed with the agency.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.sec.gov/edgar/aboutedgar.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>EDGAR, the Electronic Data Gathering, Analysis, and Retrieval system, performs automated collection, validation, indexing, acceptance, and forwarding of submissions by companies and others who are required by law to file forms with the U.S. Securities and Exchange Commission (SEC). Its primary purpose is to increase the efficiency and fairness of the securities market for the benefit of investors, corporations, and the economy by accelerating the receipt, acceptance, dissemination, and analysis of time-sensitive corporate information filed with the agency.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;EmployerIdentificationNumber">
@@ -650,19 +640,19 @@
 		</rdfs:subClassOf>
 		<rdfs:label>employer identification number</rdfs:label>
 		<skos:definition>unique nine-digit number assigned by the Internal Revenue Service (IRS) to business entities operating in the United States for the purposes of identification</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>EIN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:abbreviation>FEIN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.irs.gov/businesses/small-businesses-self-employed/employer-id-numbers</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Note that despite the name, the business may not necessarily employ anyone.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>Federal Employer Identification Number</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>Federal Tax Identification Number</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>EIN</cmns-av:abbreviation>
+		<cmns-av:abbreviation>FEIN</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.irs.gov/businesses/small-businesses-self-employed/employer-id-numbers</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Note that despite the name, the business may not necessarily employ anyone.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>Federal Employer Identification Number</cmns-av:synonym>
+		<cmns-av:synonym>Federal Tax Identification Number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;EmployerIdentificationNumberingScheme">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usjrga;TaxpayerIdentificationNumberingScheme"/>
 		<rdfs:label>employer identification numbering scheme</rdfs:label>
 		<skos:definition>taxpayer identification numbering scheme used in the United States to identify business entities</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.irs.gov/businesses/small-businesses-self-employed/employer-id-numbers</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.irs.gov/businesses/small-businesses-self-employed/employer-id-numbers</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FDICBusinessEntityIdentifier">
@@ -694,7 +684,7 @@
 		<rdfs:label>FDIC Certificate Number</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier issued to a depository institution by the FDIC on approval of that institution&apos;s application for insurance</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fdic.gov/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fdic.gov/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FDICInstitutionDirectory">
@@ -703,7 +693,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Deposit Insurance Corporation&apos;s (FDIC) institution directory, a repository of financial data and institution characteristics for covered institutions collected by the FDIC</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalDepositInsurerAndRegulator"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www7.fdic.gov/idasp/index.asp</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www7.fdic.gov/idasp/index.asp</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FDICRegistryEntry">
@@ -729,7 +719,7 @@
 		<rdfs:label>FDIC registry entry</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>an entry in the FDIC institution directory, a repository of financial institution characteristics collected by the FDIC related to the institutions they insure</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www7.fdic.gov/idasp/index.asp</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www7.fdic.gov/idasp/index.asp</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FRSMemberBank">
@@ -743,7 +733,7 @@
 		<rdfs:label>FRS member bank</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>financial institution that is a member of the Federal Reserve System (FRS)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FRSNonMemberBank">
@@ -752,7 +742,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-usjrga;FRSMemberBank"/>
 		<skos:definition>financial institution that is not a member of the Federal Reserve System (FRS)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FRSStateMemberBank">
@@ -761,7 +751,7 @@
 		<rdfs:label>FRS state member bank</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>state-chartered bank that is a member of the Federal Reserve System (FRS)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FarmCreditAdministration">
@@ -772,8 +762,8 @@
 		<skos:definition>Farm Credit Administration (FCA), an independent Federal agency that regulates and examines the banks, associations, and related entities of the Farm Credit System (FCS), including the Federal Agricultural Mortgage Corporation (Farmer Mac)</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://fca.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>FCA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The FCS is the largest agricultural lender in the United States. It is a nationwide network of lending institutions that are owned by their borrowers. It serves all 50 States and Puerto Rico.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>FCA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The FCS is the largest agricultural lender in the United States. It is a nationwide network of lending institutions that are owned by their borrowers. It serves all 50 States and Puerto Rico.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
@@ -785,7 +775,7 @@
 		<rdfs:seeAlso rdf:resource="http://fca.gov/"/>
 		<skos:definition>regulatory agency and registration authority role of the Farm Credit Administration (FCA)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;FarmCreditAdministration"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://fca.gov/about/fca_in_brief.html</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://fca.gov/about/fca_in_brief.html</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalDepositInsuranceCorporation">
@@ -797,8 +787,8 @@
 		<skos:definition>Federal Deposit Insurance Corporation (FDIC), which preserves and promotes public confidence in the U.S. financial system by insuring deposits in banks and thrift institutions for at least $250,000; by identifying, monitoring and addressing risks to the deposit insurance funds; and by limiting the effect on the economy and the financial system when a bank or thrift institution fails.</skos:definition>
 		<fibo-be-ge-ge:isInstrumentOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.fdic.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>FDIC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>An independent agency of the federal government, the FDIC was created in 1933 in response to the thousands of bank failures that occurred in the 1920s and early 1930s. Since the start of FDIC insurance on January 1, 1934, no depositor has lost a single cent of insured funds as a result of a failure.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>FDIC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>An independent agency of the federal government, the FDIC was created in 1933 in response to the thousands of bank failures that occurred in the 1920s and early 1930s. Since the start of FDIC insurance on January 1, 1934, no depositor has lost a single cent of insured funds as a result of a failure.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalDepositInsurerAndRegulator">
@@ -821,8 +811,8 @@
 		<skos:definition>FFIEC, a formal interagency body empowered to prescribe uniform principles, standards, and report forms for the federal examination of financial institutions by the Board of Governors of the Federal Reserve System (FRB), the Federal Deposit Insurance Corporation (FDIC), the National Credit Union Administration (NCUA), the Office of the Comptroller of the Currency (OCC), and the Consumer Financial Protection Bureau (CFPB), and to make recommendations to promote uniformity in the supervision of financial institutions</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>FFIEC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The Federal Financial Institutions Examination Council (FFIEC) was established on March 10, 1979, pursuant to title X of the Financial Institutions Regulatory and Interest Rate Control Act of 1978 (FIRA), Public Law 95-630. In 1989, title XI of the Financial Institutions Reform, Recovery and Enforcement Act of 1989 (FIRREA) established The Appraisal Subcommittee (ASC) within the Examination Council.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>FFIEC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The Federal Financial Institutions Examination Council (FFIEC) was established on March 10, 1979, pursuant to title X of the Financial Institutions Regulatory and Interest Rate Control Act of 1978 (FIRA), Public Law 95-630. In 1989, title XI of the Financial Institutions Reform, Recovery and Enforcement Act of 1989 (FIRREA) established The Appraisal Subcommittee (ASC) within the Examination Council.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<lcc-lr:hasMember rdf:resource="&fibo-fbc-fct-usjrga;ConsumerFinancialProtectionBureau"/>
 		<lcc-lr:hasMember rdf:resource="&fibo-fbc-fct-usjrga;FederalDepositInsuranceCorporation"/>
@@ -839,7 +829,7 @@
 		<skos:definition>regulatory agency and registration authority role of the Federal Financial Institutions Examination Council (FFIEC)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;FederalFinancialInstitutionsExaminationCouncil"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;UniformBankPerformanceReportRepository"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/about.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/about.htm</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FederalGovernmentEntity">
@@ -876,8 +866,8 @@
 		<skos:definition>Federal Housing Finance Agency (FHFA), responsible for strengthening and securing the United States secondary mortgage markets by providing effective supervision, sound research, reliable data, and relevant policies</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.fhfa.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>FHFA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The FHFA is an independent regulatory agency responsible for the oversight of vital components of the secondary mortgage markets - the housing government sponsored enterprises of Fannie Mae, Freddie Mac and the Federal Home Loan Bank System. Combined these entities provide more than $5.5 trillion in funding for the U.S. mortgage markets and financial institutions. Additionally, FHFA is the conservator of Fannie Mae and Freddie Mac.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>FHFA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The FHFA is an independent regulatory agency responsible for the oversight of vital components of the secondary mortgage markets - the housing government sponsored enterprises of Fannie Mae, Freddie Mac and the Federal Home Loan Bank System. Combined these entities provide more than $5.5 trillion in funding for the U.S. mortgage markets and financial institutions. Additionally, FHFA is the conservator of Fannie Mae and Freddie Mac.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
@@ -888,7 +878,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and registration authority role of the Federal Housing Finance Agency (FHFA)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;FederalHousingFinanceAgency"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fhfa.gov/AboutUs</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fhfa.gov/AboutUs</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfAtlanta">
@@ -1029,15 +1019,15 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Board (FRB)</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.federalreserve.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>FRB</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The members of the Board of Governors are nominated by the President of the United States and confirmed by the U.S. Senate. By law, the appointments must yield a &apos;fair representation of the financial, agricultural, industrial, and commercial interests and geographical divisions of the country,&apos; and no two Governors may come from the same Federal Reserve District.
+		<cmns-av:abbreviation>FRB</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The members of the Board of Governors are nominated by the President of the United States and confirmed by the U.S. Senate. By law, the appointments must yield a &apos;fair representation of the financial, agricultural, industrial, and commercial interests and geographical divisions of the country,&apos; and no two Governors may come from the same Federal Reserve District.
 
 The full term of a Governor is 14 years; appointments are staggered so that one term expires on January 31 of each even-numbered year. A Governor who has served a full term may not be reappointed, but a Governor who was appointed to complete the balance of an unexpired term may be reappointed to a full 14-year term.
 
 Once appointed, Governors may not be removed from office for their policy views. The lengthy terms and staggered appointments are intended to contribute to the insulation of the Board--and the Federal Reserve System as a whole--from day-to-day political pressures to which it might otherwise be subject.
 
-In addition to serving as members of the Board, the Chairman and Vice Chairman of the Board serve terms of four years, and they may be reappointed to those roles and serve until their terms as Governors expire. The Chairman serves as public spokesperson and representative of the Board and manager of the Board&apos;s staff. The Chairman also presides at Board meetings. Affirming the apolitical nature of the Board, recent Presidents of both major political parties have selected the same person as Board Chairman.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>Federal Reserve Board of Governors</fibo-fnd-utl-av:synonym>
+In addition to serving as members of the Board, the Chairman and Vice Chairman of the Board serve terms of four years, and they may be reappointed to those roles and serve until their terms as Governors expire. The Chairman serves as public spokesperson and representative of the Board and manager of the Board&apos;s staff. The Chairman also presides at Board meetings. Affirming the apolitical nature of the Board, recent Presidents of both major political parties have selected the same person as Board Chairman.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>Federal Reserve Board of Governors</cmns-av:synonym>
 		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSystem"/>
 	</owl:NamedIndividual>
 	
@@ -1046,8 +1036,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve district</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>a region of the US identifying the jurisdiction of a Federal Reserve Bank, numbered and named for the city in which that reserve bank is located</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/otherfrb.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The Federal Reserve officially identifies Districts by number and Reserve Bank city. In the 12th District, the Seattle Branch serves Alaska, and the San Francisco Bank serves Hawaii. The System serves commonwealths and territories as follows: the New York Bank serves the Commonwealth of Puerto Rico and the U.S. Virgin Islands; the San Francisco Bank serves American Samoa, Guam, and the Commonwealth of the Northern Mariana Islands. The Board of Governors revised the branch boundaries of the System in February 1996.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/otherfrb.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The Federal Reserve officially identifies Districts by number and Reserve Bank city. In the 12th District, the Seattle Branch serves Alaska, and the San Francisco Bank serves Hawaii. The System serves commonwealths and territories as follows: the New York Bank serves the Commonwealth of Puerto Rico and the U.S. Virgin Islands; the San Francisco Bank serves American Samoa, Guam, and the Commonwealth of the Northern Mariana Islands. The Board of Governors revised the branch boundaries of the System in February 1996.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FederalReserveDistrictBank">
@@ -1069,7 +1059,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve district bank</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve district and member bank, with jurisdiction over a specific region of the US, named for the city in which the reserve bank is located</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FederalReserveDistrictIdentifier">
@@ -1098,7 +1088,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Mississippi"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Missouri"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Tennessee"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.stlouisfed.org/about-us/what-we-do</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.stlouisfed.org/about-us/what-we-do</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveEighthDistrictIdentifier">
@@ -1119,7 +1109,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Louisiana"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;NewMexico"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Texas"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.dallasfed.org/fed</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.dallasfed.org/fed</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveEleventhDistrictIdentifier">
@@ -1142,7 +1132,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;SouthCarolina"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;WestVirginia"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.richmondfed.org/about_us/who_we_are_what_we_do</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.richmondfed.org/about_us/who_we_are_what_we_do</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveFifthDistrictIdentifier">
@@ -1163,7 +1153,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Maine"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Massachusetts"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;NewHampshire"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/aboutthefed/directors/map-of-districts.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://federalreserve.gov/aboutthefed/directors/map-of-districts.htm</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveFirstDistrictIdentifier">
@@ -1185,7 +1175,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Ohio"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;WestVirginia"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.clevelandfed.org/en/about-us/the-cleveland-fed.aspx</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.clevelandfed.org/en/about-us/the-cleveland-fed.aspx</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveFourthDistrictIdentifier">
@@ -1209,7 +1199,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;NorthDakota"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;SouthDakota"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Wisconsin"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.minneapolisfed.org/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.minneapolisfed.org/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveNinthDistrictIdentifier">
@@ -1244,7 +1234,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Connecticut"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;NewJersey"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;NewYork"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.newyorkfed.org/aboutthefed/whatwedo.html</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.newyorkfed.org/aboutthefed/whatwedo.html</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSecondDistrictIdentifier">
@@ -1267,7 +1257,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Iowa"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Michigan"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Wisconsin"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.chicagofed.org/utilities/about-us/index</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.chicagofed.org/utilities/about-us/index</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSeventhDistrictIdentifier">
@@ -1291,7 +1281,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Louisiana"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Mississippi"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Tennessee"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.frbatlanta.org/about/atlantafed.aspx</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.frbatlanta.org/about/atlantafed.aspx</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSixthDistrictIdentifier">
@@ -1312,10 +1302,10 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<skos:definition>central banking system of the U.S., comprised of the Federal Reserve Board, the 12 Federal Reserve Banks, the Federal Open Market Committee, and the national and state member banks</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.federalreserve.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>FRS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The Federal Reserve, the central bank of the United States, provides the nation with a safe, flexible, and stable monetary and financial system.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>Fed</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>Federal Reserve</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>FRS</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The Federal Reserve, the central bank of the United States, provides the nation with a safe, flexible, and stable monetary and financial system.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>Fed</cmns-av:synonym>
+		<cmns-av:synonym>Federal Reserve</cmns-av:synonym>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
@@ -1331,7 +1321,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;NewMexico"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Oklahoma"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Wyoming"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.kansascityfed.org/aboutus/kcfedinformation</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.kansascityfed.org/aboutus/kcfedinformation</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveTenthDistrictIdentifier">
@@ -1352,7 +1342,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Delaware"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;NewJersey"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.philadelphiafed.org/about-the-fed/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.philadelphiafed.org/about-the-fed/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveThirdDistrictIdentifier">
@@ -1382,7 +1372,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Oregon"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Utah"/>
 		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-us;Washington"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.frbsf.org/our-district/about/our-history/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.frbsf.org/our-district/about/our-history/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveTwelfthDistrictIdentifier">
@@ -1401,7 +1391,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency role of the Federal Stability Oversight Council (FSOC)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;FinancialStabilityOversightCouncil"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.treasury.gov/initiatives/fsoc/Pages/home.aspx</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.treasury.gov/initiatives/fsoc/Pages/home.aspx</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FinancialIndustryRegulator">
@@ -1410,7 +1400,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and self-regulatory organizational role of the Financial Industry Regulatory Authority (FINRA)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;FinancialIndustryRegulatoryAuthority"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.finra.org/about/what-we-do</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.finra.org/about/what-we-do</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FinancialIndustryRegulatoryAuthority">
@@ -1419,8 +1409,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>largest non-governmental regulator of securities firms in the United States, namely, the Financial Industry Regulatory Authority (FINRA)</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.finra.org/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>FINRA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.finra.org/about/what-we-do</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>FINRA</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.finra.org/about/what-we-do</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FinancialStabilityOversightCouncil">
@@ -1431,8 +1421,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<skos:definition>Financial Stability Oversight Council (FSOC), which provides comprehensive monitoring of the stability of our nation&apos;s financial system, as established under the Dodd-Frank Wall Street Reform and Consumer Protection Act</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.treasury.gov/initiatives/fsoc/Pages/home.aspx</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>FSOC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The Council is charged with identifying risks to the financial stability of the United States; promoting market discipline; and responding to emerging risks to the stability of the United States&apos; financial system. The Council consists of 10 voting members and 5 nonvoting members and brings together the expertise of federal financial regulators, state regulators, and an independent insurance expert appointed by the President.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>FSOC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The Council is charged with identifying risks to the financial stability of the United States; promoting market discipline; and responding to emerging risks to the stability of the United States&apos; financial system. The Council consists of 10 voting members and 5 nonvoting members and brings together the expertise of federal financial regulators, state regulators, and an independent insurance expert appointed by the President.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
 		<lcc-lr:hasMember rdf:resource="&fibo-fbc-fct-usjrga;CommodityFuturesTradingCommission"/>
 		<lcc-lr:hasMember rdf:resource="&fibo-fbc-fct-usjrga;ConsumerFinancialProtectionBureau"/>
@@ -1476,9 +1466,9 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/ISO/IEC_7812"/>
 		<skos:definition>a numbering system that allows a credit, debit, or other card to be identified as having been issued by a particular financial institution</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>IIN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>IINs are issued directly by the American Banker&apos;s Association (ABA) in the US. The ABA is the Registration Authority (RA) for ISO/IEC 7812, which defines the IIN, in other words.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The issuer identification number (IIN) is a six digit number that is unique to a single card issuer. The number is only used to identify the card issuer, and is not used to identify a particular product, service, or region associated with the card issuer.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>IIN</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>IINs are issued directly by the American Banker&apos;s Association (ABA) in the US. The ABA is the Registration Authority (RA) for ISO/IEC 7812, which defines the IIN, in other words.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The issuer identification number (IIN) is a six digit number that is unique to a single card issuer. The number is only used to identify the card issuer, and is not used to identify a particular product, service, or region associated with the card issuer.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrar">
@@ -1564,7 +1554,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>National Information Center (NIC) registry entry</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>an entry in the the National Information Center (NIC) repository, a repository of financial data and institution characteristics collected by the Federal Reserve System</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/nicweb/NicHome.aspx</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/nicweb/NicHome.aspx</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NationalBankingRegulator">
@@ -1575,7 +1565,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:seeAlso rdf:resource="http://www.occ.gov/"/>
 		<skos:definition>regulatory agency and registration authority role of the Office of the Comptroller of the Currency (OCC)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.occ.gov/about/what-we-do/mission/index-about.html</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.occ.gov/about/what-we-do/mission/index-about.html</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NationalCreditUnionAdministration">
@@ -1586,8 +1576,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<skos:definition>National Credit Union Administration (NCUA), the independent federal agency that regulates, charters and supervises federal credit unions</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ncua.gov/Pages/default.aspx</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>NCUA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>An independent agency of the federal government, the NCUA operates and manages the National Credit Union Share Insurance Fund (NCUSIF), insuring the deposits of more than 98 million account holders in all federal credit unions and the overwhelming majority of state-chartered credit unions.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>NCUA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>An independent agency of the federal government, the NCUA operates and manages the National Credit Union Share Insurance Fund (NCUSIF), insuring the deposits of more than 98 million account holders in all federal credit unions and the overwhelming majority of state-chartered credit unions.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
@@ -1600,7 +1590,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:seeAlso rdf:resource="http://www.ncua.gov/Pages/default.aspx"/>
 		<skos:definition>regulatory agency and registration authority role of the National Credit Union Administration (NCUA)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;NationalCreditUnionAdministration"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ncua.gov/about/Pages/default.aspx</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ncua.gov/about/Pages/default.aspx</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository">
@@ -1610,7 +1600,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<skos:definition>National Information Center (NIC) repository, a repository of financial data and institution characteristics collected by the Federal Reserve System</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/nicweb/NicHome.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveRegulatoryAgencyAndCentralBank"/>
-		<fibo-fnd-utl-av:explanatoryNote>The National Information Center (NIC)repository provides comprehensive information on banks and other institutions for which the Federal Reserve has a supervisory, regulatory, or research interest including both domestic and foreign banking organizations operating in the U.S.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The National Information Center (NIC)repository provides comprehensive information on banks and other institutions for which the Federal Reserve has a supervisory, regulatory, or research interest including both domestic and foreign banking organizations operating in the U.S.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry">
@@ -1679,8 +1669,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<skos:definition>OCC, which charters, regulates, and supervises all national banks and federal savings associations as well as federal branches and agencies of foreign banks. The OCC is an independent bureau of the U.S. Department of the Treasury.</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>OCC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The mission of the OCC is to ensure that national banks and federal savings associations operate in a safe and sound manner, provide fair access to financial services, treat customers fairly, and comply with applicable laws and regulations.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>OCC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The mission of the OCC is to ensure that national banks and federal savings associations operate in a safe and sound manner, provide fair access to financial services, treat customers fairly, and comply with applicable laws and regulations.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
 	</owl:NamedIndividual>
 	
@@ -1692,7 +1682,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<skos:definition>OTS, which is a part of the OCC, responsible for chartering, regulating, and supervising all federal savings associations</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>OTS</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>OTS</cmns-av:abbreviation>
 		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
 	</owl:NamedIndividual>
 	
@@ -1793,7 +1783,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 			</owl:Restriction>
 		</owl:equivalentClass>
 		<skos:definition>federal regulatory agency that is designated as the main agency responsible for oversight of a given institution for an institution</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/nicweb/NicHome.aspx</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/nicweb/NicHome.aspx</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier">
@@ -1815,8 +1805,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="http://www.federalreserve.gov/reportforms/mdrm/pdf/RSSD.PDF"/>
 		<skos:definition>unique identifier assigned by the Federal Reserve to financial institutions for regulatory and oversight purposes</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RSSD ID</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://cdr.ffiec.gov/CDR/Public/CDRHelp/FAQs1205.htm#FAQ16</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>RSSD ID</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://cdr.ffiec.gov/CDR/Public/CDRHelp/FAQs1205.htm#FAQ16</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;RoutingTransitNumber">
@@ -1844,11 +1834,11 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="http://www.accuity.com/aba-registrar/"/>
 		<skos:definition>unique nine digit identifier, used primarily in the United States, to identify a banking or other financial institution for clearing funds, and, as it appears on a check, denotes the banking institution that holds the account from which funds are to be drawn</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RTN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Routing transit numbers are issued by Accuity on behalf of the American Bankers Association (ABA).</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The ABA RTN was originally designed to facilitate the sorting, bundling, and shipment of paper checks back to the drawer&apos;s (check writer&apos;s) account. As new payment methods were developed (ACH and Wire), the system was expanded to accommodate these payment methods.
+		<cmns-av:abbreviation>RTN</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Routing transit numbers are issued by Accuity on behalf of the American Bankers Association (ABA).</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The ABA RTN was originally designed to facilitate the sorting, bundling, and shipment of paper checks back to the drawer&apos;s (check writer&apos;s) account. As new payment methods were developed (ACH and Wire), the system was expanded to accommodate these payment methods.
 
-The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds transfers, and by the Automated Clearing House to process direct deposits, bill payments, and other such automated transfers.</fibo-fnd-utl-av:explanatoryNote>
+The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds transfers, and by the Automated Clearing House to process direct deposits, bill payments, and other such automated transfers.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeCommission">
@@ -1859,11 +1849,11 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<skos:definition>independent commission established by the Securities Act of 1933 and Securities Exchange Act of 1934 whose mission is to protect investors, maintain fair, orderly, and efficient markets, and facilitate capital formation</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sec.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:abbreviation>SEC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The SEC oversees the key participants in the securities world, including securities exchanges, securities brokers and dealers, investment advisors, and mutual funds. Here the SEC is concerned primarily with promoting the disclosure of important market-related information, maintaining fair dealing, and protecting against fraud.
+		<cmns-av:abbreviation>SEC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The SEC oversees the key participants in the securities world, including securities exchanges, securities brokers and dealers, investment advisors, and mutual funds. Here the SEC is concerned primarily with promoting the disclosure of important market-related information, maintaining fair dealing, and protecting against fraud.
  Crucial to the SEC&apos;s effectiveness in each of these areas is its enforcement authority. Each year the SEC brings hundreds of civil enforcement actions against individuals and companies for violation of the securities laws. Typical infractions include insider trading, accounting fraud, and providing false or misleading information about securities and the companies that issue them.
  One of the major sources of information on which the SEC relies to bring enforcement action is investors themselves - another reason that educated and careful investors are so critical to the functioning of efficient markets. To help support investor education, the SEC offers the public a wealth of educational information on this Internet website, which also includes the EDGAR database of disclosure documents that public companies are required to file with the Commission.
- Though it is the primary overseer and regulator of the U.S. securities markets, the SEC works closely with many other institutions, including Congress, other federal departments and agencies, the self-regulatory organizations (e.g. the stock exchanges), state securities regulators, and various private sector organizations. In particular, the Chairman of the SEC, together with the Chairman of the Federal Reserve, the Secretary of the Treasury, and the Chairman of the Commodity Futures Trading Commission, serves as a member of the President&apos;s Working Group on Financial Markets.</fibo-fnd-utl-av:explanatoryNote>
+ Though it is the primary overseer and regulator of the U.S. securities markets, the SEC works closely with many other institutions, including Congress, other federal departments and agencies, the self-regulatory organizations (e.g. the stock exchanges), state securities regulators, and various private sector organizations. In particular, the Chairman of the SEC, together with the Chairman of the Federal Reserve, the Secretary of the Treasury, and the Chairman of the Commodity Futures Trading Commission, serves as a member of the President&apos;s Working Group on Financial Markets.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
@@ -1875,7 +1865,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<skos:definition>regulatory agency and registration authority role of the Securities and Exchange Commission (SEC)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeCommission"/>
 		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;EDGARRepository"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.sec.gov/about/whatwedo.shtml</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.sec.gov/about/whatwedo.shtml</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SouthDakotaBusinessInformationRegistry">
@@ -1996,16 +1986,16 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		</rdfs:subClassOf>
 		<rdfs:label>taxpayer identification number</rdfs:label>
 		<skos:definition>identification number used by the Internal Revenue Service (IRS) in the administration of tax laws in the United States</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>TIN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.irs.gov/individuals/international-taxpayers/taxpayer-identification-numbers-tin</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A TIN must be furnished on returns, statements, and other tax related documents. For example a number must be furnished:
+		<cmns-av:abbreviation>TIN</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.irs.gov/individuals/international-taxpayers/taxpayer-identification-numbers-tin</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A TIN must be furnished on returns, statements, and other tax related documents. For example a number must be furnished:
 - When filing tax returns.
 - When claiming treaty benefits.
 
 A TIN must be on a withholding certificate if the beneficial owner is claiming any of the following:
 - Tax treaty benefits (other than for income from marketable securities)
 - Exemption for effectively connected income
-- Exemption for certain annuities.</fibo-fnd-utl-av:explanatoryNote>
+- Exemption for certain annuities.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;TaxpayerIdentificationNumberingScheme">
@@ -2018,7 +2008,7 @@ A TIN must be on a withholding certificate if the beneficial owner is claiming a
 		</rdfs:subClassOf>
 		<rdfs:label>taxpayer identification numbering scheme</rdfs:label>
 		<skos:definition>tax identification scheme used in the United States</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.irs.gov/individuals/international-taxpayers/taxpayer-identification-numbers-tin</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.irs.gov/individuals/international-taxpayers/taxpayer-identification-numbers-tin</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;ThriftRegulator">
@@ -2027,7 +2017,7 @@ A TIN must be on a withholding certificate if the beneficial owner is claiming a
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and registration authority role of the Office of Thrift Supervision (OTS)</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfThriftSupervision"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.occ.gov/about/what-we-do/mission/index-about.html</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.occ.gov/about/what-we-do/mission/index-about.html</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury">
@@ -2038,8 +2028,8 @@ A TIN must be on a withholding certificate if the beneficial owner is claiming a
 		<skos:definition>U.S. Department of the Treasury, the executive agency responsible for promoting economic prosperity and ensuring the financial security of the United States</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.treasury.gov/Pages/default.aspx</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-utl-av:explanatoryNote>The Department is responsible for a wide range of activities such as advising the President on economic and financial issues, encouraging sustainable economic growth, and fostering improved governance in financial institutions. The Department of the Treasury operates and maintains systems that are critical to the nation&apos;s financial infrastructure, such as the production of coin and currency, the disbursement of payments to the American public, revenue collection, and the borrowing of funds necessary to run the federal government. The Department works with other federal agencies, foreign governments, and international financial institutions to encourage global economic growth, raise standards of living, and to the extent possible, predict and prevent economic and financial crises. The Treasury Department also performs a critical and far-reaching role in enhancing national security by implementing economic sanctions against foreign threats to the U.S., identifying and targeting the financial support networks of national security threats, and improving the safeguards of our financial systems.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>Treasury Department</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>The Department is responsible for a wide range of activities such as advising the President on economic and financial issues, encouraging sustainable economic growth, and fostering improved governance in financial institutions. The Department of the Treasury operates and maintains systems that are critical to the nation&apos;s financial infrastructure, such as the production of coin and currency, the disbursement of payments to the American public, revenue collection, and the borrowing of funds necessary to run the federal government. The Department works with other federal agencies, foreign governments, and international financial institutions to encourage global economic growth, raise standards of living, and to the extent possible, predict and prevent economic and financial crises. The Treasury Department also performs a critical and far-reaching role in enhancing national security by implementing economic sanctions against foreign threats to the U.S., identifying and targeting the financial support networks of national security threats, and improving the safeguards of our financial systems.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>Treasury Department</cmns-av:synonym>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
@@ -2049,7 +2039,7 @@ A TIN must be on a withholding certificate if the beneficial owner is claiming a
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Financial Institutions Examination Council (FFIEC)&apos;s Uniform Bank Performance Report (UBPR) Repository, a repository of institution characteristics and analytical tool created for bank supervisory, examination, and management purposes</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalFinancialInstitutionsExaminationRegulator"/>
-		<fibo-fnd-utl-av:explanatoryNote>In a concise format, it shows the impact of management decisions and economic conditions on a bank&apos;s performance and balance-sheet composition. The performance and composition data contained in the report can be used as an aid in evaluating the adequacy of earnings, liquidity, capital, asset and liability management, and growth management. Bankers and examiners alike can use this report to further their understanding of a bank&apos;s financial condition, and through such understanding, perform their duties more effectively.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In a concise format, it shows the impact of management decisions and economic conditions on a bank&apos;s performance and balance-sheet composition. The performance and composition data contained in the report can be used as an aid in evaluating the adequacy of earnings, liquidity, capital, asset and liability management, and growth management. Bankers and examiners alike can use this report to further their understanding of a bank&apos;s financial condition, and through such understanding, perform their duties more effectively.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-usjrga;hasPrimaryFederalRegulator">

--- a/FBC/FunctionalEntities/RegistrationAuthorities.rdf
+++ b/FBC/FunctionalEntities/RegistrationAuthorities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
@@ -17,10 +18,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
@@ -38,21 +39,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 		<rdfs:label>Registration Authorities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts for representation of registration authorities, registrars, registration-specific identifiers and related identification schemes, and registration authorities specific to ISO and the financial industry. Examples of financial industry registration authorities in the US include the Federal Deposit Insurance Corporation (FDIC) and the Securities Exchange Commission (SEC).</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-fct-ra</sm:fileAbbreviation>
-		<sm:filename>RegistrationAuthorities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
@@ -62,15 +54,19 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/RegistrationAuthorities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/RegistrationAuthorities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified as a part of organizational hierarchy simplification, to loosen the definition of registrar, and to leverage the composite date value datatype.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190201/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, make Registry a subclass of Record and StructuredCollection, make RegistryEntry a child of CollectionConstituent and correct a misspelled annotation.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to replace isAppointedBy with isDesignatedBy due to a property name change in Relations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to clarify the definition of registry identifier, eliminate an unnecessary restriction on registry identifier, and refine the definition of registry entry and hasRegistrationDate based on usage.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211101/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/RegistrationAuthorities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-ra;Registrar">
@@ -107,7 +103,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>registrar</rdfs:label>
 		<skos:definition>party that has the capacity to act as a representative of a registration authority to provide registration services, including official record keeping</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economic Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economic Terms, Fifth Edition, 2012</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-ra;RegistrationAuthority">
@@ -147,7 +143,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>registration authority</rdfs:label>
 		<skos:definition>service provider that is responsible for maintaining a registry and provides registration services</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RA</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>RA</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-ra;RegistrationCapacity">
@@ -215,8 +211,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>registry</rdfs:label>
 		<skos:definition>authoritative record or collection of records relating to something</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Electronic registries typically contain a unique identifier for each entry, so that individual records can be referenced from other documents and registries.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>register</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Electronic registries typically contain a unique identifier for each entry, so that individual records can be referenced from other documents and registries.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>register</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-ra;RegistryEntry">

--- a/FBC/FunctionalEntities/RegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/RegulatoryAgencies.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
@@ -25,10 +26,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
@@ -54,21 +55,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
 		<rdfs:label>Regulatory Agencies Ontology</rdfs:label>
 		<dct:abstract>This ontology defines general purpose concepts for representation of regulatory agencies, also known as regulatory authorities or regulators. Examples of financial industry regulatory agencies in the US include the Securities Exchange Commission, FINRA, and the FDIC, among others. The SEC and FINRA are both registration authorities and regulatory agencies. The FDIC is a regulatory agency and an insurer, and may be a registration authority for certain state-chartered banks in the US without bank holding companies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:resource="https://www.omg.org/spec/LCC/"/>
-		<sm:fileAbbreviation>fibo-fbc-fct-rga</sm:fileAbbreviation>
-		<sm:filename>RegulatoryAgencies.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
@@ -87,15 +79,19 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20211001/FunctionalEntities/RegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/RegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified per the FIBO 2.0 RFC, including deprecation of the hasJurisdiction property that was duplicated in BE via the BE 1.1 RTF.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified as a part of organizational hierarchy simplification.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to eliminate deprecated elements and duplication of concepts with LCC, and remove a redundant superclass declaration on GovernmentIssuedLicense.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to add the concept of a tax authority.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201101/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to clean up the definition of regulatory agency.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211001/FunctionalEntities/RegulatoryAgencies.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211001/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-rga;Examiner">
@@ -129,8 +125,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>examiner</rdfs:label>
 		<skos:definition>a party empowered as an official representative by a regulatory agency to investigate and review specified documents for accuracy and truthfulness</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Black&apos;s Law Dictionary, see http://thelawdictionary.org/examiner/</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Black&apos;s Law Dictionary, see http://thelawdictionary.org/examiner/</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>EDM Council</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-rga;GovernmentIssuedLicense">
@@ -143,7 +139,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>government-issued license</rdfs:label>
 		<skos:definition>grant of permission needed to legally perform some task, provide some service, exercise a certain privilege, or pursue some business or occupation</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-rga;RegulationIdentificationScheme">
@@ -209,12 +205,12 @@
 		<rdfs:label>regulatory agency</rdfs:label>
 		<skos:definition>public authority or government agency responsible for exercising authority over something in a regulatory or supervisory capacity</skos:definition>
 		<skos:example>See http://www.finra.org/AboutFINRA/ for an example describing a regulatory agency.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>http://en.wikipedia.org/wiki/Regulatory_agency</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.thefreedictionary.com/regulatory+agency</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Typically, a regulatory agency is chartered to protect some constituancy, (e.g., investors in the financial industry), to ensure the fairness and integrity of some market (e.g., the securities market), and fair and safe business practices among the service providers in that market.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>regulator</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>regulatory authority</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>regulatory body</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>http://en.wikipedia.org/wiki/Regulatory_agency</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>http://www.thefreedictionary.com/regulatory+agency</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Typically, a regulatory agency is chartered to protect some constituancy, (e.g., investors in the financial industry), to ensure the fairness and integrity of some market (e.g., the securities market), and fair and safe business practices among the service providers in that market.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>regulator</cmns-av:synonym>
+		<cmns-av:synonym>regulatory authority</cmns-av:synonym>
+		<cmns-av:synonym>regulatory body</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-rga;RegulatoryCapacity">
@@ -246,7 +242,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>regulatory report</rdfs:label>
 		<skos:definition>a report required to support operational transparency that demonstrates compliance with some specification, law, policy, restriction, or other rule specified by a regulatory agency</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Such a report may be needed for licensing, monitoring, taxation, or for other purposes that demonstrate the integrity, fairness, safety, or other capacity of a given industry, organization, or product</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Such a report may be needed for licensing, monitoring, taxation, or for other purposes that demonstrate the integrity, fairness, safety, or other capacity of a given industry, organization, or product</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-rga;RegulatoryService">
@@ -284,8 +280,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>tax authority</rdfs:label>
 		<skos:definition>regulatory agency that has jurisdiction over the assessment, determination, collection, imposition and other aspects of any tax</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.collinsdictionary.com/dictionary/english/tax-authority</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.lawinsider.com/dictionary/tax-authority</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.collinsdictionary.com/dictionary/english/tax-authority</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.lawinsider.com/dictionary/tax-authority</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-rga;isRegulatedBy">
@@ -298,7 +294,7 @@
 		<rdfs:label>regulates</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fct-rga;RegulatoryAgency"/>
 		<skos:definition>has regulatory authority over or directs according to rule or law, typically an industry, organization, or product</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.merriam-webster.com/dictionary/regulate</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>http://www.merriam-webster.com/dictionary/regulate</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-lcap;Regulation">

--- a/FBC/MetadataFBC.rdf
+++ b/FBC/MetadataFBC.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-mod "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/MetadataFBCDebtAndEquities/">
 	<!ENTITY fibo-fbc-fct-mod "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MetadataFBCFunctionalEntities/">
@@ -11,10 +12,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-mod="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/MetadataFBCDebtAndEquities/"
 	xmlns:fibo-fbc-fct-mod="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MetadataFBCFunctionalEntities/"
@@ -26,31 +27,49 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/">
 		<rdfs:label>Metadata about the EDMC-FIBO Financial Business and Commerce (FBC) Domain</rdfs:label>
 		<dct:abstract>This ontology provides metadata about the FIBO Financial Business and Commerce (FBC) Domain, which covers business concepts that are common to common to a number of finance domain areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-fbc-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataFBC.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/MetadataFBCDebtAndEquities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/MetadataFBCFinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MetadataFBCFunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/MetadataFBC/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/MetadataFBC/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-mod;FBCDomain">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Financial Business and Commerce</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>financial business and commerce domain</rdfs:label>
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Capacity Post, Inc.</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
 		<dct:creator rdf:datatype="&xsd;anyURI">https://wiki.edmcouncil.org/pages/viewpage.action?pageId=786677</dct:creator>
 		<dct:hasPart rdf:resource="&fibo-fbc-dae-mod;DebtAndEquitiesModule"/>
 		<dct:hasPart rdf:resource="&fibo-fbc-fi-mod;FinancialInstrumentsModule"/>
@@ -58,39 +77,10 @@
 		<dct:hasPart rdf:resource="&fibo-fbc-pas-mod;FBCProductsAndServicesModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain</dct:title>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>financial products</sm:keyword>
-		<sm:keyword>financial services, service providers, and accounts</sm:keyword>
-		<sm:keyword>markets</sm:keyword>
-		<sm:keyword>registration authorities</sm:keyword>
-		<sm:keyword>regulatory agencies</sm:keyword>
-		<sm:moduleAbbreviation>fibo-fbc</sm:moduleAbbreviation>
+		<dct:title>FIBO FBC Domain</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FBC/ProductsAndServices/CardAccounts.rdf
+++ b/FBC/ProductsAndServices/CardAccounts.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -23,10 +24,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -50,24 +51,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/">
 		<rdfs:label>Card Accounts Ontology</rdfs:label>
 		<dct:abstract>This ontology defines account-related concepts that are specific to credit and debit cards.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-pas-crd</sm:fileAbbreviation>
-		<sm:filename>CardAccounts.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
@@ -83,10 +72,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;AmericanExpressNetwork">
@@ -142,16 +134,16 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
 		<rdfs:label>card authentication value</rdfs:label>
 		<skos:definition>card verification value specifically for JCB payment cards</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CAV</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>CAV</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardAuthenticationValue2">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
 		<rdfs:label>card authentication value 2</rdfs:label>
 		<skos:definition>card verification value specifically for JCB payment cards</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>CAV2</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
+		<cmns-av:synonym>CAV2</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardExpirationDate">
@@ -164,8 +156,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
 		<rdfs:label>card identification number</rdfs:label>
 		<skos:definition>card verification value specifically for American Express and Discover payment cards</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CID</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>CID</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardProduct">
@@ -212,24 +204,24 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
 		<rdfs:label>card security code</rdfs:label>
 		<skos:definition>card verification value specifically for American Express payment cards</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CSC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>CSC</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardValidationCode">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
 		<rdfs:label>card validation code</rdfs:label>
 		<skos:definition>card verification code specifically for Mastercard payment cards</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PAN CVC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>PAN CVC</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardValidationCode2">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
 		<rdfs:label>card validation code 2</rdfs:label>
 		<skos:definition>card verification value specifically for Mastercard payment cards</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PAN CVC2</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>PAN CVC2</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardVerificationCodeOrValue">
@@ -249,23 +241,23 @@
 		</rdfs:subClassOf>
 		<rdfs:label>card verification code or value</rdfs:label>
 		<skos:definition>code that specifies either (1) magnetic-stripe data, or (2) printed security features that are used to protect data integrity and limit alteration, counterfeiting and fraud generally</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardVerificationValue">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
 		<rdfs:label>card verification value</rdfs:label>
 		<skos:definition>card verification value specifically for Visa and Discover payment cards</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CVV</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>CVV</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardVerificationValue2">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
 		<rdfs:label>card verification value 2</rdfs:label>
 		<skos:definition>card verification value specifically for Visa payment cards</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>CVV2</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
+		<cmns-av:synonym>CVV2</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;Cardholder">
@@ -300,7 +292,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>cardholder</rdfs:label>
 		<skos:definition>account holder to whom a payment card is issued</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCard">
@@ -320,7 +312,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>credit card</rdfs:label>
 		<skos:definition>card issued by a financial service provider that enables the cardholder to borrow funds</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Issuance of credit cards has the condition that the cardholder will pay back the original, borrowed amount plus any additional agreed-upon charges. The credit company provider may also grant a line of credit (LOC) to the cardholder which allows the holder to borrow money in the form of a cash advance. The issuer pre-sets borrowing limits which have a basis on the individual&apos;s credit rating.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Issuance of credit cards has the condition that the cardholder will pay back the original, borrowed amount plus any additional agreed-upon charges. The credit company provider may also grant a line of credit (LOC) to the cardholder which allows the holder to borrow money in the form of a cash advance. The issuer pre-sets borrowing limits which have a basis on the individual&apos;s credit rating.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardAccount">
@@ -495,22 +487,22 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:label>issuing financial institution</rdfs:label>
 		<skos:definition>issuer and financial services provider that issues payment cards or performs, facilitates, or supports issuing services including but not limited to issuing banks and issuing processors</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>issuing bank</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
+		<cmns-av:synonym>issuing bank</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;JCBNetwork">
 		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
 		<rdfs:label>JCB network</rdfs:label>
 		<skos:definition>credit card network based in Japan, with coverage throughout Asia, with strategic partners worldwide</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>JCB Co., Ltd., (formerly Japan Credit Bureau) is a credit card company based in Tokyo, Japan. As of 2020, it operates in 23 countries with over 130 million customers. In the United States, it is not a primary credit card network but has an association with the Discover Network to enable use of JCB cards.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>JCB Co., Ltd., (formerly Japan Credit Bureau) is a credit card company based in Tokyo, Japan. As of 2020, it operates in 23 countries with over 130 million customers. In the United States, it is not a primary credit card network but has an association with the Discover Network to enable use of JCB cards.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
 		<rdfs:label>magnetic stripe verification code or value</rdfs:label>
 		<skos:definition>card verification code on a card&apos;s magnetic stripe that uses secure cryptographic processes to protect data integrity on the stripe, and reveals any alteration or counterfeiting</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;MastercardNetwork">
@@ -551,8 +543,8 @@
 		<rdfs:label>payment card</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.irs.gov/payments/payment-card-transactions-faqs"/>
 		<skos:definition>legal document issued by a financial services provider that enables the cardholder to access the funds in the customer&apos;s designated bank accounts, or through a credit account and make payments by electronic funds transfer and access automated teller machines (ATMs)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>For purposes of Payment Card Industry Data Security Standard (PCI DSS), a payment card is any payment card/device that bears the logo of the founding members of PCI SSC, which are American Express, Discover Financial Services, JCB International, MasterCard, or Visa, Inc.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The term payment card includes credit cards, debit cards, and stored-value cards, as well as payment through any distinctive marks of a payment card (such as a credit card number). A payment card is issued under an agreement that provides standards and mechanisms for settling the transactions between a merchant acquiring bank or similar entity and the providers who accept the cards as payment.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>For purposes of Payment Card Industry Data Security Standard (PCI DSS), a payment card is any payment card/device that bears the logo of the founding members of PCI SSC, which are American Express, Discover Financial Services, JCB International, MasterCard, or Visa, Inc.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The term payment card includes credit cards, debit cards, and stored-value cards, as well as payment through any distinctive marks of a payment card (such as a credit card number). A payment card is issued under an agreement that provides standards and mechanisms for settling the transactions between a merchant acquiring bank or similar entity and the providers who accept the cards as payment.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;PaymentCardAgreement">
@@ -597,24 +589,24 @@
 		</rdfs:subClassOf>
 		<rdfs:label>primary card account number</rdfs:label>
 		<skos:definition>composite identifier of 14 or 16 digits embossed on a bank or payment card and encoded in the card&apos;s magnetic strip</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PAN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The PAN identifies the issuer of the card and the account including part of the account number, and contains a check digit that verifies the authenticity of the embossed account number.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>primary account number</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>PAN</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The PAN identifies the issuer of the card and the account including part of the account number, and contains a check digit that verifies the authenticity of the embossed account number.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>primary account number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;SmartCard">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
 		<rdfs:label>smart card</rdfs:label>
 		<skos:definition>payment card that has integrated circuits embedded within it</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The circuits, also referred to as the &apos;chip,&apos; contain payment card data including but not limited to data equivalent to the magnetic-stripe data.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The circuits, also referred to as the &apos;chip,&apos; contain payment card data including but not limited to data equivalent to the magnetic-stripe data.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
 		<rdfs:label>three-digit verification code or value</rdfs:label>
 		<skos:definition>card verification code that is the rightmost three-digit value printed in the signature panel area on the back of the card</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;VisaNetwork">

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
@@ -31,10 +32,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
@@ -66,26 +67,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 		<rdfs:label>Clients and Accounts Ontology</rdfs:label>
 		<dct:abstract>This ontology provides basic concepts such as account, account holder, account provider, relationship manager that are commonly used by financial services providers to describe customers and to determine counterparty identities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:fileAbbreviation>fibo-fbc-pas-caa</sm:fileAbbreviation>
-		<sm:filename>ClientsAndAccounts.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
@@ -109,9 +96,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/ProductsAndServices/ClientsAndAccounts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised per the FIBO 2.0 RFC with respect to the definitions for accounts and account identifiers, such as BBAN and IBAN identifiers, including but not limited to bank accounts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to support the addition of maturity-related properties to financial instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181101/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
@@ -126,7 +114,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to reflect the move of hasTerm from FinancialInstruments to Contracts and add the definition of a lending officer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220101/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to link a credit agreement with an account and loosen transaction-related constraints such that the notion of a transaction can be applied to credit agreements generally.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220301/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to clean up dead links and address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;CreditAgreement">
@@ -189,7 +180,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>account</rdfs:label>
 		<skos:definition>container for records associated with a business arrangement for regular transactions and services</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In general, an account is associated with a contractual relationship between a buyer and seller under which payment may be made at a later time. General ledger accounts are an exception to this, however, and typically do not have account holders, including internal account holders. They may, on the other hand, have responsible parties.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In general, an account is associated with a contractual relationship between a buyer and seller under which payment may be made at a later time. General ledger accounts are an exception to this, however, and typically do not have account holders, including internal account holders. They may, on the other hand, have responsible parties.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountAsAnAsset">
@@ -242,8 +233,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>account holder</rdfs:label>
 		<skos:definition>party that owns an account</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>An account holder is named on the account and is authorized to conduct transactions associated with the account. Authorization is typically evidenced by signatures maintained on file by the account provider.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Note that this concept of account holder applies to internal accounts that are non-general ledger accounts also have account holders, such as payroll accounts, internal checking accounts associated with cashier&apos;s checks, and so forth.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>An account holder is named on the account and is authorized to conduct transactions associated with the account. Authorization is typically evidenced by signatures maintained on file by the account provider.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that this concept of account holder applies to internal accounts that are non-general ledger accounts also have account holders, such as payroll accounts, internal checking accounts associated with cashier&apos;s checks, and so forth.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountIdentifier">
@@ -257,8 +248,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>account identifier</rdfs:label>
 		<skos:definition>identifier that denotes an account</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>account number</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</cmns-av:adaptedFrom>
+		<cmns-av:synonym>account number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountOwnership">
@@ -319,7 +310,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>account-specific service agreement</rdfs:label>
 		<skos:definition>service-agreement that is account-specific, applicable in cases where a client might hold multiple accounts with differing terms and conditions</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Customers of financial service providers frequently hold multiple accounts - brokerage accounts, checking and savings accounts, trust accounts, and so forth - which may have specific terms and conditions associated with them.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Customers of financial service providers frequently hold multiple accounts - brokerage accounts, checking and savings accounts, trust accounts, and so forth - which may have specific terms and conditions associated with them.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountStatement">
@@ -361,7 +352,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>account statement</rdfs:label>
 		<skos:definition>periodic summary of account activity for a given period of time</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Common kinds of account statements include checking account statements, usually provided monthly, and brokerage account statements, which are provided monthly or quarterly, depending on the terms of the account agreement. Monthly credit card bills are also considered account statements.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Common kinds of account statements include checking account statements, usually provided monthly, and brokerage account statements, which are provided monthly or quarterly, depending on the terms of the account agreement. Monthly credit card bills are also considered account statements.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountingTransaction">
@@ -374,7 +365,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<rdfs:label>balance</rdfs:label>
 		<skos:definition>amount of money available or owed</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The balance is the net amount after factoring in all debits and credits, including service charges and fees.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The balance is the net amount after factoring in all debits and credits, including service charges and fees.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;BankAccountIdentifier">
@@ -388,8 +379,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>bank account identifier</rdfs:label>
 		<skos:definition>identifier that identifies a demand deposit account provided by a bank</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>bank account number</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</cmns-av:adaptedFrom>
+		<cmns-av:synonym>bank account number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;BankIdentifier">
@@ -403,8 +394,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>bank identifier</rdfs:label>
 		<skos:definition>identifier that uniquely identifies the financial institution and, when appropriate, the branch of that financial institution servicing an account</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>bank number</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</cmns-av:adaptedFrom>
+		<cmns-av:synonym>bank number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;BasicBankAccountIdentifier">
@@ -426,9 +417,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>basic bank account identifier</rdfs:label>
 		<skos:definition>identifier that uniquely identifies an individual account at a specific financial institution in a particular country and which includes a bank identifier of the financial institution servicing that account</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>BBAN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>basic bank account number</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>BBAN</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</cmns-av:adaptedFrom>
+		<cmns-av:synonym>basic bank account number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;BrokerageAccount">
@@ -452,7 +443,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>brokerage account</rdfs:label>
 		<skos:definition>account offered by a broker that allows the investor to deposit funds and place investment orders</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The investor owns the assets contained in the brokerage account and must usually claim as income any capital gains incurred.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The investor owns the assets contained in the brokerage account and must usually claim as income any capital gains incurred.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;CertificateOfDeposit">
@@ -480,8 +471,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">certificate of deposit</rdfs:label>
 		<skos:definition xml:lang="en">cash instrument associated with a time deposit account that cannot be withdrawn for a certain period of time (term)</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CD</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>When the term is over it can be withdrawn or it can be held for another term. The longer the term the better the yield on the money.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>CD</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>When the term is over it can be withdrawn or it can be held for another term. The longer the term the better the yield on the money.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;CloseDate">
@@ -543,7 +534,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>customer account</rdfs:label>
 		<skos:definition>account that represents an identified, named collection of balances and cumulative totals used to summarize customer transaction-related activity over a designated period of time</skos:definition>
-		<fibo-fnd-utl-av:synonym>financial service account</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>financial service account</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;CustomerAccountHolder">
@@ -572,8 +563,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;TransactionDepositAccount"/>
 		<rdfs:label>demand deposit account</rdfs:label>
 		<skos:definition>non-interest-bearing deposit account in which deposits are payable immediately on demand, or that are issued with an original maturity or required notice period of less than seven days, or that represent funds for which the depository institution does not reserve the right to require at least seven days&apos; written notice of an intended withdrawal</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>DDA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Demand deposits include any matured time deposits without automatic renewal provisions, unless the deposit agreement provides for the funds to be transferred at maturity to another type of account. Demand deposits do not include: (i) money market deposit accounts (MMDAs) or (ii) NOW accounts.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>DDA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Demand deposits include any matured time deposits without automatic renewal provisions, unless the deposit agreement provides for the funds to be transferred at maturity to another type of account. Demand deposits do not include: (i) money market deposit accounts (MMDAs) or (ii) NOW accounts.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;DepositAccount">
@@ -588,7 +579,7 @@
 		<rdfs:label>deposit account</rdfs:label>
 		<skos:definition>account that provides a record of money placed with a depository institution for safekeeping and management</skos:definition>
 		<skos:example>Deposit accounts include savings accounts, money market accounts, and transactional accounts, such as demand deposit accounts, among others.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote>The account holder has the right to withdraw deposited funds, as set forth in the terms and conditions governing the account agreement. Deposit accounts may be insured up to a certain amount, depending on the jurisdiction.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The account holder has the right to withdraw deposited funds, as set forth in the terms and conditions governing the account agreement. Deposit accounts may be insured up to a certain amount, depending on the jurisdiction.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;Fee">
@@ -713,11 +704,11 @@
 		<rdfs:label>international bank account identifier</rdfs:label>
 		<skos:definition>identifier for a bank account that is an expanded version of the basic bank account number (BBAN), intended for use internationally</skos:definition>
 		<skos:example>For an account in Switzerland, suppose that an example domestic account number is 762 1162-3852.957. Suppose further that the bank identifier portion of that domestic account number is 762, or normalized for the BBAN is &apos;00762&apos;. For that example, the corresponding BBAN is &apos;00762011623852957&apos; and IBAN is &apos;CH9300762011623852957&apos;.</skos:example>
-		<fibo-fnd-utl-av:abbreviation>IBAN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Note that international bank account numbers are formatted uniquely by country. A description of the country-specific formats is available from SWIFT (https://www.swift.com/), which is the ISO registrar for ISO 13616.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The IBAN structure is defined in ISO 13616-1 and consists of a two-letter ISO 3166-1 country code, followed by two check digits and up to thirty alphanumeric characters for a BBAN (Basic Bank Account Number) which has a fixed length per country and, included within it, a bank identifier with a fixed position and a fixed length per country. The check digits are calculated based on the scheme defined in ISO/IEC 7064 (MOD97-10).</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>international bank account number</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>IBAN</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Note that international bank account numbers are formatted uniquely by country. A description of the country-specific formats is available from SWIFT (https://www.swift.com/), which is the ISO registrar for ISO 13616.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The IBAN structure is defined in ISO 13616-1 and consists of a two-letter ISO 3166-1 country code, followed by two check digits and up to thirty alphanumeric characters for a BBAN (Basic Bank Account Number) which has a fixed length per country and, included within it, a bank identifier with a fixed position and a fixed length per country. The check digits are calculated based on the scheme defined in ISO/IEC 7064 (MOD97-10).</cmns-av:explanatoryNote>
+		<cmns-av:synonym>international bank account number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;InvestmentAccount">
@@ -730,14 +721,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>investment account</rdfs:label>
 		<skos:definition>account that provides a record of deposits of funds and/or securities held at a financial institution</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The typical objectives of an investment account are to achieve long term growth, income or capital preservation from the deposited asset portfolio. Investment accounts are typically not insured.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The typical objectives of an investment account are to achieve long term growth, income or capital preservation from the deposited asset portfolio. Investment accounts are typically not insured.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;InvestmentOrDepositAccount">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Account"/>
 		<rdfs:label>investment or deposit account</rdfs:label>
 		<skos:definition>account associated with a product or service that requires the account holder to provide funds for management by the account provider</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The account holder may or may not be entitled to consideration in exchange for providing such funds, for example, interest, depending on the type of account and the terms and conditions associated with it. Also, there may be fees associated with management services provided by the account provider. Note too that this may be an internal account held on behalf of an institution or a customer account.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The account holder may or may not be entitled to consideration in exchange for providing such funds, for example, interest, depending on the type of account and the terms and conditions associated with it. Also, there may be fees associated with management services provided by the account provider. Note too that this may be an internal account held on behalf of an institution or a customer account.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;LedgerAccount">
@@ -758,7 +749,7 @@
 		<rdfs:label>loan or credit account</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-pas-caa;InvestmentOrDepositAccount"/>
 		<skos:definition>account associated with a service in which the account holder receives funds from the account provider under certain terms and conditions for repayment</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Note that this may be an internal account held on behalf of an institution or a customer account, such as a line of credit account associated with an internal line of business.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that this may be an internal account held on behalf of an institution or a customer account, such as a line of credit account associated with an internal line of business.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;NonTransactionDepositAccount">
@@ -766,7 +757,7 @@
 		<rdfs:label>non-transaction deposit account</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-pas-caa;TransactionDepositAccount"/>
 		<skos:definition>any deposit account that is not explicitly considered a transaction account</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Non-transaction accounts include: (a) savings deposits ((i) money market deposit accounts (MMDAs) and (ii) other savings deposits) and (b) time deposits ((i) time certificates of deposit and (ii) time deposits, open account).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Non-transaction accounts include: (a) savings deposits ((i) money market deposit accounts (MMDAs) and (ii) other savings deposits) and (b) time deposits ((i) time certificates of deposit and (ii) time deposits, open account).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;OpenDate">
@@ -797,7 +788,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>relationship manager</rdfs:label>
 		<skos:definition>responsible party who manages a client&apos;s account and oversees their relationship with the service provider</skos:definition>
-		<fibo-fnd-utl-av:synonym>account manager</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>account manager</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;TimeCertificateOfDepositAccount">
@@ -810,7 +801,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>time certificate of deposit account</rdfs:label>
 		<skos:definition>time deposit account that allows deposits evidenced by a negotiable or nonnegotiable instrument, or a deposit in book entry form evidenced by a receipt or similar acknowledgement issued by the bank, that provides, on its face, that the amount of such deposit is payable to the bearer, to any specified person, or to the order of a specified person, as follows: (1) on a certain date not less than seven days after the date of deposit, (2) at the expiration of a specified period not less than seven days after the date of the deposit, or (3) upon written notice to the bank which is to be given not less than seven days before the date of withdrawal.</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CDA</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>CDA</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;TimeDepositAccount">
@@ -818,7 +809,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ContractualProduct"/>
 		<rdfs:label>time deposit account</rdfs:label>
 		<skos:definition>deposit account that the depositor does not have a right, and is not permitted, to make withdrawals from within six days after the date of deposit unless the deposit is subject to an early withdrawal penalty of at least seven days&apos; simple interest on amounts withdrawn within the first six days after deposit</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A time deposit from which partial early withdrawals are permitted must impose additional early withdrawal penalties of at least seven days&apos; simple interest on amounts withdrawn within six days after each partial withdrawal. If such additional early withdrawal penalties are not imposed, the account ceases to be a time deposit. The account may become a savings deposit if it meets the requirements for a savings deposit; otherwise it becomes a demand deposit.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A time deposit from which partial early withdrawals are permitted must impose additional early withdrawal penalties of at least seven days&apos; simple interest on amounts withdrawn within six days after each partial withdrawal. If such additional early withdrawal penalties are not imposed, the account ceases to be a time deposit. The account may become a savings deposit if it meets the requirements for a savings deposit; otherwise it becomes a demand deposit.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;TimeDepositOpenAccount">
@@ -859,7 +850,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;DepositAccount"/>
 		<rdfs:label>transaction deposit account</rdfs:label>
 		<skos:definition>deposit account from which the depositor / account holder is permitted to make transfers or withdrawals by negotiable / transferable instruments, payment orders of withdrawal, telephone transfers, and so forth, and that may be accessible via an electronic device such as an automated teller machine (ATM), remote service unit (RSU), mobile device, and by debit card</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Excluded from transaction accounts are savings deposits (both money market deposit accounts (MMDAs) and other savings deposits), even though such deposits permit some third-party transfers. However, an account that otherwise meets the definition of a savings deposit but that authorizes or permits the depositor to exceed the transfer limitations specified for that account shall be reported as a transaction account.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Excluded from transaction accounts are savings deposits (both money market deposit accounts (MMDAs) and other savings deposits), even though such deposits permit some third-party transfers. However, an account that otherwise meets the definition of a savings deposit but that authorizes or permits the depositor to exceed the transfer limitations specified for that account shall be reported as a transaction account.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionIdentifier">
@@ -930,7 +921,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>transaction record</rdfs:label>
 		<skos:definition>record of transactions associated with an account</skos:definition>
-		<fibo-fnd-utl-av:usageNote>The date a particular transaction record is closed typically corresponds to (and may precede) the date the account is closed, though in the case of certain accounts, such as a credit card account, if a customer is issued a new account or card number due to loss, fraud, or for some other reason, it is possible that multiple transaction records would be associated with the account. In that case, the close date might correspond to the date that a hold was placed on the original account.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>The date a particular transaction record is closed typically corresponds to (and may precede) the date the account is closed, though in the case of certain accounts, such as a credit card account, if a customer is issued a new account or card number due to loss, fraud, or for some other reason, it is possible that multiple transaction records would be associated with the account. In that case, the close date might correspond to the date that a hold was placed on the original account.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionRecordIdentifier">
@@ -1040,8 +1031,8 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
 		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;CustomerAccountHolder"/>
 		<skos:definition>relates an account to a client or customer that is considered the primary owner of the account</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Note that for many financial institutions, there must be a client or customer designated as the primary owner. In cases where there is a tax identifier associated with the account, it is that of the primary owner.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>has primary account owner</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Note that for many financial institutions, there must be a client or customer designated as the primary owner. In cases where there is a tax identifier associated with the account, it is that of the primary owner.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>has primary account owner</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasSecondaryAccountHolder">
@@ -1050,8 +1041,8 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
 		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;CustomerAccountHolder"/>
 		<skos:definition>relates an account to a client or customer that is considered a secondary, co-owner of the account</skos:definition>
-		<fibo-fnd-utl-av:synonym>has account co-owner</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>has secondary account owner</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>has account co-owner</cmns-av:synonym>
+		<cmns-av:synonym>has secondary account owner</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasStartingBalance">

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -35,10 +36,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -74,22 +75,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 		<rdfs:label>Financial Products and Services Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts that extend the Foundations (FND) Products and Services concepts specifically for the financial industry, including financial product, financial service, and financial service provider.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-fbc-pas-fpas</sm:fileAbbreviation>
-		<sm:filename>FinancialProductsAndServices.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
@@ -117,9 +108,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/ProductsAndServices/FinancialProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified by the FIBO 2.0 RFC, including, but not limited to, the addition of lifecycle events, concepts related to trade settlement, and the definition of a unique transaction identifier (UTI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified as a part of organizational hierarchy simplification and to correct a logical inconsistency with respect to the representation of baskets.</skos:changeNote>
@@ -133,7 +125,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210601/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to add a property to describe the criteria for including something in a basket, if that criteria is known, and to point to a party that is responsible for determining that criteria.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210901/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to fix spelling errors.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to revise the definition of a unique transaction identifier to align with ISO 23897 and to address text formatting issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/ProductsAndServices/FinancialProductsAndServices.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;AgencyAgreement">
@@ -155,7 +150,7 @@
 		<rdfs:seeAlso rdf:resource="http://www.law.cornell.edu/wex/agent_for_service_of_process"/>
 		<rdfs:seeAlso rdf:resource="http://www.sos.state.tx.us/corp/registeredagents.shtml"/>
 		<skos:definition>a registered agent (person or organization) designated by a business entity, such as a corporation, to receive legal correspondence on behalf of the business entity in the jurisdiction in which the agent&apos;s address is located</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The person may be an officer of the corporation or a third party, such as the corporation&apos;s attorney, or a company providing such agency services.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The person may be an officer of the corporation or a third party, such as the corporation&apos;s attorney, or a company providing such agency services.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;AmendedTrade">
@@ -188,8 +183,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>basket</rdfs:label>
 		<skos:definition>collection of goods, services, or other things (e.g., financial contracts) that can be purchased and sold in some marketplace</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A basket may be associated with a specific market sector, and may be delineated for the purposes of statistical analysis, such as for calculating CPI. According to the US Bureau of Labor Statistics (BLS), with respect to the CPI, a market basket is a package of goods and services that consumers purchase for day-to-day living. The weight of each item is based on the amount of expenditure reported by a sample of households.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>From a securities perspective, a basket is a collection of products or securities that are designated to mimic the performance of a market. For investors, the market basket is the principal idea behind index funds, which are essentially a broad sample of stocks, bonds or other securities in the market; this provides investors with a benchmark against which to compare their investment returns.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A basket may be associated with a specific market sector, and may be delineated for the purposes of statistical analysis, such as for calculating CPI. According to the US Bureau of Labor Statistics (BLS), with respect to the CPI, a market basket is a package of goods and services that consumers purchase for day-to-day living. The weight of each item is based on the amount of expenditure reported by a sample of households.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>From a securities perspective, a basket is a collection of products or securities that are designated to mimic the performance of a market. For investors, the market basket is the principal idea behind index funds, which are essentially a broad sample of stocks, bonds or other securities in the market; this provides investors with a benchmark against which to compare their investment returns.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;BasketConstituent">
@@ -218,8 +213,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>broker</rdfs:label>
 		<skos:definition>any party that acts as an intermediary between a buyer and a seller, usually charging a commission</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A broker that specializes in stocks, bonds, commodities, or certain derivatives must be registered with the exchange in which the securities are traded.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A broker that specializes in stocks, bonds, commodities, or certain derivatives must be registered with the exchange in which the securities are traded.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;BrokerDealer">
@@ -236,7 +231,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>broker-dealer</rdfs:label>
 		<skos:definition>any party in the business of buying and selling securities, operating as both a broker and a dealer, depending on the transaction</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Catalog">
@@ -261,7 +256,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleStage"/>
 		<rdfs:label>cleared trade</rdfs:label>
 		<skos:definition>stage in the lifecycle of a trade indicating that a third-party clearing house, acting as an intermediary, has reconciled the orders involved in the trade</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Clearing validates the availability of funds, records the transfer, and in the case of securities ensures the delivery of the security to the buyer.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Clearing validates the availability of funds, records the transfer, and in the case of securities ensures the delivery of the security to the buyer.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;ClosedTrade">
@@ -284,7 +279,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>dealer</rdfs:label>
 		<skos:definition>any party that purchases goods or services for resale and acts on their own behalf in a transaction</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A dealer is a counterparty or principal in the transaction with the customer.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A dealer is a counterparty or principal in the transaction with the customer.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Exposure">
@@ -311,7 +306,7 @@
 		<rdfs:label>financial intermediation service</rdfs:label>
 		<skos:definition>any financial service in which a third party (the intermediary) matches lenders and investors with entrepreneurs and other borrowers in need of capital</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>Often investors and borrowers do not have precisely matching needs, and the intermediary&apos;s capital is put at risk to transform the credit risk and maturity of the liabilities to meet the needs of investors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Often investors and borrowers do not have precisely matching needs, and the intermediary&apos;s capital is put at risk to transform the credit risk and maturity of the liabilities to meet the needs of investors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;FinancialProduct">
@@ -336,7 +331,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>financial product catalog</rdfs:label>
 		<skos:definition>a catalog of financial products and/or services available for sale with their description and other product details</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Nordea Bank</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Nordea Bank</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;FinancialService">
@@ -380,7 +375,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>holding</rdfs:label>
 		<skos:definition>real or personal property (assets), including but not limited to financial assets, to which one holds title and of which one has possession</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Note that a holding may refer to a single asset, such as a piece of real estate, a portfolio of assets, multiple portfolios, and so forth, and is frequently aggregated over multiple assets.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that a holding may refer to a single asset, such as a piece of real estate, a portfolio of assets, multiple portfolios, and so forth, and is frequently aggregated over multiple assets.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;LegalAgent">
@@ -398,7 +393,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>legal agent</rdfs:label>
 		<skos:definition>any party that has been legally empowered to act on behalf of another party</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;LicensedAgent">
@@ -408,7 +403,7 @@
 		<rdfs:label>licensed agent</rdfs:label>
 		<skos:definition>any individual who is licensed to perform a legally binding function, and who has been legally empowered to act on behalf of another party</skos:definition>
 		<skos:example>Insurance agents, realtors, financial advisors, certain attorneys, and brokers are examples of legal agents.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;MaturedTrade">
@@ -462,7 +457,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>offering</rdfs:label>
 		<skos:definition>expression of interest in providing something to someone that is contingent upon acceptance, forbearance, or some other consideration, as might be desired by an offeree(s)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The making of an offer is the first of three steps in the traditional process of forming a valid contract: an offer, an acceptance of the offer, and an exchange of consideration. (Consideration is the act of doing something or promising to do something that a person is not legally required to do, or the forbearance or the promise to forbear from doing something that he or she has the legal right to do.)</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The making of an offer is the first of three steps in the traditional process of forming a valid contract: an offer, an acceptance of the offer, and an exchange of consideration. (Consideration is the act of doing something or promising to do something that a person is not legally required to do, or the forbearance or the promise to forbear from doing something that he or she has the legal right to do.)</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Offeror">
@@ -505,7 +500,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>position</rdfs:label>
 		<skos:definition>an investor&apos;s stake, i.e., a holding, in a particular asset (such as an individual security)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A position can be long or short, and it can be in any asset class, such as stocks, bonds, futures, or options. A position can be open (current) or closed (past), but in general use, unless a position is specifically referred to as closed, the assumption is that it references an open position.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A position can be long or short, and it can be in any asset class, such as stocks, bonds, futures, or options. A position can be open (current) or closed (past), but in general use, unless a position is specifically referred to as closed, the assumption is that it references an open position.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ProductLifecycle">
@@ -666,9 +661,9 @@
 		<rdfs:seeAlso rdf:resource="http://www.sos.state.tx.us/corp/registeredagents.shtml"/>
 		<rdfs:seeAlso rdf:resource="https://thelawdictionary.org/agent/"/>
 		<skos:definition>a legal agent designated by another party (person or organization), to represent and acts on their behalf under a formal agency agreement</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Agency capacity, as specified in an agency agreement, may include power of attorney, the ability to act as an agent in certain kinds of transactions such as real estate, tax, audit or other financial or legal transactions, as a fiduciary, including as a trustee or legal guardian, for service of process, and so forth.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>resident agent</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>statutory agent</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Agency capacity, as specified in an agency agreement, may include power of attorney, the ability to act as an agent in certain kinds of transactions such as real estate, tax, audit or other financial or legal transactions, as a fiduciary, including as a trustee or legal guardian, for service of process, and so forth.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>resident agent</cmns-av:synonym>
+		<cmns-av:synonym>statutory agent</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;RegulatedCommodity">
@@ -687,7 +682,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>regulated commodity</rdfs:label>
 		<skos:definition>a commodity under the jurisdiction of the regulatory agency, such as the Commodities Futures Trading Commission (CFTF), which includes any commodity traded in an organized contracts market</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The CFTC polices matters of information and disclosure, fair trading practices, registration of firms and individuals, protection of customer funds, record keeping, and maintenance of orderly options and futures markets in the United States.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The CFTC polices matters of information and disclosure, fair trading practices, registration of firms and individuals, protection of customer funds, record keeping, and maintenance of orderly options and futures markets in the United States.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;SettlementTerms">
@@ -700,14 +695,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>settlement terms</rdfs:label>
 		<skos:definition>contract terms that define the commitment to and mechanism for settling one or more sides of a transaction</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In general, settlement involves arrangement of disposition of property, typically for legal reasons. With respect to financial transactions, it involves completion of a trade, either between brokers or agents, or between a broker and client. This may include settlement in cash, either for the entire transaction or for the cash leg of a transaction, either now or at some specified time in the future.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In general, settlement involves arrangement of disposition of property, typically for legal reasons. With respect to financial transactions, it involves completion of a trade, either between brokers or agents, or between a broker and client. This may include settlement in cash, either for the entire transaction or for the cash leg of a transaction, either now or at some specified time in the future.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;TerminatedTrade">
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleStage"/>
 		<rdfs:label>terminated trade</rdfs:label>
 		<skos:definition>stage in the trade lifecycle in which the trade has been terminated early, i.e., prior to maturity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Early termination may be triggered by a position sell or early termination provision, such as auto call/cancel, knock-out, etc.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Early termination may be triggered by a position sell or early termination provision, such as auto call/cancel, knock-out, etc.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ThirdPartyAgent">
@@ -716,8 +711,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
 		<rdfs:label>third-party agent</rdfs:label>
 		<skos:definition>any service provider that is licensed to perform a legally binding function and has been legally empowered to act on behalf of another party</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:usageNote>Note that third-party agent is defined as a service provider (organization) acting in an agency capacity, such as a law firm, accountancy, or investment bank. This is distinct from the concept of an individual (licensed agent), for example one who works for a broker-dealer, that is a registered agent licensed to sell securities.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>Note that third-party agent is defined as a service provider (organization) acting in an agency capacity, such as a law firm, accountancy, or investment bank. This is distinct from the concept of an individual (licensed agent), for example one who works for a broker-dealer, that is a registered agent licensed to sell securities.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Trade">
@@ -775,10 +770,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trade</rdfs:label>
 		<skos:definition>agreement between parties participating in a voluntary action of buying and selling goods and services</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Deutsche Bank Presentation on the Lifecycle of a Trade, available at http://www.slideshare.net/ahaline/23512555-tradelifecycle</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The advent of money as a medium of exchange has allowed trade to be conducted in a manner that is much simpler and effective compared to earlier forms of trade, such as bartering. In financial markets, trading also can mean performing a transaction that involves the selling and purchasing of a security.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The seller must deliver the commodity sold to the buyer; the buyer must pay the agreed purchase price, which could be in the form of other goods or services, on the agreed date.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Trading activities typically include (a) regularly underwriting or dealing in securities; interest rate, foreign exchange rate, commodity, equity, and credit derivative contracts; other financial instruments; and other assets for resale, (b) acquiring or taking positions in such items principally for the purpose of selling in the near term or otherwise with the intent to resell in order to profit from short-term price movements, and (c) acquiring or taking positions in such items as an accommodation to customers or for other trading purposes. (Source: Instructions for Preparation of Consolidated Reports of Condition and Income (FFIEC 031 and 041), Schedule RC-D - Trading Assets and Liabilities, 2013.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Deutsche Bank Presentation on the Lifecycle of a Trade, available at http://www.slideshare.net/ahaline/23512555-tradelifecycle</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The advent of money as a medium of exchange has allowed trade to be conducted in a manner that is much simpler and effective compared to earlier forms of trade, such as bartering. In financial markets, trading also can mean performing a transaction that involves the selling and purchasing of a security.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The seller must deliver the commodity sold to the buyer; the buyer must pay the agreed purchase price, which could be in the form of other goods or services, on the agreed date.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Trading activities typically include (a) regularly underwriting or dealing in securities; interest rate, foreign exchange rate, commodity, equity, and credit derivative contracts; other financial instruments; and other assets for resale, (b) acquiring or taking positions in such items principally for the purpose of selling in the near term or otherwise with the intent to resell in order to profit from short-term price movements, and (c) acquiring or taking positions in such items as an accommodation to customers or for other trading purposes. (Source: Instructions for Preparation of Consolidated Reports of Condition and Income (FFIEC 031 and 041), Schedule RC-D - Trading Assets and Liabilities, 2013.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeIdentifier">
@@ -979,7 +974,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label>trading strategy</rdfs:label>
 		<skos:definition>approach used for buying and selling in the securities markets</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A trading strategy is a plan whose aim is to make a profit or hedge against risk, based on rules and other criteria used when making trading decisions. A trading strategy may be simple or complex, and involve considerations such as investment style (e.g., value vs. growth), market cap, technical indicators, fundamental analysis, industry sector, level of portfolio diversification, time horizon or holding period, risk tolerance, leverage, tax considerations, and so on.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A trading strategy is a plan whose aim is to make a profit or hedge against risk, based on rules and other criteria used when making trading decisions. A trading strategy may be simple or complex, and involve considerations such as investment style (e.g., value vs. growth), market cap, technical indicators, fundamental analysis, industry sector, level of portfolio diversification, time horizon or holding period, risk tolerance, leverage, tax considerations, and so on.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;UniqueTransactionIdentifier">
@@ -992,10 +987,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>unique transaction identifier</rdfs:label>
 		<skos:definition>sequence of characters identifying a financial transaction uniquely whenever useful and agreed by the parties or community involved in the transaction</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>UTI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>Harmonization of the Unique Transaction Identifier - Technical Guidance, 20 Feb 2017, described in https://www.bis.org/cpmi/publ/d158.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 23897:2020, Financial services - Unique transaction identifier (UTI)</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In particular, a UTI will help to ensure the consistent aggregation of OTC derivatives and other securities transactions by minimising the likelihood that the same transaction will be counted more than once (for instance, because it is reported by more than one counterparty to a transaction, or to more than one trade repository (TR)).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>UTI</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>Harmonization of the Unique Transaction Identifier - Technical Guidance, 20 Feb 2017, described in https://www.bis.org/cpmi/publ/d158.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 23897:2020, Financial services - Unique transaction identifier (UTI)</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In particular, a UTI will help to ensure the consistent aggregation of OTC derivatives and other securities transactions by minimising the likelihood that the same transaction will be counted more than once (for instance, because it is reported by more than one counterparty to a transaction, or to more than one trade repository (TR)).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;WeightedBasket">
@@ -1052,7 +1047,7 @@
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>specifies an identifier for the entity that generated something</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Note that the range of is identified by must be that entity&apos;s LEI in the context of a UTI</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that the range of is identified by must be that entity&apos;s LEI in the context of a UTI</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;hasLegalAgent">
@@ -1117,7 +1112,7 @@
 		<rdfs:label>has settlement date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CalculatedDate"/>
 		<skos:definition>indicates the date by which an executed order or transaction must be settled</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Settlement might involve either a buyer paying in cash or a seller delivering the relevant instrument(s) and receiving the proceeds as specified by the terms of a given transaction.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Settlement might involve either a buyer paying in cash or a seller delivering the relevant instrument(s) and receiving the proceeds as specified by the terms of a given transaction.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;hasTradeDate">

--- a/FBC/ProductsAndServices/MetadataFBCProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/MetadataFBCProductsAndServices.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-pas-mod "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-pas-mod="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -18,35 +19,34 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/">
 		<rdfs:label>Metadata about the EDMC-FIBO Financial Business and Commerce(FBC) Products and Services Module</rdfs:label>
 		<dct:abstract>The FBC Products and Services module extends the FND Products and Services module via ontologies defining financial products, financial services, financial service providers, and product catalogs as well as customer/client accounts.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-13T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-fbc-pas-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataFBCProductsAndServices.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/ProductsAndServices/MetadataFBCProductsAndServices/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/ProductsAndServices/MetadataFBCProductsAndServices/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-mod;FBCProductsAndServicesModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO FBC Products and Services Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>products and services module</rdfs:label>
 		<dct:abstract>The products and services module extends the FND Products and Services module via ontologies defining financial products, financial services, financial service providers, and product catalogs as well as customer/client accounts.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-FBC-PAS</sm:moduleAbbreviation>
+		<dct:title>FIBO FBC Products and Services Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Products and Services Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

1. Revised the FBC debt ontologies to replace specification metadata with the Commons annotation vocabulary
2. Revised the FBC financial instruments ontologies to replace specification metadata with the Commons annotation vocabulary
3. Revised the FBC products and services ontologies to replace specification metadata with the Commons annotation vocabulary
4. Revised the primary FBC functional entities ontologies to replace specification metadata with the Commons annotation vocabulary
5. Revised the FBC European functional entities ontologies to replace specification metadata with the Commons annotation vocabulary
6. Revised the FBC North American functional entities ontologies to replace specification metadata with the Commons annotation vocabulary
7. Revised the top-level FBC metadata and load files accordingly


Fixes: #1865 / FBC-305


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


