### PR TITLE
IND-123 - Replace specification metadata-related annotations with annotations from the Commons Ontology Library in the FIBO Indices and Indicators (IND) Domain

### DIFF
--- a/IND/AllIND-ExampleIndividuals.rdf
+++ b/IND/AllIND-ExampleIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-mkt-eqind "https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/EquityIndexExampleIndividuals/">
@@ -8,10 +9,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-ExampleIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-mkt-eqind="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/EquityIndexExampleIndividuals/"
@@ -20,59 +21,45 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-ExampleIndividuals/">
 		<rdfs:label>Indices and Indicators Domain, Example Individuals</rdfs:label>
 		<dct:abstract>The FIBO Indices and Indicators Domain (IND) covers market indices and reference rates including economic indicators, foreign exchange, interest rates, and other benchmarks. The ontologies cover quoted interest rates, economic measures such as employment rates, and quoted indices required to support baskets of securities, including specific kinds of securities in share indices or bond indices, as well as credit indices.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-09T18:00:00</dct:issued>
+		<dct:contributor>88 Solutions</dct:contributor>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>88 Solutions</sm:contributor>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bank of New York Mellon</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Census Bureau (US Department of Commerce)</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Federal Reserve Bank of Kansas City</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>No Magic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd</sm:contributor>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-index-all</sm:fileAbbreviation>
-		<sm:filename>AllIND-ExamplesIndividuals.rdf</sm:filename>
-		<sm:keyword>economic indicator</sm:keyword>
-		<sm:keyword>foreign exchange</sm:keyword>
-		<sm:keyword>interest rate</sm:keyword>
-		<sm:keyword>market index</sm:keyword>
-		<sm:moduleAbbreviation>fibo-ind</sm:moduleAbbreviation>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain, Example Individuals Extension</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/EquityIndexExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ExampleIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20220801/AllIND-ExampleIndividuals/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for IND example individuals is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, including all individuals, with examples of how to encode information for benchmarks such as the Dow Jones Industrial Average (DJIA). Note that in order to model such benchmarks, the example securities provided in SEC are reused.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/AllIND-ExampleIndividuals/"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for IND example individuals is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, including all individuals, with examples of how to encode information for benchmarks such as the Dow Jones Industrial Average (DJIA). Note that in order to model such benchmarks, the example securities provided in SEC are reused.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/IND/AllIND-NorthAmerica.rdf
+++ b/IND/AllIND-NorthAmerica.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ei-caei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/">
@@ -9,10 +10,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-NorthAmerica/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ei-caei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"
@@ -22,57 +23,47 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-NorthAmerica/">
 		<rdfs:label>Indices and Indicators Domain, North American Extension</rdfs:label>
 		<dct:abstract>The FIBO Indices and Indicators (IND) Domain covers market indices and reference rates including economic indicators, foreign exchange, interest rates, and other benchmarks. The ontologies cover quoted interest rates, economic measures such as employment rates, and quoted indices required to support baskets of securities, including specific kinds of securities in share indices or bond indices, as well as credit indices.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-09T18:00:00</dct:issued>
+		<dct:contributor>88 Solutions</dct:contributor>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain, North American Extension</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>88 Solutions</sm:contributor>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Census Bureau (US Department of Commerce)</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Federal Reserve Bank of Kansas City</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>No Magic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd</sm:contributor>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-indna-all</sm:fileAbbreviation>
-		<sm:filename>AllIND-NorthAmerica.rdf</sm:filename>
-		<sm:keyword>economic indicator</sm:keyword>
-		<sm:keyword>foreign exchange</sm:keyword>
-		<sm:keyword>interest rate</sm:keyword>
-		<sm:keyword>market index</sm:keyword>
-		<sm:moduleAbbreviation>fibo-ind</sm:moduleAbbreviation>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain, North American Extension</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmerica/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20220801/AllIND-NorthAmerica/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for IND, North American extension, is provided for convenience for FIBO users. It imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Indices and Indicators (IND) domains, excluding European individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/AllIND-NorthAmerica/"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for IND, North American extension, is provided for convenience for FIBO users. It imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Indices and Indicators (IND) domains, excluding European individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/IND/AllIND-ReferenceRates.rdf
+++ b/IND/AllIND-ReferenceRates.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ir-cm "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/">
@@ -9,10 +10,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-ReferenceRates/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ir-cm="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"
@@ -22,57 +23,47 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-ReferenceRates/">
 		<rdfs:label>Indices and Indicators Domain, Reference Rates</rdfs:label>
 		<dct:abstract>The FIBO Indices and Indicators (IND) Domain covers market indices and reference rates including economic indicators, foreign exchange, interest rates, and other benchmarks. The ontologies cover quoted interest rates, economic measures such as employment rates, and quoted indices required to support baskets of securities, including specific kinds of securities in share indices or bond indices, as well as credit indices.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-09T18:00:00</dct:issued>
+		<dct:contributor>88 Solutions</dct:contributor>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain, Reference Rates</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>88 Solutions</sm:contributor>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Census Bureau (US Department of Commerce)</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Federal Reserve Bank of Kansas City</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>No Magic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd</sm:contributor>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-indrr-all</sm:fileAbbreviation>
-		<sm:filename>AllIND-ReferenceRates.rdf</sm:filename>
-		<sm:keyword>economic indicator</sm:keyword>
-		<sm:keyword>foreign exchange</sm:keyword>
-		<sm:keyword>interest rate</sm:keyword>
-		<sm:keyword>market index</sm:keyword>
-		<sm:moduleAbbreviation>fibo-ind</sm:moduleAbbreviation>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain, Reference Rates</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-EuropeAndNorthAmerica/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-NorthAmerica/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20220801/AllIND-ReferenceRates/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for IND with Reference Rates is provided for convenience for FIBO users. It imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Indices and Indicators (IND) domains, including all individuals (aside from examples), with additional FpML reference rates by currency.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/AllIND-ReferenceRates/"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for IND with Reference Rates is provided for convenience for FIBO users. It imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Indices and Indicators (IND) domains, including all individuals (aside from examples), with additional FpML reference rates by currency.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/IND/AllIND.rdf
+++ b/IND/AllIND.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-all "https://spec.edmcouncil.org/fibo/ontology/IND/AllIND/">
@@ -12,10 +13,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-all="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND/"
@@ -28,53 +29,38 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND/">
 		<rdfs:label>Indices and Indicators Domain</rdfs:label>
 		<dct:abstract>The FIBO Indices and Indicators (IND) Domain covers market indices and reference rates including economic indicators, foreign exchange, interest rates, and other benchmarks. The ontologies cover quoted interest rates, economic measures such as employment rates, and quoted indices required to support baskets of securities, including specific kinds of securities in share indices or bond indices, as well as credit indices.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-09T18:00:00</dct:issued>
+		<dct:contributor>88 Solutions</dct:contributor>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain</dct:title>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>88 Solutions</sm:contributor>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bank of New York Mellon</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Census Bureau (US Department of Commerce)</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Dassault Systemes/No Magic</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Federal Reserve Bank of Kansas City</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd</sm:contributor>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-ind-all</sm:fileAbbreviation>
-		<sm:filename>AllIND.rdf</sm:filename>
-		<sm:keyword>economic indicator</sm:keyword>
-		<sm:keyword>foreign exchange</sm:keyword>
-		<sm:keyword>interest rate</sm:keyword>
-		<sm:keyword>market index</sm:keyword>
-		<sm:moduleAbbreviation>fibo-ind</sm:moduleAbbreviation>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
@@ -85,8 +71,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20220801/AllIND/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for IND is provided for convenience for FIBO users. It imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Indices and Indicators (IND) domains, excluding individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/AllIND/"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for IND is provided for convenience for FIBO users. It imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Indices and Indicators (IND) domains, excluding individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -34,10 +35,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -72,23 +73,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 		<rdfs:label>Economic Indicators Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the parameters which make up the various types of market economic indicators, along with basic facts about these such as the economies or countries they apply to.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-ind-ei-ei</sm:fileAbbreviation>
-		<sm:filename>EconomicIndicators.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
@@ -115,9 +105,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20220801/EconomicIndicators/EconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/EconomicIndicators/EconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the FIBO 2.0 RFC. Primary changes include the addition of a number of statistical measures (mean, total, etc.) and their use in existing and new indicators, and the addition of several more economic indicators.</skos:changeNote>
@@ -131,7 +122,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/2021001/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to fix spelling errors.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate the restriction on economic indicator (and its subclasses) that it has an indicator value - the restriction should be on the quantity value such that the value refers to the indicator it represents, and to revise the definition of civilian non-institutional population to correctly represent civilian non-institutional person (added).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20211201/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to address text formatting hygiene issues and clean up external links.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20220801/EconomicIndicators/EconomicIndicators.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;AverageDailyEarnings">
@@ -144,7 +138,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>average daily earnings</rdfs:label>
 		<skos:definition>a measure of the average daily wage an employee makes over the reporting period</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;AverageEarnings">
@@ -159,8 +153,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>average earnings</rdfs:label>
 		<skos:definition>a measure of the average wage an hourly or salaried worker makes in a given period of time</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Average earnings are typically calculated on an hourly, daily, weekly, or monthly basis. They may be expressed as an amount of money or in terms of a percent change with respect to a prior period, depending on the jurisdiction and report.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Average earnings are typically calculated on an hourly, daily, weekly, or monthly basis. They may be expressed as an amount of money or in terms of a percent change with respect to a prior period, depending on the jurisdiction and report.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;AverageHourlyEarnings">
@@ -173,7 +167,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>average hourly earnings</rdfs:label>
 		<skos:definition>a measure of the average hourly wage an employee makes over the reporting period</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;AverageMonthlyEarnings">
@@ -186,7 +180,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>average monthly earnings</rdfs:label>
 		<skos:definition>a measure of the average monthly wage an employee makes over the reporting period</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;AverageWeeklyEarnings">
@@ -199,41 +193,41 @@
 		</rdfs:subClassOf>
 		<rdfs:label>average weekly earnings</rdfs:label>
 		<skos:definition>a measure of the average weekly wage an employee makes over the reporting period</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CapitalLaborEnergyMaterialsMultifactorProductivity">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;Productivity"/>
 		<rdfs:label>capital-labor-energy-materials multifactor productivity</rdfs:label>
 		<skos:definition>a ratio of a quantity index of gross output to a quantity index of combined inputs</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>KLEMS-MFP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Shows the time profile of how productively combined inputs are used to generate gross output. Conceptually, the KLEMS productivity measure captures disembodied technical change. In practice, it reflects also efficiency change, economies of scale, variations in capacity utilisation and measurement errors.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>KLEMS multifactor productivity</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>KLEMS-MFP</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Shows the time profile of how productively combined inputs are used to generate gross output. Conceptually, the KLEMS productivity measure captures disembodied technical change. In practice, it reflects also efficiency change, economies of scale, variations in capacity utilisation and measurement errors.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>KLEMS multifactor productivity</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CapitalLaborMultifactorProductivityValueAdded">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;Productivity"/>
 		<rdfs:label>capital-labor multifactor productivity (MFP), based on value added</rdfs:label>
 		<skos:definition>a ratio of a quantity index of value added to a quantity index of combined labor and capital input</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Capital-labour MFP indices show the time profile of how productively combined labour and capital inputs are used to generate value added. Conceptually, capital-labour productivity is not, in general, an accurate measure of technical change. It is, however, an indicator of an industry&apos;s capacity to contribute to economy-wide growth of income per unit of primary input. In practice, the measure reflects the combined effects of disembodied technical change, economies of scale, efficiency change, variations in capacity utilisation and measurement errors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Capital-labour MFP indices show the time profile of how productively combined labour and capital inputs are used to generate value added. Conceptually, capital-labour productivity is not, in general, an accurate measure of technical change. It is, however, an indicator of an industry&apos;s capacity to contribute to economy-wide growth of income per unit of primary input. In practice, the measure reflects the combined effects of disembodied technical change, economies of scale, efficiency change, variations in capacity utilisation and measurement errors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CapitalProductivityValueAdded">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;Productivity"/>
 		<rdfs:label>capital productivity, based on value added</rdfs:label>
 		<skos:definition>a ratio of a quantity index of value added to a quantity index of capital input</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Changes in capital productivity indicate the extent to which output growth can be achieved with lower welfare costs in the form of foregone consumption.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The capital productivity index shows the time profile of how productively capital is used to generate value added. Capital productivity reflects the joint influence of labour, intermediate inputs, technical change, efficiency change, economies of scale, capacity utilisation and measurement errors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Changes in capital productivity indicate the extent to which output growth can be achieved with lower welfare costs in the form of foregone consumption.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The capital productivity index shows the time profile of how productively capital is used to generate value added. Capital productivity reflects the joint influence of labour, intermediate inputs, technical change, efficiency change, economies of scale, capacity utilisation and measurement errors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;Civilian">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
 		<rdfs:label>civilian</rdfs:label>
 		<skos:definition>a person that is not a member of the military (i.e., that is not on active duty)</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CivilianLaborForce">
@@ -241,7 +235,7 @@
 		<rdfs:label>civilian labor force</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;PopulationNotInLaborForce"/>
 		<skos:definition>subset of the civilian, non-institutional population considered to be part of the labor force during a given reporting period</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CivilianLaborForceParticipationRate">
@@ -268,8 +262,8 @@
 		<rdfs:label>civilian labor force participation rate</rdfs:label>
 		<skos:definition>economic indicator representing the rate of participation the labor force of a given economy for some specified period</skos:definition>
 		<fibo-fnd-utl-alx:actualExpression>civilian labor force ÷ civilian non-institutional population</fibo-fnd-utl-alx:actualExpression>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bls.gov/cps/definitions.htm#lfpr</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The labor force participation rate is the percentage of the population that is either employed or unemployed (that is, either working or actively seeking work).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bls.gov/cps/definitions.htm#lfpr</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The labor force participation rate is the percentage of the population that is either employed or unemployed (that is, either working or actively seeking work).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CivilianNonInstitutionalPerson">
@@ -279,8 +273,8 @@
 		<rdfs:seeAlso rdf:resource="http://www.investopedia.com/terms/w/working-age-population.asp"/>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;InstitutionalPerson"/>
 		<skos:definition>legal working-age person that does not live in an institution (for example, a correctional facility, long-term care hospital, or nursing home), and is not on active military duty</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The working-age population is the total population in a region, within a set range of ages, that is considered to be able and likely to work. The working-age population measure is used to give an estimate of the total number of potential workers within an economy. For example, in the U.S., it is 16, whereas in Canada it is 15.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The working-age population is the total population in a region, within a set range of ages, that is considered to be able and likely to work. The working-age population measure is used to give an estimate of the total number of potential workers within an economy. For example, in the U.S., it is 16, whereas in Canada it is 15.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation">
@@ -294,7 +288,7 @@
 		<rdfs:label>civilian non-institutional population</rdfs:label>
 		<skos:definition>statistical universe consisting of people of a certain age who reside in a given region, do not live in institutions (for example, correctional facilities, long-term care hospitals, and nursing homes), and are not on active military duty</skos:definition>
 		<skos:scopeNote>The civilian non-institutional population is typically reported in thousands.</skos:scopeNote>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CombinedStatisticalArea">
@@ -308,11 +302,11 @@
 		</rdfs:subClassOf>
 		<rdfs:label>combined statistical area</rdfs:label>
 		<skos:definition>combination of adjacent metropolitan and micropolitan areas with economic ties measured by commuting patterns</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CSA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://en.wikipedia.org/wiki/Combined_statistical_area"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/fedreg_2010/06282010_metro_standards-Complete.pdf"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://www.federalregister.gov/documents/2021/07/16/2021-15159/2020-standards-for-delineating-core-based-statistical-areas"/>
-		<fibo-fnd-utl-av:explanatoryNote>These areas that combine retain their own designations as metropolitan or micropolitan statistical areas within the larger combined statistical area.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>CSA</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:resource="https://en.wikipedia.org/wiki/Combined_statistical_area"/>
+		<cmns-av:adaptedFrom rdf:resource="https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/fedreg_2010/06282010_metro_standards-Complete.pdf"/>
+		<cmns-av:adaptedFrom rdf:resource="https://www.federalregister.gov/documents/2021/07/16/2021-15159/2020-standards-for-delineating-core-based-statistical-areas"/>
+		<cmns-av:explanatoryNote>These areas that combine retain their own designations as metropolitan or micropolitan statistical areas within the larger combined statistical area.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;ConsumerPriceIndex">
@@ -343,9 +337,9 @@
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;InflationRate"/>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;UnemploymentRate"/>
 		<skos:definition>economic indicator representing a measure of the change over time in the prices of consumer goods and services that households consume</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CPI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://unstats.un.org/unsd/nationalaccount/docs/SNA2008.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ilo.org/public/english/bureau/stat/guides/cpi/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>CPI</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://unstats.un.org/unsd/nationalaccount/docs/SNA2008.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ilo.org/public/english/bureau/stat/guides/cpi/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-ei;Daily">
@@ -359,7 +353,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;MarginallyAttachedPopulation"/>
 		<rdfs:label>discouraged worker population</rdfs:label>
 		<skos:definition>subset of the marginally attached population that have given a job-market related reason for not currently looking for work</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EconomicIndicator">
@@ -405,26 +399,26 @@
 		<rdfs:label>economic indicator</rdfs:label>
 		<skos:definition>statistical measure of economic activity that is regular and comparable in the context of a statistical area (region), used for analysis of economic performance and predictions of future performance</skos:definition>
 		<skos:example>Example indicators include the average work week, weekly claims for unemployment insurance, new orders, vendor performance, stock prices, and changes in the money supply.</skos:example>
-		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economic Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The two main features of any indicator are the regularity with which they are measured and published, and the fact that they are comparable from one release to the next.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economic Terms, Fifth Edition, 2012</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The two main features of any indicator are the regularity with which they are measured and published, and the fact that they are comparable from one release to the next.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulation">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
 		<rdfs:label>employed population</rdfs:label>
 		<skos:definition>a subset of the civilian labor force considered to be employed during the reporting period</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>There are a number of distinctions with respect to how individuals are counted from country to country, including whether or not they are considered employed if they are on unpaid leave for some reason, and whether or not they are counted multiple times if they have more than one paying job.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>There are a number of distinctions with respect to how individuals are counted from country to country, including whether or not they are considered employed if they are on unpaid leave for some reason, and whether or not they are counted multiple times if they have more than one paying job.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulationPartTime">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
 		<rdfs:label>employed population part-time</rdfs:label>
 		<skos:definition>subset of the employed population that includes persons that are working fewer than 30 to 35 hours per week based on usual working hours</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://stats.oecd.org/Index.aspx?DatasetCode=STLABOUR</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In the U.S., part-time workers are those who usually work fewer than 35 hours per week. See https://www.bls.gov/cps/definitions.htm for additional details.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The definition of part-time varies considerably from country to country according to the OECD. Classification may be based on (1) employee perception, (2) usual working hours, which is the most reliable measure, or (3) actual working hours, which varies due to holidays, illness, etc.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>population employed part-time</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>https://stats.oecd.org/Index.aspx?DatasetCode=STLABOUR</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In the U.S., part-time workers are those who usually work fewer than 35 hours per week. See https://www.bls.gov/cps/definitions.htm for additional details.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The definition of part-time varies considerably from country to country according to the OECD. Classification may be based on (1) employee perception, (2) usual working hours, which is the most reliable measure, or (3) actual working hours, which varies due to holidays, illness, etc.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>population employed part-time</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulationPartTimeForEconomicReasons">
@@ -432,10 +426,10 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;UnderemployedPopulation"/>
 		<rdfs:label>employed population part-time for economic reasons</rdfs:label>
 		<skos:definition>subset of the employed population that includes persons that are working fewer than 30 to 35 hours per week due to slack work, unfavorable business conditions, inability to find full-time work, and seasonal declines in demand</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://stats.oecd.org/Index.aspx?DatasetCode=STLABOUR</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/cps/definitions.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>involuntary part-time population</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>population employed part-time for economic reasons</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>https://stats.oecd.org/Index.aspx?DatasetCode=STLABOUR</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.bls.gov/cps/definitions.htm</cmns-av:adaptedFrom>
+		<cmns-av:synonym>involuntary part-time population</cmns-av:synonym>
+		<cmns-av:synonym>population employed part-time for economic reasons</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulationPartTimeForNonEconomicReasons">
@@ -443,16 +437,16 @@
 		<rdfs:label>employed population part-time for non-economic reasons</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;EmployedPopulationPartTimeForEconomicReasons"/>
 		<skos:definition>subset of the employed population that includes persons that are working fewer than 30 to 35 hours per week due to illness or other health or medical limitations, childcare problems, family or personal obligations, being in school or training, retirement or Social Security limits on earnings, and having a job where full-time work is less than 35 hours</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/cps/definitions.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>population employed part-time for non-economic reasons</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom>https://www.bls.gov/cps/definitions.htm</cmns-av:adaptedFrom>
+		<cmns-av:synonym>population employed part-time for non-economic reasons</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulationTemporarilyNotAtWork">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
 		<rdfs:label>employed population temporarily not at work</rdfs:label>
 		<skos:definition>subset of the employed population that includes persons that are temporarily absent from work for various reasons</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>This includes persons temporarily not at work because of illness or injury, holiday or vacation, strike or lockout, educational or training leave, maternity or parental leave, reduction in economic activity, temporary disorganisation or suspension of work due to such reasons as bad weather, mechanical or electrical breakdown, or shortage of raw materials or fuels, or other temporary absence with or without leave should be considered as in paid employment provided they had a formal job attachment.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>This includes persons temporarily not at work because of illness or injury, holiday or vacation, strike or lockout, educational or training leave, maternity or parental leave, reduction in economic activity, temporary disorganisation or suspension of work due to such reasons as bad weather, mechanical or electrical breakdown, or shortage of raw materials or fuels, or other temporary absence with or without leave should be considered as in paid employment provided they had a formal job attachment.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EmploymentPopulationRatio">
@@ -530,8 +524,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>enterprise</rdfs:label>
 		<skos:definition>a functional business entity that produces and/or sells goods or services</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/opub/hom/glossary.htm#E</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>An enterprise (a private firm, government, or nonprofit organization) can consist of a single establishment or multiple establishments. All establishments in an enterprise may be classified in one industry (e.g., a chain), or they may be classified in different industries (e.g., a conglomerate).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/opub/hom/glossary.htm#E</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An enterprise (a private firm, government, or nonprofit organization) can consist of a single establishment or multiple establishments. All establishments in an enterprise may be classified in one industry (e.g., a chain), or they may be classified in different industries (e.g., a conglomerate).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EnterprisePopulation">
@@ -564,10 +558,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>establishment</rdfs:label>
 		<skos:definition>an enterprise (or part of an enterprise) that operates from a single physical location</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=857</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/opub/hom/glossary.htm#E</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/concepts/units</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The physical location of a certain economic activity - for example, a factory, mine, store, or office. An individual establishment is generally classified by having one NAICS code associated with it for statistical purposes, whereas an enterprise may be classified by multiple NAICS codes. The statistical structure is defined based on the operating structure and the accounting data produced by that entity. A given location may only need to publish revenues, whereas an operating unit (establishment) has employment statistics, etc. An establishment is defined as a producing unit at a single geographical location at which or from which economic activity is conducted and for which, at a minimum, employment data are available. In the case of a home-based business, the actual physical location would be specified as two distinct institutional units - as a household from a personal living and consumer perspective and as an establishment / operating unit due to the statistics required of the business.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=857</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/opub/hom/glossary.htm#E</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/concepts/units</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The physical location of a certain economic activity - for example, a factory, mine, store, or office. An individual establishment is generally classified by having one NAICS code associated with it for statistical purposes, whereas an enterprise may be classified by multiple NAICS codes. The statistical structure is defined based on the operating structure and the accounting data produced by that entity. A given location may only need to publish revenues, whereas an operating unit (establishment) has employment statistics, etc. An establishment is defined as a producing unit at a single geographical location at which or from which economic activity is conducted and for which, at a minimum, employment data are available. In the case of a home-based business, the actual physical location would be specified as two distinct institutional units - as a household from a personal living and consumer perspective and as an establishment / operating unit due to the statistics required of the business.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EstablishmentEmployment">
@@ -587,11 +581,11 @@
 		</rdfs:subClassOf>
 		<rdfs:label>establishment employment</rdfs:label>
 		<skos:definition>economic indicator representing the total number of persons who work in or for the establishment including working proprietors, active business partners and unpaid family workers, as well as persons working outside the establishment when paid by and under the control of the establishment, for example, sales representatives, outside service engineers and repair and maintenance personnel</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=780</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Also included are salaried managers and salaried directors of incorporated enterprises. The total should include part-time workers and seasonal workers on the payroll, persons on short-term leave (sick leave, maternity leave, annual leave or vacation) and on strike, but not persons on indefinite leave, military leave or pension. 
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=780</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Also included are salaried managers and salaried directors of incorporated enterprises. The total should include part-time workers and seasonal workers on the payroll, persons on short-term leave (sick leave, maternity leave, annual leave or vacation) and on strike, but not persons on indefinite leave, military leave or pension. 
 
-Excluded are directors of incorporated enterprises and members of shareholders committees who are paid solely for their attendance at meetings, labour made available to the establishment by other units and charged for, such as contract workers paid through contractors, persons carrying out repair and maintenance work in the establishment on behalf of other units and all homeworkers.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>payroll employment</fibo-fnd-utl-av:synonym>
+Excluded are directors of incorporated enterprises and members of shareholders committees who are paid solely for their attendance at meetings, labour made available to the establishment by other units and charged for, such as contract workers paid through contractors, persons carrying out repair and maintenance work in the establishment on behalf of other units and all homeworkers.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>payroll employment</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EstablishmentPopulation">
@@ -617,8 +611,8 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 		</rdfs:subClassOf>
 		<rdfs:label>fixed basket</rdfs:label>
 		<skos:definition>basket of goods and services whose quantity and quality are held fixed for some period of time</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>basket of goods</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</cmns-av:adaptedFrom>
+		<cmns-av:synonym>basket of goods</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;FixedBasketConstituent">
@@ -663,9 +657,9 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 		</rdfs:subClassOf>
 		<rdfs:label>fixed basket population</rdfs:label>
 		<skos:definition>statistical universe consisting of specific goods and/or services designed for the purposes of supporting surveys such as those used as the basis for price indices</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:synonym>goods and services population</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>goods and/or services population</fibo-fnd-utl-av:synonym>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</cmns-av:adaptedFrom>
+		<cmns-av:synonym>goods and services population</cmns-av:synonym>
+		<cmns-av:synonym>goods and/or services population</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea">
@@ -686,12 +680,12 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 		<rdfs:seeAlso rdf:resource="http://unstats.un.org/unsd/nationalaccount/docs/SNA2008.pdf"/>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;UnemploymentRate"/>
 		<skos:definition>economic indicator representing the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>GDP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>BEA&apos;s Handbook of Methods for GDP and related national accounts, available at https://www.bea.gov/methodologies/index.htm#national_meth</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Gross_domestic_product</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://home.treasury.gov/system/files/261/FSOC-2013-Annual-Report.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>GDP represents a valuation expressed in terms of the prices actually paid by the purchaser after all applicable taxes and subsidies.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Gross domestic product (GDP) is the value of the goods and services produced by the nation&apos;s economy less the value of the goods and services used up in production. GDP is also equal to the sum of personal consumption expenditures, gross private domestic investment, net exports of goods and services, and government consumption expenditures and gross investment. Conceptually, this measure can be arrived at by three separate means: as the sum of goods and services sold to final users, as the sum of income payments and other costs incurred in the production of goods and services, and as the sum of the value added at each stage of production. Although these three ways of measuring GDP are conceptually the same, their calculation may not result in identical estimates of GDP because of differences in data sources, timing, and estimation techniques.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>GDP</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>BEA&apos;s Handbook of Methods for GDP and related national accounts, available at https://www.bea.gov/methodologies/index.htm#national_meth</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Gross_domestic_product</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://home.treasury.gov/system/files/261/FSOC-2013-Annual-Report.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>GDP represents a valuation expressed in terms of the prices actually paid by the purchaser after all applicable taxes and subsidies.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Gross domestic product (GDP) is the value of the goods and services produced by the nation&apos;s economy less the value of the goods and services used up in production. GDP is also equal to the sum of personal consumption expenditures, gross private domestic investment, net exports of goods and services, and government consumption expenditures and gross investment. Conceptually, this measure can be arrived at by three separate means: as the sum of goods and services sold to final users, as the sum of income payments and other costs incurred in the production of goods and services, and as the sum of the value added at each stage of production. Although these three ways of measuring GDP are conceptually the same, their calculation may not result in identical estimates of GDP because of differences in data sources, timing, and estimation techniques.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-ei;Hourly">
@@ -718,11 +712,11 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 		</rdfs:subClassOf>
 		<rdfs:label>household</rdfs:label>
 		<skos:definition>individual or small group of persons who occupy a housing unit (such as a house or apartment) as their usual place of residence, who pool some, or all, of their income and wealth and who consume certain types of goods and services collectively, mainly housing and food</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://stats.oecd.org/glossary/detail.asp?ID=1255"/>
-		<fibo-fnd-utl-av:explanatoryNote>A household may be either (a) a one-person household, that is to say, a person who makes provision for his or her own food or other essentials for living without combining with any other person to form part of a multi-person household or (b) a multi-person household, that is to say, a group of two or more persons living together who make common provision for food or other essentials for living. The persons in the group may pool their incomes and may, to a greater or lesser extent, have a common budget; they may be related or unrelated persons or constitute a combination of persons both related and unrelated.
+		<cmns-av:adaptedFrom rdf:resource="http://stats.oecd.org/glossary/detail.asp?ID=1255"/>
+		<cmns-av:explanatoryNote>A household may be either (a) a one-person household, that is to say, a person who makes provision for his or her own food or other essentials for living without combining with any other person to form part of a multi-person household or (b) a multi-person household, that is to say, a group of two or more persons living together who make common provision for food or other essentials for living. The persons in the group may pool their incomes and may, to a greater or lesser extent, have a common budget; they may be related or unrelated persons or constitute a combination of persons both related and unrelated.
 
-A household may be located in a housing unit or in a set of collective living quarters such as a boarding house, a hotel or a camp, or may comprise the administrative personnel in an institution. The household may also be homeless.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>From the perspective of the U.S Census Bureau, a household includes the related family members and all the unrelated people, if any, such as lodgers, foster children, wards, or employees who share the housing unit. A person living alone in a housing unit, or a group of unrelated people sharing a housing unit such as partners or roomers, is also counted as a household. The count of households excludes group quarters [such as institutional facilities]. There are two major categories of households, &apos;family&apos; and &apos;nonfamily&apos;.</fibo-fnd-utl-av:explanatoryNote>
+A household may be located in a housing unit or in a set of collective living quarters such as a boarding house, a hotel or a camp, or may comprise the administrative personnel in an institution. The household may also be homeless.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>From the perspective of the U.S Census Bureau, a household includes the related family members and all the unrelated people, if any, such as lodgers, foster children, wards, or employees who share the housing unit. A person living alone in a housing unit, or a group of unrelated people sharing a housing unit such as partners or roomers, is also counted as a household. The count of households excludes group quarters [such as institutional facilities]. There are two major categories of households, &apos;family&apos; and &apos;nonfamily&apos;.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;HousingUnit">
@@ -735,7 +729,7 @@ A household may be located in a housing unit or in a set of collective living qu
 		</rdfs:subClassOf>
 		<rdfs:label>housing unit</rdfs:label>
 		<skos:definition>house, an apartment, a mobile home or trailer, a group of rooms, or a single room occupied as separate living quarters, or if vacant, intended for occupancy as separate living quarters</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Separate living quarters are those in which the occupants live separately from any other individuals in the building and which have direct access from outside the building or through a common hall. For vacant units, the criteria of separateness and direct access are applied to the intended occupants whenever possible.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Separate living quarters are those in which the occupants live separately from any other individuals in the building and which have direct access from outside the building or through a common hall. For vacant units, the criteria of separateness and direct access are applied to the intended occupants whenever possible.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;InflationRate">
@@ -749,22 +743,22 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:label>inflation rate</rdfs:label>
 		<skos:definition>economic indicator representing a change in prices of goods and services for a specified period, for a given statistical area</skos:definition>
 		<skos:editorialNote>Always either includes or excludes: Energy prices; Food prices. ALL inflation rates cite whether or not they exclude energy and food prices. If nothing stated it is assumed they include them.</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote>Inflation rate can be used to define changes, from period-to-period, in wage (wage inflation), house prices or producer inputs/outputs. It can be calculated month-over-month and quarter-over-quarter, as well as year-over-year, or on any periodic basis required by the publisher and its community of interest.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Inflation rate can be used to define changes, from period-to-period, in wage (wage inflation), house prices or producer inputs/outputs. It can be calculated month-over-month and quarter-over-quarter, as well as year-over-year, or on any periodic basis required by the publisher and its community of interest.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;InputProducerPriceIndex">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;ProducerPriceIndex"/>
 		<rdfs:label>input producer price index</rdfs:label>
 		<skos:definition>economic indicator representing a measure of the rate of change over time in the prices of inputs of goods and services purchased by the producer</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>input PPI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>input PPI</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;InstitutionalPerson">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-aap-ppl;Person"/>
 		<rdfs:label>institutional person</rdfs:label>
 		<skos:definition>person that resides in an institution for some reason, due, for example, to hospitalization, rehabilitation, or incarceration</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;InstitutionalUnit">
@@ -772,55 +766,55 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
 		<rdfs:label>institutional unit</rdfs:label>
 		<skos:definition>party that is capable, in its own right, of owning assets, incurring liabilities, and engaging in economic activities and in transactions with other parties</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=1415</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/concepts/units</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.statcan.gc.ca/en/concepts/ccius/intro</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>There is a hierarchical relationship between institutional units and establishments. An institutional unit contains one or more entire establishment(s); an establishment belongs to one and only one institutional unit. There are two main types of units in the real world that may qualify as institutional units, namely persons or groups of persons in the form of households, and legal or social entities.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=1415</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/concepts/units</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.statcan.gc.ca/en/concepts/ccius/intro</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>There is a hierarchical relationship between institutional units and establishments. An institutional unit contains one or more entire establishment(s); an establishment belongs to one and only one institutional unit. There are two main types of units in the real world that may qualify as institutional units, namely persons or groups of persons in the form of households, and legal or social entities.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;LaborProductivityGrossOutput">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;Productivity"/>
 		<rdfs:label>labor productivity, based on gross output</rdfs:label>
 		<skos:definition>ratio of a quantity index of gross output to a quantity index of labor input</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Gross-output based labour productivity traces the labour requirements per unit of (physical) output. It reflects the change in the input coefficient of labour by industry and can help in the analysis of labour requirements by industry.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Shows the time profile of how productively labour is used to generate gross output. Labour productivity changes reflect the joint influence of changes in capital, intermediate inputs, as well as technical, organisational and efficiency change within and between firms, the influence of economies of scale, varying degrees of capacity utilisation and measurement errors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Gross-output based labour productivity traces the labour requirements per unit of (physical) output. It reflects the change in the input coefficient of labour by industry and can help in the analysis of labour requirements by industry.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Shows the time profile of how productively labour is used to generate gross output. Labour productivity changes reflect the joint influence of changes in capital, intermediate inputs, as well as technical, organisational and efficiency change within and between firms, the influence of economies of scale, varying degrees of capacity utilisation and measurement errors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;LaborProductivityValueAdded">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;Productivity"/>
 		<rdfs:label>labor productivity, based on value added</rdfs:label>
 		<skos:definition>ratio of a quantity index of value added to a quantity index of labor input</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>At the aggregate level, value-added based labour productivity forms a direct link to a widely used measure of living standards, income per capita. Productivity translates directly into living standards, by adjusting for changing working hours, unemployment, labour force participation rates and demographic changes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Shows the time profile of how productively labour is used to generate value added. Labour productivity changes reflect the joint influence of changes in capital, as well as technical, organisational and efficiency change within and between firms, the influence of economies of scale, varying degrees of capacity utilisation and measurement errors.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>At the aggregate level, value-added based labour productivity forms a direct link to a widely used measure of living standards, income per capita. Productivity translates directly into living standards, by adjusting for changing working hours, unemployment, labour force participation rates and demographic changes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Shows the time profile of how productively labour is used to generate value added. Labour productivity changes reflect the joint influence of changes in capital, as well as technical, organisational and efficiency change within and between firms, the influence of economies of scale, varying degrees of capacity utilisation and measurement errors.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;MarginallyAttachedPopulation">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;PopulationNotInLaborForce"/>
 		<rdfs:label>marginally attached population</rdfs:label>
 		<skos:definition>subset of the population that includes people who currently are neither working nor looking for work but indicate that they want and are available for a job and have looked for work sometime in the past 12 months</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;MetropolitanStatisticalArea">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea"/>
 		<rdfs:label>metropolitan statistical area</rdfs:label>
 		<skos:definition>one or more adjacent counties or county equivalents that have at least one urban core area of at least 50,000 population, plus adjacent territory that has a high degree of social and economic integration with the core as measured by commuting ties</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>MSA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://en.wikipedia.org/wiki/List_of_Metropolitan_Statistical_Areas"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/fedreg_2010/06282010_metro_standards-Complete.pdf"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://www.federalregister.gov/documents/2021/07/16/2021-15159/2020-standards-for-delineating-core-based-statistical-areas"/>
+		<cmns-av:abbreviation>MSA</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:resource="https://en.wikipedia.org/wiki/List_of_Metropolitan_Statistical_Areas"/>
+		<cmns-av:adaptedFrom rdf:resource="https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/fedreg_2010/06282010_metro_standards-Complete.pdf"/>
+		<cmns-av:adaptedFrom rdf:resource="https://www.federalregister.gov/documents/2021/07/16/2021-15159/2020-standards-for-delineating-core-based-statistical-areas"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;MicropolitanStatisticalArea">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea"/>
 		<rdfs:label>micropolitan statistical area</rdfs:label>
 		<skos:definition>one or more adjacent counties or county equivalents that have at least one urban core area of at least 10,000 population but less than 50,000, plus adjacent territory that has a high degree of social and economic integration with the core as measured by commuting ties</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>μSA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://en.wikipedia.org/wiki/List_of_micropolitan_statistical_areas"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/fedreg_2010/06282010_metro_standards-Complete.pdf"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://www.federalregister.gov/documents/2021/07/16/2021-15159/2020-standards-for-delineating-core-based-statistical-areas"/>
+		<cmns-av:abbreviation>μSA</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:resource="https://en.wikipedia.org/wiki/List_of_micropolitan_statistical_areas"/>
+		<cmns-av:adaptedFrom rdf:resource="https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/fedreg_2010/06282010_metro_standards-Complete.pdf"/>
+		<cmns-av:adaptedFrom rdf:resource="https://www.federalregister.gov/documents/2021/07/16/2021-15159/2020-standards-for-delineating-core-based-statistical-areas"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;MilitaryPerson">
@@ -828,7 +822,7 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:label>military person</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;Civilian"/>
 		<skos:definition>a person that is a member of the active duty military</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-ei;Monthly">
@@ -842,17 +836,17 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;ProducerPriceIndex"/>
 		<rdfs:label>output producer price index</rdfs:label>
 		<skos:definition>economic indicator representing a measure of the rate of change over time in the prices of products sold as they leave the producer</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>output PPI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>output PPI</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;PersonalConsumptionExpenditures">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
 		<rdfs:label>personal consumption expenditures</rdfs:label>
 		<skos:definition>economic indicator representing a measure of the value of the goods and services purchased by, or on the behalf of, &apos;persons&apos;</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PCE</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bea.gov/data/consumer-spending/main</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Personal consumption expenditures consist of purchases of goods and services by households and by nonprofit institutions serving households (NPISHs). These goods and services include imputed expenditures on items such as the services of housing by a homeowner (the equivalent of rent), financial and insurance services for which there is no explicit charge, and medical care provided to individuals and financed by government or by private insurance.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>PCE</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bea.gov/data/consumer-spending/main</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Personal consumption expenditures consist of purchases of goods and services by households and by nonprofit institutions serving households (NPISHs). These goods and services include imputed expenditures on items such as the services of housing by a homeowner (the equivalent of rent), financial and insurance services for which there is no explicit charge, and medical care provided to individuals and financed by government or by private insurance.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;PopulationNotInLaborForce">
@@ -860,8 +854,8 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:label>population not in the labor force</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
 		<skos:definition>a subset of the civilian, noninstitutional population, that is considered neither employed nor unemployed by the reporting agency during the reporting period</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>There are a number of distinctions with respect to how individuals are counted from country to country, including whether or not they are considered employed if they are on unpaid leave for some reason, and whether or not they are counted multiple times if they have more than one paying job.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>There are a number of distinctions with respect to how individuals are counted from country to country, including whether or not they are considered employed if they are on unpaid leave for some reason, and whether or not they are counted multiple times if they have more than one paying job.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;ProducerPriceIndex">
@@ -910,10 +904,10 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:label>producer price index</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;ConsumerPriceIndex"/>
 		<skos:definition>economic indicator representing a measure of the rate of change over time in the prices of goods and services bought and sold by producers</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>PPI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Statistical agencies implement the Laspeyres index by putting it into price-relative (price change from the base period) and revenue-share (from the base period) format. In this form, the Laspeyres index can be written as the sum of base-period revenue shares of the items in the index times their corresponding price relatives. Statistical agency practice has introduced some approximations to the theoretical Laspeyres target due to a number of practical problems with producing the Laspeyres index exactly. For these and other pragmatic reasons, some agencies use alternatives depending on circumstances. See the IMF publication cited for a full explanation of the most commonly used approaches and trade-offs made for determining PPI.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The standard methodology for a typical PPI is based on a Laspeyres price index with fixed quantities from an earlier base period. The construction of this index can be thought of in terms of selecting a basket of goods and services representative of base-period revenues, valuing this at base-period prices, and then repricing the same basket at current-period prices. The target PPI in this case is defined to be the ratio of these two revenues. Practicing statisticians use this methodology because it has at least three practical advantages. It is easily explained to the public, it can use often expensive and untimely weighting information from the date of the last (or an even earlier) survey or administrative source (rather than requiring sources of data for the current month), and it need not be revised if users accept the Laspeyres premise.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>PPI</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Statistical agencies implement the Laspeyres index by putting it into price-relative (price change from the base period) and revenue-share (from the base period) format. In this form, the Laspeyres index can be written as the sum of base-period revenue shares of the items in the index times their corresponding price relatives. Statistical agency practice has introduced some approximations to the theoretical Laspeyres target due to a number of practical problems with producing the Laspeyres index exactly. For these and other pragmatic reasons, some agencies use alternatives depending on circumstances. See the IMF publication cited for a full explanation of the most commonly used approaches and trade-offs made for determining PPI.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The standard methodology for a typical PPI is based on a Laspeyres price index with fixed quantities from an earlier base period. The construction of this index can be thought of in terms of selecting a basket of goods and services representative of base-period revenues, valuing this at base-period prices, and then repricing the same basket at current-period prices. The target PPI in this case is defined to be the ratio of these two revenues. Practicing statisticians use this methodology because it has at least three practical advantages. It is easily explained to the public, it can use often expensive and untimely weighting information from the date of the last (or an even earlier) survey or administrative source (rather than requiring sources of data for the current month), and it need not be revised if users accept the Laspeyres premise.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;Productivity">
@@ -921,9 +915,9 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
 		<rdfs:label>productivity</rdfs:label>
 		<skos:definition>economic indicator representing a ratio of a volume measure of output to a volume measure of input use</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=2167</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>The primary objectives of productivity measurement include: (a) tracing technology change, i.e., the currently known ways of converting resources into outputs desired by the economy, (b) identifying changes in efficiency, (c) understanding real cost savings, (d) benchmarking production processes, and (e) assessing standards of living. Productivity measures may also be single factor or multifactor.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=2167</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The primary objectives of productivity measurement include: (a) tracing technology change, i.e., the currently known ways of converting resources into outputs desired by the economy, (b) identifying changes in efficiency, (c) understanding real cost savings, (d) benchmarking production processes, and (e) assessing standards of living. Productivity measures may also be single factor or multifactor.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;StatisticalInformationPublisher">
@@ -948,16 +942,16 @@ A household may be located in a housing unit or in a set of collective living qu
 		</rdfs:subClassOf>
 		<rdfs:label>ultimate consumer</rdfs:label>
 		<skos:definition>a person that is the ultimate user of a good, product or service</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>For the purposes of the CPI and related statistics, the definition of consumer is limited to humans. In general, a consumer could include a pet, as the consumer of pet food, for example, although the pet owner would likely be the purchaser and target of advertising.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The consumer is not always the purchaser of the product. Consumers are considered to be the users of the final product. For example, purchasers of building products are interim users of these products while constructing the finished product, which then may be purchased by the consumer.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>consumer as defined by the Consumer Price Index (CPI)</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>For the purposes of the CPI and related statistics, the definition of consumer is limited to humans. In general, a consumer could include a pet, as the consumer of pet food, for example, although the pet owner would likely be the purchaser and target of advertising.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The consumer is not always the purchaser of the product. Consumers are considered to be the users of the final product. For example, purchasers of building products are interim users of these products while constructing the finished product, which then may be purchased by the consumer.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>consumer as defined by the Consumer Price Index (CPI)</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;UnderemployedPopulation">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
 		<rdfs:label>underemployed population</rdfs:label>
 		<skos:definition>subset of the employed population that includes persons employed part-time for economic reasons, who want and are available for full-time work but have had to settle for a part-time schedule</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;UnderemployedPopulationWithRespectToOccupation">
@@ -982,7 +976,7 @@ A household may be located in a housing unit or in a set of collective living qu
 			</owl:Class>
 		</owl:equivalentClass>
 		<skos:definition>subset of the civilian non-institutional population that includes persons employed part-time for economic reasons, persons that are marginally attached to the labor force, and persons that are identified as unemployed</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;UnemployedPopulation">
@@ -996,8 +990,8 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:label>unemployed population</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
 		<skos:definition>subset of the civilian labor force that is considered to have had no employment but was available for work, except for temporary illness, and had made specific efforts to find employment sometime during a specified period, during the reporting period</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Persons who were waiting to be recalled to a job from which they had been laid off need not have been looking for work to be classified as unemployed.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Persons who were waiting to be recalled to a job from which they had been laid off need not have been looking for work to be classified as unemployed.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;UnemploymentRate">
@@ -1025,8 +1019,8 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:seeAlso rdf:resource="http://www.bls.gov/news.release/pdf/empsit.pdf"/>
 		<skos:definition>economic indicator representing the ratio of the unemployed population with respect to the civilian labor force of a given economy for some specified period</skos:definition>
 		<fibo-fnd-utl-alx:actualExpression>unemployed population ÷ civilian labor force</fibo-fnd-utl-alx:actualExpression>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/cps/faq.htm#Ques3</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Persons are classified as unemployed if they do not have a job, have actively looked for work in the prior 4 weeks, and are currently available for work. Workers expecting to be recalled from layoff are counted as unemployed, whether or not they have engaged in a specific jobseeking activity. In all other cases, the individual must have been engaged in at least one active job search activity in the 4 weeks preceding the interview and be available for work (except for temporary illness).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/cps/faq.htm#Ques3</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Persons are classified as unemployed if they do not have a job, have actively looked for work in the prior 4 weeks, and are currently available for work. Workers expecting to be recalled from layoff are counted as unemployed, whether or not they have engaged in a specific jobseeking activity. In all other cases, the individual must have been engaged in at least one active job search activity in the 4 weeks preceding the interview and be available for work (except for temporary illness).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;ValueAddedProducerPriceIndex">
@@ -1045,8 +1039,8 @@ A household may be located in a housing unit or in a set of collective living qu
 		</rdfs:subClassOf>
 		<rdfs:label>value-added producer price index</rdfs:label>
 		<skos:definition>economic indicator representing a weighted average of the input and output producer price indices</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>value-added PPI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>value-added PPI</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-ei;Weekly">
@@ -1068,7 +1062,7 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:label>has duration of unemployment</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition>specifies the length of time, typically in weeks, that people classified as unemployed have been continuously looking for work</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://www.bls.gov/cps/definitions.htm"/>
+		<cmns-av:adaptedFrom rdf:resource="https://www.bls.gov/cps/definitions.htm"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-ind-ei-ei;hasIndicatorValue">
@@ -1089,7 +1083,7 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:label>is seasonally adjusted</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>a predicate indicating whether some published formal method is applied that compensates for seasonal variations in the population or index value</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Example explanation from the US Bureau of Labor Statistics: Because price data are used for different purposes by different groups, the Bureau of Labor Statistics publishes seasonally adjusted as well as unadjusted changes each month. ... Seasonal factors used in computing the seasonally adjusted indexes are derived by the X-13ARIMA-SEATS Seasonal Adjustment Method. Seasonally adjusted indexes and seasonal factors are computed annually. Each year, the last five years of seasonally adjusted data are revised.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Example explanation from the US Bureau of Labor Statistics: Because price data are used for different purposes by different groups, the Bureau of Labor Statistics publishes seasonally adjusted as well as unadjusted changes each month. ... Seasonal factors used in computing the seasonally adjusted indexes are derived by the X-13ARIMA-SEATS Seasonal Adjustment Method. Seasonally adjusted indexes and seasonal factors are computed annually. Each year, the last five years of seasonally adjusted data are revised.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/IND/EconomicIndicators/MetadataINDEconomicIndicators.rdf
+++ b/IND/EconomicIndicators/MetadataINDEconomicIndicators.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ei-mod "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/MetadataINDEconomicIndicators/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/MetadataINDEconomicIndicators/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ei-mod="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/MetadataINDEconomicIndicators/"
@@ -18,51 +19,50 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/MetadataINDEconomicIndicators/">
 		<rdfs:label>Metadata about the EDMC-FIBO Indices and Indicators (IND) Economic Indicators Module</rdfs:label>
 		<dct:abstract>The economic indicators module includes ontologies defining concepts to do with published economic indicators. These give some indication of the state of some economy. Indicators of this type are usually published by governments or government agencies, or by international agencies or agencies of countries other than the ones reported on. Examples include Gross Domestic Product (GDP) and unemployment rates.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2021-03-29T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-ind-ei-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataINDEconomicIndicators.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210301/EconomicIndicators/MetadataINDEconomicIndicators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/EconomicIndicators/MetadataINDEconomicIndicators/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-mod;EconomicIndicatorsModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO IND Economic Indicators</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>economic indicators module</rdfs:label>
 		<dct:abstract>The economic indicators module includes ontologies defining concepts to do with published economic indicators. These give some indication of the state of some economy. Indicators of this type are usually published by governments or goernment agencies, or by international agencies or agencies of countries other than the ones reported on. Examples include Gross Domestic Product (GDP) and unemployment rates.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Census Bureau (US Department of Commerce)</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Federal Reserve Bank of Kansas City</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>fibo-ind-ei</sm:moduleAbbreviation>
+		<dct:title>FIBO IND Economic Indicators Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Economic Indicators Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/IND/EconomicIndicators/MetadataINDEconomicIndicators.rdf
+++ b/IND/EconomicIndicators/MetadataINDEconomicIndicators.rdf
@@ -38,21 +38,28 @@
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>economic indicators module</rdfs:label>
 		<dct:abstract>The economic indicators module includes ontologies defining concepts to do with published economic indicators. These give some indication of the state of some economy. Indicators of this type are usually published by governments or goernment agencies, or by international agencies or agencies of countries other than the ones reported on. Examples include Gross Domestic Product (GDP) and unemployment rates.</dct:abstract>
+		<dct:contributor>88 Solutions</dct:contributor>
 		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
 		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>John F. Tierney</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
 		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
 		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"/>

--- a/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf
+++ b/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-be-ge-caj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/">
@@ -19,10 +20,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-be-ge-caj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"
@@ -42,22 +43,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/">
 		<rdfs:label>Canadian Economic Indicators Ontology</rdfs:label>
 		<dct:abstract>This ontology provides specific parameters which make up the various types of market economic indicators applicable to the Canadian economy.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-ind-ei-caei</sm:fileAbbreviation>
-		<sm:filename>CAEconomicIndicators.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"/>
@@ -68,17 +59,21 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20220801/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was added to the IND specification per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was revised per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was revised to reflect the new hasCoverageArea property in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20181101/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was revised to eliminate duplication with concepts in LCC and merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200301/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was revised to correct a datatype on an explanatory note and merge statistical information publisher with economic indicators.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was revised to correct out of date links.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20220801/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-caei;CanadianConsumerPriceIndex">
@@ -116,9 +111,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>Canadian consumer price index</rdfs:label>
 		<skos:definition>economic indicator representing a measure of changes over time in the prices of a fixed basket of consumer goods and services that Canadian private households consume</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CPI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/start</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.statcan.gc.ca/en/subjects-start/prices_and_price_indexes/consumer_price_indexes</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>CPI</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/start</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.statcan.gc.ca/en/subjects-start/prices_and_price_indexes/consumer_price_indexes</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-caei;CanadianHouseholdsConsumersUniverse">
@@ -142,7 +137,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>Canadian households consumers universe</rdfs:label>
 		<skos:definition>a statistical universe consisting of all private households in Canada, with the exception of soldiers on military bases, people living on First Nations reserves, institutionalized persons, and households living in the rural areas of the three northern territories</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>http://www.statcan.gc.ca/pub/62-553-x/62-553-x2015001-eng.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>http://www.statcan.gc.ca/pub/62-553-x/62-553-x2015001-eng.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-caei;CanadianProducerPriceIndex">
@@ -178,8 +173,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>Canadian producer price index</rdfs:label>
 		<skos:definition>an economic indicator representing a measure of the change over time in the prices of a fixed-basket of domestic producer goods and services</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www23.statcan.gc.ca/imdb-bmdi/pub/indexth-eng.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Note that Canada does not produce a high level, cross industry PPI per se. Canadian PPIs are published by industry sector. Three of the most important are captured in the union defined herein, which may be expanded over time to integrate others, as needed.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www23.statcan.gc.ca/imdb-bmdi/pub/indexth-eng.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Note that Canada does not produce a high level, cross industry PPI per se. Canadian PPIs are published by industry sector. Three of the most important are captured in the union defined herein, which may be expanded over time to integrate others, as needed.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-caei;CanadianStatisticsPublisher">
@@ -187,28 +182,28 @@
 		<rdfs:label>Canadian statistics publisher</rdfs:label>
 		<skos:definition>individual representing the functional entity that is the primary publisher of statistical information for the Canadian Government</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-ind-ei-caei;StatisticsCanada"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/about/mandate/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/about/mandate/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-caei;IndustrialProductsSector">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;IndustrySectorClassifier"/>
 		<rdfs:label>industrial products sector</rdfs:label>
 		<skos:definition>a classifier for a sector of the economy used for price indices focused on major commodities sold by manufacturers in Canada</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www23.statcan.gc.ca/imdb/p2SV.pl?Function=getSurvey&amp;SDDS=2318</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www23.statcan.gc.ca/imdb/p2SV.pl?Function=getSurvey&amp;SDDS=2318</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-caei;NewHousingSector">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;IndustrySectorClassifier"/>
 		<rdfs:label>new housing sector</rdfs:label>
 		<skos:definition>a classifier for a sector of the economy used for price indices focused on contractors&apos; selling prices of new residential houses, where detailed specifications pertaining to each house remain the same between two consecutive periods</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www23.statcan.gc.ca/imdb/p2SV.pl?Function=getSurvey&amp;SDDS=2310</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www23.statcan.gc.ca/imdb/p2SV.pl?Function=getSurvey&amp;SDDS=2310</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-caei;RawMaterialsSector">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;IndustrySectorClassifier"/>
 		<rdfs:label>raw materials sector</rdfs:label>
 		<skos:definition>a classifier used for price indices related to raw materials purchased by industries in Canada for further processing</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www23.statcan.gc.ca/imdb/p2SV.pl?Function=getSurvey&amp;SDDS=2306</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www23.statcan.gc.ca/imdb/p2SV.pl?Function=getSurvey&amp;SDDS=2306</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-caei;StatisticsCanada">
@@ -217,8 +212,8 @@
 		<rdfs:label xml:lang="fr">Statistique Canada</rdfs:label>
 		<skos:definition>individual representing Statistics Canada, a government agency mandated to collect, compile, analyse, abstract and publish statistical information relating to the commercial, industrial, financial, social, economic and general activities and condition of the people of Canada</skos:definition>
 		<fibo-fnd-plc-loc:hasCoverageArea rdf:resource="&lcc-3166-1;Canada"/>
-		<fibo-fnd-utl-av:abbreviation>StatCan</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/about/mandate</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>StatCan</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/about/mandate</cmns-av:adaptedFrom>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 	</owl:NamedIndividual>
 

--- a/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf
+++ b/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
@@ -20,10 +21,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
@@ -44,23 +45,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/">
 		<rdfs:label>American Economic Indicators Ontology</rdfs:label>
 		<dct:abstract>This ontology provides specific parameters which make up the various types of market economic indicators applicable to the American economy.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-ind-ei-usei</sm:fileAbbreviation>
-		<sm:filename>USEconomicIndicators.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
@@ -72,17 +62,21 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20220801/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was added to the IND specification per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was revised per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was revised to reflect the new hasCoverageArea property and migration of statistical measures in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190501/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was revised to eliminate duplication of concepts in LCC, merge countries with locations in FND, and eliminate a redundant superclass declaration on UrbanConsumerPriceIndex.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200401/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was revised to merge statistical information publisher with economic indicators.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was revised to correct out of date links.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20220801/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;AmericanStatisticsPublisher">
@@ -98,9 +92,9 @@
 		<rdfs:seeAlso rdf:resource="http://www.bls.gov/"/>
 		<skos:definition>the Bureau of Labor Statistics, the principal Federal agency responsible for measuring labor market activity, working conditions, and price changes in the economy</skos:definition>
 		<fibo-fnd-plc-loc:hasCoverageArea rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<fibo-fnd-utl-av:abbreviation>BLS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/bls/infohome.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Its mission is to collect, analyze, and disseminate essential economic information to support public and private decision-making. As an independent statistical agency, BLS serves its diverse user communities by providing products and services that are objective, timely, accurate, and relevant.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>BLS</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/bls/infohome.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Its mission is to collect, analyze, and disseminate essential economic information to support public and private decision-making. As an independent statistical agency, BLS serves its diverse user communities by providing products and services that are objective, timely, accurate, and relevant.</cmns-av:explanatoryNote>
 		<lcc-cr:isPartOf rdf:resource="&fibo-ind-ei-usei;UnitedStatesDepartmentOfLabor"/>
 	</owl:NamedIndividual>
 	
@@ -108,14 +102,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalProgram"/>
 		<rdfs:label>consumer expenditure survey</rdfs:label>
 		<skos:definition>statistical program conducted on a regular basis that provides information on the buying habits of consumers, including data on their expenditures, income, and consumer unit (families and single consumers) characteristics</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://www.bls.gov/cex/"/>
+		<cmns-av:adaptedFrom rdf:resource="http://www.bls.gov/cex/"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;CurrentEmploymentStatistics">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalProgram"/>
 		<rdfs:label>current employment statistics</rdfs:label>
 		<skos:definition>survey conducted on a regular basis that presents analytical information related to businesses and government agencies, in order to provide detailed industry data on employment, hours, and earnings of workers</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://www.bls.gov/ces/"/>
+		<cmns-av:adaptedFrom rdf:resource="http://www.bls.gov/ces/"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;CurrentPopulationSurvey">
@@ -128,7 +122,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>current population survey</rdfs:label>
 		<skos:definition>survey conducted on a regular basis that presents analytical information related to the general population of a given statistical area with respect to labor force, employment, unemployment, persons not in the labor force, hours of work, earnings, and other demographic and labor force characteristics</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://www.bls.gov/cps/"/>
+		<cmns-av:adaptedFrom rdf:resource="http://www.bls.gov/cps/"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;EmploymentSituationEstablishmentSurvey">
@@ -142,7 +136,7 @@
 		<rdfs:label>employment situation establishment survey</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.bls.gov/news.release/empsit.tn.htm"/>
 		<skos:definition>survey conducted on a regular basis that presents analytical information related to the labor force of a given statistical area, surveyed with respect to businesses, and is, for the most part, seasonally adjusted</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;EmploymentSituationHouseholdSurvey">
@@ -156,7 +150,7 @@
 		<rdfs:label>employment situation household survey</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.bls.gov/news.release/empsit.tn.htm"/>
 		<skos:definition>a survey conducted on a regular basis that presents analytical information related to the labor force of a given statistical area, surveyed with respect to households, and is, for the most part, seasonally adjusted</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;EmploymentSituationSurvey">
@@ -171,14 +165,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label>employment situation survey</rdfs:label>
 		<skos:definition>a survey conducted on a regular basis that presents analytical information focused on the employment characteristics of a given statistical area</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://www.bls.gov/opub/reports/about.htm"/>
+		<cmns-av:adaptedFrom rdf:resource="http://www.bls.gov/opub/reports/about.htm"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;PointOfPurchaseSurvey">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalProgram"/>
 		<rdfs:label>point of purchase survey</rdfs:label>
 		<skos:definition>a program conducted on a regular basis that provides information on purchases of various items and services by consumers</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://www.bls.gov/respondents/cpi/tpops/"/>
+		<cmns-av:adaptedFrom rdf:resource="http://www.bls.gov/respondents/cpi/tpops/"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;USProducerPriceIndex">
@@ -197,7 +191,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>U.S. producer price index</rdfs:label>
 		<skos:definition>an economic indicator representing a measure of the change over time in the selling prices received by domestic producers for their output</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/ppi/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/ppi/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-usei;UnitedStatesDepartmentOfLabor">
@@ -207,8 +201,8 @@
 		<skos:definition>individual representing the U.S. Department of Labor, a government department whose mission is to foster, promote, and develop the welfare of the wage earners, job seekers, and retirees of the United States; improve working conditions; advance opportunities for profitable employment; and assure work-related benefits and rights</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-loc:hasCoverageArea rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<fibo-fnd-utl-av:abbreviation>DOL</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.dol.gov/general/aboutdol</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>DOL</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.dol.gov/general/aboutdol</cmns-av:adaptedFrom>
 		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
@@ -247,8 +241,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>urban consumer price index</rdfs:label>
 		<skos:definition>an economic indicator representing a measure of the average change over time in the prices paid by urban consumers for a market basket of consumer goods and services</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>CPI-U</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/cpi/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>CPI-U</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/cpi/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;UrbanConsumersUniverse">
@@ -278,8 +272,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>urban consumers universe</rdfs:label>
 		<skos:definition>a statistical universe for consumer expenditure surveys consisting of people within a household that make joint expenditure decisions</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics, http://www.bls.gov/cpi/</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>In the United States, the CPI-U population, which covers about 88 percent of the U.S. population, covers households in all areas of the United States except people living in rural nonmetropolitan areas, in farm households, on military installations, in religious communities, and in institutions such as prisons and mental hospitals.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics, http://www.bls.gov/cpi/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>In the United States, the CPI-U population, which covers about 88 percent of the U.S. population, covers households in all areas of the United States except people living in rural nonmetropolitan areas, in farm households, on military installations, in religious communities, and in institutions such as prisons and mental hospitals.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/IND/ForeignExchange/ForeignExchange.rdf
+++ b/IND/ForeignExchange/ForeignExchange.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
@@ -14,10 +15,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
@@ -32,21 +33,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/">
 		<rdfs:label>Foreign Exchange Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the parameters for foreign exchange rates, covering spot and forward rates, as well as foreign exchange spot rate volatilities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/Indicators/Indicators/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-ind-fx-fx</sm:fileAbbreviation>
-		<sm:filename>ForeignExchange.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -56,20 +48,24 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20210301/ForeignExchange/ForeignExchange/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/ForeignExchange/ForeignExchange/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/ForeignExchange/ForeignExchange.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/ForeignExchange/ForeignExchange.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 2 report, namely, to take advantage of content added via the FIBO FND 1.1 with respect to higher-level concepts of Rate, ExchangeRate, and InterestRate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/ForeignExchange/ForeignExchange.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/ForeignExchange/ForeignExchange.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190901/ForeignExchange/ForeignExchange.rdf version of this ontology was modified to eliminate unnecessary references, some of which had incorrect datatypes, rename FxSpotVolatility to CurrencySpotVolatility and improve its definition and related volatility definitions more generally.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/ForeignExchange/ForeignExchange.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;CurrencyConversionService">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;ForeignExchangeService"/>
 		<rdfs:label>currency conversion service</rdfs:label>
 		<skos:definition>foreign exchange service involving the conversion of currency of one country or group of countries for another, typically, but not always, as a counter transaction</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A currency exchange service may be provided by a stand-alone business or may be part of the services offered by a bank or other financial institution. The currency exchange profits from its services either through adjusting the exchange rate or taking a commission.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A currency exchange service may be provided by a stand-alone business or may be part of the services offered by a bank or other financial institution. The currency exchange profits from its services either through adjusting the exchange rate or taking a commission.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;CurrencyForwardRate">
@@ -113,7 +109,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;QuotedExchangeRate"/>
 		<rdfs:label>currency spot rate</rdfs:label>
 		<skos:definition>rate at which one currency may be exchanged for another for immediate delivery</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Spot rates represent the prices buyers pay in one currency to purchase a second currency. Although the spot exchange rate is for delivery on the earliest value date, the standard settlement date for most spot transactions is two business days after the transaction date.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Spot rates represent the prices buyers pay in one currency to purchase a second currency. Although the spot exchange rate is for delivery on the earliest value date, the standard settlement date for most spot transactions is two business days after the transaction date.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;CurrencySpotSellRate">
@@ -157,7 +153,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>exchange rate volatility</rdfs:label>
 		<skos:definition>statistical measure of the rate of change in the rate at which one currency can be exchanged for another</skos:definition>
-		<fibo-fnd-utl-av:usageNote>Volatility is modeled here using a structured collection, comprised of a series of individual exchange rates (either projected or prior quoted rates), dates, and the source for those rates for some overall period of time</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>Volatility is modeled here using a structured collection, comprised of a series of individual exchange rates (either projected or prior quoted rates), dates, and the source for those rates for some overall period of time</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;ForeignExchangeService">
@@ -171,7 +167,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;ForeignExchangeService"/>
 		<rdfs:label>international electronic funds transfer service</rdfs:label>
 		<skos:definition>electronic funds transfer (EFT) service involving the transfer of funds across national borders, that may also involve currency conversion</skos:definition>
-		<fibo-fnd-utl-av:synonym>international wire transfer</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>international wire transfer</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-fx-fx;QuotedExchangeRate">
@@ -186,7 +182,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>quoted exchange rate</rdfs:label>
 		<skos:definition>exchange rate quoted at a specific point in time, for a given block amount of currency as quoted against another (base) currency</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>An exchange rate of R represents a rate of R units of the quoted currency to 1 unit of the base currency.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>An exchange rate of R represents a rate of R units of the quoted currency to 1 unit of the base currency.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-ind-fx-fx;hasQuotationBlockAmountBasis">

--- a/IND/ForeignExchange/MetadataINDForeignExchange.rdf
+++ b/IND/ForeignExchange/MetadataINDForeignExchange.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-fx-mod "https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/MetadataINDForeignExchange/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/MetadataINDForeignExchange/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-fx-mod="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/MetadataINDForeignExchange/"
@@ -18,38 +19,48 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/MetadataINDForeignExchange/">
 		<rdfs:label>Metadata about the EDMC-FIBO Indices and Indicators (IND) Foreign Exchange Module</rdfs:label>
 		<dct:abstract>This module includes ontologies defining concepts to do with foreign exchange.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-ind-fx-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataINDForeignExchange.rdf</sm:filename>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20180801/ForeignExchange/MetadataINDForeignExchange/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/ForeignExchange/MetadataINDForeignExchange/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-fx-mod;ForeignExchangeModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO IND Foreign Exchange Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>foreign exchange module</rdfs:label>
 		<dct:abstract>This module includes ontologies defining concepts to do with foreign exchange.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-IND-FX</sm:moduleAbbreviation>
+		<dct:title>FIBO IND Foreign Exchange Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Foreign Exchange Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/IND/ForeignExchange/MetadataINDForeignExchange.rdf
+++ b/IND/ForeignExchange/MetadataINDForeignExchange.rdf
@@ -38,21 +38,28 @@
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>foreign exchange module</rdfs:label>
 		<dct:abstract>This module includes ontologies defining concepts to do with foreign exchange.</dct:abstract>
+		<dct:contributor>88 Solutions</dct:contributor>
 		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
 		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>John F. Tierney</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
 		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
 		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>

--- a/IND/Indicators/Indicators.rdf
+++ b/IND/Indicators/Indicators.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -15,10 +16,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -34,20 +35,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
 		<rdfs:label>Indicators Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the concepts common to all market rates, indices and indicators; that is concepts descriptive of the numeric parameters themselves. These are modeled independently of the values they may take over time.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:fileAbbreviation>fibo-ind-ind-ind</sm:fileAbbreviation>
-		<sm:filename>Indicators.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
@@ -57,7 +50,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20221001/Indicators/Indicators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/Indicators/Indicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/Indicators/Indicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/Indicators/Indicators.rdf version of this ontology was modified per the FIBO 2.0 RFC, namely, to integrate concepts recently added to the FND domain including Rate, ExchangeRate, InterestRate and StructuredCollection and revise definitions of TermStructure and Volatility to better support concepts such as yield curves and analysis of market rates generally.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/Indicators/Indicators.rdf version of this ontology was modified to integrate the composite date value and reflect migration of statistical measures to Analytics.</skos:changeNote>
@@ -68,7 +62,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/Indicators/Indicators.rdf version of this ontology was modified to a restriction on isValueOf to MarketRate and eliminate its dependence on PublishedFinancialInformation, and to revise the definition of market rate, daily average market rate, and end of day market rate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210501/Indicators/Indicators.rdf version of this ontology was modified to extend the definition of price structure to include a synonym of price history and state that it is intended to be used for any sort of analysis of historic prices.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20220801/Indicators/Indicators.rdf version of this ontology was modified to loosen the nature of a price in a price structure to include any price, not limited to a quoted price from a specific source, to allow for calculated prices to be included in the structure and to deprecate redundant terms including financial information publisher, and published financial information.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20221001/Indicators/Indicators.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;DailyAverageMarketRate">
@@ -82,7 +79,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>daily average market rate</rdfs:label>
 		<skos:definition>overall level of a given rate, calculated as the sum of some selected observed values of the rates for a particular reference rate, foreign exchange rate, lending rate, or other market rate divided by the number of samples collected over the course of a twenty-four (24) hour period for a specific date</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/m/marketaverage.asp</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/m/marketaverage.asp</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;EndOfDayMarketRate">
@@ -108,14 +105,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ind-ind;PriceVolatility"/>
 		<rdfs:label>historical price volatility</rdfs:label>
 		<skos:definition>historical volatility measure of past trading ranges of prices of underlying securities and indexes</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Calculations for historical volatility are generally based on the change from one closing price to the next.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Calculations for historical volatility are generally based on the change from one closing price to the next.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;HistoricalVolatility">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ind-ind;Volatility"/>
 		<rdfs:label>historical volatility</rdfs:label>
 		<skos:definition>measure of volatility that uses actual values for pricing, rates, and other measurements calculated over some prior period</skos:definition>
-		<fibo-fnd-utl-av:synonym>realized volatility</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>realized volatility</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;ImpliedPriceVolatility">
@@ -129,7 +126,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ind-ind;Volatility"/>
 		<rdfs:label>implied volatility</rdfs:label>
 		<skos:definition>measure of volatility that is a forward-looking metric used to calculate probability</skos:definition>
-		<fibo-fnd-utl-av:synonym>projected volatility</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>projected volatility</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;MarketRate">
@@ -193,8 +190,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>price structure</rdfs:label>
 		<skos:definition>structured collection of prices, such as market prices for some index or security, such that volatility or other analyses may be performed over the structure</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Historical prices are needed not only for various statistical analyses but for determining best prices for certain kinds of options, for example. Note that prices may be quoted or calculated.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>price history</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Historical prices are needed not only for various statistical analyses but for determining best prices for certain kinds of options, for example. Note that prices may be quoted or calculated.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>price history</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;PriceVolatility">
@@ -208,7 +205,7 @@
 		<rdfs:label>price volatility</rdfs:label>
 		<skos:definition>statistical measure of the rate of change in pricing for a given security or market index</skos:definition>
 		<skos:editorialNote>Volatility is modeled here using a structured collection, comprised of a series of individual prices of something (a security, index, etc., typically quoted prices), dates, and the source for those prices for some overall period of time</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote>Volatility can be determined using the standard deviation or variance among prices for the security or market index over some period of time. For a specific security, volatility may measure the amount and frequency in rapid price fluctuation. It is computed as the annualized standard deviation of the percentage change in a security&apos;s daily price.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Volatility can be determined using the standard deviation or variance among prices for the security or market index over some period of time. For a specific security, volatility may measure the amount and frequency in rapid price fluctuation. It is computed as the annualized standard deviation of the percentage change in a security&apos;s daily price.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;PublishedFinancialInformation">
@@ -239,7 +236,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>term structure</rdfs:label>
 		<skos:definition>structured collection of rates, such as interest rates, or bond yields with different terms to maturity, such that a yield curve may be constructed for the structure</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Term structure refers to a set of discrete points; elements are ordered by time. Restrictions on the rate (see above) and a point in time, paired together, and then ordered in a structured collection is how this should ultimately be modeled. Then the concept of yield curve would be a child of term structure, for calculation of net present value, for example. Term structures consist of two or more observed or projected values, typically related to debt instruments or interest rates. assessment of monetary policy conditions, and so forth.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Term structure refers to a set of discrete points; elements are ordered by time. Restrictions on the rate (see above) and a point in time, paired together, and then ordered in a structured collection is how this should ultimately be modeled. Then the concept of yield curve would be a child of term structure, for calculation of net present value, for example. Term structures consist of two or more observed or projected values, typically related to debt instruments or interest rates. assessment of monetary policy conditions, and so forth.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;Volatility">
@@ -275,8 +272,8 @@
 		<rdfs:label>has quotation date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition>indicates the quotation date for a given market rate or indicator</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Typically this property reflects a daily average or end of day quote.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:usageNote>Note that this property requires a reified date value, if used.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:explanatoryNote>Typically this property reflects a daily average or end of day quote.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>Note that this property requires a reified date value, if used.</cmns-av:usageNote>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-ind-ind-ind;hasQuotationDateTime">

--- a/IND/Indicators/MetadataINDIndicators.rdf
+++ b/IND/Indicators/MetadataINDIndicators.rdf
@@ -38,21 +38,28 @@
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>indicators module</rdfs:label>
 		<dct:abstract>This module includes ontologies for concepts common to all market indices and market indicators, including economic measures.</dct:abstract>
+		<dct:contributor>88 Solutions</dct:contributor>
 		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
 		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>John F. Tierney</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
 		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
 		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>

--- a/IND/Indicators/MetadataINDIndicators.rdf
+++ b/IND/Indicators/MetadataINDIndicators.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ind-mod "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/MetadataINDIndicators/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/MetadataINDIndicators/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ind-mod="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/MetadataINDIndicators/"
@@ -18,39 +19,48 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/MetadataINDIndicators/">
 		<rdfs:label>Metadata about the EDMC-FIBO Indices and Indicators (IND) Indicators Module</rdfs:label>
 		<dct:abstract>This module includes ontologies for concepts common to all market indices and market indicators, including economic measures.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-ind-ind-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataINDIndicators.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/MetadataINDIndicators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/Indicators/MetadataINDIndicators/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ind-mod;IndicatorsModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO IND Indicators Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>indicators module</rdfs:label>
 		<dct:abstract>This module includes ontologies for concepts common to all market indices and market indicators, including economic measures.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-IND-IND</sm:moduleAbbreviation>
+		<dct:title>FIBO IND Indicators Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Indicators Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/IND/InterestRates/CommonInterestRates.rdf
+++ b/IND/InterestRates/CommonInterestRates.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-usfsind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/">
 	<!ENTITY fibo-fbc-fct-usjrga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/">
@@ -13,10 +14,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-usfsind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"
 	xmlns:fibo-fbc-fct-usjrga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"
@@ -30,22 +31,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/">
 		<rdfs:label>Common Interest Rates Ontology</rdfs:label>
 		<dct:abstract>This ontology provides reference data for commonly referenced interest rates, specifically those that are referenced in the ISDA FpML codes for floating interest rates. The rates included herein are generated directly from the FpML published reference data.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
-		<sm:fileAbbreviation>fibo-ind-ir-cm</sm:fileAbbreviation>
-		<sm:filename>CommonInterestRates.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"/>
@@ -53,701 +44,705 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20211201/InterestRates/CommonInterestRates/"/>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/InterestRates/InterestRates.rdf version of this ontology was modified to normalize the prefix for the EU individuals ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190101/InterestRates/InterestRates.rdf version of this ontology was revised extensively to restructure the way in which interest rate benchmarks are modeled and eliminate references to the merged interest rate publishers ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190101/InterestRates/InterestRates.rdf version of this ontology was revised to reflect the latest FpML rates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/InterestRates/InterestRates.rdf version of this ontology was revised to reflect the latest FpML rates, which include a number of changes, including deprecating some rates and replacing them with others.</skos:changeNote>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/floating-rate-index-3-2.xml</fibo-fnd-utl-av:adaptedFrom>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20211201/InterestRates/CommonInterestRates.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230201/InterestRates/InterestRates.rdf version of this ontology was modified to normalize the prefix for the EU individuals ontology.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/floating-rate-index-3-2.xml</cmns-av:adaptedFrom>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AED-EIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AED-EIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AED-EIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;UAEDirham"/>
+		<cmns-av:abbreviation>AED-EIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-AONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-AONIA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-AONIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-AONIA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-AONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-AONIA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-AONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-AONIA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBR-ISDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-BBR-ISDC</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-BBR-ISDC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-BBR-ISDC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBSW">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-BBSW</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-BBSW</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-BBSW</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBSW_Quarterly_Swap_Rate_ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-BBSW Quarterly Swap Rate ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-BBSW Quarterly Swap Rate ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-BBSW Quarterly Swap Rate ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBSW_Semi_Annual_Swap_Rate_ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-BBSW Semi Annual Swap Rate ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-BBSW Semi Annual Swap Rate ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>AUD-BBSW Semi Annual Swap Rate ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-BBSY_Bid">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-BBSY Bid</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-BBSY Bid</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-BBSY Bid</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-LIBOR-BBA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-LIBOR-BBA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-LIBOR-BBA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-LIBOR-BBA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-LIBOR-BBA-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-LIBOR-BBA-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>AUD-LIBOR-BBA-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-LIBOR-BBA-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-LIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-LIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Quarterly_Swap_Rate-ICAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Quarterly Swap Rate-ICAP-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-Quarterly Swap Rate-ICAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>AUD-Quarterly Swap Rate-ICAP-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>AUD-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>AUD-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Semi-Annual_Swap_Rate-BGCANTOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>AUD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Semi-Annual_Swap_Rate-ICAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Semi-Annual Swap Rate-ICAP-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>AUD-Semi-Annual Swap Rate-ICAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>AUD-Semi-Annual Swap Rate-ICAP-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Swap_Rate-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Swap Rate-Reuters</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>AUD-Swap Rate-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-av:abbreviation>AUD-Swap Rate-Reuters</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;BRL-CDI">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>BRL-CDI</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>BRL-CDI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;BrazilianReal"/>
+		<cmns-av:abbreviation>BRL-CDI</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-ISDD">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-BA-ISDD</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-BA-ISDD</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-BA-ISDD</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-BA-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-BA-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-BA-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-BA-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>CAD-BA-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-BA-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-CDOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-CDOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-CDOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-CDOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-CORRA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-CORRA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-CORRA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-CORRA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-CORRA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-CORRA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-CORRA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-CORRA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-ISDA-Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-ISDA-Swap Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-ISDA-Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-ISDA-Swap Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-BBA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-BBA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-LIBOR-BBA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-LIBOR-BBA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-BBA-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-BBA-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>CAD-LIBOR-BBA-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-LIBOR-BBA-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-BBA-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-BBA-SwapMarker</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
-		<fibo-fnd-utl-av:abbreviation>CAD-LIBOR-BBA-SwapMarker</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-LIBOR-BBA-SwapMarker</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-LIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-REPO-CORRA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-REPO-CORRA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-REPO-CORRA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-REPO-CORRA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-ISDD">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-ISDD</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-TBILL-ISDD</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-TBILL-ISDD</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CAD-TBILL-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-TBILL-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-Reuters</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>CAD-TBILL-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-TBILL-Reuters</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>CAD-TBILL-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-av:abbreviation>CAD-TBILL-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-3M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>CHF-3M LIBOR SWAP-CME vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>CHF-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>CHF-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBORSWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBORSWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>CHF-6M LIBORSWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>CHF-6M LIBORSWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-6M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>CHF-6M LIBOR SWAP-CME vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-Annual_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-Annual Swap Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-Annual Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>CHF-Annual Swap Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-Annual_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-Annual Swap Rate-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-Annual Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>CHF-Annual Swap Rate-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>CHF-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-Basis_Swap-3m_vs_6m-LIBOR-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-Basis Swap-3m vs 6m-LIBOR-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-Basis Swap-3m vs 6m-LIBOR-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF-Basis Swap-3m vs 6m-LIBOR-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-ISDAFIX-Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-ISDAFIX-Swap Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-ISDAFIX-Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF-ISDAFIX-Swap Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-LIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-LIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF-LIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-LIBOR-ISDA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-LIBOR-ISDA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-LIBOR-ISDA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF-LIBOR-ISDA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-LIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF-LIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-OIS-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-OIS-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-OIS-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF-OIS-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-SARON">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-SARON</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-SARON</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF-SARON</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-SARON-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-SARON-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-SARON-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF-SARON-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-TOIS-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-TOIS-OIS-COMPOUND</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF-TOIS-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF-TOIS-OIS-COMPOUND</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF_USD-Basis_Swaps-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF USD-Basis Swaps-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CHF USD-Basis Swaps-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-av:abbreviation>CHF USD-Basis Swaps-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CLP-ICP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CLP-ICP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CLP-ICP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;ChileanPeso"/>
+		<cmns-av:abbreviation>CLP-ICP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CLP-TNA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CLP-TNA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CLP-TNA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Refers to the Indice Camara Promedio (&quot;ICP&quot;) rate for Chilean Pesos which, for a Reset Date, is determined and published by the Asociacion de Bancos e Instituciones Financieras de Chile A.G. (&quot;ABIF&quot;) in accordance with the &quot;Reglamento Indice de Camara Promedio&quot; of the ABIF as published in the Diario Oficial de la Republica de Chile (the &quot;ICP Rules&quot;) and which is reported on the ABIF website by not later than 10:00 a.m., Santiago time, on that Reset Date.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;ChileanPeso"/>
+		<cmns-av:abbreviation>CLP-TNA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Refers to the Indice Camara Promedio (&quot;ICP&quot;) rate for Chilean Pesos which, for a Reset Date, is determined and published by the Asociacion de Bancos e Instituciones Financieras de Chile A.G. (&quot;ABIF&quot;) in accordance with the &quot;Reglamento Indice de Camara Promedio&quot; of the ABIF as published in the Diario Oficial de la Republica de Chile (the &quot;ICP Rules&quot;) and which is reported on the ABIF website by not later than 10:00 a.m., Santiago time, on that Reset Date.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNH-HIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNH-HIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNH-HIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<cmns-av:abbreviation>CNH-HIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNH-HIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNH-HIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNH-HIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<cmns-av:abbreviation>CNH-HIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Deposit_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Deposit Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNY-Deposit Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<cmns-av:abbreviation>CNY-Deposit Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Fixing_Repo_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Fixing Repo Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNY-Fixing Repo Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<cmns-av:abbreviation>CNY-Fixing Repo Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-LPR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-LPR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNY-LPR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<cmns-av:abbreviation>CNY-LPR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Quarterly_7D_Repo_NDS_Rate_Tradition">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Quarterly 7D Repo NDS Rate Tradition</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNY-Quarterly 7D Repo NDS Rate Tradition</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>CNY-Quarterly 7D Repo NDS Rate Tradition</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Quarterly_7_day_Repo_Non_Deliverable_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Quarterly 7 day Repo Non Deliverable Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNY-Quarterly 7 day Repo Non Deliverable Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>CNY-Quarterly 7 day Repo Non Deliverable Swap Rate-TRADITION-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-SHIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-SHIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNY-SHIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<cmns-av:abbreviation>CNY-SHIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-SHIBOR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-SHIBOR-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNY-SHIBOR-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<cmns-av:abbreviation>CNY-SHIBOR-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>CNY-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>CNY-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CNY-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>CNY-Semi-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY_7-Repo_Compounding_Date">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY 7-Repo Compounding Date</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>CNY 7-Repo Compounding Date</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: CNY 7-Repo Compounding Date - is not an floating rate index and should not be in the floating-rate-index list (it is a date).</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<cmns-av:abbreviation>CNY 7-Repo Compounding Date</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: CNY 7-Repo Compounding Date - is not an floating rate index and should not be in the floating-rate-index list (it is a date).</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;COP-IBR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>COP-IBR-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>COP-IBR-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;ColombianPeso"/>
+		<cmns-av:abbreviation>COP-IBR-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>CZK-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>CZK-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CZK-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>CZK-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-CZEONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-CZEONIA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CZK-CZEONIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
+		<cmns-av:abbreviation>CZK-CZEONIA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-CZEONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-CZEONIA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CZK-CZEONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
+		<cmns-av:abbreviation>CZK-CZEONIA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-PRIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-PRIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CZK-PRIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
+		<cmns-av:abbreviation>CZK-PRIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-PRIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-PRIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>CZK-PRIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
+		<cmns-av:abbreviation>CZK-PRIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>DKK-CIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
+		<cmns-av:abbreviation>DKK-CIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>DKK-CIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
+		<cmns-av:abbreviation>DKK-CIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CIBOR2">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>DKK-CIBOR2</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>DKK-CIBOR2</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
+		<cmns-av:abbreviation>DKK-CIBOR2</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-CITA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>DKK-CITA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>DKK-CITA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
+		<cmns-av:abbreviation>DKK-CITA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;DKK-Tom_Next-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>DKK-Tom Next-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>DKK-Tom Next-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
+		<cmns-av:abbreviation>DKK-Tom Next-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-3M_EURIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-3M_EURIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
@@ -755,20 +750,20 @@
 		<rdfs:label>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-3M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-3M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
@@ -776,20 +771,20 @@
 		<rdfs:label>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
@@ -797,20 +792,20 @@
 		<rdfs:label>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
@@ -818,170 +813,170 @@
 		<rdfs:label>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-SwapMarker</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-SwapMarker</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00-SwapMarker</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-10:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-11:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-11:00-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-11:00-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00-SwapMarker</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-11:00-SwapMarker</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-11:00-SwapMarker</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-3_Month">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-3 Month</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-3 Month</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-3 Month</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-3_Month-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-3 Month-SwapMarker</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-3 Month-SwapMarker</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-3 Month-SwapMarker</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-4:15-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-4:15-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-CNO_TEC10">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-CNO TEC10</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-CNO TEC10</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-CNO TEC10</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EONIA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-Average">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-Average</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-Average</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EONIA-Average</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-10_00-BGCANTOR">
@@ -989,18 +984,18 @@
 		<rdfs:label>EUR-EONIA-OIS-10:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-10:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EONIA-OIS-10:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-10_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-10:00-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-10:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EONIA-OIS-10:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-10_00-TRADITION">
@@ -1008,18 +1003,18 @@
 		<rdfs:label>EUR-EONIA-OIS-10:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-10:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EONIA-OIS-10:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-11:00-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EONIA-OIS-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-4_15-TRADITION">
@@ -1027,45 +1022,45 @@
 		<rdfs:label>EUR-EONIA-OIS-4:15-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EONIA-OIS-4:15-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS Compound</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EONIA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-Swap-Index">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-Swap-Index</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EONIA-Swap-Index</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EONIA-Swap-Index</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EURIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Act_365">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR-Act/365</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR-Act/365</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EURIBOR-Act/365</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Act_365-Bloomberg">
@@ -1073,18 +1068,18 @@
 		<rdfs:label>EUR-EURIBOR-Act/365-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR-Act/365-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EURIBOR-Act/365-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR-Reference Banks</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EURIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Telerate">
@@ -1092,507 +1087,507 @@
 		<rdfs:label>EUR-EURIBOR-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EURIBOR-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR_ICE_Swap_Rate-11_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR ICE Swap Rate-11:00</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR ICE Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EURIBOR ICE Swap Rate-11:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR_ICE_Swap_Rate-12_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR ICE Swap Rate-12:00</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURIBOR ICE Swap Rate-12:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EURIBOR ICE Swap Rate-12:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURONIA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-EURONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EURONIA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EuroSTR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EuroSTR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EuroSTR-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EuroSTR-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_12M">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EuroSTR Average 12M</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 12M</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EuroSTR Average 12M</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_1M">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EuroSTR Average 1M</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 1M</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EuroSTR Average 1M</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_1W">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EuroSTR Average 1W</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 1W</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EuroSTR Average 1W</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_3M">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EuroSTR Average 3M</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 3M</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EuroSTR Average 3M</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Average_6M">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EuroSTR Average 6M</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Average 6M</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EuroSTR Average 6M</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EuroSTR_Compounded_Index">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EuroSTR Compounded Index</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-EuroSTR Compounded Index</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-EuroSTR Compounded Index</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-ISDA-LIBOR_Swap_Rate-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-ISDA-LIBOR Swap Rate-10:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-ISDA-LIBOR Swap Rate-10:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-ISDA-LIBOR Swap Rate-10:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-ISDA-LIBOR_Swap_Rate-11_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-ISDA-LIBOR Swap Rate-11:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-ISDA-LIBOR Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-ISDA-LIBOR Swap Rate-11:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-LIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-LIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-LIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-LIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-LIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TAM-CDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TAM-CDC</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-TAM-CDC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-TAM-CDC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC10-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TEC10-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-TEC10-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-TEC10-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC5-CNO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TEC5-CNO</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-TEC5-CNO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-TEC5-CNO</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC5-CNO-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TEC5-CNO-SwapMarker</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
-		<fibo-fnd-utl-av:abbreviation>EUR-TEC5-CNO-SwapMarker</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-TEC5-CNO-SwapMarker</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC5-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TEC5-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-TEC5-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-TEC5-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TMM-CDC-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TMM-CDC-COMPOUND</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR-TMM-CDC-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR-TMM-CDC-COMPOUND</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_Basis_Swap-EONIA_vs_3m_EUR_IBOR_Swap_Rates-A_360-10_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR Basis Swap-EONIA vs 3m EUR+IBOR Swap Rates-A/360-10:00-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR Basis Swap-EONIA vs 3m EUR+IBOR Swap Rates-A/360-10:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR Basis Swap-EONIA vs 3m EUR+IBOR Swap Rates-A/360-10:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_EURIBOR-Annual_Bond_Swap_vs_1m-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR EURIBOR-Annual Bond Swap vs 1m-11:00-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR EURIBOR-Annual Bond Swap vs 1m-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>EUR EURIBOR-Annual Bond Swap vs 1m-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_EURIBOR-Basis_Swap-1m_vs_3m-Euribor-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR EURIBOR-Basis Swap-1m vs 3m-Euribor-11:00-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR EURIBOR-Basis Swap-1m vs 3m-Euribor-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR EURIBOR-Basis Swap-1m vs 3m-Euribor-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_EURIBOR-Basis_Swap-3m_vs_6m-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR EURIBOR-Basis Swap-3m vs 6m-11:00-ICAP</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-utl-av:abbreviation>EUR EURIBOR-Basis Swap-3m vs 6m-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR EURIBOR-Basis Swap-3m vs 6m-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR_USD-Basis_Swaps-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR USD-Basis Swaps-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>EUR USD-Basis Swaps-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>EUR USD-Basis Swaps-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-6M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-6M LIBOR SWAP-CME vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>GBP-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-LIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-LIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR-ISDA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-LIBOR-ISDA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR-ISDA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-LIBOR-ISDA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-LIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-LIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR_ICE_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-LIBOR ICE Swap Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-LIBOR ICE Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-LIBOR ICE Swap Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-RONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-RONIA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-RONIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-RONIA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-RONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-RONIA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-RONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-RONIA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-SONIA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA-OIS-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-OIS-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-SONIA-OIS-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA-OIS-11:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-OIS-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-SONIA-OIS-11:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA-OIS-4:15-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-OIS-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-SONIA-OIS-4:15-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-SONIA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_Compounded_Index">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA Compounded Index</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA Compounded Index</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-SONIA Compounded Index</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_ICE_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA ICE Swap Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA ICE Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-SONIA ICE Swap Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_ICE_Term">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA ICE Term</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA ICE Term</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-SONIA ICE Term</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA_Refinitiv_Term">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA Refinitiv Term</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-SONIA Refinitiv Term</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-SONIA Refinitiv Term</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi-Annual_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi-Annual Swap Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-Semi-Annual Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-Semi-Annual Swap Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi-Annual_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi-Annual Swap Rate-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-Semi-Annual Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-Semi-Annual Swap Rate-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-Semi-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi-Annual_Swap_Rate-SwapMarker26">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi-Annual Swap Rate-SwapMarker26</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-Semi-Annual Swap Rate-SwapMarker26</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-Semi-Annual Swap Rate-SwapMarker26</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi_Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi Annual Swap Rate-11:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>GBP-Semi Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-Semi Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi_Annual_Swap_Rate-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi Annual Swap Rate-4:15-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>GBP-Semi Annual Swap Rate-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>GBP-Semi Annual Swap Rate-4:15-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-UK_Base_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-UK Base Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP-UK Base Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP-UK Base Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP_USD-Basis_Swaps-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP USD-Basis Swaps-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GBP USD-Basis Swaps-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-av:abbreviation>GBP USD-Basis Swaps-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIBOR-ATHIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIBOR-ATHIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GRD-ATHIBOR-ATHIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>GRD-ATHIBOR-ATHIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GRD-ATHIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>GRD-ATHIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIBOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIBOR-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>GRD-ATHIBOR-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>GRD-ATHIBOR-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIMID-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIMID-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>GRD-ATHIMID-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>GRD-ATHIMID-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIMID-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIMID-Reuters</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>GRD-ATHIMID-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>GRD-ATHIMID-Reuters</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-av:abbreviation>HKD-HIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-HIBOR-Bloomberg">
@@ -1600,68 +1595,68 @@
 		<rdfs:label>HKD-HIBOR-HIBOR-Bloomberg</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-HIBOR-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-HIBOR-HIBOR-Bloomberg&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-av:abbreviation>HKD-HIBOR-HIBOR-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-HIBOR-HIBOR-Bloomberg&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-HIBOR_">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HIBOR-HIBOR=</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-HIBOR=</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-HIBOR-HIBOR=&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-av:abbreviation>HKD-HIBOR-HIBOR=</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-HIBOR-HIBOR=&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-ISDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HIBOR-ISDC</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-ISDC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-av:abbreviation>HKD-HIBOR-ISDC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HKD-HIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-av:abbreviation>HKD-HIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HONIA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HKD-HONIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-av:abbreviation>HKD-HONIA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HONIA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HKD-HONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-av:abbreviation>HKD-HONIA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-ISDA-Swap_Rate-11_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-ISDA-Swap Rate-11:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HKD-ISDA-Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-av:abbreviation>HKD-ISDA-Swap Rate-11:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-ISDA-Swap_Rate-4_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-ISDA-Swap Rate-4:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HKD-ISDA-Swap Rate-4:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-av:abbreviation>HKD-ISDA-Swap Rate-4:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-11_00-BGCANTOR">
@@ -1669,11 +1664,11 @@
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-11_00-TRADITION">
@@ -1681,11 +1676,11 @@
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-11:00-TRADITION</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-11:00-TRADITION&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>HKD-Quarterly-Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-11:00-TRADITION&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-4_00-BGCANTOR">
@@ -1693,121 +1688,121 @@
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-Reference Banks</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-Reference Banks&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>HKD-Quarterly-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-Reference Banks&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Quarterly_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Quarterly Swap Rate-11:00-ICAP</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Quarterly Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Quarterly Swap Rate-11:00-ICAP&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>HKD-Quarterly-Quarterly Swap Rate-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Quarterly Swap Rate-11:00-ICAP&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Quarterly_Swap_Rate-4_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Quarterly Swap Rate-4:00-ICAP</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Quarterly Swap Rate-4:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Quarterly Swap Rate-4:00-ICAP&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>HKD-Quarterly-Quarterly Swap Rate-4:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Quarterly Swap Rate-4:00-ICAP&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Quarterly_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Quarterly Swap Rate-Reference Banks</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>HKD-Quarterly-Quarterly Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Quarterly Swap Rate-Reference Banks&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>HKD-Quarterly-Quarterly Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Quarterly Swap Rate-Reference Banks&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HUF-BUBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HUF-BUBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HUF-BUBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Forint"/>
+		<cmns-av:abbreviation>HUF-BUBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HUF-BUBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HUF-BUBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HUF-BUBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Forint"/>
+		<cmns-av:abbreviation>HUF-BUBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HUF-HUFONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HUF-HUFONIA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>HUF-HUFONIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Forint"/>
+		<cmns-av:abbreviation>HUF-HUFONIA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-IDMA-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-IDMA-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>IDR-IDMA-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<cmns-av:abbreviation>IDR-IDMA-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-IDRFIX">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-IDRFIX</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>IDR-IDRFIX</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<cmns-av:abbreviation>IDR-IDRFIX</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-JIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-JIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>IDR-JIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<cmns-av:abbreviation>IDR-JIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SBI-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SBI-Reuters</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>IDR-SBI-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<cmns-av:abbreviation>IDR-SBI-Reuters</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>IDR-SOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<cmns-av:abbreviation>IDR-SOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SOR-Reuters">
@@ -1815,1292 +1810,1292 @@
 		<rdfs:label>IDR-SOR-Reuters</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>IDR-SOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;IDR-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<cmns-av:abbreviation>IDR-SOR-Reuters</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;IDR-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SOR-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>IDR-SOR-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<cmns-av:abbreviation>IDR-SOR-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>IDR-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>IDR-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>IDR-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>IDR-Semi-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-Semi_Annual_Swap_Rate-Non-deliverable-16_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>IDR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>IDR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ILS-TELBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ILS-TELBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ILS-TELBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewIsraeliSheqel"/>
+		<cmns-av:abbreviation>ILS-TELBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ILS-TELBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ILS-TELBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ILS-TELBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewIsraeliSheqel"/>
+		<cmns-av:abbreviation>ILS-TELBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-BMK">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-BMK</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>INR-BMK</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;INR-BMK&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-BMK</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;INR-BMK&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-CMT">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-CMT</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>INR-CMT</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;INR-CMT&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-CMT</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;INR-CMT&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-INBMK-REUTERS">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-INBMK-REUTERS</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>INR-INBMK-REUTERS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;INR-INBMK-REUTERS&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-INBMK-REUTERS</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;INR-INBMK-REUTERS&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MIBOR-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-MIBOR-OIS-COMPOUND</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>INR-MIBOR-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-MIBOR-OIS-COMPOUND</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MIBOR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-MIBOR-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>INR-MIBOR-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-MIBOR-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MIBOR_OIS">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-MIBOR OIS</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>INR-MIBOR OIS</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-MIBOR OIS</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MIFOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-MIFOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>INR-MIFOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-MIFOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-MITOR-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-MITOR-OIS-COMPOUND</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>INR-MITOR-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;INR-MITOR-OIS-COMPOUND&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-MITOR-OIS-COMPOUND</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;INR-MITOR-OIS-COMPOUND&quot; code has been deprecated in supplement 54 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Modified_MIFOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Modified MIFOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>INR-Modified MIFOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-Modified MIFOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>INR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-av:abbreviation>INR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Semi-Annual_Swap_Rate-11_30-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Semi-Annual Swap Rate-11:30-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>INR-Semi-Annual Swap Rate-11:30-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>INR-Semi-Annual Swap Rate-11:30-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>INR-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>INR-Semi-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Semi_Annual_Swap_Rate-Non-deliverable-16_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>INR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>INR-Semi Annual Swap Rate-Non-deliverable-16:00-Tullett Prebon</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ISK-REIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ISK-REIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ISK-REIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IcelandKrona"/>
+		<cmns-av:abbreviation>ISK-REIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ISK-REIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ISK-REIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ISK-REIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IcelandKrona"/>
+		<cmns-av:abbreviation>ISK-REIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-Annual Swap Rate-11:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>JPY-Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>JPY-Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Annual_Swap_Rate-3_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-Annual Swap Rate-3:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>JPY-Annual Swap Rate-3:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>JPY-Annual Swap Rate-3:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-BBSF-Bloomberg-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-BBSF-Bloomberg-10:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-BBSF-Bloomberg-10:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-BBSF-Bloomberg-10:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-BBSF-Bloomberg-15_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-BBSF-Bloomberg-15:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-BBSF-Bloomberg-15:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-BBSF-Bloomberg-15:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Euroyen_TIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-Euroyen TIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-Euroyen TIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-Euroyen TIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-ISDA-Swap_Rate-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-ISDA-Swap Rate-10:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-ISDA-Swap Rate-10:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-ISDA-Swap Rate-10:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-ISDA-Swap_Rate-15_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-ISDA-Swap Rate-15:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-ISDA-Swap Rate-15:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-ISDA-Swap Rate-15:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-LIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR-ISDA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LIBOR-ISDA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR-ISDA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-LIBOR-ISDA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-LIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR_TSR-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LIBOR TSR-10:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR TSR-10:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-LIBOR TSR-10:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LIBOR_TSR-15_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LIBOR TSR-15:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-LIBOR TSR-15:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-LIBOR TSR-15:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LTPR-TBC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LTPR-TBC</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-LTPR-TBC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-LTPR-TBC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-LTPR_MHBK">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-LTPR MHBK</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-LTPR MHBK</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-LTPR MHBK</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-MUTANCALL-TONAR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-MUTANCALL-TONAR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-MUTANCALL-TONAR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-MUTANCALL-TONAR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-OIS-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-OIS-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-OIS-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-OIS-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-OIS-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-OIS-11:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>JPY-OIS-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-OIS-11:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-OIS-3_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-OIS-3:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>JPY-OIS-3:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-OIS-3:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Quoting_Banks-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-Quoting Banks-LIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-Quoting Banks-LIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-Quoting Banks-LIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-STPR-Quoting_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-STPR-Quoting Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-STPR-Quoting Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-STPR-Quoting Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-17096">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-17096</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-17096</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TIBOR-17096</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-DTIBOR01">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-DTIBOR01</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-DTIBOR01</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TIBOR-DTIBOR01</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TIBOR-TIBM</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TIBOR-TIBM-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM_10_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM (10 Banks)</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM (10 Banks)</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;JPY-TIBOR-TIBM (10 Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TIBOR-TIBM (10 Banks)</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;JPY-TIBOR-TIBM (10 Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM_5_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM (5 Banks)</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM (5 Banks)</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;JPY-TIBOR-TIBM (5 Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TIBOR-TIBM (5 Banks)</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;JPY-TIBOR-TIBM (5 Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TIBOR-TIBM_All_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TIBOR-TIBM (All Banks)</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>JPY-TIBOR-TIBM (All Banks)</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;JPY-TIBOR-TIBM (All Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TIBOR-TIBM (All Banks)</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;JPY-TIBOR-TIBM (All Banks)&quot; code has been deprecated in supplement 47 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TONA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TONA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TONA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TONA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TONA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TONA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_Average_180D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TONA Average 180D</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TONA Average 180D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TONA Average 180D</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_Average_30D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TONA Average 30D</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TONA Average 30D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TONA Average 30D</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_Average_90D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TONA Average 90D</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TONA Average 90D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TONA Average 90D</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_Compounded_Index">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TONA Compounded Index</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TONA Compounded Index</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TONA Compounded Index</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_TSR-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TONA TSR-10:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TONA TSR-10:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TONA TSR-10:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TONA_TSR-15_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TONA TSR-15:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TONA TSR-15:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TONA TSR-15:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TORF_QUICK">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TORF QUICK</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TORF QUICK</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TORF QUICK</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TSR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TSR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TSR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TSR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TSR-Telerate-10_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TSR-Telerate-10:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TSR-Telerate-10:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TSR-Telerate-10:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-TSR-Telerate-15_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-TSR-Telerate-15:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY-TSR-Telerate-15:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY-TSR-Telerate-15:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY_USD-Basis_Swaps-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY USD-Basis Swaps-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>JPY USD-Basis Swaps-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-av:abbreviation>JPY USD-Basis Swaps-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;KRW-Bond-3222">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>KRW-Bond-3222</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>KRW-Bond-3222</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Won"/>
+		<cmns-av:abbreviation>KRW-Bond-3222</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;KRW-CD_91D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>KRW-CD 91D</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>KRW-CD 91D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Won"/>
+		<cmns-av:abbreviation>KRW-CD 91D</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;KRW-Quarterly_Annual_Swap_Rate-3_30-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>KRW-Quarterly Annual Swap Rate-3:30-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>KRW-Quarterly Annual Swap Rate-3:30-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Won"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>KRW-Quarterly Annual Swap Rate-3:30-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MXN-TIIE">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MXN-TIIE</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>MXN-TIIE</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
+		<cmns-av:abbreviation>MXN-TIIE</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MXN-TIIE-Banxico-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MXN-TIIE-Banxico-Reference Banks</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>MXN-TIIE-Banxico-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: MXN-TIIE-Banxico-Reference Banks. It was added to FpML in error, MXN-TIIE-Reference Banks should be used instead.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
+		<cmns-av:abbreviation>MXN-TIIE-Banxico-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: MXN-TIIE-Banxico-Reference Banks. It was added to FpML in error, MXN-TIIE-Reference Banks should be used instead.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MXN-TIIE-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MXN-TIIE-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>MXN-TIIE-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
+		<cmns-av:abbreviation>MXN-TIIE-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-KLIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MYR-KLIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>MYR-KLIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
+		<cmns-av:abbreviation>MYR-KLIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-KLIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MYR-KLIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>MYR-KLIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
+		<cmns-av:abbreviation>MYR-KLIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-Quarterly_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MYR-Quarterly Swap Rate-11:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>MYR-Quarterly Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>MYR-Quarterly Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-Quarterly_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MYR-Quarterly Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>MYR-Quarterly Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>MYR-Quarterly Swap Rate-TRADITION-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NOK-NIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NOK-NIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
+		<cmns-av:abbreviation>NOK-NIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NIBOR-NIBR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NOK-NIBOR-NIBR</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>NOK-NIBOR-NIBR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;NOK-NIBOR-NIBR&quot; code has been deprecated in supplement 49 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
+		<cmns-av:abbreviation>NOK-NIBOR-NIBR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;NOK-NIBOR-NIBR&quot; code has been deprecated in supplement 49 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NIBOR-NIBR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NOK-NIBOR-NIBR-Reference Banks</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>NOK-NIBOR-NIBR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: NOK-NIBOR-NIBR-Reference Banks. It was added to FpML in error, NOK-NIBOR-Reference Banks should be used instead.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
+		<cmns-av:abbreviation>NOK-NIBOR-NIBR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: NOK-NIBOR-NIBR-Reference Banks. It was added to FpML in error, NOK-NIBOR-Reference Banks should be used instead.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NOK-NIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NOK-NIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
+		<cmns-av:abbreviation>NOK-NIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NOWA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NOK-NOWA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NOK-NOWA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
+		<cmns-av:abbreviation>NOK-NOWA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NOK-NOWA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NOK-NOWA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NOK-NOWA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
+		<cmns-av:abbreviation>NOK-NOWA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BBR-ISDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BBR-ISDC</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NZD-BBR-ISDC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-av:abbreviation>NZD-BBR-ISDC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BBR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BBR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NZD-BBR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-av:abbreviation>NZD-BBR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BBR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BBR-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>NZD-BBR-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-av:abbreviation>NZD-BBR-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BKBM_Bid">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BKBM Bid</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NZD-BKBM Bid</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-av:abbreviation>NZD-BKBM Bid</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BKBM_FRA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BKBM FRA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NZD-BKBM FRA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-av:abbreviation>NZD-BKBM FRA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BKBM_FRA_Swap_Rate_ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BKBM FRA Swap Rate ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NZD-BKBM FRA Swap Rate ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-av:abbreviation>NZD-BKBM FRA Swap Rate ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-NZIONA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-NZIONA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NZD-NZIONA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-av:abbreviation>NZD-NZIONA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-NZIONA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-NZIONA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NZD-NZIONA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-av:abbreviation>NZD-NZIONA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>NZD-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>NZD-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-Semi-Annual_Swap_Rate-BGCANTOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NZD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>NZD-Semi-Annual Swap Rate-BGCANTOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-Swap_Rate-ICAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-Swap Rate-ICAP-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>NZD-Swap Rate-ICAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-av:abbreviation>NZD-Swap Rate-ICAP-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-PHIREF">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PHP-PHIREF</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PHP-PHIREF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
+		<cmns-av:abbreviation>PHP-PHIREF</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-PHIREF-BAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PHP-PHIREF-BAP</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>PHP-PHIREF-BAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;PHP-PHIREF-BAP&quot; code has been deprecated in supplement 45 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
+		<cmns-av:abbreviation>PHP-PHIREF-BAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;PHP-PHIREF-BAP&quot; code has been deprecated in supplement 45 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-PHIREF-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PHP-PHIREF-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PHP-PHIREF-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
+		<cmns-av:abbreviation>PHP-PHIREF-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PHP-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>PHP-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>PHP-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PHP-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PHP-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>PHP-Semi-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-POLONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLN-POLONIA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PLN-POLONIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+		<cmns-av:abbreviation>PLN-POLONIA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-POLONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLN-POLONIA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PLN-POLONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+		<cmns-av:abbreviation>PLN-POLONIA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-WIBID">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLN-WIBID</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PLN-WIBID</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+		<cmns-av:abbreviation>PLN-WIBID</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-WIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLN-WIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PLN-WIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+		<cmns-av:abbreviation>PLN-WIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLN-WIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLN-WIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PLN-WIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+		<cmns-av:abbreviation>PLN-WIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLZ-WIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLZ-WIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PLZ-WIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+		<cmns-av:abbreviation>PLZ-WIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PLZ-WIBOR-WIBO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PLZ-WIBOR-WIBO</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>PLZ-WIBOR-WIBO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+		<cmns-av:abbreviation>PLZ-WIBOR-WIBO</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;REPOFUNDS_RATE-FRANCE-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>REPOFUNDS RATE-FRANCE-OIS-COMPOUND</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>REPOFUNDS RATE-FRANCE-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>REPOFUNDS RATE-FRANCE-OIS-COMPOUND</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;REPOFUNDS_RATE-GERMANY-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>REPOFUNDS RATE-GERMANY-OIS-COMPOUND</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>REPOFUNDS RATE-GERMANY-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>REPOFUNDS RATE-GERMANY-OIS-COMPOUND</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;REPOFUNDS_RATE-ITALY-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>REPOFUNDS RATE-ITALY-OIS-COMPOUND</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>REPOFUNDS RATE-ITALY-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>REPOFUNDS RATE-ITALY-OIS-COMPOUND</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RON-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>RON-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>RON-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RON-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RON-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>RON-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-ROBID">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RON-ROBID</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RON-ROBID</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
+		<cmns-av:abbreviation>RON-ROBID</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-ROBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RON-ROBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RON-ROBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
+		<cmns-av:abbreviation>RON-ROBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>RUB-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-12_45-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-12:45-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-12:45-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>RUB-Annual Swap Rate-12:45-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-4:15-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-4:15-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>RUB-Annual Swap Rate-4:15-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>RUB-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RUB-Annual Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>RUB-Annual Swap Rate-TRADITION-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Key_Rate_CBRF">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Key Rate CBRF</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RUB-Key Rate CBRF</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+		<cmns-av:abbreviation>RUB-Key Rate CBRF</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-MOSPRIME-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-MOSPRIME-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RUB-MOSPRIME-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+		<cmns-av:abbreviation>RUB-MOSPRIME-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-MosPrime">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-MosPrime</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RUB-MosPrime</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+		<cmns-av:abbreviation>RUB-MosPrime</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-RUONIA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-RUONIA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RUB-RUONIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+		<cmns-av:abbreviation>RUB-RUONIA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-RUONIA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-RUONIA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>RUB-RUONIA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+		<cmns-av:abbreviation>RUB-RUONIA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SAR-SAIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SAR-SAIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SAR-SAIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SaudiRiyal"/>
+		<cmns-av:abbreviation>SAR-SAIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SAR-SRIOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SAR-SRIOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SAR-SRIOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SaudiRiyal"/>
+		<cmns-av:abbreviation>SAR-SRIOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-Annual_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SEK-Annual Swap Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SEK-Annual Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>SEK-Annual Swap Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-Annual_Swap_Rate-SESWFI">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SEK-Annual Swap Rate-SESWFI</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SEK-Annual Swap Rate-SESWFI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>SEK-Annual Swap Rate-SESWFI</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-STIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SEK-STIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SEK-STIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
+		<cmns-av:abbreviation>SEK-STIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-STIBOR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SEK-STIBOR-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SEK-STIBOR-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
+		<cmns-av:abbreviation>SEK-STIBOR-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SEK-STIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SEK-STIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SEK-STIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
+		<cmns-av:abbreviation>SEK-STIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-SIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-SIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SIBOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SIBOR-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>SGD-SIBOR-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SIBOR-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SONAR-OIS-COMPOUND">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SONAR-OIS-COMPOUND</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>SGD-SONAR-OIS-COMPOUND</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;SGD-SONAR-OIS-COMPOUND&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SONAR-OIS-COMPOUND</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;SGD-SONAR-OIS-COMPOUND&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-SOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SOR-Reference Banks</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>SGD-SOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;SGD-SOR-Reference Banks&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;SGD-SOR-Reference Banks&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SOR-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>SGD-SOR-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SOR-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-VWAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SOR-VWAP-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-SOR-VWAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SOR-VWAP-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SORA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SORA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-SORA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SORA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SORA-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SORA-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-SORA-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-av:abbreviation>SGD-SORA-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Currency_Basis_Swap_Rate-11_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Currency Basis Swap Rate-11:00-Tullett Prebon</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Currency Basis Swap Rate-11:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Currency Basis Swap Rate-11:00-Tullett Prebon</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Currency_Basis_Swap_Rate-16_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Currency Basis Swap Rate-16:00-Tullett Prebon</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Currency Basis Swap Rate-16:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Currency Basis Swap Rate-16:00-Tullett Prebon</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-11.00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-11.00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-11.00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-11.00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-11_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-11:00-Tullett Prebon</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-11:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-11:00-Tullett Prebon</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-16_00-Tullett_Prebon">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-16:00-Tullett Prebon</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-16:00-Tullett Prebon</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-16:00-Tullett Prebon</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-ICAP-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-ICAP-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-ICAP-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-ICAP-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SGD-Semi-Annual Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-TRADITION-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-BRBO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SKK-BRIBOR-BRBO</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SKK-BRIBOR-BRBO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>SKK-BRIBOR-BRBO</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SKK-BRIBOR-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>SKK-BRIBOR-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>SKK-BRIBOR-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-NBSK07">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SKK-BRIBOR-NBSK07</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SKK-BRIBOR-NBSK07</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>SKK-BRIBOR-NBSK07</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SKK-BRIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>SKK-BRIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-av:abbreviation>SKK-BRIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-SOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-SOR-Reference Banks</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>THB-SOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;THB-SOR-Reference Banks&quot; code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+		<cmns-av:abbreviation>THB-SOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;THB-SOR-Reference Banks&quot; code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-SOR-Reuters">
@@ -3108,19 +3103,19 @@
 		<rdfs:label>THB-SOR-Reuters</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>THB-SOR-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: &quot;THB-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+		<cmns-av:abbreviation>THB-SOR-Reuters</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: &quot;THB-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-SOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-SOR-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>THB-SOR-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+		<cmns-av:abbreviation>THB-SOR-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
@@ -3128,727 +3123,727 @@
 		<rdfs:label>THB-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>THB-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>THB-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>THB-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>THB-Semi-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THBFIX">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-THBFIX</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>THB-THBFIX</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+		<cmns-av:abbreviation>THB-THBFIX</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THBFIX-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-THBFIX-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>THB-THBFIX-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+		<cmns-av:abbreviation>THB-THBFIX-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-THOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>THB-THOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+		<cmns-av:abbreviation>THB-THOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-THOR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-THOR-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>THB-THOR-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+		<cmns-av:abbreviation>THB-THOR-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-Annual_Swap_Rate-11_15-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-Annual Swap Rate-11:15-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>TRY-Annual Swap Rate-11:15-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>TRY-Annual Swap Rate-11:15-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TRY-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>TRY-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-Semi-Annual_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-Semi-Annual Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TRY-Semi-Annual Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>TRY-Semi-Annual Swap Rate-TRADITION-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TLREF-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-TLREF-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TRY-TLREF-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
+		<cmns-av:abbreviation>TRY-TLREF-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TRLIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-TRLIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TRY-TRLIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
+		<cmns-av:abbreviation>TRY-TRLIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-TRYIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-TRYIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TRY-TRYIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
+		<cmns-av:abbreviation>TRY-TRYIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY_Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY Annual Swap Rate-11:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>TRY Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>TRY Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Quarterly-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>TWD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>TWD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Quarterly-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Quarterly-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TWD-Quarterly-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>TWD-Quarterly-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Reference Dealers</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TWD-Reference Dealers</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
+		<cmns-av:abbreviation>TWD-Reference Dealers</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Reuters-6165">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Reuters-6165</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TWD-Reuters-6165</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
+		<cmns-av:abbreviation>TWD-Reuters-6165</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TAIBIR01">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-TAIBIR01</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TWD-TAIBIR01</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
+		<cmns-av:abbreviation>TWD-TAIBIR01</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TAIBIR02">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-TAIBIR02</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TWD-TAIBIR02</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
+		<cmns-av:abbreviation>TWD-TAIBIR02</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TAIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-TAIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TWD-TAIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
+		<cmns-av:abbreviation>TWD-TAIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-TWCPBA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-TWCPBA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TWD-TWCPBA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
+		<cmns-av:abbreviation>TWD-TWCPBA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Telerate-6165">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Telerate-6165</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>TWD-Telerate-6165</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
+		<cmns-av:abbreviation>TWD-Telerate-6165</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-3M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-3M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-3M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>USD-3M LIBOR SWAP-CME vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-3M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>USD-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>USD-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-6M_LIBOR_SWAP-CME_vs_LCH-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-6M LIBOR SWAP-CME vs LCH-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-6M LIBOR SWAP-CME vs LCH-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>USD-6M LIBOR SWAP-CME vs LCH-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-6M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>USD-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>USD-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-AMERIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-AMERIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Average_30D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-AMERIBOR Average 30D</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Average 30D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-AMERIBOR Average 30D</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Average_90D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-AMERIBOR Average 90D</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Average 90D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-AMERIBOR Average 90D</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Term">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-AMERIBOR Term</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Term</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-AMERIBOR Term</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR_Term_Structure">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-AMERIBOR Term Structure</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-AMERIBOR Term Structure</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-AMERIBOR Term Structure</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>USD-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>USD-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Annual Swap Rate-11:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>USD-Annual Swap Rate-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>USD-Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-4_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Annual Swap Rate-4:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>USD-Annual Swap Rate-4:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
+		<cmns-av:abbreviation>USD-Annual Swap Rate-4:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-BA-H.15">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-BA-H.15</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
-		<fibo-fnd-utl-av:abbreviation>USD-BA-H.15</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-BA-H.15</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-BA-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-BA-Reference Dealers</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-BA-Reference Dealers</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-BA-Reference Dealers</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-BMA_Municipal_Swap_Index">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-BMA Municipal Swap Index</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-BMA Municipal Swap Index</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-BMA Municipal Swap Index</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-BSBY">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-BSBY</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-BSBY</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-BSBY</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CD-H.15">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CD-H.15</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
-		<fibo-fnd-utl-av:abbreviation>USD-CD-H.15</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CD-H.15</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CD-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CD-Reference Dealers</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-CD-Reference Dealers</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CD-Reference Dealers</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-CMS-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CMS-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Reference_Banks-ICAP_SwapPX">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Reference Banks-ICAP SwapPX</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-CMS-Reference Banks-ICAP SwapPX</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CMS-Reference Banks-ICAP SwapPX</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Reuters</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>USD-CMS-Reuters</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CMS-Reuters</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>USD-CMS-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CMS-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMT">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMT</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-CMT</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CMT</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMT_Average_1W">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMT Average 1W</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-CMT Average 1W</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CMT Average 1W</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-COF11-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-COF11-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
-		<fibo-fnd-utl-av:abbreviation>USD-COF11-Telerate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-COF11-Telerate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-COFI">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-COFI</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-COFI</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-COFI</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CP-Money_Market_Yield">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CP-Money Market Yield</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-CP-Money Market Yield</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CP-Money Market Yield</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CP-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CP-Reference Dealers</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-CP-Reference Dealers</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CP-Reference Dealers</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CRITR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CRITR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-CRITR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-CRITR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-FFCB-DISCO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-FFCB-DISCO</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-FFCB-DISCO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-FFCB-DISCO</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Federal_Funds">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Federal Funds</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Federal Funds</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Federal Funds</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Federal_Funds-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Federal Funds-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Federal Funds-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Federal Funds-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Federal_Funds-Reference_Dealers">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Federal Funds-Reference Dealers</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Federal Funds-Reference Dealers</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Federal Funds-Reference Dealers</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-LIBOR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-LIBOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-LIBOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR-ISDA">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-LIBOR-ISDA</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-LIBOR-ISDA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-LIBOR-ISDA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR-LIBO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-LIBOR-LIBO</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-LIBOR-LIBO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-LIBOR-LIBO</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-LIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-LIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-LIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR_ICE_Swap_Rate-11_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-LIBOR ICE Swap Rate-11:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-LIBOR ICE Swap Rate-11:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-LIBOR ICE Swap Rate-11:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-LIBOR_ICE_Swap_Rate-15_00">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-LIBOR ICE Swap Rate-15:00</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-LIBOR ICE Swap Rate-15:00</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-LIBOR ICE Swap Rate-15:00</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Municipal_Swap_Index">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Municipal Swap Index</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Municipal Swap Index</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Municipal Swap Index</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Municipal_Swap_Libor_Ratio-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Municipal Swap Libor Ratio-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Municipal Swap Libor Ratio-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Municipal Swap Libor Ratio-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Municipal_Swap_Rate-11_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Municipal Swap Rate-11:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Municipal Swap Rate-11:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Municipal Swap Rate-11:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>USD-OIS-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-OIS-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-LON-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-LON-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-OIS-11:00-LON-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-OIS-11:00-LON-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-NY-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-NY-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-OIS-11:00-NY-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-OIS-11:00-NY-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>USD-OIS-11:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-OIS-11:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-3_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-3:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>USD-OIS-3:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-OIS-3:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-3_00-NY-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-3:00-NY-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-OIS-3:00-NY-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-OIS-3:00-NY-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-4_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-4:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>USD-OIS-4:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-OIS-4:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Overnight_Bank_Funding_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Overnight Bank Funding Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Overnight Bank Funding Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Overnight Bank Funding Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Prime">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Prime</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Prime</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Prime</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Prime-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Prime-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Prime-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Prime-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SIBOR-SIBO">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SIBOR-SIBO</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-utl-av:abbreviation>USD-SIBOR-SIBO</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 36 to the 2006 ISDA definitions (Section 7.1 (ab) (xxviii) USD-SIBOR-SIBO is deleted in its entirety). The code is kept in FpML for backward compatibility purposes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SIBOR-SIBO</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 36 to the 2006 ISDA definitions (Section 7.1 (ab) (xxviii) USD-SIBOR-SIBO is deleted in its entirety). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SOFR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SOFR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SOFR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR-OIS_Compound">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SOFR-OIS Compound</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SOFR-OIS Compound</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SOFR-OIS Compound</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_Average_180D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SOFR Average 180D</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SOFR Average 180D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SOFR Average 180D</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_Average_30D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SOFR Average 30D</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SOFR Average 30D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SOFR Average 30D</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_Average_90D">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SOFR Average 90D</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SOFR Average 90D</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SOFR Average 90D</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_CME_Term">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SOFR CME Term</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SOFR CME Term</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SOFR CME Term</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_Compounded_Index">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SOFR Compounded Index</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SOFR Compounded Index</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SOFR Compounded Index</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SOFR_ICE_Swap_Rate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SOFR ICE Swap Rate</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SOFR ICE Swap Rate</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SOFR ICE Swap Rate</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix and 2006 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-SandP_Index_High_Grade">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-SandP Index High Grade</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-SandP Index High Grade</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-SandP Index High Grade</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TBILL-H.15">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-TBILL-H.15</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
-		<fibo-fnd-utl-av:abbreviation>USD-TBILL-H.15</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-TBILL-H.15</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TBILL-H.15-Bloomberg">
@@ -3856,193 +3851,193 @@
 		<rdfs:label>USD-TBILL-H.15-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
-		<fibo-fnd-utl-av:abbreviation>USD-TBILL-H.15-Bloomberg</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-TBILL-H.15-Bloomberg</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TBILL_Secondary_Market-Bond_Equivalent_Yield">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-TBILL Secondary Market-Bond Equivalent Yield</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-TBILL Secondary Market-Bond Equivalent Yield</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-TBILL Secondary Market-Bond Equivalent Yield</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TIBOR-ISDC">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-TIBOR-ISDC</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-TIBOR-ISDC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-TIBOR-ISDC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TIBOR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-TIBOR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-TIBOR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-TIBOR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury-19901-3_00-ICAP">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury-19901-3:00-ICAP</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Treasury-19901-3:00-ICAP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Treasury-19901-3:00-ICAP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-ICAP_BrokerTec">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-ICAP BrokerTec</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-ICAP BrokerTec</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Treasury Rate-ICAP BrokerTec</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-SwapMarker100">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-SwapMarker100</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-SwapMarker100</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Treasury Rate-SwapMarker100</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-SwapMarker99">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-SwapMarker99</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-SwapMarker99</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Treasury Rate-SwapMarker99</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-T19901">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-T19901</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-T19901</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Treasury Rate-T19901</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Treasury_Rate-T500">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Treasury Rate-T500</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD-Treasury Rate-T500</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD-Treasury Rate-T500</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD_Swap_Rate-BCMP1">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD Swap Rate-BCMP1</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD Swap Rate-BCMP1</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD Swap Rate-BCMP1</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD_Treasury_Rate-BCMP1">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD Treasury Rate-BCMP1</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>USD Treasury Rate-BCMP1</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-av:abbreviation>USD Treasury Rate-BCMP1</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;VND-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>VND-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
-		<fibo-fnd-utl-av:abbreviation>VND-Semi-Annual Swap Rate-11:00-BGCANTOR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Dong"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>VND-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;VND-Semi-Annual_Swap_Rate-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>VND-Semi-Annual Swap Rate-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>VND-Semi-Annual Swap Rate-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Dong"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<cmns-av:abbreviation>VND-Semi-Annual Swap Rate-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-DEPOSIT-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-DEPOSIT-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ZAR-DEPOSIT-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+		<cmns-av:abbreviation>ZAR-DEPOSIT-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-DEPOSIT-SAFEX">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-DEPOSIT-SAFEX</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ZAR-DEPOSIT-SAFEX</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+		<cmns-av:abbreviation>ZAR-DEPOSIT-SAFEX</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-JIBAR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-JIBAR</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ZAR-JIBAR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+		<cmns-av:abbreviation>ZAR-JIBAR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-JIBAR-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-JIBAR-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ZAR-JIBAR-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+		<cmns-av:abbreviation>ZAR-JIBAR-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-PRIME-AVERAGE-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-PRIME-AVERAGE-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ZAR-PRIME-AVERAGE-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+		<cmns-av:abbreviation>ZAR-PRIME-AVERAGE-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Prime_Average">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-Prime Average</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ZAR-Prime Average</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+		<cmns-av:abbreviation>ZAR-Prime Average</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2021 ISDA Interest Rate Derivatives Definitions Floating Rate Matrix, as amended through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Quarterly_Swap_Rate-1_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-Quarterly Swap Rate-1:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>ZAR-Quarterly Swap Rate-1:00-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>ZAR-Quarterly Swap Rate-1:00-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Quarterly_Swap_Rate-5_30-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-Quarterly Swap Rate-5:30-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
-		<fibo-fnd-utl-av:abbreviation>ZAR-Quarterly Swap Rate-5:30-TRADITION</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>ZAR-Quarterly Swap Rate-5:30-TRADITION</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Quarterly_Swap_Rate-TRADITION-Reference_Banks">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-Quarterly Swap Rate-TRADITION-Reference Banks</rdfs:label>
-		<fibo-fnd-utl-av:abbreviation>ZAR-Quarterly Swap Rate-TRADITION-Reference Banks</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
+		<cmns-av:abbreviation>ZAR-Quarterly Swap Rate-TRADITION-Reference Banks</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/IND/InterestRates/InterestRates.rdf
+++ b/IND/InterestRates/InterestRates.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -19,10 +20,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -42,23 +43,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/">
 		<rdfs:label>Interest Rates Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the basic types of interest rate which are recognized in the financial markets, and the relationships between these where applicable. These include bank base rates, inter-bank offer rates, overnight rates of interest and the US Federal Funds rate which is widely used as a rate of reference. It also includes the concept of a market rate spread between two interest rates.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
-		<sm:dependsOn rdf:resource="https://www.omg.org/spec/LCC/"/>
-		<sm:fileAbbreviation>fibo-ind-ir-ir</sm:fileAbbreviation>
-		<sm:filename>InterestRates.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
@@ -70,16 +60,20 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20221001/InterestRates/InterestRates/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/InterestRates/InterestRates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/InterestRates/InterestRates.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/InterestRates/InterestRates.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 2 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/InterestRates/InterestRates.rdf version of this ontology was modified per the FIBO 2.0 RFC, including adding support for reference rates from FpML.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/InterestRates/InterestRates.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190901/InterestRates/InterestRates.rdf version of this ontology was modified to add the notion of a classifier for reference rates, so that we can differentiate between kinds of rates and the rates themselves, clean up definitions to conform with ISO 704, merge classes referenced in interest rate publishers to eliminate potential circular references, and eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200201/InterestRates/InterestRates.rdf version of this ontology was modified to replace &apos;financial information publisher&apos; with publisher for simplification purposes.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20221001/InterestRates/InterestRates.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;FloatingInterestRate">
@@ -96,9 +90,9 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ir-ir;ReferenceInterestRate"/>
 		<rdfs:label>base rate</rdfs:label>
 		<skos:definition>basic rate of interest on which the actual rate a bank charges on loans to its customers is calculated</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>BBR</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote>Typically, the bank base rate is a reference rate set by a central bank. Banks that are regulated by a given central bank cannot lend below the base rate to their customers. The bank base rate is determined on an ongoing basis and represents the central bank&apos;s judgement of the price of short-term funds on their interbank market.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>bank base rate</fibo-fnd-utl-av:synonym>
+		<cmns-av:abbreviation>BBR</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>Typically, the bank base rate is a reference rate set by a central bank. Banks that are regulated by a given central bank cannot lend below the base rate to their customers. The bank base rate is determined on an ongoing basis and represents the central bank&apos;s judgement of the price of short-term funds on their interbank market.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>bank base rate</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-ir;EighteenMonths">
@@ -140,7 +134,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ir-ir;InterbankRate"/>
 		<rdfs:label>interbank bid rate</rdfs:label>
 		<skos:definition>interbank rate that is the interest rate at which participating banks are willing to borrow deposits from other banks</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Unlike an interbank offered rate, which is the rate at which banks lend money, an interbank bid rate is the rate at which banks ask to borrow.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Unlike an interbank offered rate, which is the rate at which banks lend money, an interbank bid rate is the rate at which banks ask to borrow.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ir-ir;InterbankMidRate">
@@ -159,7 +153,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ir-ir;ReferenceInterestRate"/>
 		<rdfs:label>interbank rate</rdfs:label>
 		<skos:definition>reference rate that is the rate of interest charged on short-term loans between banks</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Banks borrow and lend money in the interbank market in order to manage liquidity and meet the requirements placed on them. The interest rate charged depends on the availability of money in the market, on prevailing rates and on the specific terms of the contract, such as term length.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Banks borrow and lend money in the interbank market in order to manage liquidity and meet the requirements placed on them. The interest rate charged depends on the availability of money in the market, on prevailing rates and on the specific terms of the contract, such as term length.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ir-ir;InterestRateAuthority">
@@ -221,7 +215,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>interest rate benchmark</rdfs:label>
 		<skos:definition>classifier for regularly updated interest rates that are publicly accessible, typically set by a central bank or group of financial institutions</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Benchmark rates, such as EURIBOR, the Fed Funds rate, and many others including those identified as FpML rates, are used as benchmarks for a variety of debt instruments.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Benchmark rates, such as EURIBOR, the Fed Funds rate, and many others including those identified as FpML rates, are used as benchmarks for a variety of debt instruments.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ir-ir;InterestRateBenchmarkClassificationScheme">
@@ -293,7 +287,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>overnight rate</rdfs:label>
 		<skos:definition>reference rate that is an interest rate at which a depository institution lends funds to another depository institution (short-term), or the interest rate the central bank charges a financial institution to borrow money overnight</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The overnight rate is the lowest available interest rate, and as such, it is only available to the most creditworthy institutions. It is the underlying rate for Overnight Interest Rate Swaps (IOS).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The overnight rate is the lowest available interest rate, and as such, it is only available to the most creditworthy institutions. It is the underlying rate for Overnight Interest Rate Swaps (IOS).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ir-ir;ReferenceInterestRate">
@@ -327,7 +321,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>reference interest rate</rdfs:label>
 		<skos:definition>market rate that is a rate of interest paid by or agreed among some bank or set of banks</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The reference rate is a moving index such as EURIBOR, the prime rate or the rate on benchmark U.S. Treasuries.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The reference rate is a moving index such as EURIBOR, the prime rate or the rate on benchmark U.S. Treasuries.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-ir;SixMonths">
@@ -355,7 +349,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>specific-provider interest rate benchmark</rdfs:label>
 		<skos:definition>interest rate benchmark that is made available by a specific market data provider for reference purposes</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Benchmarks, such as those published by Bloomberg, Thomson-Reuters, and others, are usually quoted as of a specific date and time of day.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Benchmarks, such as those published by Bloomberg, Thomson-Reuters, and others, are usually quoted as of a specific date and time of day.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-ir;TenYears">
@@ -454,7 +448,7 @@
 		<rdfs:label>has tenor</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition>indicates the length of time for which a given rate, such as an interbank rate, exchange rate, other market rate is quoted, or a debt instrument has remaining prior to maturity or expiration</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The tenor of most financial instruments declines over time, while the maturity remains constant. Risk associated with a given asset tends to decline with the reduction of the time remaining to maturity. The tenor of an interest rate swap can also refer to the frequency with which coupon payments are exchanged.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The tenor of most financial instruments declines over time, while the maturity remains constant. Risk associated with a given asset tends to decline with the reduction of the time remaining to maturity. The tenor of an interest rate swap can also refer to the frequency with which coupon payments are exchanged.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/IND/InterestRates/MarketDataProviders.rdf
+++ b/IND/InterestRates/MarketDataProviders.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -33,10 +34,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -70,23 +71,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/">
 		<rdfs:label>Market Data Providers Ontology</rdfs:label>
 		<dct:abstract>This ontology provides reference data for a number of international market data providers, including, but not limited to, those that publish interest rate benchmarks referenced in the published FpML benchmark reference.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-ind-ir-mdp</sm:fileAbbreviation>
-		<sm:filename>MarketDataProviders.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
@@ -111,16 +101,20 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20221001/InterestRates/MarketDataProviders/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/InterestRates/MarketDataProviders/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200301/InterestRates/MarketDataProviders.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200701/InterestRates/MarketDataProviders.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20201201/InterestRates/MarketDataProviders.rdf version of this ontology was revised to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/InterestRates/MarketDataProviders.rdf version of this ontology was revised to clean up the LEI data.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20211201/InterestRates/MarketDataProviders.rdf version of this ontology was revised to reflect the move of market data provider from interest rates in IND to publishers in BE.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/IND/20221001/InterestRates/MarketDataProviders.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-TF1LXM1YNB81WKUH5G19-LEI">
@@ -206,7 +200,7 @@
 		<rdfs:label>European Money Markets Institute (EMMI) benchmark publisher</rdfs:label>
 		<skos:definition>individual representing the European Money Markets Institute (EMMI) functional entity that is an international financial information publisher, responsible for the publication of euro-based benchmarks, including Euribor</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-eufseind;EuropeanMoneyMarketsInstitute"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.emmi-benchmarks.eu/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.emmi-benchmarks.eu/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-mdp;FederalReserveBoardH.15RateResetTimeOfDay">
@@ -216,7 +210,7 @@
 		<fibo-fnd-dt-bd:hasBusinessDayAdjustment rdf:resource="&fibo-fbc-fct-bci;NewYorkFederalReserveBusinessDay"/>
 		<fibo-fnd-dt-fd:hasTimeValue>T16:15:00</fibo-fnd-dt-fd:hasTimeValue>
 		<fibo-fnd-plc-loc:hasBusinessCenter rdf:resource="&fibo-fbc-fct-bci;New_York"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.federalreserve.gov/releases/h15/</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.federalreserve.gov/releases/h15/</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-mdp;FenicsMarketData">
@@ -232,7 +226,7 @@
 		<rdfs:label>ICE benchmark publisher</rdfs:label>
 		<skos:definition>the ICE Benchmark Administration functional entity that is an international financial information publisher, responsible for the publication of ICE LIBOR, ICE Swap Rate, LBMA Gold Price and ISDA SIMM benchmarks</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usfsind;ICEBenchmarkAdministration"/>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.theice.com/index</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.theice.com/index</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-mdp;ReferenceBanks">
@@ -240,7 +234,7 @@
 		<rdf:type rdf:resource="&lcc-lr;Collection"/>
 		<rdfs:label>reference banks</rdfs:label>
 		<skos:definition>market data provider of interest rate benchmarks representing a group of one or more banks that either individually, or in aggregate, provide quoted rates that contribute to the benchmark</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>With respect to LIBOR, for example, the Bank of England will request the principal London office of each of the Reference Banks to provide a quotation of its rate. If at least two such quotations are provided, the rate for such date will be the arithmetic mean of the quotations. If fewer than two quotations are provided as requested, the rate for such date will be the arithmetic mean of the rates quoted by major banks in New York City selected by the Bank, at approximately 11:00 a.m. New York City time for loans in U.S. Dollars to leading European banks for such Interest Period and in an amount approximately equal to the amount requested LIBOR-Reference Banks Loan.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>With respect to LIBOR, for example, the Bank of England will request the principal London office of each of the Reference Banks to provide a quotation of its rate. If at least two such quotations are provided, the rate for such date will be the arithmetic mean of the quotations. If fewer than two quotations are provided as requested, the rate for such date will be the arithmetic mean of the rates quoted by major banks in New York City selected by the Bank, at approximately 11:00 a.m. New York City time for loans in U.S. Dollars to leading European banks for such Interest Period and in an amount approximately equal to the amount requested LIBOR-Reference Banks Loan.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-mdp;ReferenceDealers">

--- a/IND/InterestRates/MetadataINDInterestRates.rdf
+++ b/IND/InterestRates/MetadataINDInterestRates.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ir-mod "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MetadataINDInterestRates/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MetadataINDInterestRates/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ir-mod="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MetadataINDInterestRates/"
@@ -18,40 +19,50 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MetadataINDInterestRates/">
 		<rdfs:label>Metadata about the EDMC-FIBO Indices and Indicators (IND) Interest Rates Module</rdfs:label>
 		<dct:abstract>This module includes ontologies defining concepts for reference interest rates, that is, rates of interest paid on capital by central banks, groups of banks and other lenders, including inter-bank lending rates and rates of certain representative debt instruments.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-02-24T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-ind-ir-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataINDInterestRates.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20200201/InterestRates/MetadataINDInterestRates/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/InterestRates/MetadataINDInterestRates/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-mod;InterestRatesModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO IND Interest Rates Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>interest rates module</rdfs:label>
 		<dct:abstract>This module includes ontologies defining concepts for reference interest rates, that is, rates of interest paid on capital by central banks, groups of banks and other lenders, including inter-bank lending rates and rates of certain representative debt instruments.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-IND-IR</sm:moduleAbbreviation>
+		<dct:title>FIBO IND Interest Rates Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Interest Rates Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/IND/InterestRates/MetadataINDInterestRates.rdf
+++ b/IND/InterestRates/MetadataINDInterestRates.rdf
@@ -38,21 +38,28 @@
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>interest rates module</rdfs:label>
 		<dct:abstract>This module includes ontologies defining concepts for reference interest rates, that is, rates of interest paid on capital by central banks, groups of banks and other lenders, including inter-bank lending rates and rates of certain representative debt instruments.</dct:abstract>
+		<dct:contributor>88 Solutions</dct:contributor>
 		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
 		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>John F. Tierney</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
 		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
 		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>

--- a/IND/MarketIndices/BasketIndices.rdf
+++ b/IND/MarketIndices/BasketIndices.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -24,10 +25,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -52,22 +53,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/">
 		<rdfs:label xml:lang="en">Basket Indices Ontology</rdfs:label>
 		<dct:abstract>This ontology defines market indices as hypothetical portfolios of investment holdings that correspond to some segment of the financial market, whose value is determined by the prices of the underlying holdings. Coverage includes credit indices, security-based indices, economic indicator based indices, and combinations thereof.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-ind-mkt-bas</sm:fileAbbreviation>
-		<sm:filename>BasketIndices.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -85,15 +76,19 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20220801/MarketIndices/BasketIndices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/MarketIndices/BasketIndices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200901/MarketIndices/BasketIndices.rdf version of this ontology was revised to add the details needed to calculate market cap for a capitalization-based weighting function.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/MarketIndices/BasketIndices.rdf version of this ontology was revised to eliminate the restriction on reference index that it has an index value - the restriction should be on the quantity value such that the value refers to the indicator it represents.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210401/MarketIndices/BasketIndices.rdf version of this ontology was revised to loosen the restriction on a reference index to simply reference any weighted basket so that one could include commodity indices, for example.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210801/MarketIndices/BasketIndices.rdf version of this ontology was revised to remedy an illegal property chain (replacing it with an existing non-chained property) in the definition of market capitalization.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20211101/MarketIndices/BasketIndices.rdf version of this ontology was revised to reflect the move of hasTerm from FinancialInstruments to Contracts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20220101/MarketIndices/BasketIndices.rdf version of this ontology was revised to address text processing hygiene issues.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20220801/MarketIndices/BasketIndices.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-ind-mkt-bas;BasketOfCreditRisks">
@@ -107,7 +102,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">basket of credit risks</rdfs:label>
 		<skos:definition xml:lang="en">basket of instruments, legal entities, or a combination thereof collected for the purpose of analyzing risk</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that the risk related to a given constituent may be calculated based on either (1) the overall credit risk associated with the entity or, (2) the combined risk associated with an entity and the specific instrument identified, or (3) risk associated with the instrument on its own. Criteria for constituents is based on sectors (emerging market, financial, sovereign, etc), spread range (investment grade, non-investment grade), or asset type (loan, bond, mortgage-backed, asset-backed), second criteria is based on maturity of protection (2,3,5,7,10 yrs). Markit manages over 2000 CDS indexes, for example.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Note that the risk related to a given constituent may be calculated based on either (1) the overall credit risk associated with the entity or, (2) the combined risk associated with an entity and the specific instrument identified, or (3) risk associated with the instrument on its own. Criteria for constituents is based on sectors (emerging market, financial, sovereign, etc), spread range (investment grade, non-investment grade), or asset type (loan, bond, mortgage-backed, asset-backed), second criteria is based on maturity of protection (2,3,5,7,10 yrs). Markit manages over 2000 CDS indexes, for example.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-mkt-bas;BasketOfEquities">
@@ -155,7 +150,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit index</rdfs:label>
 		<skos:definition xml:lang="en">reference index that is a function of credit events that change the value of an underlying portfolio</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such an index does not necessarily reference a static portfolio, as there may be provisions for replacing defaulted securities on which the index depends.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Such an index does not necessarily reference a static portfolio, as there may be provisions for replacing defaulted securities on which the index depends.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-mkt-bas;CreditIndexConstituent">
@@ -230,7 +225,7 @@
 		<rdfs:label xml:lang="en">market capitalization</rdfs:label>
 		<skos:definition xml:lang="en">expression representing the perceived value of a company as determined by the stock market at a specific point in time</skos:definition>
 		<fibo-fnd-utl-alx:actualExpression xml:lang="en">number of shares outstanding x price per share</fibo-fnd-utl-alx:actualExpression>
-		<fibo-fnd-utl-av:synonym xml:lang="en">market cap</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym xml:lang="en">market cap</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-mkt-bas;ReferenceIndex">
@@ -284,8 +279,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">reference index</rdfs:label>
 		<skos:definition xml:lang="en">measure of change in the value of the contents of a basket over a given period of time</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An index is a function based on a set of structured calculations with respect to a basket of credit risks, financial instruments or other indices over time. Analysis may be computed based on historical values, projected values, etc.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">benchmark</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">An index is a function based on a set of structured calculations with respect to a basket of credit risks, financial instruments or other indices over time. Analysis may be computed based on historical values, projected values, etc.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">benchmark</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-ind-mkt-bas;hasDebtRanking">

--- a/IND/MarketIndices/EquityIndexExampleIndividuals.rdf
+++ b/IND/MarketIndices/EquityIndexExampleIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
@@ -31,10 +32,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/EquityIndexExampleIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
@@ -66,24 +67,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/EquityIndexExampleIndividuals/">
 		<rdfs:label>Equity Index Example Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology provides examples of how to represent common equity indices as identified in the IND-EFT-DEV use case.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2020-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2020-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-ind-mkt-eqind</sm:fileAbbreviation>
-		<sm:filename>EquityIndexExampleIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
@@ -109,9 +98,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20221001/MarketIndices/EquityIndexExampleIndividuals/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/MarketIndices/EquityIndexExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210901/MarketIndices/EquityIndexExampleIndividuals.rdf version of this ontology was modified to reflect the move of market data provider from interest rates in IND to publishers in BE.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20221001/MarketIndices/EquityIndexExampleIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-mkt-eqind;DowJonesIndustrialAverage">
@@ -121,9 +114,9 @@
 		<fibo-be-fct-pub:hasPublisher rdf:resource="&fibo-ind-mkt-eqind;SPDowJonesIndices"/>
 		<fibo-fbc-dae-dbt:isBasedOn rdf:resource="&fibo-ind-mkt-eqind;DowJonesIndustrialAverageBasket"/>
 		<fibo-fnd-utl-alx:isCalculatedViaMethodology xml:lang="en">The index is calculated by adding the price of a single share of each stock together, with equal weighting, and dividing by the Dow Divisor which is constantly adjusted, and is currently around 0.1474.</fibo-fnd-utl-alx:isCalculatedViaMethodology>
-		<fibo-fnd-utl-av:abbreviation>DJIA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:abbreviation>Dow</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en"></fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>DJIA</cmns-av:abbreviation>
+		<cmns-av:abbreviation>Dow</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en"></cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-mkt-eqind;DowJonesIndustrialAverageBasket">
@@ -219,7 +212,7 @@
 		<fibo-fnd-dt-fd:hasDateValue>1932-05-26</fibo-fnd-dt-fd:hasDateValue>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-ind-mkt-eqind;DowJonesIndustrialAverageValue-2020-03-06T120514-0500">
+	<owl:NamedIndividual rdf:about="&fibo-ind-mkt-eqind;DowJonesIndustrialAverageValue-2023-03-06T120514-0500">
 		<rdf:type rdf:resource="&fibo-fnd-utl-alx;NumericIndexValue"/>
 		<rdfs:label>Dow Jones Industrial Average value as of Mar 6, 2020</rdfs:label>
 		<skos:definition>individual representing the value of the DJIA on 6 Mar 2020 at 12:05:14 pm in NYC</skos:definition>
@@ -253,8 +246,8 @@
 		<fibo-be-fct-pub:hasPublisher rdf:resource="&fibo-ind-mkt-eqind;SPDowJonesIndices"/>
 		<fibo-fbc-dae-dbt:isBasedOn rdf:resource="&fibo-ind-mkt-eqind;StandardAndPoors500CompositeIndexBasket"/>
 		<fibo-fnd-utl-alx:isCalculatedViaMethodology xml:lang="en">The components of the S&amp;P 500 are selected by a committee. When considering the eligibility of a new addition, the committee assesses the company&apos;s merit using eight primary criteria: market capitalization, liquidity, domicile, public float, sector classification, financial viability, and length of time publicly traded and stock exchange.</fibo-fnd-utl-alx:isCalculatedViaMethodology>
-		<fibo-fnd-utl-av:abbreviation>S&amp;P 500</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The S&amp;P 500 is a market capitalization-weighted index and the performance of the 10 largest companies in the index account for 21.8 percent of the performance of the index.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation>S&amp;P 500</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">The S&amp;P 500 is a market capitalization-weighted index and the performance of the 10 largest companies in the index account for 21.8 percent of the performance of the index.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-mkt-eqind;StandardAndPoors500CompositeIndexBasket">

--- a/IND/MarketIndices/MetadataINDMarketIndices.rdf
+++ b/IND/MarketIndices/MetadataINDMarketIndices.rdf
@@ -38,21 +38,28 @@
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>market indices module</rdfs:label>
 		<dct:abstract>The market indices module includes ontologies defining a variety of reference indices such as credit and equity indicies. Examples include the Dow Jones Industrial Average (DJIA), Standard and Poors (S&amp;P) 500, exchange-specific indices, and the like.</dct:abstract>
+		<dct:contributor>88 Solutions</dct:contributor>
 		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
 		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
 		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>John F. Tierney</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
 		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
 		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/EquityIndexExampleIndividuals/"/>

--- a/IND/MarketIndices/MetadataINDMarketIndices.rdf
+++ b/IND/MarketIndices/MetadataINDMarketIndices.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-mkt-mod "https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/MetadataINDMarketIndices/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/MetadataINDMarketIndices/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-mkt-mod="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/MetadataINDMarketIndices/"
@@ -18,42 +19,49 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/MetadataINDMarketIndices/">
 		<rdfs:label>Metadata about the EDMC-FIBO Indices and Indicators (IND) Market Indices Module</rdfs:label>
 		<dct:abstract>The market indices module includes ontologies defining a variety of reference indices (benchmarks) such as credit and equity indicies. Examples include the Dow Jones Industrial Average (DJIA), Standard and Poors (S&amp;P) 500, exchange-specific indices, and the like.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-09-28T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-ind-mkt-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataINDMarketIndices.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20200901/MarketIndices/MetadataINDMarketIndices/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/MarketIndices/MetadataINDMarketIndices/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-mkt-mod;MarketIndicesModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Market Indices</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>market indices module</rdfs:label>
 		<dct:abstract>The market indices module includes ontologies defining a variety of reference indices such as credit and equity indicies. Examples include the Dow Jones Industrial Average (DJIA), Standard and Poors (S&amp;P) 500, exchange-specific indices, and the like.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/EquityIndexExampleIndividuals/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bank of New York Mellon</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-IND-MKT</sm:moduleAbbreviation>
+		<dct:title>FIBO IND Market Indices Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Market Indices Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/IND/MetadataIND.rdf
+++ b/IND/MetadataIND.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ei-mod "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/MetadataINDEconomicIndicators/">
@@ -12,10 +13,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ei-mod="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/MetadataINDEconomicIndicators/"
@@ -28,32 +29,53 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/">
 		<rdfs:label>Metadata about the EDMC-FIBO Indices and Indicators (IND) Domain</rdfs:label>
 		<dct:abstract>This ontology provides metadata about the FIBO Indices and Indicators (IND) Domain, which covers market indices and reference rates including economic indicators, foreign exchange, interest rates, and other benchmarks.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-08-09T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-ind-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataIND.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-06T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/MetadataINDEconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/MetadataINDForeignExchange/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/MetadataINDIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MetadataINDInterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/MetadataINDMarketIndices/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20220801/MetadataIND/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/MetadataIND/"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-mod;INDDomain">
-		<rdf:type rdf:resource="&sm;Module"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>Indices and Indicators</rdfs:label>
 		<dct:abstract>The FIBO Indices and Indicators (IND) Domain covers market indices and reference rates including economic indicators, foreign exchange, interest rates, and other benchmarks. The ontologies cover quoted interest rates, economic measures such as employment rates, and quoted indices required to support baskets of securities, including specific kinds of securities in share indices or bond indices, as well as credit indices.</dct:abstract>
+		<dct:contributor>88 Solutions</dct:contributor>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:creator rdf:datatype="&xsd;anyURI">https://wiki.edmcouncil.org/display/IND/FIBO+-+FCT+-+Indices+and+Indicators+Home</dct:creator>
 		<dct:hasPart rdf:resource="&fibo-ind-ei-mod;EconomicIndicatorsModule"/>
 		<dct:hasPart rdf:resource="&fibo-ind-fx-mod;ForeignExchangeModule"/>
@@ -61,39 +83,11 @@
 		<dct:hasPart rdf:resource="&fibo-ind-ir-mod;InterestRatesModule"/>
 		<dct:hasPart rdf:resource="&fibo-ind-mkt-mod;MarketIndicesModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain</dct:title>
-		<sm:contributor>88 Solutions</sm:contributor>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Bloomberg LP</sm:contributor>
-		<sm:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</sm:contributor>
-		<sm:contributor>Census Bureau (US Department of Commerce)</sm:contributor>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Federal Reserve Bank of Kansas City</sm:contributor>
-		<sm:contributor>HP Enterprise / Mphasis</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>John F. Tierney</sm:contributor>
-		<sm:contributor>NoMagic</sm:contributor>
-		<sm:contributor>Nordea Bank AB</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>State Street Bank and Trust</sm:contributor>
-		<sm:contributor>Statistics Canada</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd.</sm:contributor>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:keyword>economic indicator</sm:keyword>
-		<sm:keyword>foreign exchange</sm:keyword>
-		<sm:keyword>interest rate</sm:keyword>
-		<sm:keyword>market index</sm:keyword>
-		<sm:moduleAbbreviation>fibo-ind</sm:moduleAbbreviation>
+		<dct:title>FIBO IND Domain</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>


### PR DESCRIPTION
## Description

The Commons Ontology Library (Commons) from OMG, which was formally released as a standard in December 2022, includes an annotation vocabulary that overlaps with the FIBO annotation vocabulary and eliminates the need for use of Specification Metadata (which is not a standard and subject to change) in FIBO ontologies.

This issue involves (1) eliminating the use of Specification Metadata in all FIBO IND ontologies, which largely impacts ontology header content), and (2) replacing the use of now redundant FIBO annotations with their equivalent in the Commons annotation vocabulary where appropriate.

The mapping pattern for this effort is available in the FIBO Foundations wiki, at https://wiki.edmcouncil.org/display/FND/Replacing+Specification+Metadata+and+some+properties+in+the+FIBO+Annotation+Vocabulary+with+the+Commons+Annotation+Vocabulary.

Fixes: #1871 / IND-123


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


