### PR TITLE
IND-124 - Replace specification metadata-related annotations with annotations from the Commons Ontology Library in the FIBO Corporate Actions (CAE) Domain

### DIFF
--- a/CAE/AllCAE.rdf
+++ b/CAE/AllCAE.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-cae-all "https://spec.edmcouncil.org/fibo/ontology/CAE/AllCAE/">
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
@@ -8,10 +9,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/AllCAE/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-cae-all="https://spec.edmcouncil.org/fibo/ontology/CAE/AllCAE/"
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
@@ -20,39 +21,44 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/AllCAE/">
 		<rdfs:label>Corporate Actions and Events Domain</rdfs:label>
 		<dct:abstract>This ontology provides metadata about the FIBO Corporate Actions and Events (CAE) Domain, which covers actions including corporate, market, and regulatory actions, ranging from business oriented events such as address and name changes, to those that are more specific to securities.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-03-31T18:00:00</dct:issued>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Corporate Actions and Events (CAE) Domain</dct:title>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:contributor>Citigroup</sm:contributor>
-		<sm:contributor>Deutsche Bank</sm:contributor>
-		<sm:contributor>John F. Gemski</sm:contributor>
-		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
-		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
-		<sm:contributor>Thematix Partners LLC</sm:contributor>
-		<sm:contributor>agnos.ai UK Ltd</sm:contributor>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-cae-all</sm:fileAbbreviation>
-		<sm:filename>AllCAE.rdf</sm:filename>
-		<sm:keyword>corporate actions</sm:keyword>
-		<sm:moduleAbbreviation>fibo-cae</sm:moduleAbbreviation>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
+		<dct:title>Financial Industry Business Ontology (FIBO) Corporate Actions and Events (CAE) Domain</dct:title>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20220301/AllCAE/"/>
-		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for CAE is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports the Production (Released) ontologies that comprise the FIBO Corporate Actions and Events (CAE) domain, including all of SEC but excluding reference and example individuals.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20230201/AllCAE/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for CAE is provided for convenience for FIBO users. This ontology does not add new assertions, but imports the Production (Released) ontologies that comprise the FIBO Corporate Actions and Events (CAE) domain, including all of SEC but excluding reference and example individuals.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 
 </rdf:RDF>

--- a/CAE/CorporateEvents/CorporateActions.rdf
+++ b/CAE/CorporateEvents/CorporateActions.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
@@ -15,10 +16,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
@@ -34,21 +35,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 		<rdfs:label xml:lang="en">Corporate Actions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides a high level overview of actions including corporate, market, and regulatory actions, ranging from business oriented events such as address and name changes, to those that are more specific to securities.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-cae-ce-act</sm:fileAbbreviation>
-		<sm:filename>CorporateActions.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
@@ -56,10 +48,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20220301/CorporateEvents/CorporateActions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20230201/CorporateEvents/CorporateActions/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20220301/CorporateEvents/CorporateActions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;Action">
@@ -88,7 +84,7 @@
 		<rdfs:label xml:lang="en">action</rdfs:label>
 		<skos:definition xml:lang="en">event announced, initiated or carried out by an organization that affects a legal entity or the securities it issues and may have a material impact on that entity&apos;s stakeholders, such as shareholders and creditors</skos:definition>
 		<skos:example xml:lang="en">Actions that impact an entity may be initiated by an issuer, exchange, regulator, creditor, or other third party.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Actions initiated by an issuer are typically approved by that company&apos;s board of directors and authorized by their shareholders.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Actions initiated by an issuer are typically approved by that company&apos;s board of directors and authorized by their shareholders.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;ActionClassificationScheme">
@@ -108,7 +104,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>action classification scheme</rdfs:label>
 		<skos:definition>scheme for classifying the kinds of actions and events that may be announced, initiated or carried out by an organization that affects a legal entity or the securities it issues</skos:definition>
-		<fibo-fnd-utl-av:usageNote>The set of corporate actions and income events included herein are a subset of those specified in a combination of ISO 15022 Securities - Scheme for Messages (Data Field Dictionary) and the GLEIF LEI-related corporate actions. Other schemes that are specific to a custodian, depository, or regulatory agency may also be important, and should take a similar approach with respect to classification.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote>The set of corporate actions and income events included herein are a subset of those specified in a combination of ISO 15022 Securities - Scheme for Messages (Data Field Dictionary) and the GLEIF LEI-related corporate actions. Other schemes that are specific to a custodian, depository, or regulatory agency may also be important, and should take a similar approach with respect to classification.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;ActionClassifier">
@@ -142,7 +138,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">action classifier</rdfs:label>
 		<skos:definition xml:lang="en">classifier that distinguishes the kinds of actions and events that may be announced, initiated or carried out by an organization that affects a legal entity or the securities it issues, such as income-oriented events</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">ISO 15022 classifies events as impacting income vs. others. Other classification schemes distinguish between actions that return profits to shareholders, actions that are designed to influence the share price, and actions involving a change in structure to the issuer organization.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">ISO 15022 classifies events as impacting income vs. others. Other classification schemes distinguish between actions that return profits to shareholders, actions that are designed to influence the share price, and actions involving a change in structure to the issuer organization.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;ActionStatus">
@@ -173,15 +169,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">change action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action to disseminate information regarding a change further described in the corporate action details</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Generic changes may include a change in the terms of an issue, change in the identification of a security, change of board lot, change from global to definitive, etc.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Generic changes may include a change in the terms of an issue, change in the identification of a security, change of board lot, change from global to definitive, etc.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;ClassAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">class action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving a situation where interested parties seek restitution for financial loss</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">proposed settlement</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">The security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">proposed settlement</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;ConsentSolicitation">
@@ -196,7 +192,7 @@
 		<rdfs:label xml:lang="en">corporate action</rdfs:label>
 		<skos:definition xml:lang="en">action carried out by or specifically relating to a legal entity that may affect the securities it issues and may have a material impact on its stakeholders, such as shareholders and creditors</skos:definition>
 		<skos:example xml:lang="en">Examples of corporate actions include share issues, stock splits, consolidation, dividends, mergers and acquisitions, rights issues, spin-offs, and the inception of court actions.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Corporate actions are typically approved by a company&apos;s board of directors and authorized by the shareholders.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Corporate actions are typically approved by a company&apos;s board of directors and authorized by the shareholders.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;DisclosureAction">
@@ -216,21 +212,21 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;ActionClassifier"/>
 		<rdfs:label xml:lang="en">income-oriented classifier</rdfs:label>
 		<skos:definition xml:lang="en">classifier of corporate actions that impacts income to shareholders</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Cash dividends are a classic example where a public company declares a dividend to be paid on each outstanding share. Bonus is another case where the shareholder is rewarded. In a stricter sense, the bonus issue should not impact the share price but in reality, in rare cases, it does and results in an overall increase in value.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Cash dividends are a classic example where a public company declares a dividend to be paid on each outstanding share. Bonus is another case where the shareholder is rewarded. In a stricter sense, the bonus issue should not impact the share price but in reality, in rare cases, it does and results in an overall increase in value.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;LegalFormChange">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">legal form change</rdfs:label>
 		<skos:definition xml:lang="en">corporate action indicating a modification of the legal form of the organization</skos:definition>
-		<skos:example xml:lang="en">In the United States it is common for companies established as Subchapter S Corporations (S-Corp), typically early stage companies, to modify their structure to become full-fledged Subchapter C Corporations (C-Corp) to facilitate outside fundraising, mergers, acquisitions, and public offerings.  Other common form changes include migration from sole proprietorships to more formally registered organizations (e.g., LLC, S-Corp, C-Corp, etc.)</skos:example>
+		<skos:example xml:lang="en">In the United States it is common for companies established as Subchapter S Corporations (S-Corp), typically early stage companies, to modify their structure to become full-fledged Subchapter C Corporations (C-Corp) to facilitate outside fundraising, mergers, acquisitions, and public offerings. Other common form changes include migration from sole proprietorships to more formally registered organizations (e.g., LLC, S-Corp, C-Corp, etc.)</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;Liquidation">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;Divestiture"/>
 		<rdfs:label xml:lang="en">liquidation</rdfs:label>
 		<skos:definition xml:lang="en">corporate action related to winding up a business, including but not limited to distribution of cash, assets, or both</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by a security, for example.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by a security, for example.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;MandatoryCorporateAction">
@@ -238,14 +234,14 @@
 		<rdfs:label xml:lang="en">mandatory corporate action</rdfs:label>
 		<skos:definition xml:lang="en">action initiated by the board of directors of a corporation that affects all shareholders</skos:definition>
 		<skos:example xml:lang="en">Examples of mandatory corporate actions include cash dividends, stock splits, mergers, pre-refunding, return of capital, bonus issue, asset ID change, and spin-offs.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Mandatory means mandatory participation by all shareholders, however the shareholder is not required to do anything.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Mandatory means mandatory participation by all shareholders, however the shareholder is not required to do anything.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">mandatory with choice corporate action</rdfs:label>
 		<skos:definition xml:lang="en">mandatory corporate action where shareholders are given an opportunity to choose among several options</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In case a shareholder does not submit the election, the default option will be applied.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">In case a shareholder does not submit the election, the default option will be applied.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;MarketAction">
@@ -258,7 +254,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">merger / acquisition</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving the consolidation of legal entities or assets</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Such consolidation may be accomplished via financial transactions such as mergers, acquisitions, consolidations, tender offers, purchase of assets, and management acquisitions.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Such consolidation may be accomplished via financial transactions such as mergers, acquisitions, consolidations, tender offers, purchase of assets, and management acquisitions.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;Notification">
@@ -297,7 +293,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;Divestiture"/>
 		<rdfs:label xml:lang="en">spin off</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Spin-off represents a form of divestiture usually resulting in an independent company or in an existing company. Examples include demerger, distribution, and unbundling.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Spin-off represents a form of divestiture usually resulting in an independent company or in an existing company. Examples include demerger, distribution, and unbundling.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;VoluntaryCorporateAction">
@@ -306,7 +302,7 @@
 		<owl:disjointWith rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<skos:definition xml:lang="en">event in which the shareholders elect to participate and must respond in order for the issuer to process the action</skos:definition>
 		<skos:example xml:lang="en">An example of a voluntary corporate action is a tender offer, in which the issuer may request shareholders to tender their shares at a predetermined price.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Shareholders send responses to the issuer&apos;s agents, and the issuer will send the proceeds of the action to those shareholders who elect to participate.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Shareholders send responses to the issuer&apos;s agents, and the issuer will send the proceeds of the action to those shareholders who elect to participate.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-cae-ce-GLEIF "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/">
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
@@ -13,10 +14,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-cae-ce-GLEIF="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
@@ -30,29 +31,23 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/">
 		<rdfs:label xml:lang="en">GLEIF Corporate Action Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology includes the codes for corporate action events as specified in GLEIF LEI Common Data Format (CDF) schema, as of 4 March 2021.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-cae-ce-GLEIF</sm:fileAbbreviation>
-		<sm:filename>GLEIF-CorporateActionIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;ABSORPTION">

--- a/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-cae-ce-15022 "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/">
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
@@ -13,10 +14,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-cae-ce-15022="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
@@ -30,29 +31,23 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/">
 		<rdfs:label xml:lang="en">ISO 15022 Corporate Action Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology includes the codes for income and corporate action events as specified in ISO 15022, including extensions as of 3 September 2020. Scope excludes lower-level notification and meetings related events and message definitions associated with ISO 15022 as well as related messages covered by ISO 20022.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-cae-ce-15022</sm:fileAbbreviation>
-		<sm:filename>ISO15022-CorporateActionIndividuals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BIDS">

--- a/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
+++ b/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
@@ -1,54 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-cae-ce-mod "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-cae-ce-mod="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/">
 		<rdfs:label>Metadata for the EDMC-FIBO Corporate Actions and Events (CAE) Corporate Events Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of general corporate events and securities-related actions.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-03-31T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-cae-ce-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataCAECorporateEvents.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20220201/CorporateEvents/MetadataCAECorporateEvents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20230201/CorporateEvents/MetadataCAECorporateEvents/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-mod;CorporateEventsModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Corporate Events Module</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>corporate events module</rdfs:label>
 		<dct:abstract>This module contains ontologies that define common, general corporate events and securities-related actions.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:moduleAbbreviation>fibo-cae-ce</sm:moduleAbbreviation>
+		<dct:title>FIBO CAE Corporate Events Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Corporate Actions and Events (CAE) Domain, Corporate Events Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf
+++ b/CAE/CorporateEvents/SecurityRelatedCorporateActions.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 	<!ENTITY fibo-cae-ce-srca "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/">
@@ -18,10 +19,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
 	xmlns:fibo-cae-ce-srca="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"
@@ -40,20 +41,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/">
 		<rdfs:label xml:lang="en">Security-related Corporate Actions Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the kinds of income and corporate action events covered by ISO 15022 and other standards, including recent extensions to those standards. Scope has been limited to security-related events and actions, and excludes most notification and meetings related events.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:resource="https://www.w3.org/TR/owl2-quick-reference/"/>
-		<sm:copyright>Copyright (c) 2016-2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:fileAbbreviation>fibo-cae-ce-srca</sm:fileAbbreviation>
-		<sm:filename>SecurityRelatedCorporateActions.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -66,8 +59,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;BondDefaultAction">
@@ -87,16 +82,16 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">bonus issue</rdfs:label>
 		<skos:definition xml:lang="en">corporate action in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are different taxation rules for the bonus issue compared to the dividend. There could also be a difference in the ranking of the shares that are given to what the holder already holds. Dividends are paid from current profits and bonus may be from accumulated reserves of the company. A scrip issue is the issue of new shares at no charge pro rata to the holder of existing shares.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">capitalisation issue</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">scrip issue</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">There are different taxation rules for the bonus issue compared to the dividend. There could also be a difference in the ranking of the shares that are given to what the holder already holds. Dividends are paid from current profits and bonus may be from accumulated reserves of the company. A scrip issue is the issue of new shares at no charge pro rata to the holder of existing shares.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">capitalisation issue</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">scrip issue</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;BonusRightsIssue">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution"/>
 		<rdfs:label xml:lang="en">bonus rights issue</rdfs:label>
 		<skos:definition xml:lang="en">A Rights Issue in which the rights are given to the holders of the referenced shares for free.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Rights = right to buy shares at a specified price. May be given the right for nothing (Bonus Rights Issue) or you may be offered to purchase that right at a subscription price (which you take up or don&apos;t). Bonus Rights Issue: given the option for free. May exercise at the Exercise Price.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Rights = right to buy shares at a specified price. May be given the right for nothing (Bonus Rights Issue) or you may be offered to purchase that right at a subscription price (which you take up or don&apos;t). Bonus Rights Issue: given the option for free. May exercise at the Exercise Price.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;BonusSharePlanDistribution">
@@ -109,7 +104,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">call on intermediate securities</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This code is used for the second event, when an intermediate securities&apos; issue (rights/coupons) is composed of two events, the first event being the distribution of intermediate securities.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This code is used for the second event, when an intermediate securities&apos; issue (rights/coupons) is composed of two events, the first event being the distribution of intermediate securities.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;CancellationOfShares">
@@ -122,7 +117,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">capital distribution</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that pays shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This action does not result in a reduction of the face value of a share or in a change to the number of shares in circulation.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This action does not result in a reduction of the face value of a share or in a change to the number of shares in circulation.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;CapitalGainsDistribution">
@@ -136,7 +131,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">cash dividend action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that distributes cash to shareholders in proportion to their equity holding</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Ordinary dividends are typically recurring and regular.  The shareholder must take cash, and may be offered a choice of currency.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Ordinary dividends are typically recurring and regular. The shareholder must take cash, and may be offered a choice of currency.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;ChangeOfSecurityTradingStatusEvent">
@@ -186,7 +181,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;Duty"/>
 		<rdfs:label xml:lang="en">corporate action obligation</rdfs:label>
 		<skos:definition xml:lang="en">An obligation related to the holding of a Security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Delivery of a security. Not defining direction at this level of the model - one party may have an obligation to deliver security or to pay; other party may have an obligation to deliver or to pay. Or there may be just one.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Delivery of a security. Not defining direction at this level of the model - one party may have an obligation to deliver security or to pay; other party may have an obligation to deliver or to pay. Or there may be just one.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;CorporateActionPaymentObligation">
@@ -205,7 +200,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleEvent"/>
 		<rdfs:label xml:lang="en">corporate change of status event</rdfs:label>
 		<skos:definition xml:lang="en">Some change to the status of some security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is generally described by a corporate event message. For example, change in trading status, listing status.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is generally described by a corporate event message. For example, change in trading status, listing status.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;CouponStrip">
@@ -224,42 +219,42 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">decrease in value action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action resulting in a reduction of face value of a share or the value of fund assets</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The number of circulating shares/units remains unchanged. This event may include a cash pay out to holders.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The number of circulating shares/units remains unchanged. This event may include a cash pay out to holders.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;DividendOptionAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">dividend option action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Shareholders may choose to receive shares or cash. A dividend option action is distinguished from reinvestment (DRIP) as, like a cash dividend, the company creates new share capital in exchange for the dividend rather than investing the dividend in the market.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Shareholders may choose to receive shares or cash. A dividend option action is distinguished from reinvestment (DRIP) as, like a cash dividend, the company creates new share capital in exchange for the dividend rather than investing the dividend in the market.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;DividendReinvestmentAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">dividend reinvestment action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Dividend reinvestment is distinguished from a cash dividend in that the issuer invests the dividend in the market rather than creating new share capital in exchange for the dividend.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Dividend reinvestment is distinguished from a cash dividend in that the issuer invests the dividend in the market rather than creating new share capital in exchange for the dividend.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;Drawing">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">drawing</rdfs:label>
 		<skos:definition xml:lang="en">Redemption in part before the scheduled final maturity date of a security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notification in advance of this happening.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Notification in advance of this happening.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;DutchAuction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">dutch auction</rdfs:label>
 		<skos:definition xml:lang="en">corporate action by a party wishing to acquire a security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Holders of the security are invited to make an offer to sell, within a specific price range. The acquiring party will buy from the holder with lowest offer.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Holders of the security are invited to make an offer to sell, within a specific price range. The acquiring party will buy from the holder with lowest offer.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;ExchangeAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateAction"/>
 		<rdfs:label xml:lang="en">exchange action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that reflects an exchange of holdings for other securities and/or cash</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The exchange can be either mandatory or voluntary involving the exchange of outstanding securities for different securities and/or cash. For example, &apos;exchange offer&apos;, &apos;capital reorganisation&apos; or &apos;funds separation&apos;.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The exchange can be either mandatory or voluntary involving the exchange of outstanding securities for different securities and/or cash. For example, &apos;exchange offer&apos;, &apos;capital reorganisation&apos; or &apos;funds separation&apos;.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;FormalOffer">
@@ -318,14 +313,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">interest rate adjustment</rdfs:label>
 		<skos:definition xml:lang="en">Scheduled change to the coupon rate for a floating or adjustable rate security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The SWIFT definition as given defines the notification of the interest rate change, not the adjustment. Adjusted to describe the event. REVIEW: Is this really an action? Usually consider that it&apos;s expected. Given definition was for the announcement. SWIFT full definition &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The SWIFT definition as given defines the notification of the interest rate change, not the adjustment. Adjusted to describe the event. REVIEW: Is this really an action? Usually consider that it&apos;s expected. Given definition was for the announcement. SWIFT full definition &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">intermediate securities distribution</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
-		<fibo-fnd-utl-av:synonym xml:lang="en">rights distribution</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym xml:lang="en">rights distribution</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;ListingStatusDelistingMessage">
@@ -344,23 +339,23 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">pari-passu action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that occurs when securities with different characteristics become identical in all respects</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A pari-passu event includes cases, for example, when shares with different entitlements to dividend or voting rights become equivalent through assimilation or pari-passu. Such an event may be scheduled in advance, for example, when shares resulting from a bonus may become fungible after a pre-set period of time, or may result from outside events, for example, merger, reorganisation, issue of supplementary tranches, etc.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The term, pari-passu, means &apos;at the same rate or on an equal footing&apos;, and in finance is used to describe situations where two or more assets, securities, creditors, or obligations are equally managed without preference. An example of pari-passu occurs during bankruptcy proceedings: When the court reaches a verdict, the court regards all creditors equally, and the trustee will repay them the same fractional amount as other creditors and at the same time.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">assimilation</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">A pari-passu event includes cases, for example, when shares with different entitlements to dividend or voting rights become equivalent through assimilation or pari-passu. Such an event may be scheduled in advance, for example, when shares resulting from a bonus may become fungible after a pre-set period of time, or may result from outside events, for example, merger, reorganisation, issue of supplementary tranches, etc.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The term, pari-passu, means &apos;at the same rate or on an equal footing&apos;, and in finance is used to describe situations where two or more assets, securities, creditors, or obligations are equally managed without preference. An example of pari-passu occurs during bankruptcy proceedings: When the court reaches a verdict, the court regards all creditors equally, and the trustee will repay them the same fractional amount as other creditors and at the same time.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">assimilation</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;PartialRedemptionWithReductionOfNominalValueAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateAction"/>
 		<rdfs:label xml:lang="en">partial redemption with reduction of nominal value action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The outstanding amount of securities will be reduced proportionally. May be mandatory or voluntary.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The outstanding amount of securities will be reduced proportionally. May be mandatory or voluntary.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;PartialRedemptionWithoutReductionOfNominalValueAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateAction"/>
 		<rdfs:label xml:lang="en">partial redemption without reduction of nominal value action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is commonly done by pool factor reduction. May be mandatory or voluntary.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is commonly done by pool factor reduction. May be mandatory or voluntary.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;PostMergerSecuritiesExchange">
@@ -386,7 +381,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">post-merger securities exchange</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that involves the exchange of outstanding securities, initiated by the issuer which may include options, as the result of two or more companies combining assets, that is, an external, third party company</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an action as a result of the merger, not the merger itself, and may be mandatory or voluntary. Cash payments may accompany share exchange.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is an action as a result of the merger, not the merger itself, and may be mandatory or voluntary. Cash payments may accompany share exchange.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;PutRedemptionAction">
@@ -405,16 +400,16 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryCorporateAction"/>
 		<rdfs:label xml:lang="en">redenomination action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action by which the unit (currency and/or nominal) of a security is restated</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, the nominal/par value of security in a national currency is restated in another currency.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">For example, the nominal/par value of security in a national currency is restated in another currency.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;RepurchaseOffer">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;VoluntaryCorporateAction"/>
 		<rdfs:label xml:lang="en">repurchase offer</rdfs:label>
 		<skos:definition xml:lang="en">corporate action in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The objective of the offer is to reduce the number of outstanding equities.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">issuer bid</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">reverse rights</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">The objective of the offer is to reduce the number of outstanding equities.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">issuer bid</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">reverse rights</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;ReverseStockSplit">
@@ -428,22 +423,22 @@
 		<rdfs:label xml:lang="en">reverse stock split</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-cae-ce-srca;StockSplit"/>
 		<skos:definition xml:lang="en">corporate action involving a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equity price and nominal value are increased accordingly.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">change in nominal value</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">Equity price and nominal value are increased accordingly.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">change in nominal value</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;RightsExerciseEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateAction"/>
 		<rdfs:label xml:lang="en">rights exercise event</rdfs:label>
 		<skos:definition xml:lang="en">Exercising the right to purchase the shares. Furhter Notes: This is an action on the part of the holder. SWIFT: Call/exercise on nil-paid securities/rights resulting from a rights distribution (RHDI) (To be used for the second event in case rights issue is dealt with in 2 events, first event being the RHDI).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is a rights trading period overlaps with rights subscriptiuon period (you can trade the rights) Rights exercise period - expiry date. Some time after the expiry the new shares are distributed. This is the distribution.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">There is a rights trading period overlaps with rights subscriptiuon period (you can trade the rights) Rights exercise period - expiry date. Some time after the expiry the new shares are distributed. This is the distribution.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;SharesPremiumDividendAction">
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;MandatoryWithChoiceCorporateAction"/>
 		<rdfs:label xml:lang="en">shares premium dividend action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that pays shareholders an amount in cash issued from the shares premium reserve</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It is similar to a dividend but with different tax implications.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">It is similar to a dividend but with different tax implications.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;StockDividendAction">
@@ -462,9 +457,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">stock split</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving an increase in a corporation&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equity price and nominal value are reduced accordingly.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">change in nominal value</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">subdivision</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">Equity price and nominal value are reduced accordingly.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">change in nominal value</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">subdivision</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;TenderOffer">
@@ -477,10 +472,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">tender offer</rdfs:label>
 		<skos:definition xml:lang="en">corporate action involving an offer made to shareholders, normally by a third party, requesting them to sell (tender) or exchange their equities</skos:definition>
-		<fibo-fnd-utl-av:synonym xml:lang="en">acquisition</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">buyback</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">purchase offer</fibo-fnd-utl-av:synonym>
-		<fibo-fnd-utl-av:synonym xml:lang="en">takeover</fibo-fnd-utl-av:synonym>
+		<cmns-av:synonym xml:lang="en">acquisition</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">buyback</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">purchase offer</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">takeover</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;TradingStatusActiveMessage">
@@ -505,7 +500,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">trading status message</rdfs:label>
 		<skos:definition xml:lang="en">A message about trading status.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are a number of such messages. Events v Status: See e.g. Active: this relates to one state OR two transitions (transition from pre-issuance to Trading, or from Suspended to Trading).</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">There are a number of such messages. Events v Status: See e.g. Active: this relates to one state OR two transitions (transition from pre-issuance to Trading, or from Suspended to Trading).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;TradingStatusSuspendedMessage">
@@ -518,7 +513,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-act;CorporateAction"/>
 		<rdfs:label xml:lang="en">warrant exercise action</rdfs:label>
 		<skos:definition xml:lang="en">corporate action that offers holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time (which usually corresponds to the life of the issue)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that participation by the warrant holder may be mandatory or voluntary and may involve a choice in the mandatory case.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Note that participation by the warrant holder may be mandatory or voluntary and may involve a choice in the mandatory case.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-srca;WorthlessSecurityAction">

--- a/CAE/MetadataCAE.rdf
+++ b/CAE/MetadataCAE.rdf
@@ -1,57 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-cae-ce-mod "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/">
 	<!ENTITY fibo-cae-mod "https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-cae-ce-mod="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/"
 	xmlns:fibo-cae-mod="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/">
 		<rdfs:label>Metadata about the EDMC-FIBO Corporate Actions and Events (CAE) Domain</rdfs:label>
 		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, as well as more general business events that are relevant to investors and regulators alike.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-cae-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataCAE.rdf</sm:filename>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20201001/MetadataCAE/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20230201/MetadataCAE/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-mod;CAEDomain">
-		<rdf:type rdf:resource="&sm;Module"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>Corporate Actions and Events Domain</rdfs:label>
 		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, as well as more general business events that are relevant to investors and regulators alike.</dct:abstract>
+		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Bank of New York Mellon</dct:contributor>
+		<dct:contributor>Bloomberg LP</dct:contributor>
+		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Bureau of Labor Statistics (BLS, US Department of Commerce)</dct:contributor>
+		<dct:contributor>Census Bureau (US Department of Commerce)</dct:contributor>
+		<dct:contributor>Citigroup</dct:contributor>
+		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
+		<dct:contributor>Deutsche Bank</dct:contributor>
+		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>John F. Gemski</dct:contributor>
+		<dct:contributor>John F. Tierney</dct:contributor>
+		<dct:contributor>Nordea Bank AB</dct:contributor>
+		<dct:contributor>Office of Financial Research (OFR), U.S. Department of the Treasury</dct:contributor>
+		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
+		<dct:contributor>State Street Bank and Trust</dct:contributor>
+		<dct:contributor>Statistics Canada</dct:contributor>
+		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
+		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
+		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="&fibo-cae-ce-mod;CorporateEventsModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:keyword>corporate actions</sm:keyword>
-		<sm:keyword>corporate events</sm:keyword>
-		<sm:moduleAbbreviation>fibo-cae</sm:moduleAbbreviation>
+		<dct:title>FIBO CAE Domain</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Corporate Actions and Events (CAE) Domain</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Modified the ontologies and metadata files in the CAE Domain to use the Commons annotation vocabulary rather than specification metadata

Fixes: #1881 / IND-124


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


