### PR TITLE
LOAN-166 - Replace specification metadata-related annotations with annotations from the Commons Ontology Library in the FIBO LOAN Domain

### DIFF
--- a/LOAN/AllLOAN.rdf
+++ b/LOAN/AllLOAN.rdf
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-all "https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/">
 	<!ENTITY fibo-loan-ln-app "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/">
 	<!ENTITY fibo-loan-ln-ev "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/">
@@ -13,11 +15,12 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-all="https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/"
 	xmlns:fibo-loan-ln-app="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"
 	xmlns:fibo-loan-ln-ev="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"
@@ -30,26 +33,24 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/">
-		<rdfs:label>All imports ontology for the EDMC-FIBO Loans (LOAN) Domain</rdfs:label>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-14T18:00:00</dct:issued>
+		<rdfs:label>Loans (LOAN) Domain</rdfs:label>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Hypercube Ltd.</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Semantic Arts, Inc.</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:contributor>Elisa Kendall, Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Jennifer Caswell, Office of Financial Research (OFR)</sm:contributor>
-		<sm:contributor>Lynn Calahan, Wells Fargo</sm:contributor>
-		<sm:contributor>Michael Uschold, Semantic Arts</sm:contributor>
-		<sm:contributor>Mike Bennett, Hypercube</sm:contributor>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-loan-all</sm:fileAbbreviation>
-		<sm:filename>AllLOAN.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
+		<dct:title>Financial Industry Business Ontology (FIBO) Loans (LOAN) Domain</dct:title>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"/>
@@ -59,6 +60,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for LOAN is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Loans (LOAN) domains, excluding individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/LOAN/LoansGeneral/LoanApplications.rdf
+++ b/LOAN/LoansGeneral/LoanApplications.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-crt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -25,10 +26,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-crt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -54,21 +55,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/">
 		<rdfs:label xml:lang="en">Loan Applications Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts for the loan application process, along with kinds of loan application and the parties thereto. Another major thread of this ontology is credit risk assessment at the highest level, which includes security agreements, pre-approvals, and credit reports.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-loan-ln-app</sm:fileAbbreviation>
-		<sm:filename>LoanApplications.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
@@ -86,9 +78,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-app;AllBorrowersMonthlyIncome">
@@ -102,7 +97,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>all borrowers&apos; monthly income</rdfs:label>
 		<skos:definition>total monthly qualifying income for all borrowers on the loan</skos:definition>
-		<fibo-fnd-utl-av:usageNote>This should be computed from the income of the individual borrowers.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>This should be computed from the income of the individual borrowers.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-app;AutomaticUnderwriting">
@@ -154,7 +149,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">borrower assessment</rdfs:label>
 		<skos:definition xml:lang="en">assessment report detailing information about the borrower and their credit history that may be relevant to the loan application</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Includes credit rating information. Ongoing assessment reports both good and bad credit rating information. In the US, by regulation, lender is required to respot person&apos;s payment history on a monthly basis. This is the basis on which peope&apos;s score is changed. So the lender&apos;s reporting to the credit bureau may affect that person&apos;s credit rating. this may give rise to credit disputes. Also there is a scenario where the borrower may contact the lender and ask for some change. For student loans, they can apply for a deferment payment based on change in circumstances e.g. if losing job, or becoming disabled, then there are specific programs which they can apply for. can defer paymen for a time, and if proven eligible (e.g. also if in military, being deployed), then if they subbut the relevant document, they approve and change their repayment term, perhaps temporarily and then revert to the previously agreed terms. This results from the borrower contacting the lender.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Includes credit rating information. Ongoing assessment reports both good and bad credit rating information. In the US, by regulation, lender is required to respot person&apos;s payment history on a monthly basis. This is the basis on which peope&apos;s score is changed. So the lender&apos;s reporting to the credit bureau may affect that person&apos;s credit rating. this may give rise to credit disputes. Also there is a scenario where the borrower may contact the lender and ask for some change. For student loans, they can apply for a deferment payment based on change in circumstances e.g. if losing job, or becoming disabled, then there are specific programs which they can apply for. can defer paymen for a time, and if proven eligible (e.g. also if in military, being deployed), then if they subbut the relevant document, they approve and change their repayment term, perhaps temporarily and then revert to the previously agreed terms. This results from the borrower contacting the lender.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-app;BorrowerMonthlyIncome">
@@ -241,7 +236,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>credit risk assessment</rdfs:label>
 		<skos:definition>risk assessment that focuses on determining the likelihood of a potential borrower repaying a loan</skos:definition>
-		<fibo-fnd-utl-av:usageNote>If the risk assessment is based on one of the automated underwriting sytems, then the underwriting automation category is &apos;automated&apos;. This dependency could be automated (as it were).</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>If the risk assessment is based on one of the automated underwriting sytems, then the underwriting automation category is &apos;automated&apos;. This dependency could be automated (as it were).</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-app;DenialReason-CreditApplicationIncomplete">
@@ -408,8 +403,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>pre-approval contract</rdfs:label>
 		<skos:definition>written commitment to lend when specified conditions are met, such as finding suitable property, and unchanged creditworthiness</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A commitment from a lender to a borrower to extend a home purchase loan up to a certain amount, and subject to certain non-credit related conditions.  This commitment is entered into after a comprehensive analysis of the credit worthiness of the borrower is carried out.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>This may also include limits on the region where to purchase.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A commitment from a lender to a borrower to extend a home purchase loan up to a certain amount, and subject to certain non-credit related conditions.  This commitment is entered into after a comprehensive analysis of the credit worthiness of the borrower is carried out.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This may also include limits on the region where to purchase.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-app;PreApprovalRequest">
@@ -428,7 +423,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>pre-approval request</rdfs:label>
 		<skos:definition>request from a potential borrower that a lender commit to pre-approving the borrower for a loan of up to a specified amount of money</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This may also include limits on the region where to purchase.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This may also include limits on the region where to purchase.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-app;PublicRecord">
@@ -455,7 +450,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>public record</rdfs:label>
 		<skos:definition>record about an action involving a party that is publicly available from a court or other government agency</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This can include court actions such as bankruptcy and foreclosure, as well as liens and other events that have been recorded.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This can include court actions such as bankruptcy and foreclosure, as well as liens and other events that have been recorded.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-app;PublicRecordCategory">
@@ -508,7 +503,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;PercentageMonetaryAmount"/>
 		<rdfs:label>total debt expense ratio</rdfs:label>
 		<skos:definition>ratio of all monthly debt payments of all borrowers, including proposed expenses, with respect to the income of the borrowers as relied upon to make a credit decision</skos:definition>
-		<fibo-fnd-utl-av:synonym>back end ratio</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>back end ratio</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-app;UnderwritingAutomation">
@@ -521,7 +516,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
 		<rdfs:label>underwriting decision</rdfs:label>
 		<skos:definition>classifier providing a loan approval recommendation determined either manually or by an automated underwriting system</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-app;UnderwritingDecision-Approve">
@@ -614,7 +609,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-dae-dbt;isBasedOn"/>
 		<rdfs:label xml:lang="en">uses factor</rdfs:label>
 		<skos:definition xml:lang="en">relates e.g. a risk assessment to something used as a factor to make the assessment</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>There is intentionally no range for this property, so as not to limit what can be used as a factor. Often it will be a measure such as borrower monthly income. Thus, having a class called Factor seems unhelpful.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>There is intentionally no range for this property, so as not to limit what can be used as a factor. Often it will be a measure such as borrower monthly income. Thus, having a class called Factor seems unhelpful.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/LOAN/LoansGeneral/LoanEvents.rdf
+++ b/LOAN/LoansGeneral/LoanEvents.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -19,10 +20,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -42,17 +43,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/">
 		<rdfs:label xml:lang="en">LoanEvents</rdfs:label>
 		<dct:abstract>This ontology defines a wide range of events relating to loans. These include legal proceedings, prepayments, and so forth.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2015-2021 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2021 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-ln-ev</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -67,8 +63,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ev;CollateralValuation">
@@ -158,7 +157,7 @@
 		<rdfs:domain rdf:resource="&fibo-loan-ln-ev;LoanDefaultProceeding"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">amount before the application of sale proceeds and recoveries</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Undefined PoC SDM Notes: Default or Foreclosure amount - Total default amount before the application of sale proceeds and recoveries.&amp;nbsp; (AO 146, RR 135) Loan Default Proceeding_cd= (1) Default amount &lt;/p&gt; &lt;p&gt; Sale price - Price achieved on sale of property ( AO 147, RR 137 )&amp;nbsp; Loan Default Proceeding_cd= (2) Property Sale &lt;/p&gt; &lt;p&gt; Loss on Sale&amp;nbsp;&amp;nbsp; Total loss net of fees, accrued interest etc. after application of sale proceeds (excluding prepayment charge if subordinate to principal recoveries). Show any gain on sale as a negative number (AO 148, RR 138 )&amp;nbsp; Loan Default Proceeding_cd = (3) Loss amount &lt;/p&gt; &lt;p&gt; Cumulative Reocveries - ony relevant for cases with losses&amp;nbsp; ( AO 149, RR 139 )&amp;nbsp; Loan Default Proceeding_cd =&amp;nbsp; (4) Recoveries &lt;/p&gt; &lt;p&gt; Professional Negligence Recoveries - Any amounts received in settlement or as a result of professional negligence claims against surveyors, solicitors etc. net of any fees / costs ( AO 150, RR 140 )&amp;nbsp; Loan Default Proceeding_cd = (5) Professional Negligence &lt;/p&gt;&lt;br /&gt;</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Undefined PoC SDM Notes: Default or Foreclosure amount - Total default amount before the application of sale proceeds and recoveries.&amp;nbsp; (AO 146, RR 135) Loan Default Proceeding_cd= (1) Default amount &lt;/p&gt; &lt;p&gt; Sale price - Price achieved on sale of property ( AO 147, RR 137 )&amp;nbsp; Loan Default Proceeding_cd= (2) Property Sale &lt;/p&gt; &lt;p&gt; Loss on Sale&amp;nbsp;&amp;nbsp; Total loss net of fees, accrued interest etc. after application of sale proceeds (excluding prepayment charge if subordinate to principal recoveries). Show any gain on sale as a negative number (AO 148, RR 138 )&amp;nbsp; Loan Default Proceeding_cd = (3) Loss amount &lt;/p&gt; &lt;p&gt; Cumulative Reocveries - ony relevant for cases with losses&amp;nbsp; ( AO 149, RR 139 )&amp;nbsp; Loan Default Proceeding_cd =&amp;nbsp; (4) Recoveries &lt;/p&gt; &lt;p&gt; Professional Negligence Recoveries - Any amounts received in settlement or as a result of professional negligence claims against surveyors, solicitors etc. net of any fees / costs ( AO 150, RR 140 )&amp;nbsp; Loan Default Proceeding_cd = (5) Professional Negligence &lt;/p&gt;&lt;br /&gt;</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-ln-ev;hasDisbursementDate">

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-dae-gty "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
@@ -28,10 +29,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-dae-gty="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"
@@ -60,21 +61,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 		<rdfs:label>Loans Ontology</rdfs:label>
 		<dct:abstract>This ontology is the top-level, and most fundamental ontology for the LOAN module, extending the Debt ontology to define concepts common to all loans. It includes the primary obligations to fund the loan and to pay it back according to payment schedules. Kinds of loans covered in this ontology include open and closed end, secured and unsecured.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-loan-ln-ln</sm:fileAbbreviation>
-		<sm:filename>Loans.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -96,10 +88,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/LoansGeneral/Loans/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230201/LoansGeneral/Loans/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/LoansGeneral/Loans.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestPaymentTerms">
@@ -133,7 +129,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 		<rdfs:label>closed-end credit</rdfs:label>
 		<skos:definition>credit agreement in which the loan principal cannot be increased after funds are dispersed in full when the loan closes</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The loan may require regular payments that pay down principal periodically, or it may require the full payment of principal at maturity.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The loan may require regular payments that pay down principal periodically, or it may require the full payment of principal at maturity.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;CollateralizedLoan">
@@ -152,17 +148,17 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">collateralized loan</rdfs:label>
 		<skos:definition xml:lang="en">secured loan that is secured with cash or other acceptable collateral (real property, securities or other assets) provided by the borrower as specified in the collateral agreement</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;Comaker">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
 		<rdfs:label>co-maker</rdfs:label>
 		<skos:definition>party that signs a borrower&apos;s promissory note, providing additional security and potentially improving the quality of the debt</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Differences between a co-maker and co-borrower include: (1) a co-maker is not listed on the title of the asset to which the loan applies, (2) a co-maker does not have any legal ownership rights to the asset, and (3) the co-maker does not make regular payments on the loan unless the primary borrower(s) fails to do so.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The co-maker&apos;s liability is similar to that of an endorser or guarantor, but with additional risk/exposure, as they can be compelled to honor the debt much sooner and regardless of whether certain conditions are met.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>comaker</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>cosigner</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Differences between a co-maker and co-borrower include: (1) a co-maker is not listed on the title of the asset to which the loan applies, (2) a co-maker does not have any legal ownership rights to the asset, and (3) the co-maker does not make regular payments on the loan unless the primary borrower(s) fails to do so.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The co-maker&apos;s liability is similar to that of an endorser or guarantor, but with additional risk/exposure, as they can be compelled to honor the debt much sooner and regardless of whether certain conditions are met.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>comaker</cmns-av:synonym>
+		<cmns-av:synonym>cosigner</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;CombinedLoanToValueRatio">
@@ -193,16 +189,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label>combined loan-to-value ratio</rdfs:label>
 		<skos:definition>ratio of the total amount of debt that is secured by the asset(s) and the appraised value of the asset(s) securing the financing</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is particularly important for secondary loans, or for refinancing that combines outstanding loans against a given asset.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is particularly important for secondary loans, or for refinancing that combines outstanding loans against a given asset.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-ln;FeeSimpleOwnershipInterest">
 		<rdf:type rdf:resource="&fibo-loan-ln-ln;OwnershipInterest"/>
 		<rdfs:label>fee-simple ownership interest</rdfs:label>
 		<skos:definition>classification indicating the most common type of ownership, covering an indefinite ownership period and the freedom to transfer said ownership as desired</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Fee simple is the term used to represent the maximum ownership interest in real property that is allowed under the law. It can be referred to as &apos;complete ownership&apos;.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The asset may still be subject to government regulations such as property taxes, and the owner can place voluntary encumbrances on the real estate including its use as collateral for a loan. In the case of a mortgage, fee simple can be contrasted with lease ownership, in which case the owners have complete access to the land, but they do not own it. Owners of single-family residences typically have fee simple ownership, but condo and many townhouse owners do not, as they own their individual unit but not the land on which the development is built.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>complete ownership</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>Fee simple is the term used to represent the maximum ownership interest in real property that is allowed under the law. It can be referred to as &apos;complete ownership&apos;.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The asset may still be subject to government regulations such as property taxes, and the owner can place voluntary encumbrances on the real estate including its use as collateral for a loan. In the case of a mortgage, fee simple can be contrasted with lease ownership, in which case the owners have complete access to the land, but they do not own it. Owners of single-family residences typically have fee simple ownership, but condo and many townhouse owners do not, as they own their individual unit but not the land on which the development is built.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>complete ownership</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-ln;FractionalOwnershipInterest">
@@ -227,8 +223,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">guaranteed loan</rdfs:label>
 		<skos:definition xml:lang="en">loan that is secured with respect to repayment of principal and interest by guaranty</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A loan guarantee is a promise by one party to assume the debt obligation of a borrower if that borrower defaults. A guarantee can be limited or unlimited, making the guarantor liable for only a portion or all of the debt.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the U.S., the term &apos;guaranteed loan&apos; typically refers to a loan that is backed by a federal agency, such as the Department of Veterans Affairs or the Small Business Administration. Student loans may be guaranteed by the Student Loan Marketing Association.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">A loan guarantee is a promise by one party to assume the debt obligation of a borrower if that borrower defaults. A guarantee can be limited or unlimited, making the guarantor liable for only a portion or all of the debt.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">In the U.S., the term &apos;guaranteed loan&apos; typically refers to a loan that is backed by a federal agency, such as the Department of Veterans Affairs or the Small Business Administration. Student loans may be guaranteed by the Student Loan Marketing Association.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;IndividualPaymentTransaction">
@@ -442,7 +438,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>loan-to-value ratio</rdfs:label>
 		<skos:definition>ratio, expressed as a percentage, between the principal amount of the loan and the appraised value of the asset securing the financing</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>LTV</fibo-fnd-utl-av:abbreviation>
+		<cmns-av:abbreviation>LTV</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;OpenEndCredit">
@@ -458,9 +454,9 @@
 		<owl:disjointWith rdf:resource="&fibo-loan-ln-ln;ClosedEndCredit"/>
 		<skos:definition>credit agreement that may be extended up to an agreed credit limit and paid down at any time within the period of the line, if any, and on which interest is charged only on the outstanding balance</skos:definition>
 		<skos:example>Credit card and overdraft lines of credit are among the most widely used forms of open-end credit.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote>There is a credit limit most of the time, with exceptions including reverse mortgages with tenure payment. The borrower has the option of paying off the outstanding balance, without penalty, or making installment payments.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym>charge account credit</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym>revolving credit</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote>There is a credit limit most of the time, with exceptions including reverse mortgages with tenure payment. The borrower has the option of paying off the outstanding balance, without penalty, or making installment payments.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>charge account credit</cmns-av:synonym>
+		<cmns-av:synonym>revolving credit</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;OwnershipInterest">
@@ -473,7 +469,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>ownership interest</rdfs:label>
 		<skos:definition>classifier indicating the nature of the applicant&apos;s or borrower&apos;s ownership or leasehold interest in an asset used as collateral for the loan</skos:definition>
-		<fibo-fnd-utl-av:usageNote>Note that there are a number of variations for ownership interest that represent &apos;corner cases&apos;, including jurisdiction-specific variants, which can be added as needed for specific applications.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>Note that there are a number of variations for ownership interest that represent &apos;corner cases&apos;, including jurisdiction-specific variants, which can be added as needed for specific applications.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;PaymentHistory">
@@ -504,14 +500,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">pre-payment terms</rdfs:label>
 		<skos:definition xml:lang="en">principal repayment terms related to payment of the loan prior to maturity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Prepayment may or may not involve refinancing with the same lender. Prepayment terms include any prepayment penalty period, penalty amount and whether or not there is provision for waiver of the penalty, and any conditions related to making additional payments or payments over and above the expected installment payment over the lifetime of the loan.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Prepayment may or may not involve refinancing with the same lender. Prepayment terms include any prepayment penalty period, penalty amount and whether or not there is provision for waiver of the penalty, and any conditions related to making additional payments or payments over and above the expected installment payment over the lifetime of the loan.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-ln;PrimaryLienPosition">
 		<rdf:type rdf:resource="&fibo-loan-ln-ln;LenderLienPosition"/>
 		<rdfs:label>primary lien position</rdfs:label>
 		<skos:definition xml:lang="en">first position in the order of seniority in which the law recognizes lenders&apos; claims against a property</skos:definition>
-		<fibo-fnd-utl-av:synonym>primary lien priority</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>primary lien priority</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;SecuredLoan">
@@ -562,7 +558,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>security agreement</rdfs:label>
 		<skos:definition>agreement between parties that contains information about their relative duties and rights regarding the disposition of a specified asset used as collateral</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>ISO 20022</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 20022</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;Servicer">
@@ -570,7 +566,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
 		<rdfs:label>servicer</rdfs:label>
 		<skos:definition>party that collects principal and interest payments on behalf of the lender</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In cases where a loan has been securitized, the servicer is also responsible for forwarding payments to investors, filing reports with credit-rating agencies and investors, and so forth.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In cases where a loan has been securitized, the servicer is also responsible for forwarding payments to investors, filing reports with credit-rating agencies and investors, and so forth.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-ln;SubordinateLienPosition">
@@ -603,7 +599,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 		<rdfs:label>has cost</rdfs:label>
 		<skos:definition>has amount payable for principal, interest, fees or other expenses</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This can entail adding up other prices and/or fees (e.g. 4 units * a unit price)</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This can entail adding up other prices and/or fees (e.g. 4 units * a unit price)</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-ln-ln;hasCreditLimit">
@@ -616,7 +612,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
 		<rdfs:label>has first rate change term</rdfs:label>
 		<skos:definition>specifies a period of time in months after origination during which the interest rate cannot change</skos:definition>
-		<fibo-fnd-utl-av:usageNote>This normally applies to a variable rate loan. It may also apply to step up/step down loans that are fixed rate but whose rate changes after a pre-determined number of months.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>This normally applies to a variable rate loan. It may also apply to step up/step down loans that are fixed rate but whose rate changes after a pre-determined number of months.</cmns-av:usageNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-ln-ln;hasIndividualPayment">
@@ -651,7 +647,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
 		<rdfs:label>has pre-payment penalty term</rdfs:label>
 		<skos:definition>relates a loan to a period of time in months after which there is no prepayment penalty</skos:definition>
-		<fibo-fnd-utl-av:usageNote>A value of zero means no prepayment penalty; this avoids need for a separate boolean property about whether there is a prepayment penalty</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>A value of zero means no prepayment penalty; this avoids need for a separate boolean property about whether there is a prepayment penalty</cmns-av:usageNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-ln-ln;hasPrincipalAmount">
@@ -673,14 +669,14 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-loan-ln-ln;hasCost"/>
 		<rdfs:label>has total closing costs</rdfs:label>
 		<skos:definition>indicates the total the amount paid at the closing of a real estate transaction, i.e., at the time when the title to the property is conveyed (transferred) to the buyer</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Closing costs may be incurred by either the buyer or the seller, and may include fees paid by either or both parties for the preparation and recording of documents, title service costs, such as for title search and insurance (typically paid by the seller, depending on the jurisdiction), other recording costs, other document or transaction stamps or taxes, brokerage commissions, survey, appraisal, inspection and other such fees, home warranties, private mortgage insurance (PMI), and so forth.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Closing costs may be incurred by either the buyer or the seller, and may include fees paid by either or both parties for the preparation and recording of documents, title service costs, such as for title search and insurance (typically paid by the seller, depending on the jurisdiction), other recording costs, other document or transaction stamps or taxes, brokerage commissions, survey, appraisal, inspection and other such fees, home warranties, private mortgage insurance (PMI), and so forth.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-ln-ln;hasTotalPointsAndFees">
 		<rdfs:subPropertyOf rdf:resource="&fibo-loan-ln-ln;hasCost"/>
 		<rdfs:label>has total points and fees</rdfs:label>
 		<skos:definition>indicates a form of pre-paid interest, charged by the lender as an alternative to charging a higher rate of interest on the mortgage loan</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>One point equals one percent of the loan principal, and usually reduces the interest rate by 1/8 percent (0.125)</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>One point equals one percent of the loan principal, and usually reduces the interest rate by 1/8 percent (0.125)</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-loan-ln-ln;isAssumable">

--- a/LOAN/LoansGeneral/LoansRegulatory.rdf
+++ b/LOAN/LoansGeneral/LoansRegulatory.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -16,10 +17,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -36,16 +37,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/">
 		<rdfs:label xml:lang="en">LoansRegulatory</rdfs:label>
 		<dct:abstract>This ontology contains concepts relating to regulatory requirements around loans, including disclosure rights and a small number of regulation-specific concepts. These include definitions of rights conferred on borrowers under consumer protection law, rights to equal treatment and the like.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-ln-reg</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
@@ -56,8 +53,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;BorrowerDataProtectionRequirement">
@@ -91,7 +90,7 @@
 	<owl:Class rdf:about="&fibo-loan-ln-reg;BorrowerRight">
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-reg;ConsumerRight"/>
 		<rdfs:label xml:lang="en">borrower right</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">example the right not to have a home reposessed. Example: RESPA Real Estate Setetlement Procedures Act (promulgated by HUD to govern real estate practices and disclosures Provisions of good faith estimate (GFE) of loan settlement costs. GFE would be when you apply - you get a GFE back from the lender telling you what it would cost if you close the loan.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">example the right not to have a home reposessed. Example: RESPA Real Estate Setetlement Procedures Act (promulgated by HUD to govern real estate practices and disclosures Provisions of good faith estimate (GFE) of loan settlement costs. GFE would be when you apply - you get a GFE back from the lender telling you what it would cost if you close the loan.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;ConsumerCreditEqualTreatmentRequirement">
@@ -132,14 +131,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">consumer credit requirement</rdfs:label>
 		<skos:definition xml:lang="en">Requirement set out on the lender about how they must treat the appliction to a loan</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">e..g being able to see and challenge information about them held by the credit agency or lender. e.g. can&apos;t publish opinions only facts, etc.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">e..g being able to see and challenge information about them held by the credit agency or lender. e.g. can&apos;t publish opinions only facts, etc.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;ConsumerProtectionAgency">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-rga;RegulatoryAgency"/>
 		<rdfs:label xml:lang="en">consumer protection agency</rdfs:label>
 		<skos:definition xml:lang="en">Some agency tasked with regulating consumer protection in some jurisdiction.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that this is consumer protection, and not other regulatory requirements such as systemic risk. an instance of this is the Consumer Financial Protection Bureau in the US. This is wide rthan just lending, but also covers lender rights.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Note that this is consumer protection, and not other regulatory requirements such as systemic risk. an instance of this is the Consumer Financial Protection Bureau in the US. This is wide rthan just lending, but also covers lender rights.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;ConsumerProtectionLaw">
@@ -180,7 +179,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-reg;LoanProductRepresentations"/>
 		<rdfs:label xml:lang="en">good faith estimate</rdfs:label>
 		<skos:definition xml:lang="en">GFE - representation by the lender on the costs and implications of settlement (early termination) of the loan.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Provided in a timely way. Also associated with cooling off periods</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Provided in a timely way. Also associated with cooling off periods</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;InformationRight">
@@ -199,7 +198,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Representation"/>
 		<rdfs:label xml:lang="en">loan product representations</rdfs:label>
 		<skos:definition xml:lang="en">Representations about the loan product and the appropriateness of this for the borrower.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Covers responsible lending, consumer credit laws. See Aus Consumer Creti; US Reg Z and so on. In detail, this will include things like the representations about rates of interest, what people can or can&apos;t say when offering a product to a customer. Reg Z: Promoting the informed use of consumer credit by .. implictions and cost Also right to cancel a lien on a consumer&apos;s dwelling.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Covers responsible lending, consumer credit laws. See Aus Consumer Creti; US Reg Z and so on. In detail, this will include things like the representations about rates of interest, what people can or can&apos;t say when offering a product to a customer. Reg Z: Promoting the informed use of consumer credit by .. implictions and cost Also right to cancel a lien on a consumer&apos;s dwelling.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;LoanRegulatoryRequirement">
@@ -224,7 +223,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">loan regulatory requirement</rdfs:label>
 		<skos:definition xml:lang="en">A regulatory requirement defined in regulations by a comsumer credit act or other legislation.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Presence of a loan regulatory requirement associated with a loan indicates that the loan is regulated by the UK Consumer credit act or the equivalent in continental Europe.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Presence of a loan regulatory requirement associated with a loan indicates that the loan is regulated by the UK Consumer credit act or the equivalent in continental Europe.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;ProductDisclosureRequirement">
@@ -243,14 +242,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">product disclosure requirement</rdfs:label>
 		<skos:definition xml:lang="en">A requirement governing what representations can be made about a product, as it affects the consumer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are also rules which encompass limitations on how you might attach loans and liens to principle dwellings, e.g. when or whether you can foreclose on someone&apos;s principal dwelling with impunity; what rights the consumer has - this last will be a separate kind of regulation.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">There are also rules which encompass limitations on how you might attach loans and liens to principle dwellings, e.g. when or whether you can foreclose on someone&apos;s principal dwelling with impunity; what rights the consumer has - this last will be a separate kind of regulation.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;ProductDisclosureRight">
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-reg;InformationRight"/>
 		<rdfs:label xml:lang="en">product disclosure right</rdfs:label>
 		<skos:definition xml:lang="en">The right to information about products at the point of purchasing these.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Includes retail, insurance and financial product disclosures</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Includes retail, insurance and financial product disclosures</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;RegB">
@@ -258,14 +257,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-reg;DisclosureRequirement"/>
 		<rdfs:label xml:lang="en">reg b</rdfs:label>
 		<skos:definition xml:lang="en">US regulation concerning &quot;Equal credit opportunity act&quot; Electronic delivery of disclosures</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Timing and delivery of electronic disclosures. Applications must have equal opportunity to follow. All applications for credit to be evaluated equally and not discriminiated against. This is disclosures about the Borrower.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Timing and delivery of electronic disclosures. Applications must have equal opportunity to follow. All applications for credit to be evaluated equally and not discriminiated against. This is disclosures about the Borrower.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;RegZ">
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-reg;ProductDisclosureRequirement"/>
 		<rdfs:label xml:lang="en">reg z</rdfs:label>
 		<skos:definition xml:lang="en">US Fed regulation &quot;Truth in Lending Act&quot; uniform standards for electronic delivery of disclosures</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Creditors may delivery disclosures electronic if they obtain consumer&apos;s consent. Also relate to international, and foreign languages. This is disclosures about the Product.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Creditors may delivery disclosures electronic if they obtain consumer&apos;s consent. Also relate to international, and foreign languages. This is disclosures about the Product.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;RightOfCreditRecordCorrection">

--- a/LOAN/LoansGeneral/MetadataLOANLoansGeneral.rdf
+++ b/LOAN/LoansGeneral/MetadataLOANLoansGeneral.rdf
@@ -1,61 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-mod "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-mod="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) Loans General Module</rdfs:label>
 		<dct:abstract>This module contains ontologies defining concepts that apply to most loans, including but not limited to applications.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-10T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-ln-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataLOANLoansGeneral.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/LoansGeneral/MetadataLOANLoansGeneral/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230201/LoansGeneral/MetadataLOANLoansGeneral/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-mod;LoansGeneralModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>FIBO LOAN Loans General Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>loans general module</rdfs:label>
 		<dct:abstract>This module contains ontologies defining concepts that apply to most loans, including but not limited to applications.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Hypercube Ltd.</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Semantic Arts, Inc.</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:title>FIBO LOAN - Loans General Module</dct:title>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>Hypercube Ltd.</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Semantic Arts, Inc.</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>fibo-loan-ln</sm:moduleAbbreviation>
+		<dct:title>FIBO LOAN Loans General Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Loans (LOAN) Loans General Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/LoansSpecific/CommercialLoans.rdf
+++ b/LOAN/LoansSpecific/CommercialLoans.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -12,10 +13,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -28,23 +29,21 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/">
-		<rdfs:label xml:lang="en">CommercialLoans</rdfs:label>
+		<rdfs:label xml:lang="en">Commercial Loans Ontology</rdfs:label>
 		<dct:abstract>Commercial loans are loans where the loan purpose is some commercial purpose. Note that these are distinguished by the loan purpose not by the borrower type - borrowers may be corporate or personal, though in the majority of cases they would also be corporate loans that is loans with a corporate borrower.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-spc-com</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-com;CommercialLoan">
@@ -62,8 +61,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">commercial loan</rdfs:label>
 		<skos:definition xml:lang="en">loan extended to a corporation, commercial enterprise, joint venture, or other organization as opposed to a consumer</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such loans may include those that provide working capital, are used to finance the purchase of equipment and/or materials, for facilities and/or improvement of facilities, and so forth, and are typically secured.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">commercial and industrial loan</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">Such loans may include those that provide working capital, are used to finance the purchase of equipment and/or materials, for facilities and/or improvement of facilities, and so forth, and are typically secured.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">commercial and industrial loan</cmns-av:synonym>
 	</owl:Class>
 
 </rdf:RDF>

--- a/LOAN/LoansSpecific/ConsumerLoans.rdf
+++ b/LOAN/LoansSpecific/ConsumerLoans.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -11,10 +12,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -26,23 +27,21 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/">
 		<rdfs:label xml:lang="en">Consumer Loans Ontology</rdfs:label>
 		<dct:abstract>The consumer loans ontology defines concepts specific to loans that are offered only to consumers rather than to organization, primarily for personal, family, or household purposes.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-spc-cns</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-cns;AutoLoan">
@@ -56,7 +55,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">auto loan</rdfs:label>
 		<skos:definition xml:lang="en">collateralized, simple-interest loan that is repaid in monthly installments over a period of typically three to five years, for the purpose of purchasing a vehicle</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Many lenders will only approve auto loans for vehicles (i.e., cars, trucks) that are a certain age (typically 5 years or less) due to depreciation of the value of the vehicle. Because an auto loan is a &apos;secured&apos; type of loan, the vehicle that is being financed is used as collateral (i.e. if the borrower fails to repay the loan, the vehicle may be seized by the lender).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Many lenders will only approve auto loans for vehicles (i.e., cars, trucks) that are a certain age (typically 5 years or less) due to depreciation of the value of the vehicle. Because an auto loan is a &apos;secured&apos; type of loan, the vehicle that is being financed is used as collateral (i.e. if the borrower fails to repay the loan, the vehicle may be seized by the lender).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-cns;ConsumerLoan">
@@ -88,9 +87,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">home equity line of credit</rdfs:label>
 		<skos:definition xml:lang="en">line of credit secured by equity value in a borrower&apos;s home or other property</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">HELOC</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Home equity loans allow the borrower to borrow against the difference between the fair market value of the property, as determined by an appraisal, and the amount of any outstanding debt on that property, which is typically a first mortgage. Common practice is to set the maximum amount that can be borrowed of up to 80 percent of the fair market value less any outstanding debt.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is both a revolving line of credit and a mortgage, in that the collateral for the revolving line of credit in this case is some real estate, which is a defining fact for a mortgage. This form of product can either have an increase or decrease in principal, according to the actions of the borrower. These may also be used in the formation of asset pools for asset backed securities.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">HELOC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">Home equity loans allow the borrower to borrow against the difference between the fair market value of the property, as determined by an appraisal, and the amount of any outstanding debt on that property, which is typically a first mortgage. Common practice is to set the maximum amount that can be borrowed of up to 80 percent of the fair market value less any outstanding debt.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is both a revolving line of credit and a mortgage, in that the collateral for the revolving line of credit in this case is some real estate, which is a defining fact for a mortgage. This form of product can either have an increase or decrease in principal, according to the actions of the borrower. These may also be used in the formation of asset pools for asset backed securities.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/LOAN/LoansSpecific/LoanProducts.rdf
+++ b/LOAN/LoansSpecific/LoanProducts.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
@@ -25,10 +26,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
@@ -54,16 +55,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/">
-		<rdfs:label xml:lang="en">LoanProducts</rdfs:label>
+		<rdfs:label xml:lang="en">Loan Products Ontology</rdfs:label>
 		<dct:abstract>This ontology describes loan and mortgage loan products. A product as defined here is something marketed and offered for sale, in this case a loan, such that when a customer takes on the product, they become signatories to a corresponding loan contract. A loan product in this sense is a contractual , off-the-shelf product with terms corresponding to those in the actual contract when it is signed.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2021 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-spc-prod</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -81,10 +78,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;Loan">
@@ -211,7 +210,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-loan-spc-prod;LoanMarketCategory-SmallBusiness">
 		<rdf:type rdf:resource="&fibo-loan-spc-prod;LoanMarketCategory"/>
 		<rdfs:label>small business loan</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote>This is related to the mortgage loan purpose: &apos;business or commercial&apos;.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is related to the mortgage loan purpose: &apos;business or commercial&apos;.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-prod;LoanProduct">

--- a/LOAN/LoansSpecific/MarineFinance.rdf
+++ b/LOAN/LoansSpecific/MarineFinance.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -9,10 +10,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MarineFinance/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -22,21 +23,19 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MarineFinance/">
 		<rdfs:label xml:lang="en">Marine Finance Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts specific to marine finance, which involves financing vessel acquisitions for the spot market, time charters or bareboat charters, as well as the construction of work boats, and to finance the acquisition of vessels for scrapping.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-spc-mar</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MarineFinance/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-mar;MarineFinancing">

--- a/LOAN/LoansSpecific/MetadataLOANLoansSpecific.rdf
+++ b/LOAN/LoansSpecific/MetadataLOANLoansSpecific.rdf
@@ -1,60 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-spc-mod "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MetadataLOANLoansSpecific/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MetadataLOANLoansSpecific/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-spc-mod="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MetadataLOANLoansSpecific/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MetadataLOANLoansSpecific/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) Loans - Specific Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of concepts descriptive of a range of loans, excluding real estate, including commercial and consumer, loans differentiated by purpose, and their differentiating characteristics.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-10T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-spc-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataLOANLoansSpecific.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/LoansSpecific/MetadataLOANLoansSpecific/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230201/LoansSpecific/MetadataLOANLoansSpecific/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-spc-mod;LoansSpecificModule">
-		<rdf:type rdf:resource="&sm;Module"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>Loans - Specific Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of concepts descriptive of a range of loans, excluding real estate, including commercial and consumer, loans differentiated by purpose, and their differentiating characteristics.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Hypercube Ltd.</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Semantic Arts, Inc.</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MarineFinance/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/StudentLoans/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:title>FIBO LOAN - Loans Specific Module</dct:title>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>Hypercube Ltd.</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Semantic Arts, Inc.</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>fibo-loan-spc</sm:moduleAbbreviation>
+		<dct:title>FIBO LOAN Loans Specific Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Loans (LOAN) Loans Specific Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/LoansSpecific/StudentLoans.rdf
+++ b/LOAN/LoansSpecific/StudentLoans.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -11,10 +12,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/StudentLoans/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -26,7 +27,6 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/StudentLoans/">
@@ -34,16 +34,15 @@
 		<dct:abstract>A loan or series of loans made for the purposes of study at some institution of learning.
 		This ontology and much of the common supporting information on loan applications are based on extensive review and input from Sallie Mae in the US and there may be other variants of student loans that are not covered here. For example in principle a student loan may be framed as a credit facility in some arrangements and as a single loan with separate payment phases in others.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-spc-stu</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/StudentLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-stu;StudentLoan">
@@ -61,7 +60,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">student loan</rdfs:label>
 		<skos:definition xml:lang="en">A loan provided for the purposes of education.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Also loans which are Bridge Loan between education and professional certification, e.g. between Law School and Bar Exam. These are considered Student Loans also. So this adds to the list of types of Student Loan and the facts thereof. Also Resident and Relocation e.g. Med students, e..g when doing internship. Provide money for that purpose. Also considered a student loan. Implications: There are different crieteria in making the loan, for each of these, e.g. whether you have graduated. If residentcy and relocation aplication: would have to be completing Med raining and getting ready to go into internship. So there are liufecycle (phase) terms about the Borrower (student). In these the borrower is alwways the student.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Also loans which are Bridge Loan between education and professional certification, e.g. between Law School and Bar Exam. These are considered Student Loans also. So this adds to the list of types of Student Loan and the facts thereof. Also Resident and Relocation e.g. Med students, e..g when doing internship. Provide money for that purpose. Also considered a student loan. Implications: There are different crieteria in making the loan, for each of these, e.g. whether you have graduated. If residentcy and relocation aplication: would have to be completing Med raining and getting ready to go into internship. So there are liufecycle (phase) terms about the Borrower (student). In these the borrower is alwways the student.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/LOAN/MetadataLOAN.rdf
+++ b/LOAN/MetadataLOAN.rdf
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-mod "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/">
 	<!ENTITY fibo-loan-mod "https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/">
 	<!ENTITY fibo-loan-reln-mod "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/">
@@ -9,11 +11,12 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-mod="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/"
 	xmlns:fibo-loan-mod="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/"
 	xmlns:fibo-loan-reln-mod="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/"
@@ -22,58 +25,47 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) Domain</rdfs:label>
 		<dct:abstract>The FIBO Loan domain defines concepts that are common to loans in various market categories including but not limited to commercial, small business, automobile, education and mortgage. High-level concepts relevant to loan contracts include the obligations of parties playing different roles, credit and risk, security agreements as well as additional detail for HMDA-specific loans. Details defining debt instruments in general are covered in a separate debt module in the Securities domain.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-10T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataLOAN.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MetadataLOANLoansSpecific/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/MetadataLOAN/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230201/MetadataLOAN/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-mod;LOANDomain">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Loans</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>loan domain</rdfs:label>
 		<dct:abstract>The FIBO Loan domain defines concepts that are common to loans in various market categories including but not limited to commercial, small business, automobile, education and mortgage. High-level concepts relevant to loan contracts include the obligations of parties playing different roles, credit and risk, security agreements as well as additional detail for HMDA-specific loans. Details defining debt instruments in general are covered in a separate debt module in the Securities domain.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Hypercube Ltd.</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Semantic Arts, Inc.</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="&fibo-loan-ln-mod;LoansGeneralModule"/>
 		<dct:hasPart rdf:resource="&fibo-loan-spc-mod;LoansSpecificModule"/>
 		<dct:hasPart rdf:resource="&fibo-loan-reln-mod;RealEstateLoansModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Loans (LOAN) Domain</dct:title>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>Hypercube Ltd.</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Semantic Arts, Inc.</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/BEDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/FBCDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/FNDDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/INDDomain"/>
-		<sm:keyword>debt instruments</sm:keyword>
-		<sm:keyword>financial instruments</sm:keyword>
-		<sm:keyword>loan contracts</sm:keyword>
-		<sm:keyword>loans</sm:keyword>
-		<sm:keyword>mortgages</sm:keyword>
-		<sm:moduleAbbreviation>fibo-loan</sm:moduleAbbreviation>
+		<dct:title>FIBO LOAN Domain</dct:title>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/RealEstateLoans/ConstructionLoans.rdf
+++ b/LOAN/RealEstateLoans/ConstructionLoans.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -16,10 +17,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -36,13 +37,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/">
 		<rdfs:label xml:lang="en">Construction Loans Ontology</rdfs:label>
 		<dct:abstract>Construction loans are loans in name only, in that the concept referred to as a construction loan is effectively a credit facility, with separate draw-downs (loans as defined in these ontologies) being enabled upon evidence of completion of agreed stages of the construction project. Note that for completion this ontology will need to be extended with a number of project management concepts describing the parameters of the construction project that are referred to in the contract for this facility. Some basic project management terms such as milestones are already included but will need framing within more foundational concepts for project management.</dct:abstract>
-		<sm:fileAbbreviation>fibo-loan-reln-cnst</sm:fileAbbreviation>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -52,9 +52,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;RealEstate">
@@ -70,7 +72,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-ln;Loan"/>
 		<rdfs:label xml:lang="en">construction loan</rdfs:label>
 		<skos:definition xml:lang="en">loan covering construction and development costs, secured by a mortgage on the property financed</skos:definition>
-		<fibo-fnd-utl-av:synonym xml:lang="en">construction mortgage</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym xml:lang="en">construction mortgage</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-cnst;ConstructionLoanContract">
@@ -120,7 +122,7 @@
 		<rdf:type rdf:resource="&fibo-loan-reln-cnst;ConstructionType"/>
 		<rdfs:label>mobile home</rdfs:label>
 		<skos:definition>a dwelling unit constructed on a base frame which features wheels and axles to be used in transporting home from place to place</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>It does not meet HUD code.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>It does not meet HUD code.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-cnst;ConstructionType_Modular">

--- a/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
+++ b/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
@@ -21,10 +22,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
@@ -46,17 +47,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/">
 		<rdfs:label>Home Mortgage Disclosure Act (HMDA) Covered Mortgages Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts specific to mortgages that are covered by the Home Mortgage Disclosure Act (HMDA) and related regulations. This includes the concept of a HMDA report as well as specializations of the core classes for pre-approval requests, covered loan contracts.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-reln-hmda</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
@@ -70,9 +66,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;Ethnicity">
@@ -97,7 +96,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>HMDA covered loan contract</rdfs:label>
 		<skos:definition>a closed-end mortgage loan or open-end line of credit that is not an excluded transaction for HMDA reporting under US section 1003.3(c) of the Revised Home Mortgage Disclosure Act of 2015</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the Revised HMDA regulatory text.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the Revised HMDA regulatory text.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;HMDA-Disposition">
@@ -142,8 +141,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-app;PreApprovalRequest"/>
 		<rdfs:label>HMDA pre-approval request</rdfs:label>
 		<skos:definition>a request for pre-approval of a home purchase loan up to a certain amount, and subject to certain non-credit related conditions</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>This request is approved only after a comprehensive analysis of the credit worthiness of the borrower is carried out.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>This request is approved only after a comprehensive analysis of the credit worthiness of the borrower is carried out.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;HMDA-Report">
@@ -184,14 +183,14 @@
 		<rdfs:label>HMDA report</rdfs:label>
 		<skos:definition>a report prepared to satisfy HMDA regulatory reporting requirements as described US section 1003.3(c) of the Revised Home Mortgage Disclosure Act of 2015</skos:definition>
 		<skos:editorialNote>The filter class on the hasReportingAgent restriction comes from the hasIdentity restriction on FinancialServiceProvider, which, unfortunately,  is a PartyInRole.</skos:editorialNote>
-		<fibo-fnd-utl-av:adaptedFrom>the Revised HMDA regulatory text.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the Revised HMDA regulatory text.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;HowSubmitted">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
 		<rdfs:label>how submitted</rdfs:label>
 		<skos:definition>category indicating whether the applicant or borrower submitted the application for the covered loan directly to the reporting financial institution</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>2015 Revised HMDA regulation</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>2015 Revised HMDA regulation</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-hmda;HowSubmitted-directly">

--- a/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans.rdf
+++ b/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans.rdf
@@ -1,60 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-reln-mod "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-reln-mod="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) Real Estate Loans Module</rdfs:label>
 		<dct:abstract>This module contains ontologies defining concepts that apply to loans related to land and anything permanently attached to it, whether natural or man-made, including but not limited to construction loans.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-10T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-loan-reln-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataLOANRealEstateLoans.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/RealEstateLoans/MetadataLOANRealEstateLoans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230201/RealEstateLoans/MetadataLOANRealEstateLoans/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mod;RealEstateLoansModule">
-		<rdf:type rdf:resource="&sm;Module"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>FIBO LOAN Real Estate Loans Module</rdfs:label>
 		<dct:abstract>This module contains ontologies defining concepts that apply to related to land and anything permanently attached to it, whether natural or man-made, including but not limited to construction loans.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Hypercube Ltd.</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>Semantic Arts, Inc.</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo</dct:contributor>
+		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:title>FIBO LOAN - Real Estate Loans Module</dct:title>
-		<sm:contributor>Adaptive, Inc.</sm:contributor>
-		<sm:contributor>Federated Knowledge LLC</sm:contributor>
-		<sm:contributor>Hypercube Ltd.</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
-		<sm:contributor>Semantic Arts, Inc.</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>fibo-loan-reln</sm:moduleAbbreviation>
+		<dct:title>FIBO LOAN Real Estate Loans Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Loans (LOAN) Real Estate Loans Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/RealEstateLoans/MortgageLoans.rdf
+++ b/LOAN/RealEstateLoans/MortgageLoans.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -15,6 +16,7 @@
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
@@ -30,10 +32,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -49,6 +51,7 @@
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
@@ -64,21 +67,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
 		<rdfs:label xml:lang="en">Mortgage Loans Ontology</rdfs:label>
 		<dct:abstract>Loans that have collateral posted as security and where that collateral is real estate, and the real estate which makes up the collateral is purchased with the funds loaned. This ontology covers a range of mortgage concepts and parties, along with catewgories of mortgage loan purpose (remortgage, second home etc.).</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-loan-reln-mtg</sm:fileAbbreviation>
-		<sm:filename>MortgageLoans.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
@@ -93,6 +87,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
@@ -101,10 +96,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;RealEstate">
@@ -165,58 +163,58 @@
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
 		<rdfs:label>adjustable rate</rdfs:label>
 		<skos:definition>a loan that allows the lender to periodically adjust the interest rate in accordance with a specified index</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-fixedRate">
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
 		<rdfs:label>fixed rate</rdfs:label>
 		<skos:definition>a loan in which the interest rate and payments remain the same for the life of the loan</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-graduatedPayment">
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
 		<rdfs:label>graduated payment</rdfs:label>
 		<skos:definition>a flexible payment loan where the payments increase for a specified period of time and then level off</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Usually involves negative amortization.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Usually involves negative amortization.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-graduatedPaymentAdjustable">
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
 		<rdfs:label>graduated payment adjustable</rdfs:label>
 		<skos:definition>a loan for which there are periodic payments/rate changes with additional specified principal and interest changes as documented in the Security Instruments.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-growingEquity">
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
 		<rdfs:label>growing equity</rdfs:label>
 		<skos:definition>A graduated payment loan in which increases in a borrowers loan payments are used to accelerate reduction of principal on the mortgage</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Due to increased payment, the borrower acquires equity more rapidly and retires the debt earlier.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Due to increased payment, the borrower acquires equity more rapidly and retires the debt earlier.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-rateImprovement">
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
 		<rdfs:label>rate improvement</rdfs:label>
 		<skos:definition>a type of flexible loan where the interest rate may decrease based on payment history.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-step">
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
 		<rdfs:label>step</rdfs:label>
 		<skos:definition>a loan with fixed periodic payment/rate changes without subsidy or negative amortization.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-aap-agt;AutomatedSystem"/>
 		<rdfs:label>automated underwriting system</rdfs:label>
 		<skos:definition>software system that collects the information necessary to approve a loan application and supports a mortgage lender&apos;s analysis of a new loan application</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In the United States, automated underwriting systems review the applicant&apos;s credit history and ability to repay the loan, and determine whether the price the applicant is offering to pay is supported by the property value.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In the United States, automated underwriting systems review the applicant&apos;s credit history and ability to repay the loan, and determine whether the price the applicant is offering to pay is supported by the property value.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem-DesktopUnderwriter">
@@ -235,7 +233,7 @@
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem"/>
 		<rdfs:label>Guaranteed Underwriting System</rdfs:label>
 		<skos:definition>an automated underwriting software system used by the USDA rural development loan program</skos:definition>
-		<fibo-fnd-utl-av:synonym>GUS</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym>GUS</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem-LoanProspector">
@@ -248,7 +246,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
 		<rdfs:label>cash-out status</rdfs:label>
 		<skos:definition>classifier indicating the extent to which funds are released to the borrower on a new loan origination that refinances an existing loan</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is subject to lender and/or investor policy(s).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is subject to lender and/or investor policy(s).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;CashOutStatus-CashOut">
@@ -277,7 +275,7 @@
 		<rdfs:label>charge category</rdfs:label>
 		<skos:definition>Examples include closing costs, interest, taxes, and other service-related fees.</skos:definition>
 		<skos:definition>classifier indicating what a particular fee or other expense is for</skos:definition>
-		<fibo-fnd-utl-av:usageNote>Use with LineItem, (has ChargeCategory instance), (hasNumericalValue for number of units) and (hasCost for the amount of money)</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>Use with LineItem, (has ChargeCategory instance), (hasNumericalValue for number of units) and (hasCost for the amount of money)</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ChargeCategory-appraisalFee">
@@ -290,15 +288,15 @@
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ChargeCategory"/>
 		<rdfs:label>discount points</rdfs:label>
 		<skos:definition>a charge for lowering your interest rate</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.consumerfinance.gov/askcfpb/136/what-are-discount-points-and-lender-credits-and-how-do-they-work.html</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>https://www.consumerfinance.gov/askcfpb/136/what-are-discount-points-and-lender-credits-and-how-do-they-work.html</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ChargeCategory-lenderCredits">
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ChargeCategory"/>
 		<rdfs:label>lender credits</rdfs:label>
 		<skos:definition>a credit whereby the lender reduces closing costs in exchange for a higher interest rate.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.consumerfinance.gov/askcfpb/136/what-are-discount-points-and-lender-credits-and-how-do-they-work.html</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:usageNote>This needs to be treated as a negative charge.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:adaptedFrom>https://www.consumerfinance.gov/askcfpb/136/what-are-discount-points-and-lender-credits-and-how-do-they-work.html</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>This needs to be treated as a negative charge.</cmns-av:usageNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ChargeCategory-originationFee">
@@ -341,21 +339,21 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
 		<rdfs:label>manufactured home legal classification</rdfs:label>
 		<skos:definition>category indicating whether the covered loan is secured by a manufactured home only or with land as well</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>2015 Revised HMDA regulation</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>2015 Revised HMDA regulation</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification-personalProperty">
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification"/>
 		<rdfs:label>personal property</rdfs:label>
 		<skos:definition>the covered loan is secured by a manufactured home but not land</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification-realProperty">
 		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification"/>
 		<rdfs:label>real property</rdfs:label>
 		<skos:definition>the covered loan is secured by a manufactured home and land</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;Mortgage">
@@ -466,7 +464,7 @@
 		</owl:equivalentClass>
 		<skos:definition>a loan contract that is secured by real property</skos:definition>
 		<skos:editorialNote xml:lang="en">Definition probably incomplete. Mortgage is not only securitized on the real estate but is used to fund the purchase of that real estate. Not sure of the best form of wording.</skos:editorialNote>
-		<fibo-fnd-utl-av:adaptedFrom>the Cambridge Business English Dictionary</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the Cambridge Business English Dictionary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;MortgageIndemnityGuarantee">
@@ -493,7 +491,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-gty;Insurer"/>
 		<rdfs:label xml:lang="en">mortgage indemnity guarantor</rdfs:label>
 		<skos:definition xml:lang="en">guarantor and insurer that provides mortgage insurance in the form of a mortgage indemnity guarantee (MIG)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SME Review notes 16 Sept: Guaranty - mortgage insurance e.g. insure up to 80% exposure. When you get into indemnification, then for instance if the product doesn&apos;t meet the investor&apos;s requirement such that if it doesn&apos;t get paid then the lender steps in and takes the hit for the loan - this is usually a precondition for securitizing (issuing) the loan in a pool. If the loan is not going to be sold on the secondary market there would be no need to indemnify that loan so this term would not apply. Indemnification is insurance for the investor, while the lender is the one providing that indemnification.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">SME Review notes 16 Sept: Guaranty - mortgage insurance e.g. insure up to 80% exposure. When you get into indemnification, then for instance if the product doesn&apos;t meet the investor&apos;s requirement such that if it doesn&apos;t get paid then the lender steps in and takes the hit for the loan - this is usually a precondition for securitizing (issuing) the loan in a pool. If the loan is not going to be sold on the secondary market there would be no need to indemnify that loan so this term would not apply. Indemnification is insurance for the investor, while the lender is the one providing that indemnification.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;MortgageIndemnityInsurancePolicy">
@@ -545,11 +543,11 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;NMLSR-ID">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/LicenseIdentifier"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LicenseIdentifier"/>
 		<rdfs:label>Nationwide Mortgage Licensing System and Registry Identifier</rdfs:label>
 		<skos:definition>the number permanently assigned by the Nationwide Mortgage Licensing System and Registry (NMLS) for each company, branch, and individual that maintains a single account on NMLS.</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>NMLSR ID</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>http://mortgage.nationwidelicensingsystem.org/about/Pages/NMLSID.aspx</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:abbreviation>NMLSR ID</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>http://mortgage.nationwidelicensingsystem.org/about/Pages/NMLSID.aspx</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;PropertyInspection">
@@ -568,7 +566,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>property inspection</rdfs:label>
 		<skos:definition>assessment activity that involves analyzing one or more aspects of a real property for independent assessment of status or deficiency</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is independent and separate from conducting an appraisal. Examples are termite inspections, construction inspections, etc.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is independent and separate from conducting an appraisal. Examples are termite inspections, construction inspections, etc.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;PropertyUsage">
@@ -621,7 +619,7 @@
 		<skos:definition>value assessment that estimates the amount of money a real estate property is worth</skos:definition>
 		<skos:editorialNote>Ensure that the appraiser parties have NMLS Identifier and contact preferences, e.g. phone number and address. As needed, connect appraisers to an appraisal management company.</skos:editorialNote>
 		<skos:editorialNote>Future consideration: add information about variability analysis and maybe the algorithm used.</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote>The valuation uses one or more methodologies and is conducted by an appraiser or technology with a logical model that performs the same function.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The valuation uses one or more methodologies and is conducted by an appraiser or technology with a logical model that performs the same function.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;ReverseMortgage">
@@ -635,8 +633,8 @@
 		<rdfs:label xml:lang="en">reverse mortgage</rdfs:label>
 		<rdfs:label>reverse mortgage</rdfs:label>
 		<skos:definition>mortgage contract that pays out money to the borrower against a set principal limit that is based on the value of existing equity in the underlying collateral.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A reverse mortgage and an open end loan both have a credit limit.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>The interest is added to the principal balance.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>A reverse mortgage and an open end loan both have a credit limit.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The interest is added to the principal balance.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;UniversalLoanIdentifier">
@@ -657,7 +655,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>universal loan identifier</rdfs:label>
 		<skos:definition>a unique identifier given to unequivocally identify a specific mortgage loan.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In the US, the structure of this identifier is defined in the 2015 revision to the Home Mortgage Disclosure Act.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>In the US, the structure of this identifier is defined in the 2015 revision to the Home Mortgage Disclosure Act.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;assumes">
@@ -681,14 +679,14 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-loan-reln-mtg;hasNumberOfDwellingUnits"/>
 		<rdfs:label>has number of affordable dwelling units</rdfs:label>
 		<skos:definition>relates real estate to the number of dwelling units it contains that are income-restricted under Federal, State, or local affordable housing programs.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-loan-reln-mtg;hasNumberOfDwellingUnits">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasCount"/>
 		<rdfs:label>has number of dwelling units</rdfs:label>
 		<skos:definition>relates real estate to the number of dwelling units it contains</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>the 2015 Revised HMDA regulation.</fibo-fnd-utl-av:adaptedFrom>
+		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;hasOriginatingServiceProvider">
@@ -711,7 +709,7 @@
 			</owl:Class>
 		</rdfs:range>
 		<skos:definition>relates something, typically a loan contract, to the service provider responsible for originated the loan</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Typically this will be a bank, mortgage broker, investment bank, or other similar party.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Typically this will be a bank, mortgage broker, investment bank, or other similar party.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;hasOriginatorPerson">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Updated all ontologies and metadata files in the LOAN domain to replace specification metadata with the Commons annotation vocabulary

Fixes: #1879 / LOAN-166


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


