### PR TITLE
SEC-183 - Replace specification metadata-related annotations with annotations from the Commons Ontology Library in the FIBO Securities (SEC) Domain

### DIFF
--- a/SEC/AllSEC-ExampleIndividuals.rdf
+++ b/SEC/AllSEC-ExampleIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-eq-eqind "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/">
@@ -9,10 +10,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ExampleIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-eq-eqind="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"
@@ -22,62 +23,46 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ExampleIndividuals/">
-		<rdfs:label>Securities Domain, Example Individuals</rdfs:label>
+		<rdfs:label>all SEC - example individuals</rdfs:label>
 		<dct:abstract>The FIBO Securities (SEC) domain provides a model of concepts that are common to financial instruments that are also securities, including but not limited to exchange-traded securities. High-level concepts relevant to securities classification, identification, issuance, and registration of securities generally are covered, as well as additional detail for equities, debt instruments, and funds. More details defining derivatives in particular are covered in a separate derivatives domain area.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-14T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>BIAN</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Goldman Sachs</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Mizuho</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain with Example Individuals</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>BIAN</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>Goldman Sachs</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>Mizuho Financial Group, Inc.</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-secex-all</sm:fileAbbreviation>
-		<sm:filename>AllSEC-ExamplesIndividuals.rdf</sm:filename>
-		<sm:keyword>debt instruments, bonds, asset-backed securities</sm:keyword>
-		<sm:keyword>equities</sm:keyword>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>funds, collective investment vehicles, special purpose vehicles</sm:keyword>
-		<sm:keyword>securities</sm:keyword>
-		<sm:moduleAbbreviation>fibo-sec</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/AllSEC-ExampleIndividuals/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for SEC example individuals is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, including all individuals, with examples of how to encode information for a specific exchange-traded security.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/AllSEC-ExampleIndividuals/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for SEC example individuals is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, including all individuals, with examples of how to encode information for a specific exchange-traded security.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/SEC/AllSEC-ReferenceIndividuals.rdf
+++ b/SEC/AllSEC-ReferenceIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-eq-10962 "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
@@ -9,10 +10,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-eq-10962="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
@@ -22,63 +23,47 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/">
-		<rdfs:label>Securities Domain, Reference Individuals</rdfs:label>
+		<rdfs:label>all SEC - reference individuals</rdfs:label>
 		<dct:abstract>The FIBO Securities (SEC) domain provides a model of concepts that are common to financial instruments that are also securities, including but not limited to exchange-traded securities. High-level concepts relevant to securities classification, identification, issuance, and registration of securities generally are covered, as well as additional detail for equities, debt instruments, and funds. More details defining derivatives in particular are covered in a separate derivatives domain area.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-14T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>BIAN</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Goldman Sachs</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Mizuho</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain with Reference Individuals</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>BIAN</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>Goldman Sachs</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>Mizuho Financial Group, Inc.</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-secri-all</sm:fileAbbreviation>
-		<sm:filename>AllSEC-ReferenceIndividuals.rdf</sm:filename>
-		<sm:keyword>debt instruments, bonds, asset-backed securities</sm:keyword>
-		<sm:keyword>equities</sm:keyword>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>funds, collective investment vehicles, special purpose vehicles</sm:keyword>
-		<sm:keyword>securities</sm:keyword>
-		<sm:moduleAbbreviation>fibo-sec</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-ReferenceRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/AllSEC-ReferenceIndividuals/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for SEC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, including all individuals.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/AllSEC-ReferenceIndividuals/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for SEC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, including all individuals.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/SEC/AllSEC.rdf
+++ b/SEC/AllSEC.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-all "https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/">
@@ -23,10 +24,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-all="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"
@@ -50,55 +51,38 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/">
-		<rdfs:label>Securities Domain</rdfs:label>
+		<rdfs:label>all SEC</rdfs:label>
 		<dct:abstract>The FIBO Securities (SEC) domain provides a model of concepts that are common to financial instruments that are also securities, including but not limited to exchange-traded securities. High-level concepts relevant to securities classification, identification, issuance, and registration of securities generally are covered, as well as additional detail for equities, debt instruments, and funds. More details defining derivatives in particular are covered in a separate derivatives domain area.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-14T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>BIAN</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Goldman Sachs</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Mizuho</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>BIAN</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>Goldman Sachs</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>Mizuho Financial Group, Inc.</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-all</sm:fileAbbreviation>
-		<sm:filename>AllSEC.rdf</sm:filename>
-		<sm:keyword>debt instruments, bonds, asset-backed securities</sm:keyword>
-		<sm:keyword>equities</sm:keyword>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>funds, collective investment vehicles, special purpose vehicles</sm:keyword>
-		<sm:keyword>securities</sm:keyword>
-		<sm:moduleAbbreviation>fibo-sec</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
@@ -118,8 +102,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/AllSEC/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for SEC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, excluding most individuals for governments and jurisdictions (aside from those used in depositary receipts), financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/AllSEC/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for SEC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, excluding most individuals for governments and jurisdictions (aside from those used in depositary receipts), financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/SEC/Debt/AssetBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -23,10 +24,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -50,27 +51,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/">
 		<rdfs:label xml:lang="en">Asset-backed Securities Ontology</rdfs:label>
 		<dct:abstract>Debt securities backed by a pool of assets, including loans of various kinds, credit card pools and home equity lines of credit, as well as esoteric assets.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/LOAN/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-dbt-abs</sm:fileAbbreviation>
-		<sm:filename>AssetBackedSecurities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -89,8 +75,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;AutoLoanAssetBackedSecurity">
@@ -128,8 +116,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>controlled amortization bond</rdfs:label>
 		<skos:definition>bond that is securitized using a controlled amortization structure</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.investinginbonds.com/learnmore.asp?catid=11&amp;subcatid=57&amp;id=15</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Revolving debt (primarily credit card receivables, but also HELOCs, trade receivables, dealer floor-plan loans and some leases) may be securitized using a controlled amortization structure. This is a method of providing investors with a relatively predictable repayment schedule, even though the underlying assets are nonamortizing. Controlled-amortization ABS resemble corporate bonds with a sinking fund. After a predetermined &apos;revolving&apos; period during which only interest payments are made, these securities attempt to return principal to investors in a series of defined periodic payments that usually occur over less than a year. A risk inherent in this kind of ABS is an early amortization event. (See &apos;Early-Amortization Risk&apos;, on page 20.)</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>http://www.investinginbonds.com/learnmore.asp?catid=11&amp;subcatid=57&amp;id=15</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Revolving debt (primarily credit card receivables, but also HELOCs, trade receivables, dealer floor-plan loans and some leases) may be securitized using a controlled amortization structure. This is a method of providing investors with a relatively predictable repayment schedule, even though the underlying assets are nonamortizing. Controlled-amortization ABS resemble corporate bonds with a sinking fund. After a predetermined &apos;revolving&apos; period during which only interest payments are made, these securities attempt to return principal to investors in a series of defined periodic payments that usually occur over less than a year. A risk inherent in this kind of ABS is an early amortization event. (See &apos;Early-Amortization Risk&apos;, on page 20.)</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;ControlledAmortizationStructure">
@@ -148,16 +136,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit card asset-backed security</rdfs:label>
 		<skos:definition xml:lang="en">asset-backed security based on credit card receivables</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">Federal Deposit Insurance Corporation (FDIC) Credit Card Securitization Manual, available at https://www.fdic.gov/regulations/examinations/credit_card_securitization/ch2.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Credit card securitizations currently represent the primary funding vehicle for unsecured revolving consumer credit. Similar to mortgage and other asset securitizations, the financial institution that originates the credit card receivables sells a group of these receivables to a trust. The trust then creates and sells certificates backed by the credit card receivables to investors, which are predominately institutional investors. Very few credit card ABS are marketed to retail customers, primarily due to the complex nature of the transactions and the need to continually monitor various performance indices on the underlying receivables. The underlying credit card receivables generate income to support the interest payments on the certificates.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom xml:lang="en">Federal Deposit Insurance Corporation (FDIC) Credit Card Securitization Manual, available at https://www.fdic.gov/regulations/examinations/credit_card_securitization/ch2.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Credit card securitizations currently represent the primary funding vehicle for unsecured revolving consumer credit. Similar to mortgage and other asset securitizations, the financial institution that originates the credit card receivables sells a group of these receivables to a trust. The trust then creates and sells certificates backed by the credit card receivables to investors, which are predominately institutional investors. Very few credit card ABS are marketed to retail customers, primarily due to the complex nature of the transactions and the need to continually monitor various performance indices on the underlying receivables. The underlying credit card receivables generate income to support the interest payments on the certificates.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;CreditCardPool">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;DebtPool"/>
 		<rdfs:label xml:lang="en">credit card pool</rdfs:label>
 		<skos:definition xml:lang="en">pool of outstanding balances on designated accounts</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">Federal Deposit Insurance Corporation (FDIC) Credit Card Securitization Manual, available at https://www.fdic.gov/regulations/examinations/credit_card_securitization/ch2.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In a credit card securitization transaction only the receivables are sold, not the accounts that generate the receivables. The financial institution retains legal ownership of the credit card accounts and can continue to change the terms on the accounts. Accounts corresponding to securitized loans are typically referred to as the designated accounts (or sometimes trust accounts). The initial outstanding balances on the designated accounts are sold to the trust as are the rights to any new charges on the designated accounts. Subsequently, as cardholder purchase activity generates more receivables on the designated accounts, these new receivables are purchased by the trust from the originating institution/seller/transferor. The trust uses the monthly principal payments received from the cardholders to acquire these new charges or receivables. When the securitization is initially set up, the originating institution/seller adds sufficient receivables to support the principal balance of the certificates plus an additional amount (seller&apos;s interest) that serves to absorb fluctuations in the outstanding balance of the receivables. The originating institution/seller will make subsequent additions to the trust in order to keep the seller&apos;s interest at the required level.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom xml:lang="en">Federal Deposit Insurance Corporation (FDIC) Credit Card Securitization Manual, available at https://www.fdic.gov/regulations/examinations/credit_card_securitization/ch2.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">In a credit card securitization transaction only the receivables are sold, not the accounts that generate the receivables. The financial institution retains legal ownership of the credit card accounts and can continue to change the terms on the accounts. Accounts corresponding to securitized loans are typically referred to as the designated accounts (or sometimes trust accounts). The initial outstanding balances on the designated accounts are sold to the trust as are the rights to any new charges on the designated accounts. Subsequently, as cardholder purchase activity generates more receivables on the designated accounts, these new receivables are purchased by the trust from the originating institution/seller/transferor. The trust uses the monthly principal payments received from the cardholders to acquire these new charges or receivables. When the securitization is initially set up, the originating institution/seller adds sufficient receivables to support the principal balance of the certificates plus an additional amount (seller&apos;s interest) that serves to absorb fluctuations in the outstanding balance of the receivables. The originating institution/seller will make subsequent additions to the trust in order to keep the seller&apos;s interest at the required level.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;EsotericAssetBackedSecurity">
@@ -170,7 +158,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">esoteric asset-backed security</rdfs:label>
 		<skos:definition xml:lang="en">asset-backed security based on some underlying promised future cashflow</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Esoteric asset-backed securities have been built based on cash flows from movie revenues, royalty payments, aircraft landing slots, toll roads, and solar photovoltaics.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Esoteric asset-backed securities have been built based on cash flows from movie revenues, royalty payments, aircraft landing slots, toll roads, and solar photovoltaics.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;FullyAmortizingBond">
@@ -178,8 +166,8 @@
 		<rdfs:label>fully amortizing bond</rdfs:label>
 		<skos:definition>amortizing bond that returns principal to investors over the life of the security</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>http://www.investinginbonds.com/learnmore.asp?catid=11&amp;subcatid=57&amp;id=15</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>Fully amortizing bonds are designed to closely reflect the full repayment of the underlying loans through scheduled interest and principal payments.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>These are typically backed by HELs, auto loans, manufactured-housing contracts and other fully amortizing assets. Prepayment risk is a key consideration with such ABS, although the rate of prepayment may vary considerably by the type of underlying asset.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Fully amortizing bonds are designed to closely reflect the full repayment of the underlying loans through scheduled interest and principal payments.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>These are typically backed by HELs, auto loans, manufactured-housing contracts and other fully amortizing assets. Prepayment risk is a key consideration with such ABS, although the rate of prepayment may vary considerably by the type of underlying asset.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;HomeEquityLineOfCreditPool">
@@ -283,7 +271,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;CouponPaymentTerms"/>
 		<rdfs:label>inflation bond interest payment terms</rdfs:label>
 		<skos:definition>terms for the payment of interest on an inflation bond</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>These may for example specify that the interest payments are by way of coupone calculated with reference to the inflation rate that is referenced for that bond, or they may not (for example they may specify a fixed coupon amount). Therefore these terms may specify any potential interest payment arrangement used on bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>These may for example specify that the interest payments are by way of coupone calculated with reference to the inflation rate that is referenced for that bond, or they may not (for example they may specify a fixed coupon amount). Therefore these terms may specify any potential interest payment arrangement used on bonds.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;InflationBondPrincipalRepaymentTerms">
@@ -296,7 +284,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>inflation bond principal repayment terms</rdfs:label>
 		<skos:definition>terms specifying how the principal amount on an inflation bond is to be paid down</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Further notes: This is typically but not necessarily with reference to the Inflation rate that is referred to for this bond. Further model action: identify and model terms for the case where the bond principal repayments are not pegged to an inflation rate.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Further notes: This is typically but not necessarily with reference to the Inflation rate that is referred to for this bond. Further model action: identify and model terms for the case where the bond principal repayments are not pegged to an inflation rate.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;InflationBondVariableCoupon">
@@ -351,7 +339,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
 		<rdfs:label xml:lang="en">promised cash flow asset</rdfs:label>
 		<skos:definition xml:lang="en">An asset which takes the form of some promised future cashflow. This may be securitized.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, exotic Cash ABS instruments may be created where the underlying asset is not a pool of securities or debt but a promised cash flow. People have securitized the cash flows of businesses, artists, mobile phone tower income, airplane leases, lotto receivables, etc.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">For example, exotic Cash ABS instruments may be created where the underlying asset is not a pool of securities or debt but a promised cash flow. People have securitized the cash flows of businesses, artists, mobile phone tower income, airplane leases, lotto receivables, etc.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;WACBondCoupon">
@@ -406,8 +394,8 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-abs;InflationBondPrincipalRepaymentTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:explanatoryNote>The inflation rate is used to define the factor or multiplier for the bond, that is the factor that you multiply the bond by. How this works is that you take the inflation rate when the security was issued, and the inflation rate at the present. The difference between these becomes the Factor, e.g. 100% -&amp;gt; 101% gives 1% so for example for a $1000 issue - calculate the principal on which the interest is paid AND the principal from the point of view of how the principal is repaid. Some inflation bonds only do this on interest, some only on interest, but most apply it to the principal and interest. Coupon interest calculated based on the adjusted amount of the bond. so a fixed coupon rate is multiplied by e.g. 1010 in the example above. Variations e.g. Italy - daily published factor published for that bond, whereas other calculate based on underlying index. Typically a CPI or a statistical number generated by the govt. typically a lagging three month index. See UK bonds on this. US and Japanese ones - look at inflation rate 3 months prior. Unlike an Amortizing Security this principal value of the bond is increasing, whereas for and Amortizing, the principal is decreasing. In Canada, these are also referred to as &quot;real return bonds&quot;. 
-Further Notes:Additional review with OTPP May 05 2010 indicates that this is part of a classification of bonds where the principal amount itself varies according to some index, a point which was not understood at the original review session. Terms and labels revised to fit this picture.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The inflation rate is used to define the factor or multiplier for the bond, that is the factor that you multiply the bond by. How this works is that you take the inflation rate when the security was issued, and the inflation rate at the present. The difference between these becomes the Factor, e.g. 100% -&amp;gt; 101% gives 1% so for example for a $1000 issue - calculate the principal on which the interest is paid AND the principal from the point of view of how the principal is repaid. Some inflation bonds only do this on interest, some only on interest, but most apply it to the principal and interest. Coupon interest calculated based on the adjusted amount of the bond. so a fixed coupon rate is multiplied by e.g. 1010 in the example above. Variations e.g. Italy - daily published factor published for that bond, whereas other calculate based on underlying index. Typically a CPI or a statistical number generated by the govt. typically a lagging three month index. See UK bonds on this. US and Japanese ones - look at inflation rate 3 months prior. Unlike an Amortizing Security this principal value of the bond is increasing, whereas for and Amortizing, the principal is decreasing. In Canada, these are also referred to as &quot;real return bonds&quot;. 
+Further Notes:Additional review with OTPP May 05 2010 indicates that this is part of a classification of bonds where the principal amount itself varies according to some index, a point which was not understood at the original review session. Terms and labels revised to fit this picture.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/SEC/Debt/Bonds.rdf
+++ b/SEC/Debt/Bonds.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
@@ -39,10 +40,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
@@ -82,28 +83,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
 		<rdfs:label>Bonds Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the basic concept of a bond and a number of bond variants including convertible and callable bonds. Medium term notes (MTNs) and debentures are also defined.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-dbt-bnd</sm:fileAbbreviation>
-		<sm:filename>Bonds.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
@@ -138,8 +123,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Debt/Bonds/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/Bonds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/Debt/Bonds.rdf version of this ontology was revised to reflect the refactored definition of a listing and improve the definition of corporate bond.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and eliminate a redundant superclass from RegularCouponSchedule.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate a duplicate &apos;isBasedOn&apos; property and replace it with the property of the same name in the debt ontology, to revise the inheritance hierarchy for bond conversion terms to reflect changes in the representation of redemption more generally, to reflect the move of redemption provision from debt to financial instruments, and eliminate circular and ambiguous definitions.</skos:changeNote>
@@ -148,7 +134,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Securities/Debt/Bonds.rdf version of this ontology was revised to allow for variation in index-linked bonds, such as those whose interest payments vary with an index in addition to those that have a variable principal linked to an index and to make a number of corrections to the class hierarchy.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Securities/Debt/Bonds.rdf version of this ontology was revised to incorporate the concept of a credit agreement repaid at maturity, which is a component assumed to be part of the definition of a bond, and to add an explanatory note to the definition of Treasury Bill.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220201/Securities/Debt/Bonds.rdf version of this ontology was revised to address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Debt/Bonds.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;AmortizingBond">
@@ -181,7 +170,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>bond</rdfs:label>
 		<skos:definition>tradable debt instrument representing a loan in which the issuer owes the holder(s) a debt</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Depending on the terms of the contract, the issuer is obliged to pay interest (the coupon) and/or to repay the principal at maturity. The most common bonds are corporate or governmental, typically used to finance specific projects or operations.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Depending on the terms of the contract, the issuer is obliged to pay interest (the coupon) and/or to repay the principal at maturity. The most common bonds are corporate or governmental, typically used to finance specific projects or operations.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;BondAmortizationPaymentTerms">
@@ -213,9 +202,9 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;InterestRate"/>
 		<rdfs:label>bond coupon</rdfs:label>
 		<skos:definition>interest rate on a debt security that the issuer promises to pay to the holder until maturity, expressed as an annual percentage of the face value</skos:definition>
-		<fibo-fnd-utl-av:synonym>coupon percent rate</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>coupon rate</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>nominal yield</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>coupon percent rate</cmns-av:synonym>
+		<cmns-av:synonym>coupon rate</cmns-av:synonym>
+		<cmns-av:synonym>nominal yield</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;BondInsurance">
@@ -248,7 +237,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>bond registrar</rdfs:label>
 		<skos:definition>party responsible for maintaining records on behalf of the issuer that identify the owners of a registered bond issue</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The trustee under a bond contract often also acts as registrar.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The trustee under a bond contract often also acts as registrar.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;BondVariableCoupon">
@@ -287,7 +276,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:label>Build America Bond</rdfs:label>
 		<skos:definition>taxable municipal bond issued through December 31, 2010 under the American Recovery and Reinvestment Act of 2009 (ARRA)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>BABs may be direct pay subsidy bonds or tax credit bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>BABs may be direct pay subsidy bonds or tax credit bonds.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;BulletBond">
@@ -346,17 +335,17 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalSecurity"/>
 		<rdfs:label>certificate of obligation</rdfs:label>
 		<skos:definition>municipal security available to governing councils in case of emergency, such as a natural disaster, that needs immediate action without time for voter referendum</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>CO&apos;s are similar to GO bonds, except that they do not require voter approval before they are issued. The CO&apos;s are also guaranteed by the City&apos;s taxation power and are counted in the calculation of the tax rate that is needed to support debt payments.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>For example, when a hurricane destroys the police and emergency services building, there is no time to go through the process of voter referendum. The local council must be able to borrow the money to set up provisional buildings and necessary equipment for police and emergency services so that the community is served in continuity.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>CO</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>CO&apos;s are similar to GO bonds, except that they do not require voter approval before they are issued. The CO&apos;s are also guaranteed by the City&apos;s taxation power and are counted in the calculation of the tax rate that is needed to support debt payments.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>For example, when a hurricane destroys the police and emergency services building, there is no time to go through the process of voter referendum. The local council must be able to borrow the money to set up provisional buildings and necessary equipment for police and emergency services so that the community is served in continuity.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;CertificateOfParticipation">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DebtInstrument"/>
 		<rdfs:label>certificate of participation</rdfs:label>
 		<skos:definition>debt instrument evidencing a pro rata share in a specific pledged revenue stream, usually lease payments by the issuer that are typically subject to annual appropriation</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>COP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>A certificate of participation (COP) is a type of financing where an investor purchases a share of the lease revenues of a program rather than the bond being secured by those revenues. The certificate generally entitles the holder to receive a share, or participation, in the payments from a particular project. The payments are passed through the lessor to the certificate holders. The lessor typically assigns the lease and the payments to a trustee, which then distributes the payments to the certificate holders.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>COP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>A certificate of participation (COP) is a type of financing where an investor purchases a share of the lease revenues of a program rather than the bond being secured by those revenues. The certificate generally entitles the holder to receive a share, or participation, in the payments from a particular project. The payments are passed through the lessor to the certificate holders. The lessor typically assigns the lease and the payments to a trustee, which then distributes the payments to the certificate holders.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;ConventionalGilt">
@@ -365,7 +354,7 @@
 		<rdfs:label>conventional gilt</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.dmo.gov.uk/responsibilities/gilt-market/about-gilts/"/>
 		<skos:definition>fixed coupon bond issued by HM Treasury that guarantees to pay the holder of the gilt a fixed cash payment (coupon) every six months until the maturity date, at which point the holder receives the final coupon payment and the return of the principal</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Conventional gilts are the simplest form of government bond and constitute around 75 percent of the gilt portfolio.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Conventional gilts are the simplest form of government bond and constitute around 75 percent of the gilt portfolio.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;ConvertibleBond">
@@ -380,7 +369,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>convertible bond</rdfs:label>
 		<skos:definition>bond that gives the holder the right to convert the bond into a fixed number of shares (conversion ratio) if the equity price rises above a specified level (strike price)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>If the equity price remains below the strike price throughout the term of the bond it matures and is redeemed like a regular bond. The conversion ratio and strike price are usually set when the convertible bond is issued.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>If the equity price remains below the strike price throughout the term of the bond it matures and is redeemed like a regular bond. The conversion ratio and strike price are usually set when the convertible bond is issued.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;CorporateBond">
@@ -400,8 +389,8 @@
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;GovernmentBond"/>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<skos:definition>bond issued by a company in order to raise financing</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Corporate bonds are issued for purposes such as mergers and acquisitions, business expansion, or to cover ongoing operational needs, and are typically longer-term debt instruments that have a maturity of at least one year. Corporate debt instruments with maturity shorter than one year are referred to as commercial paper.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Note that some classification schemes consider any bond except those issued by a government in its own currency to be a corporate bond, for example, a bond issued by Canada in US dollars might be classified as a corporate bond. Bonds issued by multinational / supranational organizations such as the European Bank for Reconstruction and Development (EBRD) may also be considered corporate bonds rather than government bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Corporate bonds are issued for purposes such as mergers and acquisitions, business expansion, or to cover ongoing operational needs, and are typically longer-term debt instruments that have a maturity of at least one year. Corporate debt instruments with maturity shorter than one year are referred to as commercial paper.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that some classification schemes consider any bond except those issued by a government in its own currency to be a corporate bond, for example, a bond issued by Canada in US dollars might be classified as a corporate bond. Bonds issued by multinational / supranational organizations such as the European Bank for Reconstruction and Development (EBRD) may also be considered corporate bonds rather than government bonds.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;CouponPayment">
@@ -457,7 +446,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;CallFeature"/>
 		<rdfs:label>extraordinary redemption provision</rdfs:label>
 		<skos:definition>provision that gives a bond issuer the right to call its bonds due to an unusual one-time occurrence, as specified in the offering statement</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Such redemptions may occur when bond proceeds are not spent according to schedule; when bond proceeds are used in a way that makes nontaxable bond interest taxable; or when a catastrophe destroys the project being financed, among other reasons.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Such redemptions may occur when bond proceeds are not spent according to schedule; when bond proceeds are used in a way that makes nontaxable bond interest taxable; or when a catastrophe destroys the project being financed, among other reasons.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;FirstRegularCouponDate">
@@ -503,15 +492,15 @@
 		</rdfs:subClassOf>
 		<rdfs:label>floating rate note</rdfs:label>
 		<skos:definition>bond with a variable interest rate based on a published reference interest rate</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The adjustments to the interest rate (coupon) are made periodically, usually on a quarterly or monthly basis, and are tied to a certain money-market index. Also known as a &quot;floater&quot;. For example six months USD LIBOR + 0.20%.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The adjustments to the interest rate (coupon) are made periodically, usually on a quarterly or monthly basis, and are tied to a certain money-market index. Also known as a &quot;floater&quot;. For example six months USD LIBOR + 0.20%.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;FullFaithCreditBond">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;UnsecuredBond"/>
 		<rdfs:label>full faith credit bond</rdfs:label>
 		<skos:definition>bond secured by an unconditional promise to pay by another entity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Full faith and credit bonds are typically backed by a government entity and are considered low risk.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>full faith and credit bond</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Full faith and credit bonds are typically backed by a government entity and are considered low risk.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>full faith and credit bond</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;GeneralObligationMunicipalBond">
@@ -520,7 +509,7 @@
 		<rdfs:label>general obligation municipal bond</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;RevenueBond"/>
 		<skos:definition>municipal bond that is backed by the full faith and credit and general resources of the issuing municipality, including its general taxing authority</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>GO bond</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>GO bond</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;GovernmentBond">
@@ -528,7 +517,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;GovernmentIssuedDebtSecurity"/>
 		<rdfs:label>government bond</rdfs:label>
 		<skos:definition>debt security issued by a government to fund government spending</skos:definition>
-		<fibo-fnd-utl-av:synonym>government-issued bond</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>government-issued bond</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;GovernmentIssuedDebtSecurity">
@@ -552,15 +541,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
 		<rdfs:label>green bond</rdfs:label>
 		<skos:definition>bond issued specifically to fund climate or environmental projects</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>These bonds are typically asset-linked and backed by the issuer&apos;s balance sheet. Green bonds finance projects aimed at energy efficiency, pollution prevention, sustainable agriculture, fishery and forestry, the protection of aquatic and terrestrial ecosystems, clean transportation, sustainable water management and the cultivation of environmentally friendly technologies, and often include incentives such as tax exemption.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>These bonds are typically asset-linked and backed by the issuer&apos;s balance sheet. Green bonds finance projects aimed at energy efficiency, pollution prevention, sustainable agriculture, fishery and forestry, the protection of aquatic and terrestrial ecosystems, clean transportation, sustainable water management and the cultivation of environmentally friendly technologies, and often include incentives such as tax exemption.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;ImplicitFullFaithCreditBond">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;UnsecuredBond"/>
 		<rdfs:label>implicit full faith credit bond</rdfs:label>
 		<skos:definition>bond issued by a government sponsored agency or corporation rather than by the government directly</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>It doesn&apos;t carry an explicit full faith and credit guarantee but the market believes the government wouldn&apos;t let it default or fail.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>implicit full faith and credit bond</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>It doesn&apos;t carry an explicit full faith and credit guarantee but the market believes the government wouldn&apos;t let it default or fail.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>implicit full faith and credit bond</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;IndexLinkedBond">
@@ -594,9 +583,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>inflation-linked bond</rdfs:label>
 		<skos:definition>bond indexed to inflation so that the principal or interest payments rise and fall with the rate of inflation</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ILB</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Inflation-linked bonds are primarily issued by sovereign governments, such as the U.S. and the UK.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>inflation-indexed bond</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>ILB</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Inflation-linked bonds are primarily issued by sovereign governments, such as the U.S. and the UK.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>inflation-indexed bond</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;LastRegularCouponDate">
@@ -611,7 +600,7 @@
 		<rdfs:label>listed bond</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;UnlistedBond"/>
 		<skos:definition>bond that may be traded on an exchange</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Most exchange traded bonds are corporate bonds (but most corporate bonds are not exchange traded bonds).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Most exchange traded bonds are corporate bonds (but most corporate bonds are not exchange traded bonds).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-bnd;LotteryConvention">
@@ -624,7 +613,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;CallEvent"/>
 		<rdfs:label>make whole call</rdfs:label>
 		<skos:definition>call allowing the issuer to pay off remaining debt early</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The issuer typically has to make a lump sum payment to the investor(s) derived from a formula based on the net present value (NPV) of future coupon payments that will not be paid incrementally because of the call combined with the principal payment the investor would have received at maturity.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The issuer typically has to make a lump sum payment to the investor(s) derived from a formula based on the net present value (NPV) of future coupon payments that will not be paid incrementally because of the call combined with the principal payment the investor would have received at maturity.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;MandatoryConvertibleBond">
@@ -637,16 +626,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label>mandatory convertible bond</rdfs:label>
 		<skos:definition>convertible bond that converts into shares at maturity regardless of the equity price</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The conversion ratio at maturity reflects the equity price and par value of the bond when issued. There is also typically a second higher conversion ratio if the equity price rises above the strike during the term of the bond.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The conversion ratio at maturity reflects the equity price and par value of the bond when issued. There is also typically a second higher conversion ratio if the equity price rises above the strike during the term of the bond.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;MediumTermNote">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
 		<rdfs:label>medium term note</rdfs:label>
 		<skos:definition>bond issued over time under a shelf registration program, where each issue may have a different coupon and maturity typically ranging from one to ten years</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A medium-term note (MTN) is a debt note that usually matures (is paid back) in 5 to 10 years, but the term may be less than one year or as long as 100 years. They can be issued on a fixed or floating coupon basis.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>By shelf registration we mean the security registration process where an issuer registers in advance, and can issue lots of securities for up to three years.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Medium term notes are typically issued by corporations and financial institutions, although GSEs also have MTN programs. MTNs may be issued under a shelf registration program which allows the company to issue bonds over time with varying maturities and coupons. Companies issue MTNs to have a more flexible source of funding. They may also issue MTN in response to &apos;reverse inquiry&apos; by investors looking for bonds with specific maturities, issue size and coupon.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A medium-term note (MTN) is a debt note that usually matures (is paid back) in 5 to 10 years, but the term may be less than one year or as long as 100 years. They can be issued on a fixed or floating coupon basis.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>By shelf registration we mean the security registration process where an issuer registers in advance, and can issue lots of securities for up to three years.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Medium term notes are typically issued by corporations and financial institutions, although GSEs also have MTN programs. MTNs may be issued under a shelf registration program which allows the company to issue bonds over time with varying maturities and coupons. Companies issue MTNs to have a more flexible source of funding. They may also issue MTN in response to &apos;reverse inquiry&apos; by investors looking for bonds with specific maturities, issue size and coupon.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;MunicipalBond">
@@ -654,8 +643,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalSecurity"/>
 		<rdfs:label>municipal bond</rdfs:label>
 		<skos:definition>government bond that may be issued by a regional, rather than national, authority</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>muni</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Municipal bonds may be issued by states, cities, counties, special tax districts or special agencies or authorities of state or local governments.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>muni</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Municipal bonds may be issued by states, cities, counties, special tax districts or special agencies or authorities of state or local governments.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;MunicipalDebtFundsUsage">
@@ -669,7 +658,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
 		<rdfs:label>municipal debt remarketing agent</rdfs:label>
 		<skos:definition>municipal securities dealer responsible for reselling to investors securities (such as variable rate demand obligations and other tender option bonds) that have been tendered for purchase by their owner</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The remarketing agent also typically is responsible for resetting the interest rate for a variable rate issue and may act as tender agent.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The remarketing agent also typically is responsible for resetting the interest rate for a variable rate issue and may act as tender agent.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;MunicipalDebtSourceOfFunds">
@@ -682,7 +671,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalSecurity"/>
 		<rdfs:label>municipal note</rdfs:label>
 		<skos:definition>short-term obligation to repay a specified principal amount on a certain date, together with interest at a stated rate, usually payable from a defined source of anticipated revenues</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Notes usually mature in one year or less, although notes of longer maturities are also issued.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Notes usually mature in one year or less, although notes of longer maturities are also issued.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;MunicipalSecurity">
@@ -722,7 +711,7 @@
 		<rdfs:label>municipal security</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;SovereignDebtInstrument"/>
 		<skos:definition>debt obligation issued by a regional governmental entity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A municipal security is typically a bond, note, warrant, certificate or other similar obligation issued by a state or local government or their agencies or authorities (such as cities, towns, villages, counties or special districts or authorities). A prime feature of most municipal securities is that interest or other investment earnings on them are generally excluded from gross income of the bondholder for federal income tax purposes. Some municipal securities are subject to federal income tax, although the issuers or bondholders may receive other federal tax advantages for certain types of taxable municipal securities. Some examples include Build America Bonds, municipal fund securities and direct pay subsidy bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A municipal security is typically a bond, note, warrant, certificate or other similar obligation issued by a state or local government or their agencies or authorities (such as cities, towns, villages, counties or special districts or authorities). A prime feature of most municipal securities is that interest or other investment earnings on them are generally excluded from gross income of the bondholder for federal income tax purposes. Some municipal securities are subject to federal income tax, although the issuers or bondholders may receive other federal tax advantages for certain types of taxable municipal securities. Some examples include Build America Bonds, municipal fund securities and direct pay subsidy bonds.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;MunicipalTrustee">
@@ -730,7 +719,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label>municipal trustee</rdfs:label>
 		<skos:definition>financial institution with trust powers, designated by the issuer, that acts, pursuant to a bond contract, in a fiduciary capacity for the benefit of the bondholders in enforcing the terms of the bond contract</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In many cases, the trustee also acts as custodian, paying agent, registrar and/or transfer agent for the bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In many cases, the trustee also acts as custodian, paying agent, registrar and/or transfer agent for the bonds.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;OriginalIssueDiscountBond">
@@ -750,9 +739,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>original issue discount bond</rdfs:label>
 		<skos:definition>interest-bearing bond issued at a deep discount to face value</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>An original issue discount (OID) is the discount in price from a bond&apos;s face value at the time a bond or other debt instrument is first issued. The OID is the amount of discount or the difference between the original face value and the price paid for the bond.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The principal amount accretes over time at a constant accrual rate and is redeemed at full face value at maturity.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>OID bond</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>An original issue discount (OID) is the discount in price from a bond&apos;s face value at the time a bond or other debt instrument is first issued. The OID is the amount of discount or the difference between the original face value and the price paid for the bond.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The principal amount accretes over time at a constant accrual rate and is redeemed at full face value at maturity.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>OID bond</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;PartialCall">
@@ -790,7 +779,7 @@
 		<rdf:type rdf:resource="&fibo-sec-dbt-bnd;RateBasisConvention"/>
 		<rdfs:label>percentage cumulative average value</rdfs:label>
 		<skos:definition>rate basis calculated as a percentage of cumulative average value</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>percentage CAV</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>percentage CAV</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-bnd;PercentageParValue">
@@ -803,8 +792,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
 		<rdfs:label>perpetual bond</rdfs:label>
 		<skos:definition>bond that has no maturity date, i.e., one that pays interest in perpetuity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Perpetual bonds function much like dividend-paying stocks or certain preferred securities. Just as the owner of the stock receives a dividend payment as long as the stock is held, the perpetual bond owner receives an interest payment as long as the bond is held.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>consul</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Perpetual bonds function much like dividend-paying stocks or certain preferred securities. Just as the owner of the stock receives a dividend payment as long as the stock is held, the perpetual bond owner receives an interest payment as long as the bond is held.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>consul</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-bnd;ProRataConvention">
@@ -849,7 +838,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;CouponSchedule"/>
 		<rdfs:label>regular coupon schedule</rdfs:label>
 		<skos:definition>schedule including an interval of regular coupon payment dates</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A regular schedule may include an initial and/or final stub period.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A regular schedule may include an initial and/or final stub period.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;RegulatoryCall">
@@ -863,7 +852,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;FloatingRateNote"/>
 		<rdfs:label>remarketable bond</rdfs:label>
 		<skos:definition>corporate bond program where the coupon rate on outstanding bonds is periodically reset through an auction process</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A remarketing agent (dealer or underwriter) periodically surveys bond holders to identify those who want to sell bonds. The agent surveys market (or holds an auction) to determine interest rate at which the bonds can be resold. The rate on all outstanding bonds resets at the new rate. These programs are perpetual in the sense they often don&apos;t have a fixed maturity date, but the company can redeem them. If an auction fails, i.e., the agent can&apos;t place all the bonds then.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A remarketing agent (dealer or underwriter) periodically surveys bond holders to identify those who want to sell bonds. The agent surveys market (or holds an auction) to determine interest rate at which the bonds can be resold. The rate on all outstanding bonds resets at the new rate. These programs are perpetual in the sense they often don&apos;t have a fixed maturity date, but the company can redeem them. If an auction fails, i.e., the agent can&apos;t place all the bonds then.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;RevenueBond">
@@ -871,7 +860,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;SecuredBond"/>
 		<rdfs:label>revenue bond</rdfs:label>
 		<skos:definition>municipal bond supported by the revenue from a specific project</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Revenue bonds are municipal bonds that finance income-producing projects, such as toll bridges, highways, or local stadiums, and are secured by a specified revenue source. Typically, revenue bonds can be issued by any government agency or fund that is managed in the manner of a business, such as entities having both operating revenues and expenses.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Revenue bonds are municipal bonds that finance income-producing projects, such as toll bridges, highways, or local stadiums, and are secured by a specified revenue source. Typically, revenue bonds can be issued by any government agency or fund that is managed in the manner of a business, such as entities having both operating revenues and expenses.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SecuredBond">
@@ -879,7 +868,7 @@
 		<rdfs:label>secured bond</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;UnsecuredBond"/>
 		<skos:definition>bond that is backed by collateral, such as a tangible asset or income stream, in addition to a general promise to pay</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A secured bond may be collateralized by a claim on real assets, such as a factory or auto fleet; or by a claim on a revenue stream. A secured bond differs from a mortgage in that proceeds of the bond sale aren&apos;t used to acquire the asset.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A secured bond may be collateralized by a claim on real assets, such as a factory or auto fleet; or by a claim on a revenue stream. A secured bond differs from a mortgage in that proceeds of the bond sale aren&apos;t used to acquire the asset.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SinkingFundAmortizationTerms">
@@ -902,7 +891,7 @@
 		<rdfs:label>sovereign bond</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<skos:definition>bond issued by the government of a country</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Sovereign bonds issued by G20 developed countries are generally full faith and credit obligations. Sovereign bonds issued by emerging and developing countries may be issued in local currency or a G7 currency, and may either be full faith and credit (unsecured) or secured.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Sovereign bonds issued by G20 developed countries are generally full faith and credit obligations. Sovereign bonds issued by emerging and developing countries may be issued in local currency or a G7 currency, and may either be full faith and credit (unsecured) or secured.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SovereignDebtInstrument">
@@ -927,7 +916,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;SecuredBond"/>
 		<rdfs:label>special assessment bond</rdfs:label>
 		<skos:definition>municipal bond used to fund a development project that is payable from the revenues of an assessment (tax) on the community that is intended to benefit from the project</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A special assessment is a charge imposed against a property in a particular locality because that property receives a special benefit by virtue of some public improvement, separate and apart from the general benefit accruing to the public at large. Special assessments may be apportioned according to the value of the benefit received, rather than merely the cost of the improvement.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A special assessment is a charge imposed against a property in a particular locality because that property receives a special benefit by virtue of some public improvement, separate and apart from the general benefit accruing to the public at large. Special assessments may be apportioned according to the value of the benefit received, rather than merely the cost of the improvement.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SpecialObligationBond">
@@ -979,8 +968,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>step up bond</rdfs:label>
 		<skos:definition>bond with a coupon that increases (steps up) while the bond is outstanding</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The step change may be one time, or occur according to a schedule or at regular intervals.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>step down bond</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>The step change may be one time, or occur according to a schedule or at regular intervals.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>step down bond</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SteppedCouponTerms">
@@ -1013,7 +1002,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;SecuredBond"/>
 		<rdfs:label>tax allocation bond</rdfs:label>
 		<skos:definition>bond payable from the incremental increase in tax revenues realized from any increase in property value and other economic activity, often designed to capture the economic benefit resulting from a bond financing</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Tax increment bonds, also known as tax allocation bonds, often are used to finance the redevelopment of blighted areas.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Tax increment bonds, also known as tax allocation bonds, often are used to finance the redevelopment of blighted areas.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;TreasuryBill">
@@ -1041,8 +1030,8 @@
 		<rdfs:seeAlso rdf:resource="https://www.treasurydirect.gov/indiv/research/indepth/tbills/res_tbill.htm"/>
 		<rdfs:seeAlso rdf:resource="https://www.treasurydirect.gov/indiv/research/indepth/tbills/res_tbill_rates.htm"/>
 		<skos:definition>short-term zero coupon treasury obligation with a maturity ranging from one to twelve months</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>T-bill</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The pricing of T-bills is unique among U.S. government debt issues. Treasury bills are offered in multiples of $100 and in terms ranging from a few days to 52 weeks. Rather than providing interest payments as Treasury Bonds or Notes do, T-bills are sold at a discount, and the entire return is realized upon maturity. The price of a bill is determined at auction. The annualized interest rate earned on T-bills is equal to the difference between the purchase price and maturity value, divided by the maturity value.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>T-bill</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The pricing of T-bills is unique among U.S. government debt issues. Treasury bills are offered in multiples of $100 and in terms ranging from a few days to 52 weeks. Rather than providing interest payments as Treasury Bonds or Notes do, T-bills are sold at a discount, and the entire return is realized upon maturity. The price of a bill is determined at auction. The annualized interest rate earned on T-bills is equal to the difference between the purchase price and maturity value, divided by the maturity value.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;TreasuryBond">
@@ -1060,8 +1049,8 @@
 		<rdfs:label>treasury inflation-protected security</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.treasurydirect.gov/indiv/products/prod_tips_glance.htm"/>
 		<skos:definition>variable income bond whose principal is indexed to inflation or deflation and thus changes over the life of the security</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>TIPS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Treasury Inflation-Protected Securities, or TIPS, provide protection against inflation. The principal of a TIPS increases with inflation and decreases with deflation, as measured by the Consumer Price Index. When a TIPS matures, you are paid the adjusted principal or original principal, whichever is greater.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>TIPS</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Treasury Inflation-Protected Securities, or TIPS, provide protection against inflation. The principal of a TIPS increases with inflation and decreases with deflation, as measured by the Consumer Price Index. When a TIPS matures, you are paid the adjusted principal or original principal, whichever is greater.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;TreasuryNote">
@@ -1076,10 +1065,10 @@
 		<rdfs:label>U.K. Government security</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.dmo.gov.uk/responsibilities/gilt-market/buying-selling/"/>
 		<skos:definition>debt instrument issued by HM Treasury and listed on the London Stock Exchange</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>If a private investor wishes to purchase gilts the secondary market can be accessed through a stockbroker, bank or the DMO&apos;s Purchase and Sale Service.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The term &apos;gilt&apos; or &apos;gilt-edged security&apos; is a reference to the primary characteristic of gilts as an investment: their security. This is a reflection of the fact that the British Government has never failed to make interest or principal payments on gilts as they fall due.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>gilt</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>gilt-edged security</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>If a private investor wishes to purchase gilts the secondary market can be accessed through a stockbroker, bank or the DMO&apos;s Purchase and Sale Service.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The term &apos;gilt&apos; or &apos;gilt-edged security&apos; is a reference to the primary characteristic of gilts as an investment: their security. This is a reflection of the fact that the British Government has never failed to make interest or principal payments on gilts as they fall due.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>gilt</cmns-av:synonym>
+		<cmns-av:synonym>gilt-edged security</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;USTreasurySecurity">
@@ -1098,15 +1087,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
 		<rdfs:label>unlisted bond</rdfs:label>
 		<skos:definition>bond that is traded over the counter rather than via an exchange or other listing facility</skos:definition>
-		<fibo-fnd-utl-av:synonym>OTC Bond</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>OTC Bond</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;UnsecuredBond">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
 		<rdfs:label>unsecured bond</rdfs:label>
 		<skos:definition>bond that is only secured by the bond issuer&apos;s good credit standing</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Most unsecured bonds pose limited risk of default, as the organizations that issue them are typically financially sound.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>debenture</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Most unsecured bonds pose limited risk of default, as the organizations that issue them are typically financially sound.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>debenture</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;VariableCouponBond">
@@ -1119,7 +1108,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>variable coupon bond</rdfs:label>
 		<skos:definition>bond that has a floating interest rate</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The rate adjusts according to a predetermined formula outlined in the bond&apos;s prospectus or official statement.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The rate adjusts according to a predetermined formula outlined in the bond&apos;s prospectus or official statement.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;VariableCouponTerms">
@@ -1150,7 +1139,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>variable debt principal</rdfs:label>
 		<skos:definition>principal that is defined in relation to some variable and so varies over time, as principal</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Not the same as principal paydown. This is when the principal itself varies over time, usually as a result of being defined in relation to some index such as an inflation index. Forms the debt principal in instruments such as inflation bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Not the same as principal paydown. This is when the principal itself varies over time, usually as a result of being defined in relation to some index such as an inflation index. Forms the debt principal in instruments such as inflation bonds.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;VariableIncomeBond">
@@ -1203,7 +1192,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>variable principal bond</rdfs:label>
 		<skos:definition>bond whose principal adjusts over time with changes in an index</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The principal on variable principal bonds adjusts line with an index such as inflation or GDP. For example, for a bond linked to the CPI, if inflation rises two percent the principal increases by 2 percent. The coupon rate is typically fixed. The best-known example is TIPS or Treasury Inflation Protected Bonds, which are linked to the CPI. TIPs offer a real or inflation adjusted rate of return.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The principal on variable principal bonds adjusts line with an index such as inflation or GDP. For example, for a bond linked to the CPI, if inflation rises two percent the principal increases by 2 percent. The coupon rate is typically fixed. The best-known example is TIPS or Treasury Inflation Protected Bonds, which are linked to the CPI. TIPs offer a real or inflation adjusted rate of return.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;ZeroCouponBond">
@@ -1230,9 +1219,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>zero coupon bond</rdfs:label>
 		<skos:definition>bond issued with a coupon rate of zero and that trades at a deep discount to face value</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Fannie Mae also issues zero-coupon callable debt securities. Zero-coupon notes are debt securities on which no coupon interest is paid to the investor. Rather, the security is purchased at a discounted dollar price and matures at par. If the option on a callable zero-coupon security is exercised, it is redeemed at a higher dollar price than the original issue price. The yield for a callable zero-coupon security is based on the difference between the original discounted price and the principal payment at the call date.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The principal amount accretes over time at a constant accrual rate and is redeemed at full face value at maturity. In effect, the accrual rate is the coupon rate or yield which is added to the outstanding principal rather than being paid out to investors.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>z-bond</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Fannie Mae also issues zero-coupon callable debt securities. Zero-coupon notes are debt securities on which no coupon interest is paid to the investor. Rather, the security is purchased at a discounted dollar price and matures at par. If the option on a callable zero-coupon security is exercised, it is redeemed at a higher dollar price than the original issue price. The yield for a callable zero-coupon security is based on the difference between the original discounted price and the principal payment at the call date.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The principal amount accretes over time at a constant accrual rate and is redeemed at full face value at maturity. In effect, the accrual rate is the coupon rate or yield which is added to the outstanding principal rather than being paid out to investors.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>z-bond</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;ZeroCouponTerms">
@@ -1261,7 +1250,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>specifies the date on which bonds are awarded to the lead manager or syndicate on negotiated deals, or the date of bidding on competitive deals</skos:definition>
-		<fibo-fnd-utl-av:synonym>has sale date</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>has sale date</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasCallPrice">
@@ -1270,8 +1259,8 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;CallFeature"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<skos:definition>indicates the amount of the call on the specified call date, typically the sum of par value and the call premium, as specified in the contract</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is the price a bond issuer or preferred stock issuer must pay investors to buy back, or call, all or part of an issue before the maturity date.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>has redemption price</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>This is the price a bond issuer or preferred stock issuer must pay investors to buy back, or call, all or part of an issue before the maturity date.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>has redemption price</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasCallRateBasis">
@@ -1279,7 +1268,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;CallEvent"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-bnd;RateBasisConvention"/>
 		<skos:definition>for each call event on the schedule, indicates whether the rate is expressed as a percentage of par or percentage of percentage of cumulative average value (CAV)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Zero coupon bonds and OID bonds are callable at an accreted value.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Zero coupon bonds and OID bonds are callable at an accreted value.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bnd;hasCeiling">
@@ -1329,8 +1318,8 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;CouponPaymentTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>specifies the first date on which the issuer or its agent expects or commits to make a coupon payment</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The first coupon date sometimes occurs at an irregular time; that is, if the bond pays coupons every six months, the first coupon period may be longer or shorter than six months.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The first coupon payment period can be long or short when this date doesn&apos;t coincide with the start of a normal coupon payment period.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The first coupon date sometimes occurs at an irregular time; that is, if the bond pays coupons every six months, the first coupon period may be longer or shorter than six months.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The first coupon payment period can be long or short when this date doesn&apos;t coincide with the start of a normal coupon payment period.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasFirstParCallDate">
@@ -1407,7 +1396,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;CouponPaymentTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>specifies the final date on which the issuer expects to make a final coupon payment</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The last coupon date sometimes occurs at an irregular time; that is, if the bond pays coupons every six months, the last coupon period may be longer or shorter than six months.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The last coupon date sometimes occurs at an irregular time; that is, if the bond pays coupons every six months, the last coupon period may be longer or shorter than six months.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasLockoutPeriod">
@@ -1448,7 +1437,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;CouponPaymentTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>specifies the last coupon payment prior to maturity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is important since the securities processing area needs to start its procedures in anticipation of maturity. For zero coupon bonds, it is the last compounding date prior to maturity.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is important since the securities processing area needs to start its procedures in anticipation of maturity. For zero coupon bonds, it is the last compounding date prior to maturity.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasPremiumAmount">
@@ -1504,7 +1493,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether or not a given municipal bond conforms with section 265(b)(3) of the IRS tax code; when purchased by a commercial bank for its portfolio, such designation allows the bank to deduct a portion of the interest cost of carry for the position</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A bond that is bank qualified is also known as a qualified tax-exempt obligation.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A bond that is bank qualified is also known as a qualified tax-exempt obligation.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bnd;isLegalOpinionAvailable">
@@ -1520,7 +1509,7 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-bnd;GovernmentBond"/>
 		<skos:definition>relates an index-linked instrument to a government bond that may be selected by a calculation agent</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Fallback Bond means, in relation to an Inflation Index applicable to an Inflation Linked Note, a bond selected by the Calculation Agent and issued by the government or one of the governments (but not any government agency) of the country (or countries) to whose level of inflation the Inflation Index relates and which pays a coupon and/or redemption amount which is calculated by reference to the Inflation Index, with a maturity date which falls on the same day as the Maturity Date of the Inflation Linked Notes, or such other date as the Calculation Agent shall select if there is no such bond maturing on the Maturity Date of the Inflation Linked Notes. If any bond so selected is redeemed, the Calculation Agent will select a new Fallback Bond on the same basis, but selected from all eligible bonds in issue at the time the original Fallback Bond is redeemed (including any bond for which the redeemed bond is exchanged). Note the rate of the fallback bond is used as a substitute for the inflation index if, for example, it is no longer published.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Fallback Bond means, in relation to an Inflation Index applicable to an Inflation Linked Note, a bond selected by the Calculation Agent and issued by the government or one of the governments (but not any government agency) of the country (or countries) to whose level of inflation the Inflation Index relates and which pays a coupon and/or redemption amount which is calculated by reference to the Inflation Index, with a maturity date which falls on the same day as the Maturity Date of the Inflation Linked Notes, or such other date as the Calculation Agent shall select if there is no such bond maturing on the Maturity Date of the Inflation Linked Notes. If any bond so selected is redeemed, the Calculation Agent will select a new Fallback Bond on the same basis, but selected from all eligible bonds in issue at the time the original Fallback Bond is redeemed (including any bond for which the redeemed bond is exchanged). Note the rate of the fallback bond is used as a substitute for the inflation index if, for example, it is no longer published.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bnd;isMandatory">
@@ -1541,7 +1530,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;SinkingFundAmortizationTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates that the bond has a long-term coupon but short potential short maturity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Super-sinker is a colloquial term for a term maturity, usually from a single family mortgage revenue issue with several term maturities, that will be the first to be called from a sinking fund into which all proceeds from prepayments of mortgages financed by the issue are deposited. The maturity&apos;s priority status under the call provisions means that it is likely to be redeemed in its entirety well before the stated maturity date.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Super-sinker is a colloquial term for a term maturity, usually from a single family mortgage revenue issue with several term maturities, that will be the first to be called from a sinking fund into which all proceeds from prepayments of mortgages financed by the issue are deposited. The maturity&apos;s priority status under the call provisions means that it is likely to be redeemed in its entirety well before the stated maturity date.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PutFeature">

--- a/SEC/Debt/CollateralizedDebtObligations.rdf
+++ b/SEC/Debt/CollateralizedDebtObligations.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -23,10 +24,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -50,17 +51,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/">
 		<rdfs:label xml:lang="en">Collateralized Debt Obligations Ontology</rdfs:label>
 		<dct:abstract>Collateralized debt obligations are tranched debt instruments based on pools of debt instruments, and those pools may have different management styles and objectives. Generally includes an equity tranche. This ontology also covers CDO squared.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-sec-dbt-cdo</sm:fileAbbreviation>
-		<sm:filename>CollateralizedDebtObligations.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -82,8 +78,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;ABSCDODeal">
@@ -288,7 +286,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">c d o deal</rdfs:label>
 		<skos:definition xml:lang="en">An Issue of a set of CDO tranches as part of an offering to the market.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Multiple tranches of securities are issued by the CDO issue (usually referred to simply as the CDO), offering investors various maturity and credit risk characteristics. Note that it is in the sense of CDO as an issue that one might say that a CDO &quot;has tranches&quot;. The CDO as an individual instrument (labelled CDO in this model) does not have tranches but is itself a member of one or another tranche.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Multiple tranches of securities are issued by the CDO issue (usually referred to simply as the CDO), offering investors various maturity and credit risk characteristics. Note that it is in the sense of CDO as an issue that one might say that a CDO &quot;has tranches&quot;. The CDO as an individual instrument (labelled CDO in this model) does not have tranches but is itself a member of one or another tranche.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;CDOManagementStyle">
@@ -421,7 +419,7 @@
 		<rdfs:label xml:lang="en">cashflow c d o</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-cdo;MarketValueCDO"/>
 		<skos:definition xml:lang="en">A cash-flow CDO is analogous to a CMO. Cash flows from collateral are used to pay principal and interest to investors. If such cash flows prove inadequate, principal and interest is paid to tranches according to seniority. At any point in time, all immediate obligations to a given tranch are met before any payments are made to less senior tranches.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are some cases where &quot;triggers&quot; can come into effect to cause the payments to be distributed in other ways. For example, if the CDO fails its senior overcollateralization (OC) trigger, it may cause extra cash to be diverted to the senior tranches&apos; principal in order to bring the deal back into compliance with the OC test.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">There are some cases where &quot;triggers&quot; can come into effect to cause the payments to be distributed in other ways. For example, if the CDO fails its senior overcollateralization (OC) trigger, it may cause extra cash to be diverted to the senior tranches&apos; principal in order to bring the deal back into compliance with the OC test.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;CashflowStructure">
@@ -442,8 +440,8 @@
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-cdo;AgencyCMO"/>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-cdo;CollateralizedLoanObligationOffering"/>
 		<skos:definition xml:lang="en">structured debt security that has investment-grade bonds as its underlying assets backed by the receivables on high-yield or junk bonds</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">CBO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A multitranche debt structure similar in some respects to a collateralized mortgage obligation (CMO) structure. Typically low-rated bonds rather than mortgages serve as the collateral. The organization creating and promoting the structure usually holds the underlying equity and may also collect a fee. Junk bonds are typically not investment grade, but because they pool several types of credit quality bonds together, they offer enough diversification to be &quot;investment grade.&quot; For example high yield [emerging market] CBO which consists of a portfolio of different high yield [emerging market] bonds. Investopedia: Similar in structure to a collateralized mortgage obligation (CMO), but different in that CBOs represent different levels of credit risk, not different maturities. Defoinition Origin:Investopedia</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">CBO</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">A multitranche debt structure similar in some respects to a collateralized mortgage obligation (CMO) structure. Typically low-rated bonds rather than mortgages serve as the collateral. The organization creating and promoting the structure usually holds the underlying equity and may also collect a fee. Junk bonds are typically not investment grade, but because they pool several types of credit quality bonds together, they offer enough diversification to be &quot;investment grade.&quot; For example high yield [emerging market] CBO which consists of a portfolio of different high yield [emerging market] bonds. Investopedia: Similar in structure to a collateralized mortgage obligation (CMO), but different in that CBOs represent different levels of credit risk, not different maturities. Defoinition Origin:Investopedia</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;CollateralizedDebtObligation">
@@ -457,7 +455,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">collateralized debt obligation</rdfs:label>
 		<skos:definition xml:lang="en">structured finance constructed from a portfolio of fixed income assets including corporate loans and mortgage backed securities. A special purpose vehicle (SPV) issues notes to investors in order to raise funds that are invested in a portfolio of those fixed income assets, held by the SPV as collateral for the notes. Further notes: Collateralized Debt Obligation, for example, ABS CDO which consists of a portfolio of different ABS bonds, and the payments to the holders of these trust certificates are derived from the cash flows of the ABS bonds. This CDO instrument is part of a CDO issue, consisting of individual CDO instruments of a given seniority. Often referred to as tranches and slices (Investopedia). Investopedia: Similar in structure to a collateralized mortgage obligation (CMO) or collateralized bond obligation (CBO), CDOs are unique in that they represent different types of debt and credit risk. In the case of CDOs, these different types of debt are often referred to as &apos;tranches&apos; or &apos;slices&apos;. Each slice has a different maturity and risk associated with it. The higher the risk, the more the CDO pays. Further details: Collateralized Debt obligations are securitized interests in pools of - generally non-mortgage - assets. Assets - called collateral - usually comprise loans or debt instruments. A CDO may be called a collateralized loan obligation (CLO) or collateralized bond obligation (CBO) if it holds only loans or bonds, respectively. Investors bear the credit risk of the collateral. Multiple tranches of securities are issued by the CDO, offering investors various maturity and credit risk characteristics.</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">CDO</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation xml:lang="en">CDO</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;CollateralizedLoanObligationOffering">
@@ -470,7 +468,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">collateralized loan obligation offering</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-cdo;AgencyCMO"/>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">CLO offering</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation xml:lang="en">CLO offering</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;HybridCDO">
@@ -504,7 +502,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-cdo;TriggerEvent"/>
 		<rdfs:label xml:lang="en">jump z trigger event</rdfs:label>
 		<skos:definition xml:lang="en">The event which triggers the Jump Z</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If this trigger event is reached then the holders of the Jump Z tranche will begin to receive payments. Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed. The event may be a market event or an event relating to the deal.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">If this trigger event is reached then the holders of the Jump Z tranche will begin to receive payments. Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed. The event may be a market event or an event relating to the deal.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;JumpZTriggerEventReversal">
@@ -550,7 +548,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">m b s instrument slice</rdfs:label>
 		<skos:definition xml:lang="en">A holding of an individual slice or slices of a tranche.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These may be held in different notes, with different denominations. Tranche slice in this sense is only relevant in the context of something like a CDO or analogous things such as CBO.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">These may be held in different notes, with different denominations. Tranche slice in this sense is only relevant in the context of something like a CDO or analogous things such as CBO.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;ManagedCDO">
@@ -615,7 +613,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">mezzanine c d o tranche</rdfs:label>
 		<skos:definition xml:lang="en">The tranche between senior and subordinated. Mezzanine tranches of a CDO issue are typically rated B to BBB.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to mezzanine tranches take precedence over those to subordinated/equity tranches.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to mezzanine tranches take precedence over those to subordinated/equity tranches.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;PAC-1Class">
@@ -628,7 +626,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">p a c-1 class</rdfs:label>
 		<skos:definition xml:lang="en">Planned Amortization Class tranche. PAC-1 is the most senior Planned Amortization Class tranche.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;PAC-2Class">
@@ -641,14 +639,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">p a c-2 class</rdfs:label>
 		<skos:definition xml:lang="en">Planned Amortization Class tranche. PAC-2 refers to a support tranche that is given a scheduled payment structure like a PAC bond.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. For example, let&apos;s say you have a deal with a PAC tranche and a support tranche (i.e., a tranche that is a support tranche and is therefore subordinate to the PAC tranche) that has a scheduled payment structure like you did with the PAC bond. That support bond then is called the PAC-2 bond. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. For example, let&apos;s say you have a deal with a PAC tranche and a support tranche (i.e., a tranche that is a support tranche and is therefore subordinate to the PAC tranche) that has a scheduled payment structure like you did with the PAC bond. That support bond then is called the PAC-2 bond. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;PAC-3Class">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-cdo;PlannedAmortizationClassBond"/>
 		<rdfs:label xml:lang="en">p a c-3 class</rdfs:label>
 		<skos:definition xml:lang="en">Planned Amortization Class tranche. Additional support tranche with scheduled payments.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. See PAC-2 for explanation. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. See PAC-2 for explanation. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;PAC-ZTranche">
@@ -693,7 +691,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">planned amortization class bond</rdfs:label>
 		<skos:definition xml:lang="en">Planned Amortization Class tranche.This is a tranche where the principal payment must follow a certain schedule.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. There are usually several PAC tranches created. PAC-1, PAC-2, PAC-3 -- this requires some more explanation. PAC-2 refers to a support tranche that is given a scheduled payment structure like a PAC bond. For example, let&apos;s say you have a deal with a PAC tranche and a support tranche (i.e., a tranche that is a support tranche and is therefore subordinate to the PAC tranche) that has a scheduled payment structure like you did with the PAC bond. That support bond then is called the PAC-2 bond. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond. Prospectus will cover each class. Prospectus is at the level of an issue.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. There are usually several PAC tranches created. PAC-1, PAC-2, PAC-3 -- this requires some more explanation. PAC-2 refers to a support tranche that is given a scheduled payment structure like a PAC bond. For example, let&apos;s say you have a deal with a PAC tranche and a support tranche (i.e., a tranche that is a support tranche and is therefore subordinate to the PAC tranche) that has a scheduled payment structure like you did with the PAC bond. That support bond then is called the PAC-2 bond. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond. Prospectus will cover each class. Prospectus is at the level of an issue.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;SeniorCDOTranche">
@@ -719,7 +717,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">static c d o</rdfs:label>
 		<skos:definition xml:lang="en">A CDO where collateral is fixed through the life of the CDO. The reference assets are bought and then are kept untouched for the term of the product.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Investors can assess the various tranches of the CDO with full knowledge of what the collateral will be. The primary risk they face is credit risk. A deal that starts off managed can become static if the performance is too poor. Also, some deals are static but allow managers to sell out poorly performing assets subject to certain conditions, but do not allow purchase of new assets, so are semi-static.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Investors can assess the various tranches of the CDO with full knowledge of what the collateral will be. The primary risk they face is credit risk. A deal that starts off managed can become static if the performance is too poor. Also, some deals are static but allow managers to sell out poorly performing assets subject to certain conditions, but do not allow purchase of new assets, so are semi-static.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;StaticCDOPortfolio">
@@ -738,7 +736,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
 		<rdfs:label xml:lang="en">subordinated c d o equity</rdfs:label>
 		<skos:definition xml:lang="en">The subordinated (also known as equity) CDO tranche is the most junior tranche in the CDO issue. If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to senior and mezzanine tranches take precedence over those to subordinated/equity tranches.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is not a tranche of the debt in the CDO but an equity interest in the pool of underlying. There is a very bottom piece, not a tranche, but rather called the preferred shares (or just pref shares, or equity) that is the very bottom most layer in a CDO and is also referred to as the &quot;first loss piece&quot; since, like equity in a corporation, losses are incurred here before any of the actual bond holders take losses. This isn&apos;t a tranche</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is not a tranche of the debt in the CDO but an equity interest in the pool of underlying. There is a very bottom piece, not a tranche, but rather called the preferred shares (or just pref shares, or equity) that is the very bottom most layer in a CDO and is also referred to as the &quot;first loss piece&quot; since, like equity in a corporation, losses are incurred here before any of the actual bond holders take losses. This isn&apos;t a tranche</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;SuperPOTranche">
@@ -762,7 +760,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">support tranche</rdfs:label>
 		<skos:definition xml:lang="en">A tranche which provides payment support to a PAC Tranche.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">PAC tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">PAC tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;TACTranche">

--- a/SEC/Debt/DebtInstruments.rdf
+++ b/SEC/Debt/DebtInstruments.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-dae-gty "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
@@ -23,10 +24,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-dae-gty="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"
@@ -50,22 +51,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
 		<rdfs:label>Debt Instruments Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts that are specific to debt instruments (tradable and non-tradable).</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-dbt-dbti</sm:fileAbbreviation>
-		<sm:filename>DebtInstruments.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -83,7 +74,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Debt/DebtInstruments/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/DebtInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Debt/DebtInstruments.rdf version of this ontology was modified to reflect use of actualExpression as an annotation rather than datatype property, to deprecate maturity-related properties which have been moved to financial instruments more generally, and to simplify restrictions on tradable debt instrument.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to support integration of the bonds ontology.</skos:changeNote>
@@ -92,7 +84,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, hasMaturityDate, to Financial Instruments, since a maturity date can apply to a preferred share in addition to a debt instrument or offering rename &apos;mayBeSubordinatedTo&apos;, which violates the policy related to masquerading properties, eliminate a circular definition and unnecessary references to external sources, eliminate call price and put price, which are overreaching and confusing, in favor of monetary price, and eliminate the restriction for hasTimeToMaturity from debt instrument, made redundant by the broader restriction in financial instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Debt/DebtInstruments.rdf version of this ontology was modified to make hasDefaultLotSize a subproperty of hasLotSize.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Debt/DebtInstruments.rdf version of this ontology was modified to generalize the definition of fixed income security.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Debt/DebtInstruments.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;DebtInstrument">
@@ -141,15 +136,15 @@
 		<rdf:type rdf:resource="&fibo-sec-dbt-dbti;RelativePrice"/>
 		<rdfs:label>at a discount</rdfs:label>
 		<skos:definition>a selling price that is less than the face or nominal value</skos:definition>
-		<fibo-fnd-utl-av:synonym>below par</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>below par</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-dbti;AtAPremium">
 		<rdf:type rdf:resource="&fibo-sec-dbt-dbti;RelativePrice"/>
 		<rdfs:label>at a premium</rdfs:label>
 		<skos:definition>a selling price significantly above the stated face or redemption value due to high demand or timing of redemption</skos:definition>
-		<fibo-fnd-utl-av:synonym>above par</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>premium</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>above par</cmns-av:synonym>
+		<cmns-av:synonym>premium</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;CallEvent">
@@ -175,8 +170,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>call feature</rdfs:label>
 		<skos:definition>redemption provision defining the rights of the issuer to buy back a security at a call price after a call protection period</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Most corporate and municipal bonds have ten-year call features (termed call protection by holders); government securities typically have none.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>call provision</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Most corporate and municipal bonds have ten-year call features (termed call protection by holders); government securities typically have none.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>call provision</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;CallNotificationProvision">
@@ -246,7 +241,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 		<rdfs:label>fixed income security</rdfs:label>
 		<skos:definition>tradeable debt instrument that provides a return in the form of fixed periodic payments and typically the return of principal at maturity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Fixed income securities provide payments according to a regular schedule. This does not necessarily mean that the payments themselves are of a fixed amount, however.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Fixed income securities provide payments according to a regular schedule. This does not necessarily mean that the payments themselves are of a fixed amount, however.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;FullyIndexedInterestRate">
@@ -267,7 +262,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>fully-indexed interest rate</rdfs:label>
 		<skos:definition>a variable interest rate that is calculated by adding a margin to a specified index rate</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Fully indexed interest rates are used for variable rate credit products. The interest rate on a variable (adjustable) rate mortgage corresponds to a specific benchmark (often the prime rate, but sometimes LIBOR, the one-year constant-maturity Treasury, or other benchmarks) plus a spread (also called the margin. The margin on a fully indexed interest rate product is determined by the underwriter and based on the borrower&apos;s credit quality.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Fully indexed interest rates are used for variable rate credit products. The interest rate on a variable (adjustable) rate mortgage corresponds to a specific benchmark (often the prime rate, but sometimes LIBOR, the one-year constant-maturity Treasury, or other benchmarks) plus a spread (also called the margin. The margin on a fully indexed interest rate product is determined by the underwriter and based on the borrower&apos;s credit quality.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;InterestOnlyStrip">
@@ -275,8 +270,8 @@
 		<rdfs:label xml:lang="en">interest-only strip</rdfs:label>
 		<skos:definition xml:lang="en">a strip that represents the non-principal portion of the monthly payments on the underlying debt instrument, such as a bond</skos:definition>
 		<skos:example>An interest-only strip can be reintegrated into other synthetic or engineered products. For example, interest-only strips can be pooled to create or make up a portion of a larger collateralized mortgage obligation (CMO), asset-backed security (ABS) or collateralized debt obligation (CDO) structure.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote>An interest-only strip holder is interested in rising rates and no prepayment, as prepayment would cause them forfeit future interest payments and receive nothing from the return of the principal.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">IO strip</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>An interest-only strip holder is interested in rising rates and no prepayment, as prepayment would cause them forfeit future interest payments and receive nothing from the return of the principal.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">IO strip</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;IssuedDebt">
@@ -301,15 +296,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;CallFeature"/>
 		<rdfs:label>make whole feature</rdfs:label>
 		<skos:definition>a call provision allowing the issuer to pay off remaining debt early</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The issuer typically has to make a lump sum payment to the investor derived from a formula based on the net present value (NPV) of future interest or coupon payments that will not be paid incrementally because of the call combined with the principal payment the investor would have received at maturity.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>make whole provision</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>The issuer typically has to make a lump sum payment to the investor derived from a formula based on the net present value (NPV) of future interest or coupon payments that will not be paid incrementally because of the call combined with the principal payment the investor would have received at maturity.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>make whole provision</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;Margin">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Variable"/>
 		<rdfs:label>margin</rdfs:label>
 		<skos:definition>a variable that is added to a specified index rate to determine the fully indexed interest rate charged to a borrower on a credit balance</skos:definition>
-		<fibo-fnd-utl-av:synonym>spread</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>spread</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;NonTradableDebtInstrument">
@@ -338,7 +333,7 @@
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 		<skos:definition>a debt instrument that may not be bought or sold</skos:definition>
 		<skos:example>Low-risk instruments such as savings bonds are examples of nonnegotiable debt instruments.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote>Generally, a nonnegotiable instrument may be redeemed by the issuer, but this is often subject to some limitations.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Generally, a nonnegotiable instrument may be redeemed by the issuer, but this is often subject to some limitations.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;NotificationProvision">
@@ -357,9 +352,9 @@
 		<rdf:type rdf:resource="&fibo-sec-dbt-dbti;RelativePrice"/>
 		<rdfs:label>par value</rdfs:label>
 		<skos:definition>the stated value of a negotiable instrument, stock, or bond, as compared with the value that instrument might receive when sold</skos:definition>
-		<fibo-fnd-utl-av:synonym>face value</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>nominal value</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>par</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>face value</cmns-av:synonym>
+		<cmns-av:synonym>nominal value</cmns-av:synonym>
+		<cmns-av:synonym>par</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PrescriptiveEvent">
@@ -412,7 +407,7 @@
 		<rdfs:label>put feature</rdfs:label>
 		<skos:definition>redemption provision giving the holder the right, but not the obligation, to sell a specified amount of the debt instrument (i.e., redeem it), prior to maturity</skos:definition>
 		<skos:editorialNote>FIBIM has term &quot;Putable Date&quot; which (by implication, and comparing with definition for &quot;Next Call Date&quot;) is presumably a single calendar date in the future, at a given point in time. That does not cover the definition of formal terms defining when and how the issue may be put, which is what is modeled here.</skos:editorialNote>
-		<fibo-fnd-utl-av:synonym>put provision</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>put provision</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PutNotificationProvision">
@@ -482,8 +477,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;FixedIncomeSecurity"/>
 		<rdfs:label xml:lang="en">strip</rdfs:label>
 		<skos:definition xml:lang="en">a tradeable debt instrument created either through the process of removing coupons from a bond and then selling the separate parts as a zero coupon bond and an interest paying coupon bond or through taking the opposite position from some variant in the options market</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">STRIPS is an acronym for Separate Trading of Registered Interest and Principal of Securities, which has come to be used as a term in its own right.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">Separate Trading of Registered Interest and Principal of Securities</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">STRIPS is an acronym for Separate Trading of Registered Interest and Principal of Securities, which has come to be used as a term in its own right.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">Separate Trading of Registered Interest and Principal of Securities</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;TradableDebtInstrument">
@@ -505,14 +500,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>tradable debt instrument</rdfs:label>
 		<skos:definition>a debt instrument that is also a security, i.e., that can be bought and sold by the holder</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Details from Ecofin: A [debt] instrument can be traded, if its features depend only on one borrower. If the instrument has no bilateral or multilateral obligations, the investor can easily transfer it to another investor without asking the borrower (except the terms prohibit this explicitly). This is simplified with securitised instruments, where the debt is already split into handy denominations which trade easily (e.g. in round thousands or millions as with bonds, commercial paper, etc.). But in principle it works also with interbank loans and similar instruments. FIBIM Definition: Financial instruments evidencing moneys owed by the issuer to the holder on terms as specified.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Details from Ecofin: A [debt] instrument can be traded, if its features depend only on one borrower. If the instrument has no bilateral or multilateral obligations, the investor can easily transfer it to another investor without asking the borrower (except the terms prohibit this explicitly). This is simplified with securitised instruments, where the debt is already split into handy denominations which trade easily (e.g. in round thousands or millions as with bonds, commercial paper, etc.). But in principle it works also with interbank loans and similar instruments. FIBIM Definition: Financial instruments evidencing moneys owed by the issuer to the holder on terms as specified.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;VariableIncomeSecurity">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 		<rdfs:label>variable income security</rdfs:label>
 		<skos:definition>tradeable debt instrument that provide their owners with a rate of return that is dynamic and determined by market forces</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Variable-income securities provide investors with both greater risks as well as rewards.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Variable-income securities provide investors with both greater risks as well as rewards.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-dbti;allowsAutoReinvestment">
@@ -552,7 +547,7 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>specifies the date on which interest begins to accrue on a fixed-income security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Investors who purchase a fixed-income security between interest payment dates must also pay the seller or issuer any interest that has accrued from the dated date to the purchase date, or settlement date, in addition to the face value.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Investors who purchase a fixed-income security between interest payment dates must also pay the seller or issuer any interest that has accrued from the dated date to the purchase date, or settlement date, in addition to the face value.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-dbti;hasDefaultLotSize">
@@ -570,7 +565,7 @@
 		</rdfs:domain>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition>indicates the default number of units of the security that may be held at any one time</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is the minimum denomination required for transfer or change of ownership of a tradable debt security.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is the minimum denomination required for transfer or change of ownership of a tradable debt security.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-dbti;hasEstateOrDeathPutFeature">
@@ -706,7 +701,7 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;RedemptionProvision"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether the issuer has the option to extend the debt rather than refinancing</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>If not, the issuer may only refinance the debt by calling the issue and creating a new issue.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>If not, the issuer may only refinance the debt by calling the issue and creating a new issue.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-dbti;isPutable">

--- a/SEC/Debt/ExerciseConventions.rdf
+++ b/SEC/Debt/ExerciseConventions.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -13,10 +14,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -30,35 +31,30 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
 		<rdfs:label xml:lang="en">Exercise Conventions Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the various kinds of exercise conventions that are common to debt and options instruments. They are distinguished primarily in terms of the date period during which an optional contract clause may be exercised.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-dbt-ex</sm:fileAbbreviation>
-		<sm:filename>ExerciseConventions.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Debt/ExerciseConventions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/ExerciseConventions/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20211001/Debt/ExerciseConventions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190101/Debt/ExerciseConventions.rdf version of this ontology was added to support integration of Bonds and Options in SEC and DER, respectively.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190101/Debt/ExerciseConventions.rdf version of this ontology was modified to add the hasExerciseTerms property.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/ExerciseConventions.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Debt/ExerciseConventions.rdf version of this ontology was modified to revise the definition of American exercise terms to say that an option with such terms may be exercised on or before the expiration date of the contract.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210901/Debt/ExerciseConventions.rdf version of this ontology was modified to loosen the domain of hasExerciseTerms to allow for entitlements to have such terms.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-ex;AmericanExerciseConvention">
@@ -79,7 +75,7 @@
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ex;BermudanExerciseTerms"/>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ex;EuropeanExerciseTerms"/>
 		<skos:definition xml:lang="en">exercise terms that stipulate that an option may be exercised on or before the date of expiration</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Under certain circumstances, early exercise may be advantageous to the option holder.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Under certain circumstances, early exercise may be advantageous to the option holder.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-ex;BermudanExerciseConvention">
@@ -111,7 +107,7 @@
 		<rdfs:label xml:lang="en">Bermudan exercise terms</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ex;EuropeanExerciseTerms"/>
 		<skos:definition xml:lang="en">exercise terms that stipulate that an option may only be exercised on predetermined dates within some exercise window, often on one day each month or at the date of expiration</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The Bermuda option is named as such because its exercise dates are more flexible than European options and less flexible than American options. Thus, it is in the middle, just like Bermuda is between Europe and America. Bermuda options are also referred to as Mid-Atlantic, Quasi American, or Semi-American options.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The Bermuda option is named as such because its exercise dates are more flexible than European options and less flexible than American options. Thus, it is in the middle, just like Bermuda is between Europe and America. Bermuda options are also referred to as Mid-Atlantic, Quasi American, or Semi-American options.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-ex;CanaryExerciseConvention">

--- a/SEC/Debt/LoanParticipationNotes.rdf
+++ b/SEC/Debt/LoanParticipationNotes.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -13,10 +14,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/LoanParticipationNotes/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -30,13 +31,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/LoanParticipationNotes/">
-		<rdfs:label xml:lang="en">LoanParticipationNotes</rdfs:label>
-		<dct:abstract>Contracts which give the holder some formal participation in some loan.</dct:abstract>
-		<sm:fileAbbreviation>fibo-sec-dbt-lpn</sm:fileAbbreviation>
+		<rdfs:label xml:lang="en">Loan Participation Notes Ontology</rdfs:label>
+		<dct:abstract>This ontology defines contracts which give the holder some formal participation in some loan.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -46,8 +46,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/LoanParticipationNotes/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-lpn;LeadManager">

--- a/SEC/Debt/MetadataSECDebt.rdf
+++ b/SEC/Debt/MetadataSECDebt.rdf
@@ -36,7 +36,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-mod;DebtModule">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
-		<rdfs:label>FIBO SEC Debt Module</rdfs:label>
+		<rdfs:label>debt module</rdfs:label>
 		<dct:abstract>This module defines debt securities contracts both cash and synthetic, such as bonds, structured finance instruments, short term or money market instruments, and other contracts characterized by the holding of some debt of the issuer or primary party by the holder or counterparty.</dct:abstract>
 		<dct:contributor>Adaptive, Inc.</dct:contributor>
 		<dct:contributor>BIAN</dct:contributor>

--- a/SEC/Debt/MetadataSECDebt.rdf
+++ b/SEC/Debt/MetadataSECDebt.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-dbt-mod "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-dbt-mod="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/"
@@ -18,27 +19,48 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/">
 		<rdfs:label>Metadata about the EDMC-FIBO Securities (SEC) Debt Module</rdfs:label>
 		<dct:abstract>The SEC Debt Module covers content specific to debt instruments, including but not limited to bonds and asset-backed securities. This ontology provides metadata about the Debt module and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-03-31T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-sec-dbt-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataSECDebt.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Debt/MetadataSECDebt/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/MetadataSECDebt/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-mod;DebtModule">
-		<rdf:type rdf:resource="&sm;Module"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>FIBO SEC Debt Module</rdfs:label>
 		<dct:abstract>This module defines debt securities contracts both cash and synthetic, such as bonds, structured finance instruments, short term or money market instruments, and other contracts characterized by the holding of some debt of the issuer or primary party by the holder or counterparty.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>BIAN</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Goldman Sachs</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Mizuho</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"/>
@@ -50,32 +72,11 @@
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyntheticCDOs/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>BIAN</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Goldman Sachs</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>Mizuho</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:contributor>agnos.ai U.K. Ltd</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-SEC-DBT</sm:moduleAbbreviation>
+		<dct:title>FIBO SEC Debt Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Securities and Equities (SEC) Debt Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/Debt/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/MortgageBackedSecurities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -33,10 +34,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -70,30 +71,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/">
 		<rdfs:label xml:lang="en">Mortgage-backed Securities Ontology</rdfs:label>
 		<dct:abstract>Mortgage backed securities are like asset backed securities except that the underlying loan pool is a pool of mortgage loans.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BP/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/LOAN/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/MD/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-dbt-mbs</sm:fileAbbreviation>
-		<sm:filename>MortgageBackedSecurities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/"/>
@@ -120,9 +103,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;HomeEquityLineOfCreditPool">
@@ -134,7 +119,7 @@
 		<rdfs:label xml:lang="en">agency m b s deal</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-mbs;PrivateLabelMBSDeal"/>
 		<skos:definition xml:lang="en">An issue of securities backed by pools of mortgages held by government agencies.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are Ginnie Mae, Freddie Mac and Fannie Mae (for the US). Of these agencies, GNMA (Ginnie Mae) issues mortgages in its own right (Investorwords differs on this). Fannie Mae and Freddie Mac purchase mortgages. Those mortgages are issued by banks. Before one of these agencies purchases a mortgage, there are certain criteria that have to be met. These are specified in terms of, for example, the balance of the mortgage, limits to credit ratings.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">These are Ginnie Mae, Freddie Mac and Fannie Mae (for the US). Of these agencies, GNMA (Ginnie Mae) issues mortgages in its own right (Investorwords differs on this). Fannie Mae and Freddie Mac purchase mortgages. Those mortgages are issued by banks. Before one of these agencies purchases a mortgage, there are certain criteria that have to be met. These are specified in terms of, for example, the balance of the mortgage, limits to credit ratings.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;AgencyMBSIssuer">
@@ -148,7 +133,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mbs;MBSPool"/>
 		<rdfs:label xml:lang="en">agency m b s pool</rdfs:label>
 		<skos:definition xml:lang="en">A pool investment consisting of a collection of Agency MBS instruments.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This pool may be used as the underlying for an agency CMO. Non agency CMOs do not exist.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This pool may be used as the underlying for an agency CMO. Non agency CMOs do not exist.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;AgencyMortgagePool">
@@ -189,7 +174,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">floater tranche</rdfs:label>
 		<skos:definition xml:lang="en">A floater tranche is a tranche that is keyed to an index and a spread.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, 3 month LIBOR +50 -- meaning that the coupon would be whatever the 3 month LIBOR is plus 50 basis points. This is not a continuously updated number, rather it resets at specified intervals.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">For example, 3 month LIBOR +50 -- meaning that the coupon would be whatever the 3 month LIBOR is plus 50 basis points. This is not a continuously updated number, rather it resets at specified intervals.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;GNMA-IIPool">
@@ -268,7 +253,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">m b s issuer</rdfs:label>
 		<skos:definition xml:lang="en">The issuer of a Mortgage Backed Security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can be an agency that exists for this purpose or it may be the issuer of the original mortgages in the pool.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This can be an agency that exists for this purpose or it may be the issuer of the original mortgages in the pool.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;MBSPool">
@@ -281,7 +266,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
 		<rdfs:label xml:lang="en">m b s tranche note</rdfs:label>
 		<skos:definition xml:lang="en">An individual note of a tranche.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Tranche is made up of e.g. $500m in notes and so on. These may be in different notes, with different denominations. Analytics that would apply to the Tranche would by implication apply to each slice of the tranche.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A Tranche is made up of e.g. $500m in notes and so on. These may be in different notes, with different denominations. Analytics that would apply to the Tranche would by implication apply to each slice of the tranche.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;MezzanineMBSTranche">
@@ -312,9 +297,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">mortgage-backed security</rdfs:label>
 		<skos:definition xml:lang="en">debt obligations that represent claims to the cash flows from pools of mortgage loans, most commonly on residential property</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">MBS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Mortgage loans are purchased from banks, mortgage companies and other originators, and then assembled into pools by a governmental, quasigovernmental or private entity. The entity then issues securities that represent claims on the principal and interest payments made by borrowers on the loans in the pool, a process known as securitization.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">MBS</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Mortgage loans are purchased from banks, mortgage companies and other originators, and then assembled into pools by a governmental, quasigovernmental or private entity. The entity then issues securities that represent claims on the principal and interest payments made by borrowers on the loans in the pool, a process known as securitization.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;MortgageBackedSecurityOfferingProspectus">
@@ -512,8 +497,8 @@ Consensus:Review.</skos:editorialNote>
 		<rdfs:label xml:lang="en">real estate mortgage investment conduit</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/r/real-estate-mortgage-investment-conduit-remic.asp"/>
 		<skos:definition xml:lang="en">special purpose vehicle that pools mortgage loans together and issues mortgage-backed securities</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">REMIC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A real estate mortgage investment conduit may be organized as a partnership, a trust, a corporation, or an association and is exempt from federal taxes.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">REMIC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">A real estate mortgage investment conduit may be organized as a partnership, a trust, a corporation, or an association and is exempt from federal taxes.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;RegularFloaterTranche">
@@ -521,14 +506,14 @@ Consensus:Review.</skos:editorialNote>
 		<rdfs:label xml:lang="en">regular floater tranche</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-mbs;SuperFloaterTranche"/>
 		<skos:definition xml:lang="en">A floater tranche is a tranche that is keyed to an index and a spread. The spread is added to the index.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, 3 month LIBOR +50 -- meaning that the coupon would be whatever the 3 month LIBOR is plus 50 basis points. This is not a continuously updated number, rather it resets at specified intervals.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">For example, 3 month LIBOR +50 -- meaning that the coupon would be whatever the 3 month LIBOR is plus 50 basis points. This is not a continuously updated number, rather it resets at specified intervals.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;ResidentialMBS">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mbs;MortgageBackedSecurity"/>
 		<rdfs:label xml:lang="en">residential m b s</rdfs:label>
 		<skos:definition xml:lang="en">Residential Mortgage-Backed Securities, which are trust certificates (bonds) backed by a pool of residential mortgage loans.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notes from CESR: They are issued by banks and backed by an underlying pool of residential mortgages. There can be some distinctions between prime RMBS and sub-prime/non-conforming RMBS although there is no consensus about what constitutes a sub-prime/non-conforming mortgage in Europe.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Notes from CESR: They are issued by banks and backed by an underlying pool of residential mortgages. There can be some distinctions between prime RMBS and sub-prime/non-conforming RMBS although there is no consensus about what constitutes a sub-prime/non-conforming mortgage in Europe.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;ResidualTranche">

--- a/SEC/Debt/PoolBackedSecurities.rdf
+++ b/SEC/Debt/PoolBackedSecurities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -14,10 +15,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -32,23 +33,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/">
 		<rdfs:label xml:lang="en">Pool-backed Securities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts that are common to asset-backed and mortgage-backed securities, including pools, as well as structured finance instruments.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-dbt-pbs</sm:fileAbbreviation>
-		<sm:filename>PoolBackedSecurities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
@@ -57,18 +47,22 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Debt/PoolBackedSecurities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/PoolBackedSecurities/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Debt/PoolBackedSecurities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;AssetBackedSecurity">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;PoolBackedSecurity"/>
 		<rdfs:label xml:lang="en">asset-backed security</rdfs:label>
 		<skos:definition xml:lang="en">debt instrument backed by receivables other than those arising out of real estate loans or mortgages</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">ABS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Asset-backed securities, for example home equity loans (HEL), credit cards, and so forth are backed by receivables [payments] that are either secured (such as HEL) or unsecured (for example, credit cards). They are typically tranched based on default risk.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">One difference between an ABs and a collateralized debt obligation (CDO) is that the CDO issuer is generally a special purpose vehicle (SPV) or trust.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">ABS</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Asset-backed securities, for example home equity loans (HEL), credit cards, and so forth are backed by receivables [payments] that are either secured (such as HEL) or unsecured (for example, credit cards). They are typically tranched based on default risk.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">One difference between an ABs and a collateralized debt obligation (CDO) is that the CDO issuer is generally a special purpose vehicle (SPV) or trust.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;PoolBackedSecurity">
@@ -88,16 +82,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">pool-backed security</rdfs:label>
 		<skos:definition xml:lang="en">debt instrument that derives its cashflow from an underlying pool of mortgage loans or other receivables</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the security is a component of a collateralized debt obligation, then the underlying pool is typically segmented into various tranches, each of which provides cash flows to hedge particular risks, or that offset other gains by time to maturity or other factors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">If the security is a component of a collateralized debt obligation, then the underlying pool is typically segmented into various tranches, each of which provides cash flows to hedge particular risks, or that offset other gains by time to maturity or other factors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;PrincipalProtectedNote">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;StructuredFinanceInstrument"/>
 		<rdfs:label xml:lang="en">principal protected note</rdfs:label>
 		<skos:definition xml:lang="en">structured finance that offers investors exposure to chosen underlying assets using various approaches and asymmetric pay-off profiles</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are one or more reference entities underlying the product. Redemption is made at least in the amount of the conditional capital protection at maturity, provided that no credit event by the reference entity has occurred. Conditional capital protection only applies to the nominal amount and not to the purchase price. The general functioning of a capital guaranteed structured instrument is as follows: the notional amount is split into a zero bond, that will deliver the capital guarantee at maturity, and the difference between the zero bond&apos;s value (= present value of the guarantee level at maturity) and the notional amount is used for structuring the performance component with options which deliver the agreed pay-off profile of the structured instrument.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">capital protected note</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">There are one or more reference entities underlying the product. Redemption is made at least in the amount of the conditional capital protection at maturity, provided that no credit event by the reference entity has occurred. Conditional capital protection only applies to the nominal amount and not to the purchase price. The general functioning of a capital guaranteed structured instrument is as follows: the notional amount is split into a zero bond, that will deliver the capital guarantee at maturity, and the difference between the zero bond&apos;s value (= present value of the guarantee level at maturity) and the notional amount is used for structuring the performance component with options which deliver the agreed pay-off profile of the structured instrument.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">capital protected note</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;StructuredFinanceInstrument">
@@ -117,8 +111,8 @@
 		<rdfs:seeAlso rdf:resource="https://www.bis.org/publ/cgfs23mitchell.pdf"/>
 		<skos:definition xml:lang="en">pool-backed security wherein the risk associated with the pool has been uncoupled from the risk associated with the originating institution through a special purpose vehicle</skos:definition>
 		<skos:example xml:lang="en">Collateralized debt obligations (CDOs), synthetic financial instruments, collateralized bond obligations (CBOs), and syndicated loans are examples of structured finance instruments.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Structured finance instruments represent a form of securitization technology which can be defined by three key characteristics: (1) pooling of financial assets, such as loans, bonds, or credit-default swaps; (2) de-linking of the credit risk of the asset pool from the credit risk of the originating firm, usually through use of a finite-lived, stand-alone special purpose vehicle (SPV); and (3) issuance by the SPV of &quot;tranched&quot; liabilities backed by the asset pool. Structured finance instruments are typically presented to large financial institutions or companies with complicated financing needs that are unsatisfied with conventional financial products.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">structured finance</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">Structured finance instruments represent a form of securitization technology which can be defined by three key characteristics: (1) pooling of financial assets, such as loans, bonds, or credit-default swaps; (2) de-linking of the credit risk of the asset pool from the credit risk of the originating firm, usually through use of a finite-lived, stand-alone special purpose vehicle (SPV); and (3) issuance by the SPV of &quot;tranched&quot; liabilities backed by the asset pool. Structured finance instruments are typically presented to large financial institutions or companies with complicated financing needs that are unsatisfied with conventional financial products.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">structured finance</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;StructuredFinanceWithoutPrincipalProtection">
@@ -126,9 +120,9 @@
 		<rdfs:label xml:lang="en">structured finance without principal protection</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-pbs;PrincipalProtectedNote"/>
 		<skos:definition xml:lang="en">structured finance that is a short-term note linked to an underlying asset that offers a steady stream of income</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The redemption at the end of the term is determined on the basis of the performance and final fixing of the underlying asset: a redemption at the nominal value is guaranteed as long as the underlying asset has not touched its barrier during relevant barrier monitoring. If the underlying asset has touched its barrier but is again above the strike price at final fixing, the nominal price is also repaid. Nevertheless, if the underlying asset has touched its barrier during barrier monitoring and closes below the strike price at final fixing, the underlying asset is delivered or cash compensation paid, provided that no credit event by the reference entity has occurred. Depending on the characteristics of the product, either a coupon or a discount to the underlying asset can apply. A coupon is paid out regardless of the performance of the underlying asset, provided that no credit event by the reference entity has occurred.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">structured finance without capital protection</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">The redemption at the end of the term is determined on the basis of the performance and final fixing of the underlying asset: a redemption at the nominal value is guaranteed as long as the underlying asset has not touched its barrier during relevant barrier monitoring. If the underlying asset has touched its barrier but is again above the strike price at final fixing, the nominal price is also repaid. Nevertheless, if the underlying asset has touched its barrier during barrier monitoring and closes below the strike price at final fixing, the underlying asset is delivered or cash compensation paid, provided that no credit event by the reference entity has occurred. Depending on the characteristics of the product, either a coupon or a discount to the underlying asset can apply. A coupon is paid out regardless of the performance of the underlying asset, provided that no credit event by the reference entity has occurred.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">structured finance without capital protection</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;Tranche">
@@ -147,7 +141,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">tranche</rdfs:label>
 		<skos:definition xml:lang="en">segment of a pool of securities, typically debt instruments</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A tranche is one of a number of related securities in the same offering that represents a partition of a debt pool whose cash flow is derived from the combined cash flows of the instruments in that partition.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A tranche is one of a number of related securities in the same offering that represents a partition of a debt pool whose cash flow is derived from the combined cash flows of the instruments in that partition.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-pbs;isPassThrough">

--- a/SEC/Debt/SyntheticCDOs.rdf
+++ b/SEC/Debt/SyntheticCDOs.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
@@ -17,10 +18,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyntheticCDOs/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"
@@ -38,22 +39,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyntheticCDOs/">
 		<rdfs:label xml:lang="en">SyntheticCDOs</rdfs:label>
 		<dct:abstract>Synthetic collateralized debt obligations are instruments designed to provide the same kind of structure and returns as a CDO, but these are not backed by an actual pool of debt assets.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-dbt-syn</sm:fileAbbreviation>
-		<sm:filename>SyntheticCDOs.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"/>
@@ -65,8 +56,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyntheticCDOs/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;CashCDOTranche">
@@ -91,7 +84,7 @@
 		<rdfs:label xml:lang="en">arbitrage synthetic c d o</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-syn;SyntheticBalanceSheetCDO"/>
 		<skos:definition xml:lang="en">Arbitrage synthetic CDO deals are motivated by regulatory or practical considerations that might make a bank want to retain ownership of debt while achieving capital relief through CDSs. In this case, the sponsoring bank has a portfolio of obligations, called the reference portfolio. It retains that portfolio, but offloads its credit risk by transacting CDSs with the CDO.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For arbitrage synthetic deals, two advantages are - an abbreviated ramp-up period (for managed deals), and - the possibility that selling protection through CDSs can be less expensive than directly buying the underlying bonds. This is often true at the lower end of the credit spectrum.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">For arbitrage synthetic deals, two advantages are - an abbreviated ramp-up period (for managed deals), and - the possibility that selling protection through CDSs can be less expensive than directly buying the underlying bonds. This is often true at the lower end of the credit spectrum.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-syn;SyntheticAmortizingSecurity">

--- a/SEC/Debt/TradedShortTermDebt.rdf
+++ b/SEC/Debt/TradedShortTermDebt.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-gty "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
@@ -19,10 +20,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-gty="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
@@ -42,22 +43,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/">
 		<rdfs:label xml:lang="en">Traded Short-Term Debt Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a number of basic, traded short-term debt instruments, many of which are considered money market instruments that may be freely traded.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
-		<sm:fileAbbreviation>fibo-sec-dbt-tstd</sm:fileAbbreviation>
-		<sm:filename>TradedShortTermDebt.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
@@ -71,11 +62,15 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20211201/Debt/TradedShortTermDebt/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/TradedShortTermDebt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Debt/TradedShortTermDebt.rdf version of this ontology was modified to eliminate a circular definition.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Debt/TradedShortTermDebt.rdf version of this ontology was modified to clarify the definition of bill of exchange.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210901/Debt/TradedShortTermDebt.rdf version of this ontology was modified to remove the subclass relationship with respect to fixed income from bankers&apos; acceptance, make bill of exchange a subclass of money market instrument and fix spelling errors.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211201/Debt/TradedShortTermDebt.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;BankersAcceptance">
@@ -100,7 +95,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bankers&apos; acceptance</rdfs:label>
 		<skos:definition xml:lang="en">short-term debt instrument that is guaranteed and paid by a bank and used as a relatively safe form of payment for large transactions</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Considered negotiable instruments with features of a time draft, bankers&apos; acceptances are created by the drawer and provide the bearer with the right to the amount noted on the face of the acceptance on the specified date. Unlike traditional checks, bankers&apos; acceptances function based on the creditworthiness of the banking institution instead of the individual or business acting as the drawer. Additionally, the drawer must provide the funds necessary to support the bankers&apos; acceptance, eliminating the risk associated with insufficient funds on the part of the drawer.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Considered negotiable instruments with features of a time draft, bankers&apos; acceptances are created by the drawer and provide the bearer with the right to the amount noted on the face of the acceptance on the specified date. Unlike traditional checks, bankers&apos; acceptances function based on the creditworthiness of the banking institution instead of the individual or business acting as the drawer. Additionally, the drawer must provide the funds necessary to support the bankers&apos; acceptance, eliminating the risk associated with insufficient funds on the part of the drawer.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;BillOfExchange">
@@ -133,9 +128,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bill of exchange</rdfs:label>
 		<skos:definition xml:lang="en">short-term negotiable financial instrument consisting of an order in writing addressed by one person (the seller of goods) to another (the buyer), requiring the latter to pay a fixed amount of money on demand (a sight draft) or on a predetermined date (a time draft)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A bill of exchange is a written agreement between two parties - the buyer and the seller - used primarily in international trade. The buyer or seller typically employs a bank to issue the bill of exchange due to the risks involved with international transactions. Bills of exchange can be transferred by endorsement, much like a check. They can also require the buyer to pay a third party - a bank - in the event that the buyer fails to make good on his agreement with the seller.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">bank draft</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">draft</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">A bill of exchange is a written agreement between two parties - the buyer and the seller - used primarily in international trade. The buyer or seller typically employs a bank to issue the bill of exchange due to the risks involved with international transactions. Bills of exchange can be transferred by endorsement, much like a check. They can also require the buyer to pay a third party - a bank - in the event that the buyer fails to make good on his agreement with the seller.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">bank draft</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">draft</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;CommercialPaper">
@@ -154,7 +149,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">commercial paper</rdfs:label>
 		<skos:definition xml:lang="en">an unsecured short-term debt instrument typically issued by a bank, corporation, or foreign government to obtain funds to meet short-term debt obligations, such as accounts receivable, inventories, or payroll, backed only by an issuing bank or company promise to pay the face amount on the maturity date specified on the note</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Commercial paper has a very-short to short maturity period (usually, 2 to 30 days, and rarely more than 270 days).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Commercial paper has a very-short to short maturity period (usually, 2 to 30 days, and rarely more than 270 days).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;Drawee">
@@ -195,15 +190,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;CertificateOfDeposit"/>
 		<rdfs:label xml:lang="en">eurodollar deposit</rdfs:label>
 		<skos:definition xml:lang="en">a certificate of deposit with a fixed interest rate issued in U.S. dollars outside the jurisdiction of the Federal Reserve, held at banks outside of the United States, including branches of U.S. banks located outside of the U.S.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A bank in Japan or Singapore may accept dollar deposits, but these are still called Eurodollar deposits. The market also includes other currencies, so there are Eurosterling, Euroyen, Euroswiss, etc. Eurocurrency is the general term for any currency deposited in bank branches outside countries where it is the national currency.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A bank in Japan or Singapore may accept dollar deposits, but these are still called Eurodollar deposits. The market also includes other currencies, so there are Eurosterling, Euroyen, Euroswiss, etc. Eurocurrency is the general term for any currency deposited in bank branches outside countries where it is the national currency.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;MoneyMarketInstrument">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;FixedIncomeSecurity"/>
 		<rdfs:label xml:lang="en">money market instrument</rdfs:label>
 		<skos:definition xml:lang="en">a short-term debt security that gives the owner the unconditional right to receive a stated, fixed sum of money on a specified date</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=6073</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments usually are traded at a discount in organized markets; the discount is dependent upon the interest rate and the time remaining to maturity. Included are such instruments as treasury bills, commercial and financial paper, bankers&apos; acceptances, negotiable certificates of deposit (with original maturities of one year or less), and short-term notes issued under note issuance facilities.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=6073</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">These instruments usually are traded at a discount in organized markets; the discount is dependent upon the interest rate and the time remaining to maturity. Included are such instruments as treasury bills, commercial and financial paper, bankers&apos; acceptances, negotiable certificates of deposit (with original maturities of one year or less), and short-term notes issued under note issuance facilities.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-tstd;RepurchaseAgreement">
@@ -218,8 +213,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">repurchase agreement</rdfs:label>
 		<skos:definition xml:lang="en">agreement between two parties whereby one party lends the other a security at a specified price with a commitment to take the security back at a later date for another specified price</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">REPO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Most repos are overnight transactions, with the sale taking place one day and being reversed the next day. Long-term repos - called term repos - can extend for a month or more. Usually, repos are for a fixed period of time, but open-ended deals are also possible. Reverse repo is a term used to describe the opposite side of a repo transaction. The party who sells and later repurchases a security is said to perform a repo. The other party - who purchases and later resells the security - is said to perform a reverse repo. While a repo functions like the sale and subsequent repurchase of a security, but the legal reality and the economic effect is that of a secured loan. This is a loan as the original owner retains the rights to the cashflows of the underlying security. Economically, the party purchasing the security makes funds available to the seller and holds the security as collateral. If the repurchased security pays a dividend, coupon or partial redemptions during the repo, the funds are returned to the original owner. The difference between the sale and repurchase prices paid for the security represent interest on the loan. Indeed, repos are quoted as interest rates. A repo always pays interest at maturity, i.e. there are no periodic interest payments.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">REPO</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">Most repos are overnight transactions, with the sale taking place one day and being reversed the next day. Long-term repos - called term repos - can extend for a month or more. Usually, repos are for a fixed period of time, but open-ended deals are also possible. Reverse repo is a term used to describe the opposite side of a repo transaction. The party who sells and later repurchases a security is said to perform a repo. The other party - who purchases and later resells the security - is said to perform a reverse repo. While a repo functions like the sale and subsequent repurchase of a security, but the legal reality and the economic effect is that of a secured loan. This is a loan as the original owner retains the rights to the cashflows of the underlying security. Economically, the party purchasing the security makes funds available to the seller and holds the security as collateral. If the repurchased security pays a dividend, coupon or partial redemptions during the repo, the funds are returned to the original owner. The difference between the sale and repurchase prices paid for the security represent interest on the loan. Indeed, repos are quoted as interest rates. A repo always pays interest at maturity, i.e. there are no periodic interest payments.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/SEC/Equities/DepositaryReceipts.rdf
+++ b/SEC/Equities/DepositaryReceipts.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-easj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/AsianJurisdiction/EasternAsiaGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-be-ge-euj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/">
@@ -19,10 +20,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-easj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/AsianJurisdiction/EasternAsiaGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-be-ge-euj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"
@@ -42,25 +43,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/">
 		<rdfs:label xml:lang="en">Depositary Receipts</rdfs:label>
 		<dct:abstract>Depositary receipts are certificates which represent ownership of some underlying security. They are issued by a bank and give the holder the ability to participate in the returns on an instrument that they may not be able to hold directly.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-eq-dr</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/AsianJurisdiction/EasternAsiaGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/AsianJurisdiction/SouthernAsiaGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"/>
@@ -73,13 +61,17 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20221001/Equities/DepositaryReceipts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/DepositaryReceipts/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20221001/Equities/DepositaryReceipts.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Equities/DepositaryReceipts.rdf version of this ontology was modified to expand the definition of a depositary receipt to cover a broader range of securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211101/Equities/DepositaryReceipts.rdf version of this ontology was modified to further refine the definition of a depositary receipt, add participatory notes, and broaden explanatory notes to allow for coverage of Chinese ADRs.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Equities/DepositaryReceipts.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/DepositaryReceipts.rdf version of this ontology was modified to add the concept of a Chinese depositary receipt.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;AmericanDepositaryReceipt">
@@ -100,8 +92,8 @@
 		<rdfs:label xml:lang="en">American depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">depositary receipt that represents securities of a foreign company and allows that company&apos;s securities to trade in the U.S. financial markets</skos:definition>
 		<skos:example xml:lang="en">For example, Accton Technology is traded on the Taiwanese exchange. In order for Accton Technology to be traded in the United States, Citibank, acting as a domestic custodian bank, purchases shares of Accton Technology and creates a security, ISIN US00437R1032, which can be traded on a U.S. exchange, in this case PORTAL. Note that the depositary shares do not have to equal the number of original shares. In the case of Accton Technology, one depositary share is equivalent to two original shares.</skos:example>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">ADR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Most ADRs are issued by a domestic custodian bank when the underlying securities are deposited in a foreign depositary bank, usually by a broker who has purchased the securities in the open market local to the foreign company. An ADR can represent a fraction of a share, a single share, or multiple shares of a foreign security. The holder of an ADR has the right to obtain the underlying foreign security that the ADR represents, but investors usually find it more convenient to own the ADR. The price of an ADR generally tracks the price of the foreign security in its home market, adjusted for the ratio of ADRs to foreign company shares. In the case of companies domiciled in the United Kingdom, creation of ADRs attracts a 1.5 percent creation fee; this creation fee is different than stamp duty reserve tax charge by the UK government. Depositary banks have various responsibilities to ADR holders and to the issuing foreign company the ADR represents.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">ADR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">Most ADRs are issued by a domestic custodian bank when the underlying securities are deposited in a foreign depositary bank, usually by a broker who has purchased the securities in the open market local to the foreign company. An ADR can represent a fraction of a share, a single share, or multiple shares of a foreign security. The holder of an ADR has the right to obtain the underlying foreign security that the ADR represents, but investors usually find it more convenient to own the ADR. The price of an ADR generally tracks the price of the foreign security in its home market, adjusted for the ratio of ADRs to foreign company shares. In the case of companies domiciled in the United Kingdom, creation of ADRs attracts a 1.5 percent creation fee; this creation fee is different than stamp duty reserve tax charge by the UK government. Depositary banks have various responsibilities to ADR holders and to the issuing foreign company the ADR represents.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;AmericanDepositaryReceiptLevel">
@@ -120,7 +112,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">American depositary receipt level</rdfs:label>
 		<skos:definition xml:lang="en">classifier for American depositary receipts that categorizes ADRs into levels based on the extent to which the foreign company has access to the U.S. market</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">ADR level</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation xml:lang="en">ADR level</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;AmericanDepositaryReceiptLevelScheme">
@@ -133,7 +125,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">American depositary receipt level scheme</rdfs:label>
 		<skos:definition xml:lang="en">classifier for American depositary receipts that categorizes ADRs into levels based on the extent to which the foreign company has access to the U.S. market</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">ADR level</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation xml:lang="en">ADR level</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;ChineseDepositaryReceipt">
@@ -146,8 +138,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">Chinese depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">global depositary receipt that represents ownership in the securities of a non-Chinese company that trades on a public exchange in China</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">CDR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It refers to shares in non-Chinese companies that trade in China the same way that American depositary receipts (ADRs) allow non-U.S. company shares to trade on American exchanges.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">CDR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">It refers to shares in non-Chinese companies that trade in China the same way that American depositary receipts (ADRs) allow non-U.S. company shares to trade on American exchanges.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;DepositaryReceipt">
@@ -167,11 +159,11 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">negotiable financial instrument issued by a trust company, security depositary, or bank that is evidence of the deposit of publicly traded securities and that facilitates the ownership of securities traded in other jurisdictions</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">DR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Depositary receipts are widely used in order to allow the trading of securities in jurisdictions other than
-the one where the original securities were issued, such as in a local market. Depositary receipts facilitate buying securities in foreign companies, because the securities do not have to leave the home country. They enable domestic investors to buy securities of foreign companies without the accompanying risks or inconveniences of cross-border and cross-currency transactions.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">depositary receipt</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation xml:lang="en">DR</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Depositary receipts are widely used in order to allow the trading of securities in jurisdictions other than
+the one where the original securities were issued, such as in a local market. Depositary receipts facilitate buying securities in foreign companies, because the securities do not have to leave the home country. They enable domestic investors to buy securities of foreign companies without the accompanying risks or inconveniences of cross-border and cross-currency transactions.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">depositary receipt</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;EuropeanDepositaryReceipt">
@@ -184,17 +176,17 @@ the one where the original securities were issued, such as in a local market. De
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">European depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">global depositary receipt that represents ownership in the securities of a non-European company that trades in European financial markets</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">EDR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A European depositary receipt is a European equivalent of the original American depositary receipt (ADR). The EDR is issued by a bank in Europe representing securities traded on an exchange outside of the bank&apos;s home country.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">EDR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">A European depositary receipt is a European equivalent of the original American depositary receipt (ADR). The EDR is issued by a bank in Europe representing securities traded on an exchange outside of the bank&apos;s home country.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;GlobalDepositaryReceipt">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-dr;DepositaryReceipt"/>
 		<rdfs:label xml:lang="en">global depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">depositary receipt where a certificate issued by a depositary bank, which purchases securities of foreign companies, creates a security on a local exchange backed by those securities</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">GDR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Global depositary receipts are the global equivalent of the original American depositary receipts (ADR) on which they are based. GDRs represent ownership of an underlying number of securities of a foreign company and are commonly used to invest in companies from developing or emerging markets by investors in developed markets.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">international depositary receipt</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation xml:lang="en">GDR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">Global depositary receipts are the global equivalent of the original American depositary receipts (ADR) on which they are based. GDRs represent ownership of an underlying number of securities of a foreign company and are commonly used to invest in companies from developing or emerging markets by investors in developed markets.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">international depositary receipt</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;HongKongDepositaryReceipt">
@@ -207,8 +199,8 @@ the one where the original securities were issued, such as in a local market. De
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">Hong Kong depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">global depositary receipt that represents the purchase, or ownership, of foreign assets which are deposited in a depositary bank in Hong Kong</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">HKDR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Hong Kong Depositary Receipt (HDR) is a negotiable instrument issued by a depositary bank that evidences ownership of securities in a corporation organized outside Hong Kong. HDRs trade on the Hong Kong Stock Exchange (HKEx), thus enabling foreign issuers to tap the Hong Kong market and local investors to efficiently invest in quality international companies.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">HKDR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">A Hong Kong Depositary Receipt (HDR) is a negotiable instrument issued by a depositary bank that evidences ownership of securities in a corporation organized outside Hong Kong. HDRs trade on the Hong Kong Stock Exchange (HKEx), thus enabling foreign issuers to tap the Hong Kong market and local investors to efficiently invest in quality international companies.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;IndianDepositoryReceipt">
@@ -222,8 +214,8 @@ the one where the original securities were issued, such as in a local market. De
 		<rdfs:label xml:lang="en">Indian depositary receipt</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Indian_Depository_Receipt"/>
 		<skos:definition xml:lang="en">global depositary receipt that represents the purchase, or ownership, of foreign assets which are deposited in a Indian account managed by the Domestic Depository in India</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">IDR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An Indian Depository Receipt (IDR) is an instrument denominated in Indian Rupees in the form of a depositary receipt created by a Domestic Depository (custodian of securities registered with the Securities and Exchange Board of India) against the underlying securities of issuing company to enable foreign companies to raise funds from the Indian securities Markets.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">IDR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">An Indian Depository Receipt (IDR) is an instrument denominated in Indian Rupees in the form of a depositary receipt created by a Domestic Depository (custodian of securities registered with the Securities and Exchange Board of India) against the underlying securities of issuing company to enable foreign companies to raise funds from the Indian securities Markets.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;JapaneseDepositaryReceipt">
@@ -236,31 +228,31 @@ the one where the original securities were issued, such as in a local market. De
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">Japanese depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">global depositary receipt that represents the purchase, or ownership, of foreign assets which are deposited in a trust bank in Japan</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">JDR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Japanese Depositary Receipt (JDR) is an instrument issued by a trust bank in Japan that evidences ownership of securities in a corporation organized outside Japan. JDRs trade on the Tokyo Stock Exchange (TSE) in yen, and in accordance with Japanese market conventions, enabling foreign issuers to tap the Japanese capital market and local investors to efficiently invest in quality international companies.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">JDR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">A Japanese Depositary Receipt (JDR) is an instrument issued by a trust bank in Japan that evidences ownership of securities in a corporation organized outside Japan. JDRs trade on the Tokyo Stock Exchange (TSE) in yen, and in accordance with Japanese market conventions, enabling foreign issuers to tap the Japanese capital market and local investors to efficiently invest in quality international companies.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-dr;LevelIAmericanDepositaryReceipt">
 		<rdf:type rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceiptLevel"/>
 		<rdfs:label xml:lang="en">Level I American depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">American Depositary Receipt level indicating that the ADR can only be traded over-the-counter in the U.S.</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">Level I ADR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This level can apply to sponsored and unsponsored ADRs. However, this is the only level available for unsponsored ADRs. A Level I ADR is easier to set up for foreign companies since it does not require the same disclosures or the need to abide by generally accepted accounting principles (GAAP). There is some degree of risk with Level I ADRs given their relative lack of transparency.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">Level I ADR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">This level can apply to sponsored and unsponsored ADRs. However, this is the only level available for unsponsored ADRs. A Level I ADR is easier to set up for foreign companies since it does not require the same disclosures or the need to abide by generally accepted accounting principles (GAAP). There is some degree of risk with Level I ADRs given their relative lack of transparency.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-dr;LevelIIAmericanDepositaryReceipt">
 		<rdf:type rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceiptLevel"/>
 		<rdfs:label xml:lang="en">Level II American depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">American Depositary Receipt level that is sponsored and can be listed on an exchange</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">Level II ADR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This level is visible to a wider market and requires the company to comply with the SEC regulatory rules. However, they cannot be used to raise capital.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">Level II ADR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">This level is visible to a wider market and requires the company to comply with the SEC regulatory rules. However, they cannot be used to raise capital.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-dr;LevelIIIAmericanDepositaryReceipt">
 		<rdf:type rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceiptLevel"/>
 		<rdfs:label xml:lang="en">Level III American depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">American Depositary Receipt level that can be listed on an exchange and permit companies to issue shares to raise capital for the foreign issuer, but require the highest level of compliance and disclosure</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">Level III ADR</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation xml:lang="en">Level III ADR</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;LuxembourgDepositaryReceipt">
@@ -273,8 +265,8 @@ the one where the original securities were issued, such as in a local market. De
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">Luxembourg depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">global depositary receipt that represents the purchase, or ownership, of foreign assets which are deposited in a Luxembourg-based account</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">LDR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Luxembourg Depositary Receipt (LDR) is a certificate which represents the purchase, or ownership, of foreign assets which are deposited in a Luxembourg-based account. An LDR functions in much the same way as a global depositary receipt (GDR). LDRs may represent ownership of either an underlying number of shares or a notional amount of bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">LDR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">A Luxembourg Depositary Receipt (LDR) is a certificate which represents the purchase, or ownership, of foreign assets which are deposited in a Luxembourg-based account. An LDR functions in much the same way as a global depositary receipt (GDR). LDRs may represent ownership of either an underlying number of shares or a notional amount of bonds.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;OffshoreDepositaryReceipt">
@@ -287,7 +279,7 @@ the one where the original securities were issued, such as in a local market. De
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">offshore depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">depositary receipt issued under SEC Regulation S</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This regulation means that the securities are not, and will not be registered with any U.S. securities regulation authority. Regulation S shares cannot be held or traded by any &apos;U.S. person&apos; as defined by SEC Regulation S rules. The shares are registered and issued to offshore, non-U.S. residents.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This regulation means that the securities are not, and will not be registered with any U.S. securities regulation authority. Regulation S shares cannot be held or traded by any &apos;U.S. person&apos; as defined by SEC Regulation S rules. The shares are registered and issued to offshore, non-U.S. residents.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;ParticipatoryNote">
@@ -302,13 +294,13 @@ the one where the original securities were issued, such as in a local market. De
 		<rdfs:label xml:lang="en">participatory note</rdfs:label>
 		<skos:definition xml:lang="en">tradable debt instrument that facilitates the ownership of securities traded in other jurisdictions</skos:definition>
 		<skos:example xml:lang="en">Participation notes are required by investors or hedge funds to invest in Indian securities without having to register with the Securities and Exchange Board of India (SEBI). P-Notes are among the group of investments considered to be Offshore Derivative Investments (ODIs) in Indian markets.</skos:example>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">P-Note</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">PN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Depository receipts are widely used in order to allow the trading of debt instruments in
-jurisdictions other than the one where the original debt instruments were issued</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically P-Notes are SPVs that are created to allow participation from outside that market. The SPV purchases a security on shore and issues a note that represents that security to offshore investors. They are similar to an ADR but always a debt security.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">participation note</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation xml:lang="en">P-Note</cmns-av:abbreviation>
+		<cmns-av:abbreviation xml:lang="en">PN</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Depository receipts are widely used in order to allow the trading of debt instruments in
+jurisdictions other than the one where the original debt instruments were issued</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Typically P-Notes are SPVs that are created to allow participation from outside that market. The SPV purchases a security on shore and issues a note that represents that security to offshore investors. They are similar to an ADR but always a debt security.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">participation note</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;PrivatelyPlacedDepositaryReceipt">
@@ -321,14 +313,14 @@ jurisdictions other than the one where the original debt instruments were issued
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">privately placed depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">depositary receipt that represents shares in a private placement under the SEC Rule 144-A</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Some foreign companies will set up an ADR program under SEC Rule 144-A. This provision makes the issuance of shares a private placement. Shares of companies registered under Rule 144-A are restricted stock and may only be issued to or traded by qualified institutional buyers (QIBs). U.S. public shareholders are generally not permitted to invest in these ADR programs, and most are held exclusively through the Depository Trust &amp; Clearing Corporation, so there is often very little information on these companies.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Some foreign companies will set up an ADR program under SEC Rule 144-A. This provision makes the issuance of shares a private placement. Shares of companies registered under Rule 144-A are restricted stock and may only be issued to or traded by qualified institutional buyers (QIBs). U.S. public shareholders are generally not permitted to invest in these ADR programs, and most are held exclusively through the Depository Trust &amp; Clearing Corporation, so there is often very little information on these companies.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;SponsoredDepositaryReceipt">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceipt"/>
 		<rdfs:label xml:lang="en">sponsored depositary receipt</rdfs:label>
 		<skos:definition xml:lang="en">depositary receipt that is issued in collaboration with the foreign company enabling them to tap into international capital markets directly</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Although a sponsored ADR would be listed in the United States, the issuing company still has its revenue and profit denominated in its home currency.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Although a sponsored ADR would be listed in the United States, the issuing company still has its revenue and profit denominated in its home currency.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-dr;UnsponsoredDepositaryReceipt">
@@ -342,7 +334,7 @@ jurisdictions other than the one where the original debt instruments were issued
 		<rdfs:label xml:lang="en">unsponsored depositary receipt</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-eq-dr;SponsoredDepositaryReceipt"/>
 		<skos:definition xml:lang="en">depositary receipt that is established without the company&apos;s cooperation</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For an unsponsored ADR, a depositary entity can issue certificates when there&apos;s heavy demand from investors for ownership in a specific company from abroad. The issuing entity is normally a broker-dealer that owns common stock in the company. Because they&apos;re issued without the consent or cooperation of the foreign company, unsponsored ADRs generally trade over-the-counter (OTC)—rather than on a stock exchange. Also, shareholder benefits and voting rights may not be extended to the holders of these particular securities. Many large global corporations use unsponsored ADRs to attract American capital. For example, American investors can invest in Royal Mail PLC, a postal and delivery service company from the United Kingdom that was founded by Henry VIII. The company&apos;s unsponsored ADR trades OTC under the ticker symbol ROYMY.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">For an unsponsored ADR, a depositary entity can issue certificates when there&apos;s heavy demand from investors for ownership in a specific company from abroad. The issuing entity is normally a broker-dealer that owns common stock in the company. Because they&apos;re issued without the consent or cooperation of the foreign company, unsponsored ADRs generally trade over-the-counter (OTC)—rather than on a stock exchange. Also, shareholder benefits and voting rights may not be extended to the holders of these particular securities. Many large global corporations use unsponsored ADRs to attract American capital. For example, American investors can invest in Royal Mail PLC, a postal and delivery service company from the United Kingdom that was founded by Henry VIII. The company&apos;s unsponsored ADR trades OTC under the ticker symbol ROYMY.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-dr;hasMultiplier">

--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-usj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-be-le-usee "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/NorthAmericanEntities/USExampleEntities/">
@@ -27,10 +28,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-usj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-be-le-usee="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/NorthAmericanEntities/USExampleEntities/"
@@ -58,28 +59,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/">
 		<rdfs:label>Equities Example Individuals Ontology</rdfs:label>
-		<dct:abstract>This ontologyprovides examples of how to represent simple equities.</dct:abstract>
+		<dct:abstract>This ontology provides examples of how to represent simple equities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2019-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2019-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-eq-eqind</sm:fileAbbreviation>
-		<sm:filename>EquitiesExampleIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -99,15 +84,19 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20221201/Equities/EquitiesExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/EquitiesExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was modified to add CFI codes to the example equity instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to add the share class to some of the examples, replace registered form with book entry (registered) form, and add detail to the common share and listing individuals.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to replace equity issuer with share issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to address changes to the markets individuals ontology.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20221201/Equities/EquitiesExampleIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2019-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2019-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock">

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -15,10 +16,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -34,40 +35,32 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
 		<rdfs:label>Equities CFI Classification Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology covers the ISO 10962, Fourth edition, 2019-10 classification codes for instruments that represent an ownership interest in an entity or pool of assets. It is intended to cover sections most of the codes included in section 6.2 of the standard, with the exception of structured instruments, section 6.2.8, which will be covered under derivatives.</dct:abstract>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:copyright>Copyright (c) 2020-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-eq-10962</sm:fileAbbreviation>
-		<sm:filename>EquityCFIClassificationIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityCFIClassificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/EquityCFIClassificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form, eliminate embedded restrictions, and build out additional classes representing the various feature-based descriptions supported by the CFI standard.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to complete the set of possible common share representations corresponding to the CFI standard, complete the set of corresponding codes for common shares (non-convertible), and add the set of possible combinations for preferred shares (non-convertible).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to simplify the encoding of the individual instrument classifiers to eliminate unnecessary restrictions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityCFIClassificationIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonEnhancedVotingRestrictedFullyPaidRegisteredShare">

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -38,10 +39,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -80,25 +81,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
 		<rdfs:label xml:lang="en">Equity Instruments Ontology</rdfs:label>
 		<dct:abstract>Core terms are those fundamental to all equity instruments. This ontology also distinguishes between privately held and publicly traded equity instruments, and defines a number of related concepts, such as voting rights.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-eq-eq</sm:fileAbbreviation>
-		<sm:filename>EquityInstruments.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
@@ -128,9 +116,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20221001/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
@@ -144,7 +133,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220301/Equities/EquityInstruments.rdf version of this ontology was revised to clean up deprecated elements, most of which had been in the ontology for awhile.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220501/Equities/EquityInstruments.rdf version of this ontology was revised to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityInstruments.rdf version of this ontology was revised to add the notion of a VIE share and integrate dividend distribution method with strategy.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20221001/Equities/EquityInstruments.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;AdjustableRateDividend">
@@ -163,7 +155,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>adjustable rate dividend</rdfs:label>
 		<skos:definition>dividend that varies with a benchmark</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The value of the dividend from the preferred share is set by a predetermined formula to move with rates, and because of this flexibility preferred prices are often more stable then fixed-rate preferred stocks.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The value of the dividend from the preferred share is set by a predetermined formula to move with rates, and because of this flexibility preferred prices are often more stable then fixed-rate preferred stocks.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;AuctionRateDividend">
@@ -190,8 +182,8 @@
 		<rdfs:label xml:lang="en-US">common share</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
 		<skos:definition>share that signifies a unit of ownership in a corporation and represents a claim on part of the corporation&apos;s assets and earnings</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In the event that the corporation is liquidated, claims of secured and unsecured creditors and owners of bonds and preferred shares take precedence over claims of common share holders.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en-GB">ordinary share</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>In the event that the corporation is liquidated, claims of secured and unsecured creditors and owners of bonds and preferred shares take precedence over claims of common share holders.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en-GB">ordinary share</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ConvertibleCommonShare">
@@ -206,14 +198,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;ConvertibleSecurity"/>
 		<rdfs:label>convertible preferred share</rdfs:label>
 		<skos:definition>preferred share that includes an option for the holder to convert the shares into a fixed number of common shares after a predetermined date</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Most convertible preferred stock is exchanged at the request of the shareholder, but sometimes there is a provision that allows the company, or issuer, to force conversion. The value of a convertible preferred stock is ultimately based on the performance of the common stock.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Most convertible preferred stock is exchanged at the request of the shareholder, but sometimes there is a provision that allows the company, or issuer, to force conversion. The value of a convertible preferred stock is ultimately based on the performance of the common stock.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;CumulativePreferredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
 		<rdfs:label>cumulative preferred share</rdfs:label>
 		<skos:definition>preferred share whose dividends, if not paid on time, accumulate until paid out</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>These dividends have precedence over ordinary dividends which cannot be paid until any cumulative dividend obligations have been paid. Dividends are typically deferred due to insufficient earnings or other business reasons.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>These dividends have precedence over ordinary dividends which cannot be paid until any cumulative dividend obligations have been paid. Dividends are typically deferred due to insufficient earnings or other business reasons.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;Custodian">
@@ -227,8 +219,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>custodian</rdfs:label>
 		<skos:definition xml:lang="en">financial institution that holds customers&apos; securities for safekeeping</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.investopedia.com/terms/c/custodian.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The custodian may hold stocks or other assets in electronic or physical form for mutual funds, individuals, and organizational clients.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.investopedia.com/terms/c/custodian.asp</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The custodian may hold stocks or other assets in electronic or physical form for mutual funds, individuals, and organizational clients.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eq;DistributionByCashPayment">
@@ -268,7 +260,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>dividend</rdfs:label>
 		<skos:definition>announced commitment to make a specific distribution of a portion of earnings to shareholders, prorated by class of security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The amount and timing of payment is set by the board of directors, typically quarterly. Dividends may be paid in the form of money, shares, scrip, or on rare occasion, property.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The amount and timing of payment is set by the board of directors, typically quarterly. Dividends may be paid in the form of money, shares, scrip, or on rare occasion, property.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;DividendDistributionMethod">
@@ -276,7 +268,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label>dividend distribution method</rdfs:label>
 		<skos:definition>convention by which dividends are provided to shareholders</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Distribution may be by payment of a monetary amount or by reinvestment, as specified by the board of directors at the time a decision to issue a dividend is made.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Distribution may be by payment of a monetary amount or by reinvestment, as specified by the board of directors at the time a decision to issue a dividend is made.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;DividendSchedule">
@@ -448,7 +440,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>fixed rate dividend</rdfs:label>
 		<skos:definition>dividend that provides a specified annual return on the nominal value (and any premium) paid on shares</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In other words, the return is not variable depending on whether or not the company makes a profit. Annual dividends are calculated as a percentage of the par value, which is the price of the preferred stock at the time it was issued. Most preferred shares have fixed rate dividends.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In other words, the return is not variable depending on whether or not the company makes a profit. Annual dividends are calculated as a percentage of the par value, which is the price of the preferred stock at the time it was issued. Most preferred shares have fixed rate dividends.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;FullyPaidShare">
@@ -503,7 +495,7 @@
 		<rdfs:label xml:lang="en">listed share</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/l/listedsecurity.asp"/>
 		<skos:definition xml:lang="en">share that is listed on at least one platform</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Listing requirements vary by exchange and include minimum stockholder&apos;s equity, a minimum share price and a minimum number of shareholders. Exchanges have listing requirements to ensure that only high quality securities are traded on them and to uphold the exchange&apos;s reputation among investors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Listing requirements vary by exchange and include minimum stockholder&apos;s equity, a minimum share price and a minimum number of shareholders. Exchanges have listing requirements to ensure that only high quality securities are traded on them and to uphold the exchange&apos;s reputation among investors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;NilPaidShare">
@@ -564,8 +556,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>ordinary dividend</rdfs:label>
 		<skos:definition>dividend that is paid to shareholders periodically</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Most dividends are considered ordinary, unless they are specifically designated as qualified dividends.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Note that the terms related to ordinary dividend payment are typically specified in the context of a board resolution rather than contractually.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Most dividends are considered ordinary, unless they are specifically designated as qualified dividends.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that the terms related to ordinary dividend payment are typically specified in the context of a board resolution rather than contractually.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;PartiallyPaidShare">
@@ -585,7 +577,7 @@
 		<rdfs:label>partially paid share status</rdfs:label>
 		<owl:differentFrom rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
 		<skos:definition>status indicating that only a portion of the market value has been received by the company for the shares</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In the case of partially paid shares, the shareholder is still required to pay the remaining amount to the company. Typically, partially paid shares are only issued to a shareholder if there are compelling business reasons to do so.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In the case of partially paid shares, the shareholder is still required to pay the remaining amount to the company. Typically, partially paid shares are only issued to a shareholder if there are compelling business reasons to do so.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ParticipatingPreferredShare">
@@ -599,7 +591,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>participating preferred share</rdfs:label>
 		<skos:definition>preferred share that, in addition to paying a stipulated dividend, gives the holder the right to participate with common share holders in additional distributions of earnings under specified conditions</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Participating preferred shares are rare, typically only issued when needed to attract investors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Participating preferred shares are rare, typically only issued when needed to attract investors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;PerpetualPreferredShare">
@@ -674,7 +666,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>preferred share</rdfs:label>
 		<skos:definition>share that pays dividends at a specified rate and has preference over common shares in the payment of dividends and liquidation of corporate assets</skos:definition>
-		<fibo-fnd-utl-av:synonym>preference share</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>preference share</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend">
@@ -739,8 +731,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>price per share</rdfs:label>
 		<skos:definition>price for one share of a given security at some point in time</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PPS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:synonym>share price</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>PPS</cmns-av:abbreviation>
+		<cmns-av:synonym>share price</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;PrivatelyHeldShare">
@@ -748,7 +740,7 @@
 		<rdfs:label xml:lang="en">privately held share</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
 		<skos:definition xml:lang="en">share in a security that signifies ownership in an entity that is not publicly traded</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Privately owned companies include family-owned businesses, sole proprietorships and the vast majority of small and medium-sized businesses. These companies are often too small for an initial public offering (IPO) due, for example to a small market capitalization and/or low trading volume, and fulfill their financing requirements in other ways, including through smaller offerings.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Privately owned companies include family-owned businesses, sole proprietorships and the vast majority of small and medium-sized businesses. These companies are often too small for an initial public offering (IPO) due, for example to a small market capitalization and/or low trading volume, and fulfill their financing requirements in other ways, including through smaller offerings.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;QualifiedDividend">
@@ -792,7 +784,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>redeemable preferred share with extendable redemption date</rdfs:label>
 		<skos:definition>redeemable preferred share whose redemption date can be modified</skos:definition>
-		<fibo-fnd-utl-av:synonym>extendible preferred share</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>extendible preferred share</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;RestrictedShare">
@@ -833,7 +825,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>retractable preferred share</rdfs:label>
 		<skos:definition>preferred share that gives the owner (shareholder) the right to redeem the stock under specified conditions</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>When retractable preferred shares reach maturity, the shareholder has the right to sell them back to the stock issuer at the price stated on the agreement. In some cases, the issuer can force the shareholder to sell, and may have the option of exchanging retractable preferred shares for common shares instead of cash.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>When retractable preferred shares reach maturity, the shareholder has the right to sell them back to the stock issuer at the price stated on the agreement. In some cases, the issuer can force the shareholder to sell, and may have the option of exchanging retractable preferred shares for common shares instead of cash.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;RetractablePreferredShareWithExtendableMaturityDate">
@@ -871,7 +863,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>retractable preferred share with extendable redemption date</rdfs:label>
 		<skos:definition>retractable preferred share whose redemption date can be modified</skos:definition>
-		<fibo-fnd-utl-av:synonym>extendible preferred share</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>extendible preferred share</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
@@ -956,7 +948,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>share issuer</rdfs:label>
 		<skos:definition>issuer of securities that represent an ownership interest in something</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This includes shares that represent equity ownership in a corporation, or ownership in a mutual fund, or an interest in a general or limited partnership, or ownership in a structured product, such as a real estate investment trust.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This includes shares that represent equity ownership in a corporation, or ownership in a mutual fund, or an interest in a general or limited partnership, or ownership in a structured product, such as a real estate investment trust.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;SharePaymentStatus">
@@ -969,7 +961,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>share payment status</rdfs:label>
 		<skos:definition>classifier that specifies the overall payment status for shares issued</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>When a company issues shares upon incorporation or through an initial or secondary issuance, shareholders are required to pay a set amount for those shares. Once the company has received the full amount from shareholders, the shares become fully paid shares.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>When a company issues shares upon incorporation or through an initial or secondary issuance, shareholders are required to pay a set amount for those shares. Once the company has received the full amount from shareholders, the shares become fully paid shares.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ShareYield">
@@ -991,8 +983,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">share yield</rdfs:label>
 		<skos:definition xml:lang="en">ratio of the annualized dividend per share divided by the (current) price per share</skos:definition>
-		<fibo-fnd-utl-av:synonym xml:lang="en">dividend yield</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">dividend-price ratio</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym xml:lang="en">dividend yield</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">dividend-price ratio</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;SingleVotingShare">
@@ -1017,7 +1009,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Dividend"/>
 		<rdfs:label>special dividend</rdfs:label>
 		<skos:definition>dividend that is paid to shareholders on a one-time basis</skos:definition>
-		<fibo-fnd-utl-av:usageNote xml:lang="en">Special dividends may be included in a dividend schedule as an ad-hoc entry, since they still need to be tracked based on the date of issuance.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote xml:lang="en">Special dividends may be included in a dividend schedule as an ad-hoc entry, since they still need to be tracked based on the date of issuance.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
@@ -1042,8 +1034,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">variable interest entity share</rdfs:label>
 		<skos:definition>share that certifies ownership of a contractual right to a percentage of a company&apos;s profits</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Unlike a traditional stock certificate, the VIE share provides a legal proprietary interest in a completely separate company&apos;s assets, sometimes referred to as a shell company. The contractual right certified by the VIE share is derived from a contract between (1) the company named on the VIE share and (2) the shell company. In other words, VIE shareholders only have a traditional stock certificate in the completely separate shell company, which is entitled to a percentage of the named company&apos;s profits via a private contract.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en-GB">VIE share</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Unlike a traditional stock certificate, the VIE share provides a legal proprietary interest in a completely separate company&apos;s assets, sometimes referred to as a shell company. The contractual right certified by the VIE share is derived from a contract between (1) the company named on the VIE share and (2) the shell company. In other words, VIE shareholders only have a traditional stock certificate in the completely separate shell company, which is entitled to a percentage of the named company&apos;s profits via a private contract.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en-GB">VIE share</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;VotingRight">
@@ -1056,7 +1048,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>voting right</rdfs:label>
 		<skos:definition>contractual right that specifies shareholder voting entitlements, such as to elect directors, elect outside auditors, and vote on matters of corporate policy</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Voting may involve decisions on issuing securities, initiating stock splits, and making substantial changes in the corporation&apos;s operations. Note that a given share may not have voting rights, in which case the number of votes per share would be zero.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Voting may involve decisions on issuing securities, initiating stock splits, and making substantial changes in the corporation&apos;s operations. Note that a given share may not have voting rights, in which case the number of votes per share would be zero.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;confersNumberOfVotesPerShare">
@@ -1064,7 +1056,7 @@
 		<rdfs:label xml:lang="en">number of votes per share</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 		<skos:definition xml:lang="en">grants the right to vote on a per share basis to the shareholder</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A given share may have zero, fractional, one, or more votes per share, depending on the contract.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A given share may have zero, fractional, one, or more votes per share, depending on the contract.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersOwnershipOf">
@@ -1113,7 +1105,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>indicates a date on which an organization states that a dividend payment may be anticipated, including the the dividend amount and the ex-dividend and payment dates</skos:definition>
-		<fibo-fnd-utl-av:synonym>has announcement date</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>has announcement date</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasDividendGracePeriod">
@@ -1138,11 +1130,11 @@
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>indicates a date on which a stock &apos;goes ex-dividend&apos;, typically about three weeks before the dividend is paid to shareholders of record</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.investor.gov/introduction-investing/investing-basics/glossary/ex-dividend-dates-when-are-you-entitled-stock-and</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Once the company sets the record date, the ex-dividend date is set based on stock exchange rules. If you purchase a stock on its ex-dividend date or after, you will not receive the next dividend payment.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Shares listed on the New York Stock Exchange go ex-dividend four business days prior to the record date.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>has ex-date</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>has expected dividend date</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.investor.gov/introduction-investing/investing-basics/glossary/ex-dividend-dates-when-are-you-entitled-stock-and</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Once the company sets the record date, the ex-dividend date is set based on stock exchange rules. If you purchase a stock on its ex-dividend date or after, you will not receive the next dividend payment.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Shares listed on the New York Stock Exchange go ex-dividend four business days prior to the record date.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>has ex-date</cmns-av:synonym>
+		<cmns-av:synonym>has expected dividend date</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasExtendableMaturityDate">
@@ -1172,7 +1164,7 @@
 		<rdfs:label xml:lang="en">has floating shares</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the number of shares that are available for trading, i.e., the number of shares outstanding less closely held shares (those held by insiders) and restricted shares</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A relatively small float results in higher volatility, as a large purchase or sell order will have significant influence on the value of the stock.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A relatively small float results in higher volatility, as a large purchase or sell order will have significant influence on the value of the stock.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasMinimumRedemptionPrice">
@@ -1189,9 +1181,9 @@
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>indicates the date on which the issuer checks to determine whether a party was on the company&apos;s books as a shareholder when required (i.e., they must have been on the books prior to the ex-dividend date), to identify who is eligible to receive the next dividend</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.investor.gov/introduction-investing/investing-basics/glossary/ex-dividend-dates-when-are-you-entitled-stock-and</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Companies also use this date to determine who is sent proxy statements, financial reports, and other information.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>has date of record</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.investor.gov/introduction-investing/investing-basics/glossary/ex-dividend-dates-when-are-you-entitled-stock-and</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Companies also use this date to determine who is sent proxy statements, financial reports, and other information.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>has date of record</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasRedemptionPremium">
@@ -1207,7 +1199,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition xml:lang="en">indicates the class to which the share belongs, typically differentiated by privileges, such as voting rights</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Classes of shares, including shares in a mutual fund, are designated by name or a character (letter), such as A, B, C, etc. In the case of a mutual fund, different classes of shares may incur different fees and expenses.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Classes of shares, including shares in a mutual fund, are designated by name or a character (letter), such as A, B, C, etc. In the case of a mutual fund, different classes of shares may incur different fees and expenses.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasSharePaymentStatus">
@@ -1230,7 +1222,7 @@
 		<rdfs:label xml:lang="en">has shares outstanding</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the number of shares currently held by shareholders, including those held by retail investors, institutional investors and insiders, and typically available for trading</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The number of outstanding shares is used in calculating key metrics such as a company&apos;s market capitalization, as well as its earnings per share (EPS) and cash flow per share (CFPS).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The number of outstanding shares is used in calculating key metrics such as a company&apos;s market capitalization, as well as its earnings per share (EPS) and cash flow per share (CFPS).</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasTreasuryShares">
@@ -1245,7 +1237,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition>specifies restrictions on voting rights, if any</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Such restrictions may apply regardless of the number of votes per share.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Such restrictions may apply regardless of the number of votes per share.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;indicatesNumberOfShares">

--- a/SEC/Equities/MetadataSECEquities.rdf
+++ b/SEC/Equities/MetadataSECEquities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-eq-mod "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/MetadataSECEquities/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/MetadataSECEquities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-eq-mod="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/MetadataSECEquities/"
@@ -18,53 +19,58 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/MetadataSECEquities/">
 		<rdfs:label>Metadata about the EDMC-FIBO Securities (SEC), Equities Module</rdfs:label>
 		<dct:abstract>The SEC Equities Module covers concepts that are common to equities, including share-specific terminology and shareholder rights, for stocks and partnership equity, as well as depository receipts. This ontology provides metadata about the Equities module and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2021-06-28T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-sec-eq-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataSECEquities.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210601/Equities/MetadataSECEquities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/MetadataSECEquities/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-mod;EquitiesModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO SEC Equities Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>equities module</rdfs:label>
 		<dct:abstract>This module defines concepts common to equities, including share-specific terminology and shareholder rights, for stocks and partnership equity, as well as depository receipts.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>BIAN</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Goldman Sachs</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Mizuho</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>BNY Mellon</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup Inc.</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>Mizuho</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-SEC-EQ</sm:moduleAbbreviation>
+		<dct:title>FIBO SEC Equities Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Securities and Equities (SEC) Equities Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/Equities/MetadataSECEquities.rdf
+++ b/SEC/Equities/MetadataSECEquities.rdf
@@ -59,7 +59,7 @@
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
-		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"/>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-ge-euj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/">
@@ -47,10 +48,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-ge-euj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"
@@ -98,22 +99,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/">
 		<rdfs:label xml:lang="en">Collective Investment Vehicles Ontology</rdfs:label>
 		<dct:abstract>Reference data terms and non time dependent facts about funds and CIVs.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/"/>
-		<sm:dependsOn rdf:resource="https://www.omg.org/spec/LCC/"/>
-		<sm:fileAbbreviation>fibo-sec-fund-civ</sm:fileAbbreviation>
-		<sm:filename>CollectiveInvestmentVehicles.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
@@ -154,10 +145,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;SpecialPurposeVehicle">
@@ -179,7 +172,7 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;SPVPurpose"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Special Purpose Vehicle (SPV) set up specifically to issue a security or securities. It is set up by a company or a group of companies for some purpose such as to create instruments that are off the company&apos;s balance sheet or to issue Participation Notes for investors in another jurisdiction. The SPV is formed for a specific reason and exists for a specific period of time and is then disbanded. Further notes: Special Purpose Vehicles are also referred to as bankruptcy remote entities, as they isolate financial risk. For Participation Notes: slightly different purpose but the same kind of vehicle. The only investment made by the SPV is that they buy in the stock. These are the same kind of entity in all of the contexts in which they exist.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A Special Purpose Vehicle (SPV) set up specifically to issue a security or securities. It is set up by a company or a group of companies for some purpose such as to create instruments that are off the company&apos;s balance sheet or to issue Participation Notes for investors in another jurisdiction. The SPV is formed for a specific reason and exists for a specific period of time and is then disbanded. Further notes: Special Purpose Vehicles are also referred to as bankruptcy remote entities, as they isolate financial risk. For Participation Notes: slightly different purpose but the same kind of vehicle. The only investment made by the SPV is that they buy in the stock. These are the same kind of entity in all of the contexts in which they exist.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;AccumulatingShareClass">
@@ -187,7 +180,7 @@
 		<rdfs:label xml:lang="en">accumulating share class</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-fund-civ;DistributingShareClass"/>
 		<skos:definition xml:lang="en">A share class in which there is no option to reinvest.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This fact would be determined by the fund unit having a specific Fund Distribution Policy of Accumulating.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This fact would be determined by the fund unit having a specific Fund Distribution Policy of Accumulating.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;AnnualReportingPolicy">
@@ -212,7 +205,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">asset class strategy</rdfs:label>
 		<skos:definition xml:lang="en">Strategy which is asset class based.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">EFAMA: The type of securities or other holdings that may be invested in. FIBIM: Strategy which is asset class based. Can implement this in terms of a classification of those things. Wording implies this is a policy.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">EFAMA: The type of securities or other holdings that may be invested in. FIBIM: Strategy which is asset class based. Can implement this in terms of a classification of those things. Wording implies this is a policy.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;BricksAndMortarHolding">
@@ -232,7 +225,7 @@
 		<rdfs:label xml:lang="en">common share in fund</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-fund-civ;PreferredShareInFund"/>
 		<skos:definition xml:lang="en">A share unit in a fund, which is classified as a Common Share class.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SR Review session notes: US: Closed and open ended funds may have common and preferred shares.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">SR Review session notes: US: Closed and open ended funds may have common and preferred shares.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;CurrencyStrategy">
@@ -245,7 +238,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;StakeInFund"/>
 		<rdfs:label xml:lang="en">debt stake in fund</rdfs:label>
 		<skos:definition xml:lang="en">A stake held in a fund by way of a Bond Unit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that you cannot buy fractional amounts in a bond. Review Session Note: Similar to what happens in a CDO where the collaterial manager and the issuer are two different entities. So model this along the same lines as the SPV in the structured finance model. Therefore: further modeling and review required</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Note that you cannot buy fractional amounts in a bond. Review Session Note: Similar to what happens in a CDO where the collaterial manager and the issuer are two different entities. So model this along the same lines as the SPV in the structured finance model. Therefore: further modeling and review required</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;DistributingShareClass">
@@ -287,7 +280,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;StakeInFund"/>
 		<rdfs:label xml:lang="en">equity stake in fund</rdfs:label>
 		<skos:definition xml:lang="en">A stake held in a fund by way of a Share Class Unit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Theoretically you can buy a fraction of a share in a fund. This would depend on the legal structure of the fund, e.g. a minimum investment. There is always a distribution plan.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Theoretically you can buy a fraction of a share in a fund. This would depend on the legal structure of the fund, e.g. a minimum investment. There is always a distribution plan.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FCP">
@@ -318,7 +311,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund administrator</rdfs:label>
 		<skos:definition xml:lang="en">Entity that has to fulfil the legal and supervisory requirements of the fund. Responsible for all the business purposes around the investment pool, and so is reponsible for the issuing of the shares.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the unit is a bond, then the issuer is separate from the Fund Administrator. WG11 text: The party in charge of financial accounting, NAV calculation, management and performance fee calculation. Can also be in charge of orders centralisation and registration. Definition origin:EFAMA DD</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">If the unit is a bond, then the issuer is separate from the Fund Administrator. WG11 text: The party in charge of financial accounting, NAV calculation, management and performance fee calculation. Can also be in charge of orders centralisation and registration. Definition origin:EFAMA DD</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundAuditor">
@@ -349,7 +342,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund bond class unit</rdfs:label>
 		<skos:definition xml:lang="en">A fund unit which takes the form of debt in that fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From EFAMA Review: called denominations e.g. issued in $5000 pieces. You cannot buy fractional amounts in a bond.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">From EFAMA Review: called denominations e.g. issued in $5000 pieces. You cannot buy fractional amounts in a bond.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundBondUnitCoupon">
@@ -416,7 +409,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Debt"/>
 		<rdfs:label xml:lang="en">fund debt</rdfs:label>
 		<skos:definition xml:lang="en">Debt issued by a Fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This would normally be held by participants in that pool. in this case the pool is a fund which is formed by each of the participants extending credit to that pool and holding bond units in the pool representing that debt.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This would normally be held by participants in that pool. in this case the pool is a fund which is formed by each of the participants extending credit to that pool and holding bond units in the pool representing that debt.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundDepositary">
@@ -429,14 +422,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund depositary</rdfs:label>
 		<skos:definition xml:lang="en">The party that holds and safeguards holdings owned by a fund. It is also responsible for compliance of the portfolio with legal ratios etc.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The depository may delegate custody to another entity (custodian). Definition origin:EFAMA DD</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The depository may delegate custody to another entity (custodian). Definition origin:EFAMA DD</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundDistributionPolicy">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;Policy"/>
 		<rdfs:label xml:lang="en">fund distribution policy</rdfs:label>
 		<skos:definition xml:lang="en">policy indicating the overall strategy or limitations on distribution for the fund</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that individual classes of Fund Unit also have specific distribution polcies as they effect that class of unit. This class is for terms with wording of the form: &quot; ... whether or not it is possible to hold shares ...&quot; for a given parameter.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Note that individual classes of Fund Unit also have specific distribution polcies as they effect that class of unit. This class is for terms with wording of the form: &quot; ... whether or not it is possible to hold shares ...&quot; for a given parameter.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundDistributor">
@@ -493,21 +486,21 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund investment policy</rdfs:label>
 		<skos:definition xml:lang="en">policy that the fund implements in order to achieve the stated fund objectives</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">EFAMA Note: Model distinguishes between strategy (what you intend to invest in) and portfolio structure (what is held). This semantics matches the EFAMA DD &quot;Fund Investment Policy&quot; No stated definition in EFAMA DD (&quot;Further discussion required&quot;).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">EFAMA Note: Model distinguishes between strategy (what you intend to invest in) and portfolio structure (what is held). This semantics matches the EFAMA DD &quot;Fund Investment Policy&quot; No stated definition in EFAMA DD (&quot;Further discussion required&quot;).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundLegalFormDocumentation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-cor;Constitution"/>
 		<rdfs:label xml:lang="en">fund legal form documentation</rdfs:label>
 		<skos:definition xml:lang="en">For a fund which is constituted under the law of contract, the constitution or articles that define the fund. These are embodied in a Contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From ISO FIBIM &quot;Umbrella Fund&quot; narrative: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">From ISO FIBIM &quot;Umbrella Fund&quot; narrative: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundManagementCompany">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:label xml:lang="en">fund management company</rdfs:label>
 		<skos:definition xml:lang="en">The party that sets up the fund, decides the investment strategy, appoints the agents, and is responsible for the promotion and the marketing of the fund. It makes all of the important decisions related to the fund. Also called fund promotor or fund sponsor or fund manager.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the US: operates on a percentage of the Portfolio assets under management.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">In the US: operates on a percentage of the Portfolio assets under management.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundManager">
@@ -593,7 +586,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;InvestmentRestriction"/>
 		<rdfs:label xml:lang="en">fund portfolio investment limitations</rdfs:label>
 		<skos:definition xml:lang="en">Detailed Policy on approximately how the portfolio is to be allocated to achieve the stated investment goals. This underpins the detailed strategy of how to achieve this.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Defined as &quot;Strategy&quot; in FIBIM and elsewhere. WG11: Rough allocation of the portfolio.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Defined as &quot;Strategy&quot; in FIBIM and elsewhere. WG11: Rough allocation of the portfolio.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundPortfolioInvestmentPolicy">
@@ -612,7 +605,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund portfolio investment policy</rdfs:label>
 		<skos:definition xml:lang="en">policy with respect to allocation of the portfolio that is designed to meet the stated investment strategy and goals</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">ISO FIBIM: Rough allocation of the portfolio.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">ISO FIBIM: Rough allocation of the portfolio.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundProcessingForm">
@@ -626,7 +619,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund processing form</rdfs:label>
 		<skos:definition xml:lang="en">The form of documentation or control mechanism required for some funds processing activity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equates to the &quot;Physical Form&quot; in SIO FIBIM for certain activities in funds processing. May or may not be a written physical document. ISO FIBIM Definition: Specifies whether a physical form is required.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Equates to the &quot;Physical Form&quot; in SIO FIBIM for certain activities in funds processing. May or may not be a written physical document. ISO FIBIM Definition: Specifies whether a physical form is required.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundProcessingGeneralTerms">
@@ -651,7 +644,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund processing terms</rdfs:label>
 		<skos:definition xml:lang="en">Formal terms for processing of the fund. These set out what the investor and the fund may or may not do. These include terms for redemption and subscription processing as well as general processing terms. ISO FIBIM definition: Processing characteristics linked to the instrument, ie, not to the market.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These include Fund Subscription Terms, Fund Redemption Terms. and terms which relate to general processing and restrictions or otherwise on the holder. FPP notes: FPP presentation identifies many of these terms under the heading of Valuation Dealing characteristics. May need to revise which goes where in line with FPP. See also terms under NAV Valuation Calculation Method. Others of these terms appear in FPP under Instrument Restrictions. These cover the subscription, redemption and holding amounts and units and minimum holding period.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">These include Fund Subscription Terms, Fund Redemption Terms. and terms which relate to general processing and restrictions or otherwise on the holder. FPP notes: FPP presentation identifies many of these terms under the heading of Valuation Dealing characteristics. May need to revise which goes where in line with FPP. See also terms under NAV Valuation Calculation Method. Others of these terms appear in FPP under Instrument Restrictions. These cover the subscription, redemption and holding amounts and units and minimum holding period.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundPromoter">
@@ -724,7 +717,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund share class unit</rdfs:label>
 		<skos:definition xml:lang="en">The legal structure in which you can purchase part of an investment pool, defined by a variety of characteristics like investor type, minimum size of investment, distribution type, fee and currency. A fund unit which gives the holder an equity stake in the fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From review sessions: Theoretically you can buy a fraction of a share in a fund. This would depend on the legal structure of the fund, e.g. a minimum investment. There is always a distribution plan.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">From review sessions: Theoretically you can buy a fraction of a share in a fund. This would depend on the legal structure of the fund, e.g. a minimum investment. There is always a distribution plan.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundSubscriptionTerms">
@@ -815,7 +808,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">funds processing account</rdfs:label>
 		<skos:definition xml:lang="en">An account used specifically in the processing of funds. Like all accounts this is (per FIBIM definition) a business relationship between two entities; one entity is the account owner, the other entity is the account servicer. Please refer to Financial global model for treatment of accounts relationships in this model.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Derived from FIBIM definition for &quot;Account&quot;, which is: &quot;Business relationship between two entities; one entity is the account owner, the other entity is the account servicer.&quot; this corresponds to the Global Terms definition for Account.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Derived from FIBIM definition for &quot;Account&quot;, which is: &quot;Business relationship between two entities; one entity is the account owner, the other entity is the account servicer.&quot; this corresponds to the Global Terms definition for Account.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundsProcessingParty">
@@ -883,7 +876,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund investment restrictions set</rdfs:label>
 		<skos:definition xml:lang="en">Limitations that apply to the fund as a whole, such as risk factors. these are used to determine whether the fund is appropriate for a given type of investor to invest in.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are defined by the overall Fund investment policy. Not the same as the detailed policies for investing in percentages of this or that.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">These are defined by the overall Fund investment policy. Not the same as the detailed policies for investing in percentages of this or that.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;InvestmentStrategy">
@@ -926,9 +919,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>key investor information document</rdfs:label>
 		<skos:definition>short document that provides critical information for investors, summarizing content derived from a prospectus such that it can be understood by investors without reference to other documents, as required by law in the European Union</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>KIID</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://eur-lex.europa.eu/eli/dir/2009/65/2020-01-07</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Key investor information shall include appropriate information about the essential characteristics of the UCITS concerned, which is to be provided to investors so that they are reasonably able to understand the nature and the risks of the investment product that is being offered to them and, consequently, to take investment decisions on an informed basis.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>KIID</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://eur-lex.europa.eu/eli/dir/2009/65/2020-01-07</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Key investor information shall include appropriate information about the essential characteristics of the UCITS concerned, which is to be provided to investors so that they are reasonably able to understand the nature and the risks of the investment product that is being offered to them and, consequently, to take investment decisions on an informed basis.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;Liquidity">
@@ -1022,7 +1015,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">portfolio investment strategy</rdfs:label>
 		<skos:definition xml:lang="en">The manner in which the portfolio manager tries to reach the funds objectives.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Describes how you get there. E.g fully invested v not fully invested. MB Note: The terms labeled &quot;Strategy&quot; in EFAMA and in FIBIM are more like dictionary definition of policy, while &quot;How you get there&quot; is a dictionary definition of Strategy. Therefore original labels may be reversed from dictionary definition of the global semantics these are derived from.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Describes how you get there. E.g fully invested v not fully invested. MB Note: The terms labeled &quot;Strategy&quot; in EFAMA and in FIBIM are more like dictionary definition of policy, while &quot;How you get there&quot; is a dictionary definition of Strategy. Therefore original labels may be reversed from dictionary definition of the global semantics these are derived from.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;PortfolioManager">
@@ -1492,7 +1485,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-fund-fund;CollectiveInvestmentVehicle"/>
 		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundUnitDistributionMethod"/>
 		<skos:definition xml:lang="en">Income policy relating to a class type, ie, if income is paid out or retained in the fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a fact about each individual type of Fund Unit. Additional facts may apply to the Fund as a whole - to be reviewed. Need to determine if there is an overall distribution policy term applicable to the Fund. Kept as a place holder in case there is.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is a fact about each individual type of Fund Unit. Additional facts may apply to the Fund as a whole - to be reviewed. Need to determine if there is an overall distribution policy term applicable to the Fund. Kept as a place holder in case there is.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasDistributionPolicy.2">
@@ -2371,7 +2364,7 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundSupervisoryAuthority"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From EFAMA DD: The word fund can refer to either an investment pool, umbrella or share class, and is commonly refered to as a collective investment vehicle (can have ISIN or not). The meaning here is for the investment pool (of which an Umbrella fund is also one such) and not to the share class.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">From EFAMA DD: The word fund can refer to either an investment pool, umbrella or share class, and is commonly refered to as a collective investment vehicle (can have ISIN or not). The meaning here is for the investment pool (of which an Umbrella fund is also one such) and not to the share class.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;FundContract">
@@ -2381,7 +2374,7 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundLegalFormDocumentation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From ISO FIBIM &quot;Umbrella Fund&quot; narrative: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">From ISO FIBIM &quot;Umbrella Fund&quot; narrative: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;FundUnit">
@@ -2403,7 +2396,7 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundRedemptionTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If it is a closed fund, you can still trade the units. You trade back with the fund. Not with a counterparty. Therefore this is a tradable contract, though it may not necessarily be a transferable contract.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">If it is a closed fund, you can still trade the units. You trade back with the fund. Not with a counterparty. Therefore this is a tradable contract, though it may not necessarily be a transferable contract.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/SEC/Funds/Funds.rdf
+++ b/SEC/Funds/Funds.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -24,10 +25,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -52,26 +53,14 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/">
 		<rdfs:label xml:lang="en">Funds Ontology</rdfs:label>
 		<dct:abstract>This ontology defines fundamental concepts about funds and collective investment vehicles (CIVs).</dct:abstract>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
-		<sm:dependsOn rdf:resource="https://www.omg.org/spec/LCC/"/>
-		<sm:fileAbbreviation>fibo-sec-fund-fund</sm:fileAbbreviation>
-		<sm:filename>Funds.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/"/>
@@ -88,14 +77,18 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Funds/Funds/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Funds/Funds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Funds/Funds.rdf version of this ontology was modified to replace the original fibo-sec-fnd-fnd prefix with fibo-sec-fund-fund for the sake of clarity and to change the restriction on LegalFundStructure from an equivalence to a subclass relationship to address a reasoning error as well as adding a missing restriction on jurisdiction.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Funds/Funds.rdf version of this ontology was modified to move the definition of SpecialPurposeVehicle to the Pools ontology to make it available for use more generally.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Funds/Funds.rdf version of this ontology was modified to eliminate a deprecated element for SpecialPurposeVehicle, which was moved to Pools last quarter.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220501/Funds/Funds.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Funds/Funds.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;ClosedEndInvestment">
@@ -108,7 +101,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">closed-end investment</rdfs:label>
 		<skos:definition xml:lang="en">investment fund that has a fixed number of shares offered by an investment company through an initial public offering</skos:definition>
-		<fibo-fnd-utl-av:synonym xml:lang="en">closed-end fund</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym xml:lang="en">closed-end fund</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;CollectiveInvestmentVehicle">
@@ -121,17 +114,17 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">collective investment vehicle</rdfs:label>
 		<skos:definition xml:lang="en">assets pooled by investors whose share capital remains separate from the assets of the vehicle</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Collective investment vehicles are typically organized and operated by management companies, banks, or trust companies. Shares or units are issued in the form of unit trusts, mutual funds, or other similar contracts. Common kinds of funds include pension funds, insurance funds, foundations, and endowments. Such pools are often invested and professionally managed, including investment pools, umbrella pools, share class pools, etc.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Collective investment vehicles are typically organized and operated by management companies, banks, or trust companies. Shares or units are issued in the form of unit trusts, mutual funds, or other similar contracts. Common kinds of funds include pension funds, insurance funds, foundations, and endowments. Such pools are often invested and professionally managed, including investment pools, umbrella pools, share class pools, etc.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;ExchangeTradedFund">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;OpenEndInvestment"/>
 		<rdfs:label xml:lang="en">exchange-traded fund</rdfs:label>
 		<skos:definition xml:lang="en">investment fund whose fund units are traded on an exchange, much like stocks</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">ETF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An ETF holds assets such as stocks, commodities, or bonds, and trades close to its net asset value over the course of the trading day. Most ETFs track an index, such as a stock, bond, or commodity index.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">ETF</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">An ETF holds assets such as stocks, commodities, or bonds, and trades close to its net asset value over the course of the trading day. Most ETFs track an index, such as a stock, bond, or commodity index.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;FundContract">
@@ -150,8 +143,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund of funds</rdfs:label>
 		<skos:definition xml:lang="en">investment fund that invests directly in other investment funds rather than investing in stocks, bonds, and other securities</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym xml:lang="en">umbrella fund</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:synonym xml:lang="en">umbrella fund</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;FundUnit">
@@ -176,7 +169,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;OpenEndInvestment"/>
 		<rdfs:label xml:lang="en">hedge fund</rdfs:label>
 		<skos:definition xml:lang="en">investment fund that pursues a total return and is usually open to qualified investors only</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;LegalFundStructure">
@@ -205,8 +198,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;OpenEndInvestment"/>
 		<rdfs:label xml:lang="en">mutual fund</rdfs:label>
 		<skos:definition xml:lang="en">open-end professionally managed investment fund established for the purpose of investing in securities such as stocks, bonds, money market instruments and similar assets</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym xml:lang="en">standard (vanilla) investment fund</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:synonym xml:lang="en">standard (vanilla) investment fund</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;OpenEndInvestment">
@@ -220,25 +213,25 @@
 		<rdfs:label xml:lang="en">open-end investment</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-fund-fund;ClosedEndInvestment"/>
 		<skos:definition xml:lang="en">investment fund that offered through a fund company that sells shares directly to investors</skos:definition>
-		<fibo-fnd-utl-av:synonym xml:lang="en">open-end fund</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym xml:lang="en">open-end fund</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;PensionFund">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;ManagedInvestment"/>
 		<rdfs:label xml:lang="en">pension fund</rdfs:label>
 		<skos:definition xml:lang="en">investment fund run by a financial intermediary on behalf of an organization and its employees/members</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">ETF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A pension fund is a common asset pool meant to generate stable growth over a long-term investment horizon.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">ETF</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">A pension fund is a common asset pool meant to generate stable growth over a long-term investment horizon.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;PrivateEquityFund">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;ManagedInvestment"/>
 		<rdfs:label xml:lang="en">private equity fund</rdfs:label>
 		<skos:definition xml:lang="en">investment fund used for making investments in various equity (and to a lesser extent debt) securities according to an investment strategy associated with private equity</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">ETF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Private equity funds are typically structured as limited partnerships or limited liability companies, wherein investors are limited partners, and the fund is managed by one or more general partners. It is composed of investors and funds that invest directly in private companies, or that engage in buyouts of public companies, resulting in the delisting of the public equity.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">ETF</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Private equity funds are typically structured as limited partnerships or limited liability companies, wherein investors are limited partners, and the fund is managed by one or more general partners. It is composed of investors and funds that invest directly in private companies, or that engage in buyouts of public companies, resulting in the delisting of the public equity.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;RealEstateInvestmentTrust">
@@ -251,18 +244,18 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">real estate investment trust</rdfs:label>
 		<skos:definition xml:lang="en">investment fund that offers shares/units to the public and invests in real estate directly</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">REIT</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Real estate investment trusts own, and in most cases operate, income-producing real estate. REITs own many types of commercial real estate, ranging from office and apartment buildings to warehouses, hospitals, shopping centers, hotels and commercial forests. Some REITs engage in financing real estate.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">REIT</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Real estate investment trusts own, and in most cases operate, income-producing real estate. REITs own many types of commercial real estate, ranging from office and apartment buildings to warehouses, hospitals, shopping centers, hotels and commercial forests. Some REITs engage in financing real estate.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;SovereignWealthFund">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;CollectiveInvestmentVehicle"/>
 		<rdfs:label xml:lang="en">sovereign wealth fund</rdfs:label>
 		<skos:definition xml:lang="en">state-owned investment fund that consists of pools of money derived from a country&apos;s reserves</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Sovereign wealth funds include the International Monetary Fund, whose corresponding legal entity is a polity.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">social wealth fund</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">sovereign investment fund</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">Sovereign wealth funds include the International Monetary Fund, whose corresponding legal entity is a polity.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">social wealth fund</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">sovereign investment fund</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-fund;hasLegalStructure">
@@ -304,9 +297,9 @@
 				<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A managed investment is an investment vehicle that consists of a pool of funds collected from many different investors run by a management company.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">investment fund</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">A managed investment is an investment vehicle that consists of a pool of funds collected from many different investors run by a management company.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">investment fund</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-pls;PooledFund">
@@ -329,8 +322,8 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-gao-obj;InvestmentObjective"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A fund can be established for any purpose, such as a municipality setting aside money for a construction project, monies designated to endow a university chair or for scholarships, or funds set aside by insurance companies to settle claims.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">fund</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">A fund can be established for any purpose, such as a municipality setting aside money for a construction project, monies designated to endow a university chair or for scholarships, or funds set aside by insurance companies to settle claims.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">fund</cmns-av:synonym>
 	</owl:Class>
 
 </rdf:RDF>

--- a/SEC/Funds/MetadataSECFunds.rdf
+++ b/SEC/Funds/MetadataSECFunds.rdf
@@ -1,60 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-fnd-mod "https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/MetadataSECFunds/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/MetadataSECFunds/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-fnd-mod="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/MetadataSECFunds/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/MetadataSECFunds/">
 		<rdfs:label>Metadata SEC Funds Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of funds concepts covering fund structure, definition and involved parties, along with concepts for tradable fund units.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2021-03-29T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain, Funds Module</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-fnd-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataSECFunds.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210301/Funds/MetadataSECFunds/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Funds/MetadataSECFunds/"/>
+		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-fnd-mod;FundsModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Funds Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>funds module</rdfs:label>
 		<dct:abstract>This module contains ontologies of funds concepts covering fund structure, definition and involved parties, along with concepts for tradable fund units.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>BIAN</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Goldman Sachs</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Mizuho</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
-		<sm:copyright>Copyright (c) 2020-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:keyword>collective investment vehicles, CIV, special purpose vehicles</sm:keyword>
-		<sm:keyword>exchange traded funds (ETFs), hedge funds, mutual funds, pension funds, real estate investment trusts (REITs)</sm:keyword>
-		<sm:keyword>funds</sm:keyword>
-		<sm:moduleAbbreviation>fibo-sec-fund</sm:moduleAbbreviation>
+		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain Funds Module</dct:title>
+		<dct:title>FIBO SEC Funds Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/MetadataSEC.rdf
+++ b/SEC/MetadataSEC.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-dbt-mod "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/">
@@ -11,10 +12,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-dbt-mod="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/"
@@ -26,77 +27,63 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/">
 		<rdfs:label>Metadata about the EDMC-FIBO Securities (SEC) Domain</rdfs:label>
 		<dct:abstract>The Securities (SEC) Domain covers many of the concepts that are common to a wide variety of securities as well as those specific to equities and various debt instruments, including but not limited to bonds and a wide range of asset-backed securities. This ontology provides metadata about the Securities Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-14T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-sec-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataSEC.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/MetadataSECEquities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/MetadataSECFunds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/MetadataSECSecurities/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/MetadataSEC/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/MetadataSEC/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-mod;SECDomain">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Securities</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>securities domain</rdfs:label>
 		<dct:abstract>The FIBO Securities (SEC) domain provides a model of concepts that are common to financial instruments that are also securities, including but not limited to exchange-traded securities and funds. High-level concepts relevant to securities classification, identification, issuance, and registration of securities generally are covered, as well as additional detail for equities, debt instruments, and funds. More details defining derivatives in particular are covered in a separate derivatives domain area.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>BIAN</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Goldman Sachs</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Mizuho</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:creator rdf:datatype="&xsd;anyURI">https://wiki.edmcouncil.org/pages/viewpage.action?pageId=786661</dct:creator>
 		<dct:hasPart rdf:resource="&fibo-sec-dbt-mod;DebtModule"/>
 		<dct:hasPart rdf:resource="&fibo-sec-eq-mod;EquitiesModule"/>
 		<dct:hasPart rdf:resource="&fibo-sec-fnd-mod;FundsModule"/>
 		<dct:hasPart rdf:resource="&fibo-sec-sec-mod;SecuritiesModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain</dct:title>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>BIAN</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>Goldman Sachs</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>Mizuho</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo Bank, N.A.</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:keyword>debt instruments, bonds, asset-backed securities</sm:keyword>
-		<sm:keyword>equities</sm:keyword>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>funds, collective investment vehicles, special purpose vehicles</sm:keyword>
-		<sm:keyword>securities</sm:keyword>
-		<sm:moduleAbbreviation>fibo-sec</sm:moduleAbbreviation>
+		<dct:title>FIBO SEC Domain</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Securities (SEC) Domain</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/Securities/Baskets.rdf
+++ b/SEC/Securities/Baskets.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
@@ -14,10 +15,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
@@ -32,21 +33,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/">
 		<rdfs:label>Baskets Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the concept of a tradable container of securities, indices, and/or market rates, and identifies the elements that can be constituents of a such a basket.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-bsk</sm:fileAbbreviation>
-		<sm:filename>Baskets.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
@@ -55,11 +47,15 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/Baskets/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/Baskets/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/Baskets.rdf version of this ontology was revised to augment the definitions of various baskets to include weighting and to be dated, as needed to represent various benchmarks and funds based on these baskets.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/Baskets.rdf version of this ontology was revised to add the date a given constituent is added to a basket, and use involves rather than hasIdentity to link a security or index to the basket constituent it is referenced by.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/Baskets.rdf version of this ontology was revised to reflect the move of dated collections from arrangements to financial dates, and replace &apos;involves&apos; with &apos;comprises&apos; for consistency across basket definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/Baskets.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-bsk;BasketOfIndices">

--- a/SEC/Securities/MetadataSECSecurities.rdf
+++ b/SEC/Securities/MetadataSECSecurities.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-mod "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/MetadataSECSecurities/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/MetadataSECSecurities/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-mod="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/MetadataSECSecurities/"
@@ -18,27 +19,48 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/MetadataSECSecurities/">
 		<rdfs:label>Metadata about the EDMC-FIBO Securities (SEC), Securities Module</rdfs:label>
 		<dct:abstract>The SEC Securities Module covers basic information that are common to many securities, including classification schemes, parametric schedules, and common identification, issuance, listing, and restriction-specific concepts. This ontology provides metadata about the Securities module and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-sec-sec-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataSECSecurities.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/MetadataSECSecurities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/MetadataSECSecurities/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-mod;SecuritiesModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO SEC Securities Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>securities module</rdfs:label>
 		<dct:abstract>This module defines concepts common to all securities contracts or referenced in multiple classes of security.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>BIAN</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Credit Suisse</dct:contributor>
+		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Exprentis</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Goldman Sachs</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Mizuho</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Quarule</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
@@ -50,29 +72,11 @@
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>BIAN</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Credit Suisse</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Exprentis</sm:contributor>
-		<sm:contributor>Goldman Sachs</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>Mizuho</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Quarule</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:copyright>Copyright (c) 2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-SEC-SEC</sm:moduleAbbreviation>
+		<dct:title>FIBO SEC Securities Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Securities and Equities (SEC) Securities Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/Securities/ParametricSchedules.rdf
+++ b/SEC/Securities/ParametricSchedules.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
@@ -11,10 +12,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
@@ -26,29 +27,26 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/">
 		<rdfs:label>Parametric Schedules Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts related to parametric schedules, including how to represent individual schedules as well as related date periods, explicit dates, and other concepts needed for parametric schedule representation.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-sch</sm:fileAbbreviation>
-		<sm:filename>ParametricSchedules.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/ParametricSchedules/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/ParametricSchedules.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/ParametricSchedules.rdf version of this ontology was modified to eliminate circular definitions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/ParametricSchedules.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/ParametricSchedules.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;AuctionDateRule">
@@ -125,22 +123,22 @@
 		</rdfs:subClassOf>
 		<rdfs:label>floating-rate note date</rdfs:label>
 		<skos:definition>a calculated date associated with a floating-rate note, also known as a floater or FRN, which is a debt instrument with a variable interest rate</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>FRN date</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>FRN date</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;FloatingRateNoteDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-bd;BusinessDayAdjustment"/>
 		<rdfs:label>floating-rate note date rule</rdfs:label>
 		<skos:definition>a business day adjustment rule applied to floating-rate note instruments</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>FRN date rule</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>FRN date rule</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;InternationalMoneyMarketAustralianDollarTradingDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;TradingDateRule"/>
 		<rdfs:label>International Money Market (IMM) Australian Dollar (AUD) trading date rule</rdfs:label>
 		<skos:definition>a trading date rule defined as the last trading day of an Australian Stock Exchange (ASX) 90-Day Bank Accepted Futures and Options product, one Sydney business day preceding the second Friday of the relevant settlement month</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>IMM AUD trading date rule</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.asx.com.au/documents/products/90-Day-bank-bill-futures-factsheet.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>IMM AUD trading date rule</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.asx.com.au/documents/products/90-Day-bank-bill-futures-factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;InternationalMoneyMarketCanadianDollarTradingDateRule">
@@ -154,22 +152,22 @@
 		<rdfs:label>International Money Market (IMM) Canadian Dollar (CAD) trading date rule</rdfs:label>
 		<skos:definition>a trading date rule defined as the last trading day / expiration day of the Canadian Derivatives Exchange (Bourse do Montreal Inc.), three month Bankers&apos; Acceptance Futures (Ticker symbol BAX), the second London banking day prior to the third Wednesday of the contract month</skos:definition>
 		<skos:editorialNote>(continued within FpML definition): If the determined day is a bourse or bank holiday in Toronto or Montreal, the last trading day shall be the previous bank business day. Per Canadian Derivatives Exchange BAX contract specification. The above description implies a Date Roll Rule which is presumably referenced by referring to this rule, so that when this rule is referenced, there would be no Date Roll Rule defined in the FpML message. Semantically, this is still a Date Roll Rule, specifically a &quot;Roll forward&quot; rule with no modification (the third Wednesday of a month will never roll forward to a day in the following month so no Modified rule is required).</skos:editorialNote>
-		<fibo-fnd-utl-av:abbreviation>IMM CAD trading date rule</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>IMM CAD trading date rule</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;InternationalMoneyMarketNewZealandDollarTradingDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;TradingDateRule"/>
 		<rdfs:label>International Money Market (IMM) New Zealand Dollar (NZD) trading date rule</rdfs:label>
 		<skos:definition>a trading date rule defined as the last trading day of an Australian Stock Exchange (ASX) New Zealand (NZ) 90-Day Bank Accepted Futures and Options product, the first Wednesday after the ninth day of the relevant settlement month</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>IMM NZD trading date rule</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>IMM NZD trading date rule</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;InternationalMoneyMarketSettlementDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;SettlementDateRule"/>
 		<rdfs:label>International Money Market (IMM) settlement date rule</rdfs:label>
 		<skos:definition>a settlement date rule as defined in the International Money Market (IMM) settlement dates calendar</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>IMM settlement date rule</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>The International Money Market (IMM) is a division of the Chicago Mercantile Exchange (CME) that deals with the trading of currency and interest rate futures and options.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>IMM settlement date rule</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The International Money Market (IMM) is a division of the Chicago Mercantile Exchange (CME) that deals with the trading of currency and interest rate futures and options.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;NonRollingDate">
@@ -223,14 +221,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
 		<rdfs:label>scheduled calculation period end event</rdfs:label>
 		<skos:definition>the end date of a specific calculation period</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Note that this is not necessarily the same as the day before the next period&apos;s start date. Calculation schedules specify periods of time, with a start and an end as well as a duration, with the end date being determined by some convention or published list of dates. FpML for CalculationPeriod &apos;A type defining the parameters used in the calculation of a fixed or floating rate calculation period amount. This type forms part of cashflows representation of a swap stream.&apos;</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that this is not necessarily the same as the day before the next period&apos;s start date. Calculation schedules specify periods of time, with a start and an end as well as a duration, with the end date being determined by some convention or published list of dates. FpML for CalculationPeriod &apos;A type defining the parameters used in the calculation of a fixed or floating rate calculation period amount. This type forms part of cashflows representation of a swap stream.&apos;</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;ScheduledCalculationPeriodStartEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
 		<rdfs:label>scheduled calculation period start event</rdfs:label>
 		<skos:definition>the start of a specific calculation period</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>FpML for CalculationPeriod &apos;A type defining the parameters used in the calculation of a fixed or floating rate calculation period amount. This type forms part of cashflows representation of a swap stream.&apos;</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>FpML for CalculationPeriod &apos;A type defining the parameters used in the calculation of a fixed or floating rate calculation period amount. This type forms part of cashflows representation of a swap stream.&apos;</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;SettlementDateRule">
@@ -256,8 +254,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>US Treasury bill auction date rule</rdfs:label>
 		<skos:definition>a rule for setting auction dates for US Treasury bills</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.treasurydirect.gov/instit/auctfund/work/work.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>To finance the public debt, the U.S. Treasury sells bills, notes, bonds, Floating Rate Notes (FRNs), and Treasury Inflation-Protected Securities (TIPS) to institutional and individual investors through public auctions. Treasury auctions occur regularly and have a set schedule. Rules and other information are available via announcements of pending auctions.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.treasurydirect.gov/instit/auctfund/work/work.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>To finance the public debt, the U.S. Treasury sells bills, notes, bonds, Floating Rate Notes (FRNs), and Treasury Inflation-Protected Securities (TIPS) to institutional and individual investors through public auctions. Treasury auctions occur regularly and have a set schedule. Rules and other information are available via announcements of pending auctions.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;USTreasuryBillDate">

--- a/SEC/Securities/Pools.rdf
+++ b/SEC/Securities/Pools.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
@@ -17,10 +18,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
@@ -38,22 +39,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/">
 		<rdfs:label>Securities Pools Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts related to high-level securities pools.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-pls</sm:fileAbbreviation>
-		<sm:filename>Pools.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
@@ -64,15 +55,19 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220501/Securities/Pools/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/Pools/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20211201/Securities/Pools.rdf version of this ontology was modified to move the definition of SpecialPurposeVehicle to this ontology to make it available for use more generally and augment the definition of an instrument pool with ownership.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/Pools/ version of this ontology was modified to correct a logical inconsistency with respect to the representation of baskets.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/Pools/ version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/Pools/ version of this ontology was modified to replace equity with owners equity in the definition of pool equity.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201001/Securities/Pools/ version of this ontology was modified to deprecate the concept of &apos;pool equity&apos; which was not used elsewhere and was poorly defined and eliminate an improper restriction on managed investment.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Securities/Pools/ version of this ontology was modified to eliminate the deprecated concept for pool equity.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220501/Securities/Pools.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-pls;DebtPool">
@@ -157,7 +152,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>managed investment</rdfs:label>
 		<skos:definition>investment pool that is controlled by a professional investment manager who invests the pool in various financial instruments and assets that align with their investment objectives and is overseen by a board of directors</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Bloomberg LP</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Bloomberg LP</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-pls;Pool">
@@ -170,7 +165,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>pool</rdfs:label>
 		<skos:definition>a combination of resources for a common purpose or benefit</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-pls;PoolConstituent">
@@ -183,7 +178,7 @@
 			</owl:Restriction>
 		</owl:equivalentClass>
 		<skos:definition>component of a pool</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The pool may be a pool of almost anything, brought together for some purpose. It differs from a less formal collection in that there are facts defined about the constituents and the proportions of these in the pool. Modeling note: A constituent of a pool may have facts which vary over time (such as balances) but the basic nature of the thing as a member of the pool remains the same, along with some facts which vary over time but which have a value as of the time they become members of the pool.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The pool may be a pool of almost anything, brought together for some purpose. It differs from a less formal collection in that there are facts defined about the constituents and the proportions of these in the pool. Modeling note: A constituent of a pool may have facts which vary over time (such as balances) but the basic nature of the thing as a member of the pool remains the same, along with some facts which vary over time but which have a value as of the time they become members of the pool.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-pls;PooledFund">
@@ -222,7 +217,7 @@
 			</owl:Restriction>
 		</owl:equivalentClass>
 		<skos:definition>security that is included in a securities pool</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is a pool of any kind of security, and not therefore necessarily a pool of debt, though usually it is debt securities which are pooled.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is a pool of any kind of security, and not therefore necessarily a pool of debt, though usually it is debt securities which are pooled.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/SEC/Securities/SecuritiesClassification.rdf
+++ b/SEC/Securities/SecuritiesClassification.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
@@ -12,10 +13,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
@@ -28,34 +29,29 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
 		<rdfs:label>Securities Classification Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for classifying financial instruments, particularly securities, including, but not limited to classification schemes developed by government, regulatory agencies, and industry to classify the issuers of such securities as well as the securities themselves.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-cls</sm:fileAbbreviation>
-		<sm:filename>SecuritiesClassification.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210401/Securities/SecuritiesClassification/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecuritiesClassification/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesClassification.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesClassification.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesClassification.rdf version of this ontology was modified to add an class representing the ISO 10962 CFI standard and an individual for the 2019 version of that standard.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Securities/SecuritiesClassification.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/SecuritiesClassification.rdf version of this ontology was revised to eliminate a reasoning issue with respect to the CFI codes related to making the classification code a code element (which makes it a code that applies to exactly one thing).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210401/Securities/SecuritiesClassification.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
@@ -85,10 +81,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>asset class</rdfs:label>
 		<skos:definition>a financial instrument classifier for a group of securities that exhibit similar characteristics, behave similarly in the marketplace and are subject to the same laws and regulations</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/a/assetclasses.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/cfr/text/17/45.1</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Asset class means the broad category of goods, services or commodities, including any &apos;excluded commodity&apos; as defined in CEA section 1a(19), with common characteristics underlying a swap. The asset classes include credit, equity, foreign exchange (excluding cross-currency), interest rate (including cross-currency), other commodity, and such other asset classes as may be determined by the Commission.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The three main asset classes are equities, or stocks; fixed income, or bonds; and cash equivalents, or money market instruments. Some investment professionals add real estate and commodities, and possibly other types of investments, to the asset class mix.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/a/assetclasses.asp</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/cfr/text/17/45.1</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Asset class means the broad category of goods, services or commodities, including any &apos;excluded commodity&apos; as defined in CEA section 1a(19), with common characteristics underlying a swap. The asset classes include credit, equity, foreign exchange (excluding cross-currency), interest rate (including cross-currency), other commodity, and such other asset classes as may be determined by the Commission.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The three main asset classes are equities, or stocks; fixed income, or bonds; and cash equivalents, or money market instruments. Some investment professionals add real estate and commodities, and possibly other types of investments, to the asset class mix.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-cls;ClassificationOfFinancialInstrumentsCodeScheme">
@@ -101,9 +97,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>classification of financial instruments code scheme</rdfs:label>
 		<skos:definition>classification scheme for set of codes for financial instruments that can be used globally for straight-through processing by all involved participants in an electronic data processing environment</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CFI code scheme</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/73564.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The ISO 10962 Securities and related financial instruments - Classification of financial instruments (CFI) code was developed as a solution to a number of challenges. One is to establish a series of codes which clearly classify financial instruments having similar features. The other is to develop a glossary of terms and provide common definitions which allow market participants to easily understand terminology being used.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>CFI code scheme</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/73564.html</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The ISO 10962 Securities and related financial instruments - Classification of financial instruments (CFI) code was developed as a solution to a number of challenges. One is to establish a series of codes which clearly classify financial instruments having similar features. The other is to develop a glossary of terms and provide common definitions which allow market participants to easily understand terminology being used.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode">
@@ -124,8 +120,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>financial instrument classification code</rdfs:label>
 		<skos:definition>classifier and code for a financial instrument defined in the ISO 10962 Classification of Financial Instruments (CFI) Code Scheme</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CFI code</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/73564.html</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>CFI code</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/73564.html</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-cls;FinancialInstrumentClassificationScheme">

--- a/SEC/Securities/SecuritiesIdentification.rdf
+++ b/SEC/Securities/SecuritiesIdentification.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
@@ -20,10 +21,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
@@ -44,23 +45,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/">
 		<rdfs:label>Securities Identification Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts required to identify securities, including a number of well-known securities identifiers and related schemes, registries, and registration authorities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-id</sm:fileAbbreviation>
-		<sm:filename>SecuritiesIdentification.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"/>
@@ -73,9 +63,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/SecuritiesIdentification/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecuritiesIdentification/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20180801/Securities/SecuritiesIdentification.rdf version of this ontology was modified to use the hasCoverageArea property rather than hasJurisdiction for coverage of national numbering agencies, and eliminate redundant subclass relationships for two of the schemes defined herein.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20181101/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was modified to add the concept of a ticker symbol and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
@@ -84,7 +75,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesIdentification/ version of this ontology was modified to make a ticker symbol reassignable and address circular or ambiguous definitions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200901/Securities/SecuritiesIdentification.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesIdentification.rdf version of this ontology was revised to leverage the notion of a composite identifier and address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/SecuritiesIdentification.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;FinancialInstrumentIdentificationScheme">
@@ -119,8 +113,8 @@
 		<rdfs:label>international securities identification number</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.iso.org/iso/catalogue_detail?csnumber=44811"/>
 		<skos:definition>security identifier that is defined as specified in ISO 6166, Securities and related financial instruments -- International securities identification numbering system (ISIN)</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ISIN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>ISINs consist of two alphabetic characters, which are the ISO 3166-1 alpha-2 code for the issuing country, nine alpha-numeric characters (the National Securities Identifying Number, or NSIN, which identifies the security, padded as necessary with leading zeros), and one numerical check digit. The ISIN is specified as a class of identifiers because although there is a scheme associated with the structure of an ISIN, there are many country-specific variations issued by national numbering agencies.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>ISIN</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>ISINs consist of two alphabetic characters, which are the ISO 3166-1 alpha-2 code for the issuing country, nine alpha-numeric characters (the National Securities Identifying Number, or NSIN, which identifies the security, padded as necessary with leading zeros), and one numerical check digit. The ISIN is specified as a class of identifiers because although there is a scheme associated with the structure of an ISIN, there are many country-specific variations issued by national numbering agencies.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumberingScheme">
@@ -134,7 +128,7 @@
 		<rdfs:label>international securities identification numbering scheme</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.iso.org/iso/catalogue_detail?csnumber=44811"/>
 		<skos:definition>formal definition of the structure and application of a ISINs as defined in ISO 6166</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>ISIN scheme</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>ISIN scheme</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;ListedSecurityIdentifier">
@@ -195,7 +189,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>national numbering agency</rdfs:label>
 		<skos:definition>registration authority responsible for issuing and managing National Securities Identifying Numbers for securities in accordance with the ISO 6166 standard in some jurisdiction (typically that of a country)</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NNA</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>NNA</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;NationalSecuritiesIdentifyingNumber">
@@ -214,7 +208,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>National Securities Identifying Number</rdfs:label>
 		<skos:definition>generic, nine-digit alpha numeric code which identifies a fungible security, assigned by a national numbering agency under the ISO 6166 standard</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NSIN</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>NSIN</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;NationalSecuritiesIdentifyingNumberRegistry">
@@ -240,7 +234,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>National Securities Identifying Number registry</rdfs:label>
 		<skos:definition>registry used by a national numbering agency to manage the financial instrument identifiers and related information that it registers</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NSIN registry</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>NSIN registry</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;NationalSecuritiesIdentifyingNumberRegistryEntry">
@@ -271,7 +265,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>national security identification scheme</rdfs:label>
 		<skos:definition>security identification scheme, defining the format and structure of a National Securities Identifying Number (NSIN), published nationally on behalf of a country</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>generally incorporated into the ISIN scheme as well</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>generally incorporated into the ISIN scheme as well</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme">
@@ -284,7 +278,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>proprietary security identification scheme</rdfs:label>
 		<skos:definition>security identification scheme published by a commercial entity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Proprietary schemes may be unique to an exchange or data provider, for example.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Proprietary schemes may be unique to an exchange or data provider, for example.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;ProprietarySecurityIdentifier">
@@ -353,7 +347,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>security registry</rdfs:label>
 		<skos:definition>registry used to manage security identifiers and related information</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Securities registries may be managed by an exchange, clearing house, custodian, bank, or other financial services provider.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Securities registries may be managed by an exchange, clearing house, custodian, bank, or other financial services provider.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;SecurityRegistryEntry">
@@ -394,8 +388,8 @@
 		<rdfs:label>ticker symbol</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/t/tickersymbol.asp"/>
 		<skos:definition>exchange-specific identifier for a particular security or listing for that security, depending on the country</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Every listed security has at least one unique ticker symbol, facilitating the vast array of trade orders that flow through the financial markets every day. However, in some countries this relationship may be indirect, through the listing, rather than direct, as is the case in the United States. In the US, the relationship between a ticker symbol and the listed security is one-to-one. This is not, however, the case in Singapore, where there may be unique ticker symbols for the same security based on the lot size.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:usageNote>Ticker symbols are reusable, assigned to a given instrument by an exchange for some period of time.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:explanatoryNote>Every listed security has at least one unique ticker symbol, facilitating the vast array of trade orders that flow through the financial markets every day. However, in some countries this relationship may be indirect, through the listing, rather than direct, as is the case in the United States. In the US, the relationship between a ticker symbol and the listed security is one-to-one. This is not, however, the case in Singapore, where there may be unique ticker symbols for the same security based on the lot size.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>Ticker symbols are reusable, assigned to a given instrument by an exchange for some period of time.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;Listing">

--- a/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
+++ b/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -24,10 +25,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -52,24 +53,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/">
 		<rdfs:label>Securities Identification Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts and primarily individuals required to identify securities, including the individuals that represent a number of well-known securities identifiers and related schemes, registries, and registration authorities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-idind</sm:fileAbbreviation>
-		<sm:filename>SecuritiesIdentificationIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
@@ -87,8 +76,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20221001/Securities/SecuritiesIdentificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecuritiesIdentificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was updated to represent identifiers as classes rather than individuals and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
@@ -100,7 +90,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211201/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to correct a typo in an annotation property name.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to address text formatting hygiene issues and clean up dead or irrelevant links.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to replace &apos;financial information publisher&apos; with &apos;publisher&apos;.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20221001/Securities/SecuritiesIdentificationIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;Clearstream">
@@ -192,16 +185,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label>CUSIP International Numbering System (CINS) number</rdfs:label>
 		<skos:definition>9-character alphanumeric identifier that employs the same 9 characters as CUSIP, but also contains a letter of the alphabet in the first position signifying the issuer&apos;s country or geographic region, issued by CUSIP Global Services</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CINS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.cusip.com/cusip/about-cgs-identifiers.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>CINS number</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>CINS</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.cusip.com/cusip/about-cgs-identifiers.htm</cmns-av:adaptedFrom>
+		<cmns-av:synonym>CINS number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;CUSIPInternationalNumberingSystemScheme">
 		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
 		<rdfs:label>CUSIP International Numbering System (CINS) scheme</rdfs:label>
 		<skos:definition>security identification scheme that extends the CUSIP scheme, used to identify securities outside of the United States and Canada for the purposes of facilitating clearing and settlement of trades</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CINS scheme</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>CINS scheme</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber">
@@ -242,8 +235,8 @@
 		<rdfs:label>Committee on Uniform Securities Identification Procedures (CUSIP) number</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.cusip.com/cusip/about-cgs-identifiers.htm"/>
 		<skos:definition>nine-character alphanumeric number that identifies all North American stocks and registered bonds for the purposes of facilitating clearing and settlement of trades, issued by CUSIP Global Services on behalf of the American Bankers&apos; Association, which is a part of Standard and Poor&apos;s Capital IQ, that is the National Numbering Agency Identifier for securities issued in North America, which is also part of the ISIN for the security it identifies</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CUSIP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:synonym>CUSIP number</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>CUSIP</cmns-av:abbreviation>
+		<cmns-av:synonym>CUSIP number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresScheme">
@@ -252,7 +245,7 @@
 		<rdfs:label>Committee on Uniform Securities Identification Procedures (CUSIP) scheme</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.cusip.com/cusip/about-cgs-identifiers.htm"/>
 		<skos:definition>national security identification scheme used to identify all North American stocks and registered bonds for the purposes of facilitating clearing and settlement of trades</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CUSIP scheme</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>CUSIP scheme</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;CommonCodeRegistryEntry">
@@ -285,7 +278,7 @@
 		<rdfs:seeAlso rdf:resource="http://www.isin.net/common-code-isin/"/>
 		<skos:definition>distributed international repository of security identifiers, issued by Euroclear or Clearstream (CEDEL), that are used to identify securities in Europe for the purposes of facilitating clearing and settlement of trades</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-eufseind;Clearstream"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.isin.net/common-code-isin/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.isin.net/common-code-isin/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;EuroclearClearstreamCommonCode">
@@ -342,8 +335,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>Euroclear Clearstream common code</rdfs:label>
 		<skos:definition>nine-character alphanumeric securities identifier, issued in Luxembourg, jointly by Euroclear and Clearstream</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.isin.net/common-code-isin/</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>common code</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.isin.net/common-code-isin/</cmns-av:adaptedFrom>
+		<cmns-av:synonym>common code</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;EuroclearClearstreamCommonCodeScheme">
@@ -351,7 +344,7 @@
 		<rdfs:label>Euroclear Clearstream common code scheme</rdfs:label>
 		<skos:definition>nine-digit security identification scheme, defined originally by Euroclear and CEDEL (now Clearstream) that is used to identify securities in Europe for the purposes of facilitating clearing and settlement of trades</skos:definition>
 		<fibo-fnd-rel-rel:describes rdf:resource="&fibo-sec-sec-idind;CommonCodeRepository"/>
-		<fibo-fnd-utl-av:synonym>common code scheme</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>common code scheme</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier">
@@ -397,8 +390,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>financial instrument global identifier</rdfs:label>
 		<skos:definition>financial instrument identifier that is defined as specified in the Object Management Group (OMG) Financial Instrument Global Identifier (FIGI) Specification</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>FIGI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>While in most cases, a FIGI uniquely identifies a security, there are situations outside of the U.S. where it instead identifies a listing for a security, similarly to a ticker symbol.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>FIGI</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>While in most cases, a FIGI uniquely identifies a security, there are situations outside of the U.S. where it instead identifies a listing for a security, similarly to a ticker symbol.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry">
@@ -407,7 +400,7 @@
 		<rdfs:seeAlso rdf:resource="http://www.openfigi.com/"/>
 		<skos:definition>open, OMG standards-based registry used by the FIGI registration authority to manage the financial instrument identifiers and related information that it registers according to the Financial Instrument Global Identifier (FIGI) standard</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>FIGI Registry</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>FIGI Registry</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistryEntry">
@@ -441,7 +434,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>Financial Instrument Global Identifier (FIGI) registry entry</rdfs:label>
 		<skos:definition>entry in a Financial Instrument Global Identifier (FIGI) registry</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>FIGI registry entry</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>FIGI registry entry</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierScheme">
@@ -450,14 +443,14 @@
 		<rdfs:label>financial instrument global identifier scheme</rdfs:label>
 		<skos:definition>standard identification scheme for financial instrument identifiers (not limited to securities) and, in some cases, related listings, published by the Object Management Group (OMG)</skos:definition>
 		<fibo-fnd-rel-rel:describes rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry"/>
-		<fibo-fnd-utl-av:abbreviation>FIGI scheme</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>FIGI scheme</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;FinancialTimesInteractiveDataScheme">
 		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
 		<rdfs:label>Financial Times interactive data scheme</rdfs:label>
 		<skos:definition>proprietary identification scheme for securities identifiers managed by the Financial Times</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>FTID scheme</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>FTID scheme</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;ReutersInstrumentCode">
@@ -482,14 +475,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>Reuters instrument code</rdfs:label>
 		<skos:definition>ticker-like identifier to identify financial instruments and indices owned, managed, and distributed by Thomson Reuters</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RIC</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>RIC</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;ReutersInstrumentCodeScheme">
 		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
 		<rdfs:label>Reuters instrument code scheme</rdfs:label>
 		<skos:definition>proprietary identification scheme for securities identifiers managed by Thomson Reuters</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>RIC scheme</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>RIC scheme</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;SEDOLMasterFile">
@@ -530,7 +523,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>Stock Exchange Daily Official List (SEDOL) code</rdfs:label>
 		<skos:definition>seven-character security identifier, issued by the London Stock Exchange, that is the National Securities Identifying Number (NSIN) for securities issued in the United Kingdom, which is also part of the ISIN for the security it identifies</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>SEDOL code</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>SEDOL code</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;StockExchangeDailyOfficialListScheme">
@@ -540,7 +533,7 @@
 		<rdfs:label>Stock Exchange Daily Official List (SEDOL) scheme</rdfs:label>
 		<skos:definition>national security identification scheme used to identify all stocks and registered bonds in the United Kingdom for the purposes of facilitating clearing and settlement of trades</skos:definition>
 		<fibo-fnd-rel-rel:describes rdf:resource="&fibo-sec-sec-idind;SEDOLMasterFile"/>
-		<fibo-fnd-utl-av:abbreviation>SEDOL scheme</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>SEDOL scheme</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;TelekursId">
@@ -565,14 +558,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>Telekurs Id</rdfs:label>
 		<skos:definition>identifier used to identify financial instruments owned, managed, and distributed by SIX Financial Information (formerly Telekurs AG and subsequently SIX Telekurs Ltd.)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The Telekurs Id was phased out in favor of the Valoren (Valor Nummer in Swiss German) in 2013.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The Telekurs Id was phased out in favor of the Valoren (Valor Nummer in Swiss German) in 2013.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;TelekursSecurityIdentifierScheme">
 		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
 		<rdfs:label>Telekurs security identifier scheme</rdfs:label>
 		<skos:definition>proprietary identification scheme for securities identifiers formerly managed by SIX Telekurs Ltd, a subsidiary of the SIX Group (Swiss Infrastructure and eXchange), now SIX Financial Information AG</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>Telekurs security ID scheme</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>Telekurs security ID scheme</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;Valoren">
@@ -600,14 +593,14 @@
 		<rdfs:label>Valoren</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.six-group.com/en/products-services/financial-information.html"/>
 		<skos:definition>identification number assigned to financial instruments in Switzerland, Liechtenstein and Belgium, issued by SIX Financial Information, that is the National Securities Identifying Number (NSIN) for securities issued in those countries and is also part of the ISIN for the security it identifies</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.isin.net/valoren/</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A VALOR code is between six and nine characters in length and like other securities identification codes (like ISIN, CUSIPs etc). A VALOR is utilized for identification purposes as well as clearing and settlement, similar to an ISIN code, and identifies debt and equity securities.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="de">Valor</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">Valor</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">Valor Code</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="de">Valor Nummer</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">Valoren Code</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">Valoren Number</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.isin.net/valoren/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A VALOR code is between six and nine characters in length and like other securities identification codes (like ISIN, CUSIPs etc). A VALOR is utilized for identification purposes as well as clearing and settlement, similar to an ISIN code, and identifies debt and equity securities.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="de">Valor</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">Valor</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">Valor Code</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="de">Valor Nummer</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">Valoren Code</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">Valoren Number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;ValorenScheme">
@@ -616,7 +609,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;SecurityIdentificationScheme"/>
 		<rdfs:label>Valoren scheme</rdfs:label>
 		<skos:definition>national security identification scheme used to identify equity and debt securities in Switzerland, Liechtenstein and Belgium for the purposes of facilitating clearing and settlement of trades</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The VALOR number is a numeric code that intrinsically has no meaning. When a new VALOR is needed, the next one from the list is simply allocated. An instrument&apos;s number indicates nothing about the instrument itself.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The VALOR number is a numeric code that intrinsically has no meaning. When a new VALOR is needed, the next one from the list is simply allocated. An instrument&apos;s number indicates nothing about the instrument itself.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/Securities/SecuritiesIssuance.rdf
+++ b/SEC/Securities/SecuritiesIssuance.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -27,10 +28,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -58,22 +59,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 		<rdfs:label>Securities Issuance Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for issuing securities, including securities offering, offering document, offering statement, securities underwriter, prospectus, and so forth.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-iss</sm:fileAbbreviation>
-		<sm:filename>SecuritiesIssuance.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
@@ -98,16 +89,20 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Securities/SecuritiesIssuance/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecuritiesIssuance/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIssuance/ version of this ontology was modified to refine the concept of a securities underwriter.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20181201/Securities/SecuritiesIssuance/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesIssuance/ version of this ontology was modified to add the concept of the form the security is issued in, namely bearer or registered.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesIssuance/ version of this ontology was modified to refactor conversion terms as a child of redemption provision, move redemption provision to financial instruments, and eliminate the unnecessary securities contract terms class.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Securities/SecuritiesIssuance/ version of this ontology was modified to add book entry form as a kind of registered security, make registered security a class with two individuals, namely book entry and &apos;bearer and registered&apos;, and clean up definitions to eliminate ambiguity where possible and conform to ISO 704.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesIssuance/ version of this ontology was modified to clarify the definition of isIssuedInForm.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Securities/SecuritiesIssuance.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Securities/SecuritiesIssuance/ version of this ontology was modified to address text formatting hygiene issues and eliminate dead links.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
@@ -159,22 +154,22 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
 		<rdfs:label>bearer form</rdfs:label>
 		<skos:definition>form of a security that is not registered in the books of the issuer or of the registrar and is payable to the person possessing the stock or bond certificate</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Unlike normal registered instruments, no record is kept of who owns bearer instruments or of transactions involving the transfer of ownership.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Unlike normal registered instruments, no record is kept of who owns bearer instruments or of transactions involving the transfer of ownership.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;BestEffortsOffering">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecuritiesOffering"/>
 		<rdfs:label>best efforts offering</rdfs:label>
 		<skos:definition>securities offering whereby investment bankers commit to doing their best to sell the securities offered, but do not assume the full risk of an underwriter</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In a best efforts offering, the agreement is strictly an agency arrangement, with no obligation on the part of the agent to purchase the securities. They act as a broker, in other words.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In a best efforts offering, the agreement is strictly an agency arrangement, with no obligation on the part of the agent to purchase the securities. They act as a broker, in other words.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;BookEntryForm">
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<rdfs:label>book entry form</rdfs:label>
 		<skos:definition>form of a security in which ownership is recorded electronically by a central depository</skos:definition>
-		<fibo-fnd-utl-av:synonym>registered form</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>registered form</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;ConversionTerms">
@@ -214,7 +209,7 @@
 		<rdfs:label>exempt issuer</rdfs:label>
 		<skos:definition>issuer that issues securities that are excused from certain regulatory reporting requirements</skos:definition>
 		<skos:example>In general, these include governments and issuers of tax exempt securities such as municipalities, banks and depository institutions, and authorized insurance companies, railroads and public utilities, and certain non-profit organizations.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/exam-guide/series-66/regulation-of-securities/exempt-securities.asp</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/exam-guide/series-66/regulation-of-securities/exempt-securities.asp</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;ExemptOffering">
@@ -235,9 +230,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>exempt offering</rdfs:label>
 		<skos:definition>public offering involving securities that are excused from certain regulatory reporting requirements</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/exam-guide/series-66/regulation-of-securities/exempt-securities.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Such an offering may be considered exempt either because the issuer is exempt or the transaction specific to the offering is exempt.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/exam-guide/series-66/regulation-of-securities/exempt-securities.asp</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Such an offering may be considered exempt either because the issuer is exempt or the transaction specific to the offering is exempt.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;ExemptTransaction">
@@ -245,7 +240,7 @@
 		<rdfs:label>exempt transaction</rdfs:label>
 		<skos:definition>securities transaction for which there is no requirement to register the transaction with a regulatory agency</skos:definition>
 		<skos:example>Examples include non-issuer transactions in outstanding securities, other isolated non-issuer transactions, certain unsolicited / de minimis transactions, fiduciary transactions, transactions with financial institutions, private placement transactions that meet certain conditions, and so forth.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/e/exempttransaction.asp</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/e/exempttransaction.asp</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;FinancialInstrumentShortName">
@@ -266,8 +261,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>financial instrument short name</rdfs:label>
 		<skos:definition>abbreviated name for a financial instrument within a defined structure as specified in ISO 18774</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>FISN</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 18774:2015(E), Securities and related financial instruments - Financial Instrument Short Name (FISN)</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>FISN</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 18774:2015(E), Securities and related financial instruments - Financial Instrument Short Name (FISN)</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;FirmCommitmentOffering">
@@ -275,14 +270,14 @@
 		<rdfs:label>firm commitment offering</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-sec-iss;BestEffortsOffering"/>
 		<skos:definition>securities offering whereby the underwriter purchases the securities outright for their own account</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;MiscellaneousForm">
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
 		<rdfs:label>miscellaneous form</rdfs:label>
 		<skos:definition>form of a security that is not categorized</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Miscellaneous form is used to describe securities wherein the form is not stated as being bearer or registered.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Miscellaneous form is used to describe securities wherein the form is not stated as being bearer or registered.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;OfferingDocument">
@@ -317,15 +312,15 @@
 		</rdfs:subClassOf>
 		<rdfs:label>offering document</rdfs:label>
 		<skos:definition>legal document that states the objectives, risks and terms of an investment</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>There are many variations, including offering memorandum, which is typically used in the context of a private placement, offering statement, which has slightly different meanings depending on the context (for securities, for bonds, etc.) and so forth. This concept is intended to act as a more abstract parent for these more nuanced concepts.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>EDM Council</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>There are many variations, including offering memorandum, which is typically used in the context of a private placement, offering statement, which has slightly different meanings depending on the context (for securities, for bonds, etc.) and so forth. This concept is intended to act as a more abstract parent for these more nuanced concepts.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;OfferingStatement">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;OfferingDocument"/>
 		<rdfs:label>offering statement</rdfs:label>
 		<skos:definition>offering memorandum that conforms to Regulation A, Offering Statement, of the Securities Act of 1933</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>See https://www.sec.gov/about/forms/form1-a.pdf for the actual form detail</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>See https://www.sec.gov/about/forms/form1-a.pdf for the actual form detail</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;PrivateOffering">
@@ -338,20 +333,20 @@
 		</rdfs:subClassOf>
 		<rdfs:label>private offering</rdfs:label>
 		<skos:definition>offering of securities made privately to a limited number of qualified potential investors</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>EDM Council / Quarule</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Unlike a public offering, a private placement does not have to be registered with a regulatory agency if the securities are purchased for investment rather than resale.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>private placement</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>EDM Council / Quarule</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Unlike a public offering, a private placement does not have to be registered with a regulatory agency if the securities are purchased for investment rather than resale.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>private placement</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;PrivatePlacementMemorandum">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;OfferingDocument"/>
 		<rdfs:label>private placement memorandum</rdfs:label>
 		<skos:definition>legal document stating the objectives, risks and terms of investment involved with a private placement</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PPM</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/o/offeringmemorandum.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An offering memorandum serves to provide buyers with information on the offering and to protect the sellers from the liability associated with selling unregistered securities. It includes information such as the financial statements, management biographies, a detailed description of the business, etc.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>offering memorandum</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>PPM</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/o/offeringmemorandum.asp</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An offering memorandum serves to provide buyers with information on the offering and to protect the sellers from the liability associated with selling unregistered securities. It includes information such as the financial statements, management biographies, a detailed description of the business, etc.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>offering memorandum</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;Prospectus">
@@ -359,10 +354,10 @@
 		<rdfs:label>prospectus</rdfs:label>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/prospectus.asp</rdfs:seeAlso>
 		<skos:definition>formal, written offering document to sell securities that provides the facts an investor needs to make an informed investment decision</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>The Securities Act of 1933, as amended 5 April 2012, see http://www.sec.gov/about/laws/sa33.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>A prospectus may specify the facts about an offering of securities, mutual funds, or limited partnerships for investments in oil, gas, equipment leasing, or other kinds of limited partnerships.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>In the United States, a prospectus may be a formal legal document, required by and filed with the Securities and Exchange Commission, if it provides details about an investment offering for sale to the public.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>The Securities Act of 1933, as amended 5 April 2012, see http://www.sec.gov/about/laws/sa33.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A prospectus may specify the facts about an offering of securities, mutual funds, or limited partnerships for investments in oil, gas, equipment leasing, or other kinds of limited partnerships.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In the United States, a prospectus may be a formal legal document, required by and filed with the Securities and Exchange Commission, if it provides details about an investment offering for sale to the public.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;PublicOffering">
@@ -375,15 +370,15 @@
 		</rdfs:subClassOf>
 		<rdfs:label>public offering</rdfs:label>
 		<skos:definition>offering of securities for sale to the investment public, after compliance with registration requirements of the relevant regulatory authorities</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In the US, public offerings generally require approval of the Securities Exchange Commission and/or relevant state regulators, unless the issuer is an exempt issuer, and are usually conducted by an investment banker or a syndicate made up of several investment bankers, at a price agreed upon between the issuer and the investment bankers.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In the US, public offerings generally require approval of the Securities Exchange Commission and/or relevant state regulators, unless the issuer is an exempt issuer, and are usually conducted by an investment banker or a syndicate made up of several investment bankers, at a price agreed upon between the issuer and the investment bankers.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;RegisteredForm">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
 		<rdfs:label>registered form</rdfs:label>
 		<skos:definition>form of a security whereby ownership is recorded in the name of the owner on the books of the issuer or the issuer&apos;s registrar and can only be transferred to another owner when endorsed by the registered owner</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>With registered securities, a ledger is kept by the issuing company or agent which records the owners of all the securities. Transfer of ownership can only occur when names are changed in the ledger.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>With registered securities, a ledger is kept by the issuing company or agent which records the owners of all the securities. Transfer of ownership can only occur when names are changed in the ledger.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;SecuritiesOffering">
@@ -445,9 +440,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>securities offering</rdfs:label>
 		<skos:definition>offering of a security (or securities) for sale</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>If the offering is public, then it can only be made after regulatory registration requirements have been met. The securities may be new or a secondary offering of a previously issued security, and may include stock, multiple classes of equity shares, municipal or other government bonds, and so forth. Offerings, especially to the investment public, are typically made by an investment banker, or syndicate of investment bankers.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>If the offering is public, then it can only be made after regulatory registration requirements have been met. The securities may be new or a secondary offering of a previously issued security, and may include stock, multiple classes of equity shares, municipal or other government bonds, and so forth. Offerings, especially to the investment public, are typically made by an investment banker, or syndicate of investment bankers.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;SecurityForm">
@@ -466,7 +461,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>security form</rdfs:label>
 		<skos:definition>nature of the proof of ownership of a security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Securities are typically issued in one of two forms, registered or bearer. Most securities issued today are in registered form, which enables the issuing firm or registrar to keep records of a security&apos;s owner and mail them any dividend, coupon, or other payments. Registered securities may be issued in book entry (digital only) or certificate (physical) form, but most today are entirely digital.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Securities are typically issued in one of two forms, registered or bearer. Most securities issued today are in registered form, which enables the issuing firm or registrar to keep records of a security&apos;s owner and mail them any dividend, coupon, or other payments. Registered securities may be issued in book entry (digital only) or certificate (physical) form, but most today are entirely digital.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<rdfs:Datatype rdf:about="&fibo-sec-sec-iss;SecurityOfferingDistributionType">
@@ -517,7 +512,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>security underwriter</rdfs:label>
 		<skos:definition>party that has purchased from an issuer with a view to, or sells for an issuer in connection with, the distribution of any security, or participates or has a direct or indirect participation in any such undertaking, or participates or has a participation in the direct or indirect underwriting of any such undertaking</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;SecurityUnderwritingArrangement">
@@ -530,8 +525,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>security underwriting arrangement</rdfs:label>
 		<skos:definition>underwriting agreement between an organization (typically an investment bank) and a securities issuer that commits the underwriter to assuming risk involved in buying a new issue of securities and reselling it to the public</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Sales may be made either directly or through third-party dealers.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Sales may be made either directly or through third-party dealers.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-iss;hasActualClosingDate">
@@ -546,7 +541,7 @@
 		<rdfs:label>has announcement date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition>indicates the first day the public will receive information regarding a new security issue</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>An announcement date may also refer to the release of a corporate event or new financial news, such as interest rate changes or earnings reports.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>An announcement date may also refer to the release of a corporate event or new financial news, such as interest rate changes or earnings reports.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-iss;hasFinancialInstrumentShortName">
@@ -555,7 +550,7 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
 		<rdfs:range rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<skos:definition>relates a security to its ISO 18774-compliant short name, which includes an issuer short name, abbreviated instrument characteristics, and abbreviated instrument description per the ISO standard</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 18774:2015(E), Securities and related financial instruments - Financial Instrument Short Name (FISN)</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 18774:2015(E), Securities and related financial instruments - Financial Instrument Short Name (FISN)</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-iss;hasFirstTradeDate">
@@ -585,7 +580,7 @@
 		</rdfs:domain>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition>relates a financial instrument or FISN to an ISO 18774-compliant instrument description, that is, a collection of characteristics and attributes defining a financial instrument with a maximum length up to 19 alphanumeric characters</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 18774:2015(E), Securities and related financial instruments - Financial Instrument Short Name (FISN)</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 18774:2015(E), Securities and related financial instruments - Financial Instrument Short Name (FISN)</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-sec-iss;hasIssuerShortName">
@@ -603,7 +598,7 @@
 		</rdfs:domain>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition>relates a security issuer or FISN to an ISO 18774-compliant issuer short name, that is, an abbreviation of the official issuer name, limited to a maximum of 15 alphanumeric characters</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 18774:2015(E), Securities and related financial instruments - Financial Instrument Short Name (FISN)</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 18774:2015(E), Securities and related financial instruments - Financial Instrument Short Name (FISN)</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-sec-iss;hasSeries">
@@ -669,8 +664,8 @@
 		<rdfs:range rdf:resource="&fibo-sec-sec-iss;SecuritiesOffering"/>
 		<owl:inverseOf rdf:resource="&fibo-sec-sec-iss;isUnderwrittenBy"/>
 		<skos:definition>identifies one or more underwriters involved in raising capital for or distributing the instruments that are the subject of the offering</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/u/underwriting.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Underwriting is the process by which investment bankers raise investment capital from investors on behalf of corporations and governments that are issuing either equity or debt securities.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/u/underwriting.asp</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Underwriting is the process by which investment bankers raise investment capital from investors on behalf of corporations and governments that are issuing either equity or debt securities.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-breg "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
@@ -21,10 +22,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-breg="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
@@ -46,22 +47,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
 		<rdfs:label>Securities Listings Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for listing securities, such as registered, listed, and exchange-traded security, the notion of a securities exchange, and related services.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-lst</sm:fileAbbreviation>
-		<sm:filename>SecuritiesListings.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"/>
@@ -78,6 +69,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20210601/Securities/SecuritiesListings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesListings.rdf version of this ontology was revised to reuse the composite date value datatype and add disjointness between registered security and exempt security.</skos:changeNote>
@@ -89,7 +81,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate confusion between listed security and listing (which caused reasoning issues), adjust definitions to eliminate ambiguity, add a property for lot size on listing, and eliminate the now redundant and confusing registered security form class.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate a false positive hygiene testing issue due to a concept whose name included &apos;and&apos; but that actually was a singular concept.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate an unused ontology import, changed the range of hasLotSize to xsd:decimal, and modified the definition of listing to point to an offering rather than directly to the instrument that the offering pertains to.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210601/Securities/SecuritiesListings.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;Exchange">
@@ -125,8 +120,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>listed security</rdfs:label>
 		<skos:definition>registered security listed on at least one exchange</skos:definition>
-		<fibo-fnd-utl-av:synonym>exchange-traded security</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:usageNote>One can, as appropriate, multiply classify a share as being a common share and listed share, and, in the case whereby multiple securities are issued in different currencies (i.e., there are multiple listed shares corresponding to a given common share that have different identifiers, including more than one ISIN, CUSIP, share class FIGI), multiply classify the listed share individuals as individuals of the same common share.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:synonym>exchange-traded security</cmns-av:synonym>
+		<cmns-av:usageNote>One can, as appropriate, multiply classify a share as being a common share and listed share, and, in the case whereby multiple securities are issued in different currencies (i.e., there are multiple listed shares corresponding to a given common share that have different identifiers, including more than one ISIN, CUSIP, share class FIGI), multiply classify the listed share individuals as individuals of the same common share.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;Listing">
@@ -187,7 +182,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">listing</rdfs:label>
 		<skos:definition>catalog entry for a securities offering managed by an exchange that provides the terms under which that security is made available on that exchange</skos:definition>
-		<fibo-fnd-utl-av:synonym xml:lang="en">market listing</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym xml:lang="en">market listing</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-lst;ListingService">
@@ -254,9 +249,9 @@
 		<rdfs:range rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<skos:definition>indicates the exchange that is considered the primary market for a security; typically, but not always, in the country in which the security was originally issued</skos:definition>
 		<skos:example>A security may have been originally listed on the Frankfurt exchange, but its current home is the London Stock Exchange, for example.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote>A primary market is one that issues new securities on an exchange for companies, governments, and other groups to obtain financing through debt-based or equity-based securities.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>has primary market</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>has primary trading market</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>A primary market is one that issues new securities on an exchange for companies, governments, and other groups to obtain financing through debt-based or equity-based securities.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>has primary market</cmns-av:synonym>
+		<cmns-av:synonym>has primary trading market</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;hasLastTradingDateTime">
@@ -300,7 +295,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates that the security has been publicly traded long enough to eliminate any short-term volume volatility from its initial public offering</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Short-term volatility may be with respect to price or trading volume.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Short-term volatility may be with respect to price or trading volume.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;isTradedOn">

--- a/SEC/Securities/SecuritiesRestrictions.rdf
+++ b/SEC/Securities/SecuritiesRestrictions.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-usj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -23,10 +24,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-usj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -50,22 +51,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/">
 		<rdfs:label>Securities Restrictions Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the concepts related to restrictions on finanicial instruments, securities and listings.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-rst</sm:fileAbbreviation>
-		<sm:filename>SecuritiesRestrictions.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
@@ -81,15 +72,19 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20211201/Securities/SecuritiesRestrictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecuritiesRestrictions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to simplify the hierarchy with respect to regulatory requirements and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180901/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to reflect the change in representation of a listing.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to eliminate an unused ontology import and to augment the information associated with references needed to define depositary receipts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210401/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to fix spelling errors.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211201/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
@@ -116,7 +111,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-rst;SecuritiesRegulation"/>
 		<rdfs:label>Blue-Sky law</rdfs:label>
 		<skos:definition>securities regulation passed by various states, designed to protect investors against securities fraud by requiring sellers of new issues to register their offerings and provide financial details</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This allows investors to base their judgments on trustworthy data.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This allows investors to base their judgments on trustworthy data.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-rst;ContractualRestriction">
@@ -155,7 +150,7 @@
 		<rdfs:label>institutional investor</rdfs:label>
 		<skos:definition>investor that is an organization that trades large volumes of securities</skos:definition>
 		<skos:example>Example institutional investors include banks, insurance companies, mutual funds, pension funds, and other similar large funds.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote>Typically more than 70 percent of the daily trading on the New York Stock Exchange is conducted on behalf of institutional investors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Typically more than 70 percent of the daily trading on the New York Stock Exchange is conducted on behalf of institutional investors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-rst;InvestorsDomicileRestriction">
@@ -180,7 +175,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>qualified investor restriction</rdfs:label>
 		<skos:definition>legal holding restriction that defines the concept of a qualified investor for a given purpose and specifies that only such qualified investors may hold the security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>If a holding period is not defined, then the period for which the restriction applies is indefinite.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>If a holding period is not defined, then the period for which the restriction applies is indefinite.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-rst;RegulationS">
@@ -197,7 +192,7 @@
 		<rdfs:seeAlso rdf:resource="https://www.law.cornell.edu/cfr/text/17/230.902"/>
 		<rdfs:seeAlso rdf:resource="https://www.sec.gov/divisions/corpfin/ecfrlinks.shtml"/>
 		<skos:definition>securities regulation defining an exemption through which corporations can issue unregistered securities to qualified foreign investors and foreign institutions</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Regulation S covers rules governing offers and sales made outside the United States without registration under the Securities Act of 1933. Created in 1990, this regulation was intended to encourage foreign investors to purchase American stocks in order to increase the liquidity of American markets.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Regulation S covers rules governing offers and sales made outside the United States without registration under the Securities Act of 1933. Created in 1990, this regulation was intended to encourage foreign investors to purchase American stocks in order to increase the liquidity of American markets.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-rst;Restriction144A">

--- a/SEC/Securities/SecurityAssets.rdf
+++ b/SEC/Securities/SecurityAssets.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -16,10 +17,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -36,22 +37,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/">
 		<rdfs:label>Security Assets Ontology</rdfs:label>
 		<dct:abstract>This ontology defines basic concepts such as portfolio, security holding and holder, and extends the notion of a financial asset to include an acquisition price.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-sec-sec-ast</sm:fileAbbreviation>
-		<sm:filename>SecurityAssets.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -61,14 +52,18 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/SecurityAssets/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecurityAssets/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecurityAssets.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecurityAssets.rdf version of this ontology was revised to simplify the contract party hierarchy and eliminate complexity introduced by &apos;security holding&apos;.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201101/Securities/SecurityAssets.rdf version of this ontology was revised to fix spelling errors.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211201/Securities/SecurityAssets.rdf version of this ontology was revised to address text formatting hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/SecurityAssets.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-aeq;FinancialAsset">
@@ -120,7 +115,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>portfolio</rdfs:label>
 		<skos:definition>a collection of investments (financial assets) such as stocks, bonds and cash equivalents, as well as mutual funds</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/portfolio.asp</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/portfolio.asp</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-ast;PortfolioHolding">
@@ -148,10 +143,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>portfolio holding</rdfs:label>
 		<skos:definition>the contents of holding of one or more portfolios of investments held by an individual investor or entity</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/h/holdings.asp</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Portfolio holdings may cover a variety of investment products, including stocks, bonds and mutual funds to options, futures and exchange-traded funds, and relatively esoteric instruments such as private equity and hedge funds. 
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/h/holdings.asp</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Portfolio holdings may cover a variety of investment products, including stocks, bonds and mutual funds to options, futures and exchange-traded funds, and relatively esoteric instruments such as private equity and hedge funds. 
 
-The number and nature of holdings contribute to the degree of diversification of a portfolio. A mix of stocks across different sectors, bonds of different maturities, and other investments would suggest a well-diversified portfolio, while concentrated holdings in a handful of stocks within a single sector indicates a portfolio with limited diversification.</fibo-fnd-utl-av:explanatoryNote>
+The number and nature of holdings contribute to the degree of diversification of a portfolio. A mix of stocks across different sectors, bonds of different maturities, and other investments would suggest a well-diversified portfolio, while concentrated holdings in a handful of stocks within a single sector indicates a portfolio with limited diversification.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-ast;hasAcquisitionPrice">


### PR DESCRIPTION
## Description

The Commons Ontology Library (Commons) from OMG, which was formally released as a standard in December 2022, includes an annotation vocabulary that overlaps with the FIBO annotation vocabulary and eliminates the need for use of Specification Metadata (which is not a standard and subject to change) in FIBO ontologies.

The resolution to this issue inclides (1) eliminating the use of Specification Metadata in all FIBO SEC ontologies, which largely impacts ontology header content), and (2) replacing the use of now redundant FIBO annotations with their equivalent in the Commons annotation vocabulary where appropriate.

The mapping pattern for this effort is available in the FIBO Foundations wiki, at https://wiki.edmcouncil.org/display/FND/Replacing+Specification+Metadata+and+some+properties+in+the+FIBO+Annotation+Vocabulary+with+the+Commons+Annotation+Vocabulary.

Fixes: #1867 / SEC-183


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


