### PR TITLE
FND-372 - Replace specification metadata-related annotations with annotations from the Commons Ontology Library in the FIBO Market Data (MD) Domain

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-dev "https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">	
 ]>	
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-dev="https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/"
@@ -18,20 +19,16 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/">
   		<rdfs:label>About FIBO Development</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users.  It loads the very latest version of every FIBO ontology (released, provisional, and informative) based on the contents of GitHub, for use in particular while working on revisions.  Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-09-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:submitter>Thematix Partners LLC</sm:submitter>
-		<sm:fileAbbreviation>fibo-dev</sm:fileAbbreviation>
-		<sm:filename>AboutFIBODev.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		
 	<!-- 
@@ -359,7 +356,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 	 
-	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20220901/AboutFIBODev/"/>
+	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230201/AboutFIBODev/"/>
   </owl:Ontology>
   
 </rdf:RDF>

--- a/AboutFIBOProd-IncludingReferenceData.rdf
+++ b/AboutFIBOProd-IncludingReferenceData.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-prod-ref "https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-IncludingReferenceData/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">	
 ]>	
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-IncludingReferenceData/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-prod-ref="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-IncludingReferenceData/"
@@ -18,19 +19,16 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-IncludingReferenceData/">
 		<rdfs:label>About FIBO Production - including Reference Data</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, including reference data but excluding examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. By reference data we mean ISO currency codes and USPS individuals in FND, juridictions and governments in BE, regulatory agencies and related financial services entities as well as business centers and MIC codes in FBC, FpML interest rates in IND, CFI codes in SEC (incomplete but planned for extension in subsequent releases), and so forth. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-09-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-prod-ref</sm:fileAbbreviation>
-		<sm:filename>AboutFIBOProd-IncludingReferenceData.rdf</sm:filename>		
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		
 	<!-- 
@@ -377,7 +375,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20221201/AboutFIBOProd-IncludingReferenceData/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230201/AboutFIBOProd-IncludingReferenceData/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBOProd-TBoxOnly.rdf
+++ b/AboutFIBOProd-TBoxOnly.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-prod-tbox "https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-TBoxOnly/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">	
 ]>	
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-TBoxOnly/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-prod-tbox="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-TBoxOnly/"
@@ -18,21 +19,18 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
  <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd-TBoxOnly/">
  		<rdfs:label>About FIBO Production - T-Box Only</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, excluding reference data and examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-09-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2022 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-prod-tbox</sm:fileAbbreviation>
-		<sm:filename>AboutFIBOProd-TBoxOnly.rdf</sm:filename>		
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
-		<fibo-fnd-utl-av:usageNote>As of the Q3 2022 release of FIBO, there is one ontology, Bonds, in Securities, that brings in some reference individuals. The intent is to address this for the Q4 2022 release.</fibo-fnd-utl-av:usageNote>
+		<fibo-fnd-utl-av:usageNote>As of the Q3 2022 release of FIBO, there is one ontology, Bonds, in Securities, that brings in some reference individuals. The intent is to address this in a future release.</fibo-fnd-utl-av:usageNote>
 		
 	<!-- 
 	///////////////////////////////////////////////////////////////////////////////////////

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-prod "https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/">
@@ -7,10 +8,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">	
 ]>	
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-prod="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/"
@@ -18,20 +19,16 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
  <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/">
  		<rdfs:label>About FIBO Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-12-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</sm:copyright>
-		<sm:submitter>Thematix Partners LLC</sm:submitter>
-		<sm:fileAbbreviation>fibo-prod</sm:fileAbbreviation>
-		<sm:filename>AboutFIBOProd.rdf</sm:filename>		
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>	
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		
 	<!-- 
@@ -291,7 +288,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20221201/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230201/AboutFIBOProd/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/BE/Partnerships/Partnerships.rdf
+++ b/BE/Partnerships/Partnerships.rdf
@@ -254,7 +254,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>partnership agreement</rdfs:label>
 		<skos:definition>contract between partners in a partnership that establishes the terms and conditions of the relationship between the partners</skos:definition>
-		<cmns-av:aynonym>articles of partnership</cmns-av:aynonym>
+		<cmns-av:synonym>articles of partnership</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-ptr-ptr;hasGeneralPartner">

--- a/BE/SoleProprietorships/SoleProprietorships.rdf
+++ b/BE/SoleProprietorships/SoleProprietorships.rdf
@@ -85,9 +85,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>sole proprietor</rdfs:label>
 		<skos:definition>party that owns a business, has the rights to all profits from that business and is considered a single entity (unincorporated) together with that business for tax and liability purposes</skos:definition>
-		<cmns-av:aynonym>sole owner</cmns-av:aynonym>
-		<cmns-av:aynonym>sole trader</cmns-av:aynonym>
 		<cmns-av:explanatoryNote>A sole proprietor has unlimited liability with respect to any business debts.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>sole owner</cmns-av:synonym>
+		<cmns-av:synonym>sole trader</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-sps-sps;SoleProprietorship">

--- a/BE/Trusts/Trusts.rdf
+++ b/BE/Trusts/Trusts.rdf
@@ -150,10 +150,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trust agreement</rdfs:label>
 		<skos:definition>formal agreement that establishes a trust, whereby the trustor(s) gives the trustee(s) the responsibility to hold and manage assets for the beneficiary(ies)</skos:definition>
-		<cmns-av:aynonym>trust deed</cmns-av:aynonym>
-		<cmns-av:aynonym>trust document</cmns-av:aynonym>
-		<cmns-av:aynonym>trust instrument</cmns-av:aynonym>
 		<cmns-av:explanatoryNote>A trust agreement typically states the (1) purpose for which the trust was established and fulfillment of which will terminate the trust, (2) details of the assets placed in the trust, (3) powers and limitations of the trustees, their reporting requirements, and other associated provisions, and (4) may also specify the trustees&apos; compensation, if any. A trust agreement involving real estate requires its exact description and the trustor&apos;s express, written consent to create the trust to be valid.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>trust deed</cmns-av:synonym>
+		<cmns-av:synonym>trust document</cmns-av:synonym>
+		<cmns-av:synonym>trust instrument</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;TrustBeneficiary">
@@ -254,9 +254,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trustor</rdfs:label>
 		<skos:definition>party that establishes a trust and places property under the protection and management of one or more trustees for the benefit of at least one beneficiary</skos:definition>
-		<cmns-av:aynonym>grantor</cmns-av:aynonym>
-		<cmns-av:aynonym>settlor</cmns-av:aynonym>
 		<cmns-av:explanatoryNote>It is not always necessary to identify the trustor who may be also be a trustee and/or one of the beneficiaries. In legal parlance, a trustor is called a settlor in the UK and a grantor in the US, whereas in common usage he or she may also be called a creator, donor, initiator, owner, or trust maker.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>grantor</cmns-av:synonym>
+		<cmns-av:synonym>settlor</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-tr-tr;hasBeneficiary">

--- a/MD/CIVTemporal/FundsTemporal.rdf
+++ b/MD/CIVTemporal/FundsTemporal.rdf
@@ -98,13 +98,6 @@
 		<rdfs:label xml:lang="en">swing price</rdfs:label>
 	</owl:Class>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;declarationTime">
-		<rdfs:label xml:lang="en">declaration time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;NetAssetValue"/>
-		<rdfs:range rdf:resource="&xsd;dateTime"/>
-		<skos:definition xml:lang="en">Time of the net asset value publication. Further Notes REVIEW: time of day, year or what?</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationDate.1">
 		<rdfs:label xml:lang="en">determination date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>

--- a/MD/CIVTemporal/FundsTemporal.rdf
+++ b/MD/CIVTemporal/FundsTemporal.rdf
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
+	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-md-civx-fun "https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/">
 	<!ENTITY fibo-sec-fund-civ "https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/">
@@ -11,13 +14,15 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
+	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-md-civx-fun="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/"
 	xmlns:fibo-sec-fund-civ="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/"
@@ -26,20 +31,23 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/">
 		<rdfs:label xml:lang="en">FundsTemporal</rdfs:label>
 		<dct:abstract>Terms which have a time component (either real time, intra-day or dated terms). These include Net Present Value (NPV) and related analytics.</dct:abstract>
-		<sm:fileAbbreviation>fibo-md-civx-fun</sm:fileAbbreviation>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-md-civx-fun;AccruedFees">
@@ -54,17 +62,12 @@
 		<rdfs:label xml:lang="en">accrued taxes</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-civx-fun;BidPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:label xml:lang="en">bid price</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-civx-fun;mutuallyExclusive"/>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-civx-fun;FeePayable">
 		<rdfs:label xml:lang="en">fee payable</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-civx-fun;FundPrice">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:label xml:lang="en">fund price</rdfs:label>
 	</owl:Class>
 	
@@ -75,21 +78,11 @@
 	<owl:Class rdf:about="&fibo-md-civx-fun;FundsTax">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-civx-fun;appliesTo"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-oac-opty;Investor"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">funds tax</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;NetAssetValue">
-		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:label xml:lang="en">net asset value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;RedemptionPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:label xml:lang="en">redemption price</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-civx-fun;SigmaValueOfHoldings">
@@ -105,26 +98,12 @@
 		<rdfs:label xml:lang="en">swing price</rdfs:label>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;appliesTo">
-		<rdfs:label xml:lang="en">applies to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundsTax"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-opty;Investor"/>
-		<owl:inverseOf rdf:resource="&fibo-md-civx-fun;incursTax"/>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;declarationTime">
 		<rdfs:label xml:lang="en">declaration time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;NetAssetValue"/>
+		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;NetAssetValue"/>
 		<rdfs:range rdf:resource="&xsd;dateTime"/>
 		<skos:definition xml:lang="en">Time of the net asset value publication. Further Notes REVIEW: time of day, year or what?</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationDate">
-		<rdfs:label xml:lang="en">determination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date when the price is determined. and time.</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationDate.1">
 		<rdfs:label xml:lang="en">determination date</rdfs:label>
@@ -149,12 +128,6 @@
 		<rdfs:label xml:lang="en">has performance</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
 		<rdfs:range rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;hasPrice">
-		<rdfs:label xml:lang="en">has price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FundPrice"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incurs">
@@ -193,22 +166,10 @@
 		<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
 	</owl:ObjectProperty>
 	
-	<owl:Class rdf:about="&fibo-md-civx-fun;mutuallyExclusive">
-		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:label xml:lang="en">offer price</rdfs:label>
-	</owl:Class>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;netOrGrossOfFees">
 		<rdfs:label xml:lang="en">net or gross of fees</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;valuationTime">
-		<rdfs:label xml:lang="en">valuation time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;NetAssetValue"/>
-		<rdfs:range rdf:resource="&xsd;dateTime"/>
-		<skos:definition xml:lang="en">Time of the price valuation for the investment fund/fund class.</skos:definition>
 	</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/MD/CIVTemporal/MetadataMDCIVTemporal.rdf
+++ b/MD/CIVTemporal/MetadataMDCIVTemporal.rdf
@@ -1,47 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-md-civx-mod "https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-md-civx-mod="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/">
-		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) CIVTemporal Module</rdfs:label>
+		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) CIV Temporal Module</rdfs:label>
 		<dct:abstract>This module provides time-dependent concepts specific to funds and other collective investment vehicles.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-md-civx-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataMDCIVTemporal.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20200401/CIVTemporal/MetadataMDCIVTemporal/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20230201/CIVTemporal/MetadataMDCIVTemporal/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-civx-mod;CIVTemporalModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>CIV Temporal</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>CIV temporal module</rdfs:label>
 		<dct:abstract>This module provides time-dependent concepts specific to funds and other collective investment vehicles.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>FIBO Market Data - Collective Investment Vehicles Temporal Terms Module</dct:title>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>fibo-md-civx</sm:moduleAbbreviation>
+		<dct:title>FIBO MD Collective Investment Vehicles Temporal Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Market Data (MD) Collective Investment Vehicles Temporal Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/DebtTemporal/DebtAnalytics.rdf
+++ b/MD/DebtTemporal/DebtAnalytics.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
@@ -21,10 +22,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
@@ -46,13 +47,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/">
 		<rdfs:label xml:lang="en">Debt Analytics Ontology</rdfs:label>
 		<dct:abstract>This ontology covers an extensive range of analytical measures for debt instruments and pools of debt instruments. These cover the well-known concepts of convexity, duration and life, as well as weighted average loan ages and maturities, prepayments speeds etc. for debt pools. Most of the widely referenced variants of these are included, for example modified duration. Some yield related concepts (e.g. for equivalent yield) are also included. Debt pricing and yields are intimately related, and this ontology sets out the basic concepts of debt price, including different ways in which debt and bod prices are described and calculated, as well as a range of different kinds of yield (simple yield, Wall Street Yield, Japanese Yield and so on). The pricing terms are supported by a range of trading and exchange related concepts that are used to differentiate different kinds of debt price, for example last, high and low exchange prices.</dct:abstract>
-		<sm:fileAbbreviation>fibo-md-dbtx-aly</sm:fileAbbreviation>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
@@ -68,8 +68,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;AbsolutePrepaymentRate">
@@ -82,7 +84,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">absolute prepayment rate</rdfs:label>
 		<skos:definition xml:lang="en">The absolute prepayment rate (for ABS) is the standard measure of prepayment rates in the auto-loan sector. ABS measures the monthly rate of loan prepayments as a percentage of the original pool balance. ABS is defined by the following formula where SMM refers to Single Monthly Mortality, which measures the percentage of dollars prepaid in a given month expressed as a percentage of the scheduled loan balance. ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The ABS measurement differs from conditional prepayment rate (CPR) used in the mortgage industry, which measures prepayment as an annualized percentage of the current pool balance.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The ABS measurement differs from conditional prepayment rate (CPR) used in the mortgage industry, which measures prepayment as an annualized percentage of the current pool balance.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;AbsolutePrepaymentRateFormula">
@@ -108,7 +110,7 @@
 		<rdfs:label xml:lang="en">average life</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
 		<skos:definition xml:lang="en">An estimate of the number of terms to maturity, taking the possibility of early payments into account. Average life is calculated using the weighted average time to the receipt of all future cash flows.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Where it refers to pre-payment above, if the bond does not include prepayment then this is not included. However, analytics that refer to this e.g. Yield to Average Life, then this figure is relevant. It is not relevant for other types of bond where e.g. you would use yield to next call, yield to worst etc. Average Life used in place of Maturity for Yield Calculation. This is not only used for Yield calculations though. It is referred to as an analytic figure in its own right. Average Life uses one of a number of standard pre-payment models (for structured finance at least). For MBS, the average life includes some calculations to take account of pre-payments on the underlying mortgages. This takes account of the possibillity of borrowers paying early. This has to be modeled or forecast (not given) as it&apos;s a function of market conditions and interest rate. You would not see this in a market data feed. When you model MBS you calculate Average Life as part of the model i.e. you estimate the percentage of prepayment in the next x length of time and factor this into the Average Life. Refers to Weighted Average Time to receipt of future cash flows. For MBS, early payments will shorten the Average Life. For Student Loans, Credit Card, Loan etc, i.e. all Pool Backed (any bond that has securitized debt). Other bonds: Sinking Funds etc., also Early Payment - partial Call for a corporate / regular bond. Early Payment for pass through has the same effect. Sinking Fund: Each payment is part principal and part interest, this is implicit in the overall definition of &quot;Early payment&quot;.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Where it refers to pre-payment above, if the bond does not include prepayment then this is not included. However, analytics that refer to this e.g. Yield to Average Life, then this figure is relevant. It is not relevant for other types of bond where e.g. you would use yield to next call, yield to worst etc. Average Life used in place of Maturity for Yield Calculation. This is not only used for Yield calculations though. It is referred to as an analytic figure in its own right. Average Life uses one of a number of standard pre-payment models (for structured finance at least). For MBS, the average life includes some calculations to take account of pre-payments on the underlying mortgages. This takes account of the possibillity of borrowers paying early. This has to be modeled or forecast (not given) as it&apos;s a function of market conditions and interest rate. You would not see this in a market data feed. When you model MBS you calculate Average Life as part of the model i.e. you estimate the percentage of prepayment in the next x length of time and factor this into the Average Life. Refers to Weighted Average Time to receipt of future cash flows. For MBS, early payments will shorten the Average Life. For Student Loans, Credit Card, Loan etc, i.e. all Pool Backed (any bond that has securitized debt). Other bonds: Sinking Funds etc., also Early Payment - partial Call for a corporate / regular bond. Early Payment for pass through has the same effect. Sinking Fund: Each payment is part principal and part interest, this is implicit in the overall definition of &quot;Early payment&quot;.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;AverageLifeAtIssue">
@@ -127,14 +129,14 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">bond equivalent yield</rdfs:label>
 		<skos:definition xml:lang="en">Yield determined on an equivalent basis to the yield of another bond. This is used to be able to realistically compare prices between debt instruments across different markets.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example when comparing Treasury with Corp it&apos;s called a Corp Bond Equivalent Yield; when comparing other kinds of yields this would be labelled differently. Treasury bills typically in discount rates - that&apos;s one of the ways you would compare TB or MM or RePo to BEQ - by changing the day count. Detailed implementation of this: This term refers to the type of bond that it is equivalent to, that is the type of bond whose yield is normally determined according to the yield calculation method that is used in determining this Bond Equivalent Yield figure. The type of bond in this instance is defined in relation to the market on which that bond trades, for example the US Corporate Bond Market.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">For example when comparing Treasury with Corp it&apos;s called a Corp Bond Equivalent Yield; when comparing other kinds of yields this would be labelled differently. Treasury bills typically in discount rates - that&apos;s one of the ways you would compare TB or MM or RePo to BEQ - by changing the day count. Detailed implementation of this: This term refers to the type of bond that it is equivalent to, that is the type of bond whose yield is normally determined according to the yield calculation method that is used in determining this Bond Equivalent Yield figure. The type of bond in this instance is defined in relation to the market on which that bond trades, for example the US Corporate Bond Market.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;CashStructuredFinanceInstrumentPrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:label xml:lang="en">cash structured finance instrument price</rdfs:label>
 		<skos:definition xml:lang="en">When the price is above a certain level (70), you get a quote in reference to an index e.g. LIBOR+50bp i.e. the yield. When you get below a certain price you get a quote such as 65c to a dollar. Percentage? not seen. Would be a whole number, interpreted as c/$</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This might be a Price, a Spread or a Yield, i.e. &quot;here&apos;s the price., the current Yield is this, and here&apos;s the Spread&quot;.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This might be a Price, a Spread or a Yield, i.e. &quot;here&apos;s the price., the current Yield is this, and here&apos;s the Spread&quot;.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;CleanPrice">
@@ -166,7 +168,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit spread</rdfs:label>
 		<skos:definition xml:lang="en">yield spread that reflects the additional net yield an investor can earn from a security with more credit risk relative to one with less credit risk</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The credit spread of a particular security is often quoted in relation to the yield on a credit risk-free benchmark security or reference rate. Further Notes There are several measures of credit spread, including Z-spread and option-adjusted spread. Old definition (Algo) The spread between the credit rating of something and its maturity. THis is now defined as a different term pending further review with Algorithmics. Update from SMER. difference between risk free price (price of govt bond) and the price of this security. (matches Wikipedia definition above) i.e. price of this credit versus the price of a (near) risk free credit. The latter is a reference security with low risk such as a Treasury Bond. Is this between prices or between yields? can be expressed as either wrt price or yield, and this is detemined by context for different markets. Try and get a list. This is more generic - the meaning is not that it is speciufically wrt yield as such. Debt Price Spread is in context of price, whereas this is more generic.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The credit spread of a particular security is often quoted in relation to the yield on a credit risk-free benchmark security or reference rate. Further Notes There are several measures of credit spread, including Z-spread and option-adjusted spread. Old definition (Algo) The spread between the credit rating of something and its maturity. THis is now defined as a different term pending further review with Algorithmics. Update from SMER. difference between risk free price (price of govt bond) and the price of this security. (matches Wikipedia definition above) i.e. price of this credit versus the price of a (near) risk free credit. The latter is a reference security with low risk such as a Treasury Bond. Is this between prices or between yields? can be expressed as either wrt price or yield, and this is detemined by context for different markets. Try and get a list. This is more generic - the meaning is not that it is speciufically wrt yield as such. Debt Price Spread is in context of price, whereas this is more generic.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;CurrentYieldCalculationMethod">
@@ -179,7 +181,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">current yield calculation method</rdfs:label>
 		<skos:definition xml:lang="en">The ratio of the interest payment amount to the clean price.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a kind of yield that applies to debt instruments only as it relates to the clean price. It differs from the simple yield in that simple yield relates to the actual price paid for the bond, which on will differ from the clean price by the amount of accrued interest.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is a kind of yield that applies to debt instruments only as it relates to the clean price. It differs from the simple yield in that simple yield relates to the actual price paid for the bond, which on will differ from the clean price by the amount of accrued interest.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtConvexityAnalytic">
@@ -261,7 +263,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">debt instrument yield</rdfs:label>
 		<skos:definition xml:lang="en">The return on the debt instrument at the stated price.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Yield has a relationship to the price.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Yield has a relationship to the price.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter">
@@ -384,7 +386,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:label xml:lang="en">derived price</rdfs:label>
 		<skos:definition xml:lang="en">price that stems from another source or calculation rather than being quoted or based on actual trading data</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are evaluated prices in which an independent source evaluates a price they have derived, and there are prices which are derived within a firm, from supplied, published end of day price spreads or other market data.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">There are evaluated prices in which an independent source evaluates a price they have derived, and there are prices which are derived within a firm, from supplied, published end of day price spreads or other market data.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DirtyPrice">
@@ -403,7 +405,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentYield"/>
 		<rdfs:label xml:lang="en">discounted instrument yield</rdfs:label>
 		<skos:definition xml:lang="en">Yield quoted for a discount instrument. This is the ratio of the discount to the face value, divided by the period to maturity as a fraction of a year.</skos:definition>
-		<fibo-fnd-utl-av:usageNote xml:lang="en">Applies to Debt only.</fibo-fnd-utl-av:usageNote>
+		<cmns-av:usageNote xml:lang="en">Applies to Debt only.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DurationAnalytic">
@@ -476,7 +478,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;YieldCalculationFormula"/>
 		<rdfs:label xml:lang="en">i c m a yield formula</rdfs:label>
 		<skos:definition xml:lang="en">The calculation method specified by ICMA (formerly ISMA) for determination of yield for fixed-rate bonds.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This basic formula is used across many markets, including the US and most of Europe. While individual markets may have different flavors (French round their bonds to 5 decimals, UK Gilts have ex-div), the formula is still the same. This would be the formula used by &quot;Wall Street Yield&quot;, &quot;US Treasury Yield&quot;, &quot;Corporate Bond Yield&quot; etc. Notes Origin:Fidessa</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This basic formula is used across many markets, including the US and most of Europe. While individual markets may have different flavors (French round their bonds to 5 decimals, UK Gilts have ex-div), the formula is still the same. This would be the formula used by &quot;Wall Street Yield&quot;, &quot;US Treasury Yield&quot;, &quot;Corporate Bond Yield&quot; etc. Notes Origin:Fidessa</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;ImpliedForwardRate">
@@ -494,7 +496,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">instrument weighted average loan age</rdfs:label>
 		<skos:definition xml:lang="en">A dollar-weighted average measuring the age of the individual loans in a mortgage pass-through or pooled security, such as Ginnie Mae or a Freddie Mac security. The WALA is measured as the time in months since the origination of the loans, with the weighting based on each loan&apos;s size in proportion to the aggregate total of the pool.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is defined by the issuer. WALA is more official, not an analysis from a vendor. This changes but the values are relayed by the issuer on an ongoing basis. Investopedia explains Weighted Average Loan Age - WALA The weighted average age will change over time as some mortgages get paid off faster than others. Based on the issuer of the mortgage-backed securities (MBS), the WALA may be weighted on the remaining principal balance dollar figure, or the beginning notional value of the loan. The flip side of the WALA is the weighted average maturity (WAM), which is a dollar-weighted measure of the months remaining until the principal amounts are completely repaid on each loan in the pool.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is defined by the issuer. WALA is more official, not an analysis from a vendor. This changes but the values are relayed by the issuer on an ongoing basis. Investopedia explains Weighted Average Loan Age - WALA The weighted average age will change over time as some mortgages get paid off faster than others. Based on the issuer of the mortgage-backed securities (MBS), the WALA may be weighted on the remaining principal balance dollar figure, or the beginning notional value of the loan. The flip side of the WALA is the weighted average maturity (WAM), which is a dollar-weighted measure of the months remaining until the principal amounts are completely repaid on each loan in the pool.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity">
@@ -519,7 +521,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DerivedPrice"/>
 		<rdfs:label xml:lang="en">interpolated price</rdfs:label>
 		<skos:definition xml:lang="en">A price determined by interpolation between available price figures, using some algorithm or curve.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Uses an algorithm to interpolate a price from two observed prices. Examples include price derived by interpolation between prices e.g. between Bid and Offer (among others). also includes Yield Curves and implied forward curves. That is, interpolation may either be linear (straight line interpolation between two values) or may be expressed as a non linear curve such as a yield curve or an implied forward curve.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Uses an algorithm to interpolate a price from two observed prices. Examples include price derived by interpolation between prices e.g. between Bid and Offer (among others). also includes Yield Curves and implied forward curves. That is, interpolation may either be linear (straight line interpolation between two values) or may be expressed as a non linear curve such as a yield curve or an implied forward curve.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;JapaneseCompoundYieldCalculationMethod">
@@ -555,7 +557,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">loan pool prepayment model</rdfs:label>
 		<skos:definition xml:lang="en">Model of the prepayments of loans in a pool of individual loans, such as a mortgage pool or loan pool.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This model captures the parameters that may influence the prepayment of loans or mortgages and relates these mathematically.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This model captures the parameters that may influence the prepayment of loans or mortgages and relates these mathematically.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;LoanPrepaymentFormula">
@@ -594,7 +596,7 @@
 		<rdfs:label xml:lang="en">modified duration analytic</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-md-dbtx-aly;MacCaulaysDurationAnalytic"/>
 		<skos:definition xml:lang="en">The percentage price change of a security for a given change in yield. The higher the modified duration of a security, the higher its risk. Ad/ModDuration = [duration / {1 + (IRR/M)}]; where IRR is the internal rate of return and M is the number of compounding periods per year.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The higher the MD the greater the change in price for a given change in yield.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The higher the MD the greater the change in price for a given change in yield.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity">
@@ -614,7 +616,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">native yield</rdfs:label>
 		<skos:definition xml:lang="en">The yield of the security as determined using the Yield Calculation Method that is the default for the market that the security is traded in.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">conventional yield for that security type and geo location, ie. would be in relation too</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">conventional yield for that security type and geo location, ie. would be in relation too</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;NativeYieldCalculationMethod">
@@ -682,7 +684,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
 		<rdfs:label xml:lang="en">pool factor</rdfs:label>
 		<skos:definition xml:lang="en">How much of the original pool is still outstanding. This is a number below one. Expressed as percentage.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Would multiply the factor by the starting value of the pool. This determines how much it is paying down. Would take the form of a 10 digit decimal factor showing how much of the pool is outstanding. You get Factor information every month or so which includes the WAM figure (and the WALA and WAC). The rate can be derived from this. that would be the rate at which the pool is paying down. These all come from the issuer.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Would multiply the factor by the starting value of the pool. This determines how much it is paying down. Would take the form of a 10 digit decimal factor showing how much of the pool is outstanding. You get Factor information every month or so which includes the WAM figure (and the WALA and WAC). The rate can be derived from this. that would be the rate at which the pool is paying down. These all come from the issuer.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolPaydownRate">
@@ -744,8 +746,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">price value of basis point</rdfs:label>
 		<skos:definition xml:lang="en">Sensitivity of the price for one basis point change in yield, defined as the difference in price given 1 bp change in yield.</skos:definition>
-		<fibo-fnd-utl-av:abbreviation xml:lang="en">PVBP</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Price value of Basis Point Definition: The difference in price given 1 bp change in yield. This is like Duration but normalized to 1 basis point. Synonym DV01</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:abbreviation xml:lang="en">PVBP</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">Price value of Basis Point Definition: The difference in price given 1 bp change in yield. This is like Duration but normalized to 1 basis point. Synonym DV01</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;RelativeYieldCalculationMethod">
@@ -786,7 +788,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">simple yield calculation method</rdfs:label>
 		<skos:definition xml:lang="en">The annual rate of return expressed as a percentage. This is the return divided by the outlay and multiplied by 100 to express the figure as a percentage.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is yield in its simplest sense, expressed as a percentage of return to outlay. As such, this is the same way that yield is determined for any investments, not just financial instruments or debt investments.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is yield in its simplest sense, expressed as a percentage of return to outlay. As such, this is the same way that yield is determined for any investments, not just financial instruments or debt investments.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;SpanishYieldCalculationMethod">
@@ -862,7 +864,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">yield calculation formula</rdfs:label>
 		<skos:definition xml:lang="en">The formula used in determining the Yield.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The subject of this Formula is the Yield. The formula has an expression which can be defined either in tectual terms or by further local extension of the term &quot;Formula Expression&quot; to define the parameters used.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The subject of this Formula is the Yield. The formula has an expression which can be defined either in tectual terms or by further local extension of the term &quot;Formula Expression&quot; to define the parameters used.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;YieldCalculationMethod">

--- a/MD/DebtTemporal/MetadataMDDebtTemporal.rdf
+++ b/MD/DebtTemporal/MetadataMDDebtTemporal.rdf
@@ -1,47 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-md-dbtx-mod "https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-md-dbtx-mod="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) DebtTemporal Module</rdfs:label>
 		<dct:abstract>This module covers time-dependent concepts related to debt instruments, such as pricing, yields and analytics.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2022-01-26T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-md-dbtx-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataMDDebtTemporal.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20220101/DebtTemporal/MetadataMDDebtTemporal/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20230201/DebtTemporal/MetadataMDDebtTemporal/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-dbtx-mod;DebtTemporalModule">
-		<rdf:type rdf:resource="&sm;Module"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>Debt Temporal</rdfs:label>
 		<dct:abstract>This module covers time-dependent concepts related to debt instruments, such as pricing, yields and analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>FIBO Market Data - Debt Temporal Terms Module</dct:title>
-		<sm:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>fibo-md-dbtx</sm:moduleAbbreviation>
+		<dct:title>FIBO MD Debt Temporal Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Market Data (MD) Debt Temporal Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/DerivativesTemporal/ETOptionsTemporal.rdf
+++ b/MD/DerivativesTemporal/ETOptionsTemporal.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
@@ -15,10 +16,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/ETOptionsTemporal/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
@@ -34,22 +35,12 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/ETOptionsTemporal/">
 		<rdfs:label xml:lang="en">Exchange-Traded Options Temporal</rdfs:label>
 		<dct:abstract>Exchange traded options date and time dependent terms such as pricing and other analytics, including greeks (deltas, thetas etc.)</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/"/>
-		<sm:fileAbbreviation>fibo-md-derx-eto</sm:fileAbbreviation>
-		<sm:filename>ETOptionsTemporal.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
@@ -59,15 +50,17 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/ETOptionsTemporal/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-md-derx-eto;Delta">
 		<rdfs:subClassOf rdf:resource="&fibo-md-derx-eto;OptionsGreek"/>
 		<rdfs:label xml:lang="en">delta</rdfs:label>
 		<skos:definition xml:lang="en">First derivative of option value with respect to theoretical price is a delta (or on a position). Theoretical price</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Delta tells you what options to buy to get the equivalent price sensitivity to the underlying. How many at that price to get that hedge. So for example an at the money option has a delta of 50. Units</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Delta tells you what options to buy to get the equivalent price sensitivity to the underlying. How many at that price to get that hedge. So for example an at the money option has a delta of 50. Units</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-derx-eto;OptionDailySettlementPrice">
@@ -102,7 +95,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option theoretical value</rdfs:label>
 		<skos:definition xml:lang="en">fair value of the option as determined by an option pricing model</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The pricing model (such as the Black-Scholes model) takes into account current values such as implied volatility, the price of the underlying, the strike price, and time to expiration to determine what an option should be worth.  Each of the input values fluctuate, which means theoretical price will also be a fluctuating value.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The pricing model (such as the Black-Scholes model) takes into account current values such as implied volatility, the price of the underlying, the strike price, and time to expiration to determine what an option should be worth.  Each of the input values fluctuate, which means theoretical price will also be a fluctuating value.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-derx-eto;OptionsGreek">

--- a/MD/DerivativesTemporal/FuturesTemporal.rdf
+++ b/MD/DerivativesTemporal/FuturesTemporal.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
@@ -11,10 +12,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/FuturesTemporal/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
@@ -26,20 +27,21 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/FuturesTemporal/">
 		<rdfs:label xml:lang="en">FuturesTemporal</rdfs:label>
 		<dct:abstract>Exchange traded futures date and time dependent terms such as prices and margining. Also covers greeks (thetas etc.)</dct:abstract>
-		<sm:fileAbbreviation>fibo-md-der-fut</sm:fileAbbreviation>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/FuturesTemporal/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-md-der-fut;ExchangeFuturesPrice">
@@ -95,8 +97,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">initial margin</rdfs:label>
 		<skos:definition xml:lang="en">money or securities put up as a good faith deposit assuring that a future contract will be fulfilled</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">When you open a futures contract, the futures exchange will state a minimum amount of money that you must deposit into your account. This original deposit of money is called the initial margin. When your contract is liquidated, you will be refunded the initial margin plus or minus any gains or losses that occur over the span of the futures contract. In other words, the amount in your margin account changes daily as the market fluctuates in relation to your futures contract. The minimum-level margin is determined by the futures exchange and is usually 5% to 10% of the futures contract. These predetermined initial margin amounts are continuously under review: at times of high market volatility, initial margin requirements can be raised.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">security deposit</fibo-fnd-utl-av:synonym>
+		<cmns-av:explanatoryNote xml:lang="en">When you open a futures contract, the futures exchange will state a minimum amount of money that you must deposit into your account. This original deposit of money is called the initial margin. When your contract is liquidated, you will be refunded the initial margin plus or minus any gains or losses that occur over the span of the futures contract. In other words, the amount in your margin account changes daily as the market fluctuates in relation to your futures contract. The minimum-level margin is determined by the futures exchange and is usually 5% to 10% of the futures contract. These predetermined initial margin amounts are continuously under review: at times of high market volatility, initial margin requirements can be raised.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">security deposit</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-der-fut;MinimumMargin">

--- a/MD/DerivativesTemporal/MetadataMDDerivativesTemporal.rdf
+++ b/MD/DerivativesTemporal/MetadataMDDerivativesTemporal.rdf
@@ -1,48 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-md-derx-mod "https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-md-derx-mod="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) DerivativesTemporal Module</rdfs:label>
 		<dct:abstract>This module covers time-dependent concepts related to derivative instruments, such as the various derivatives-related greeks and other analytics.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-md-derx-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataMDDerivativesTemporal.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20200401/DerivativesTemporal/MetadataMDDerivativesTemporal/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20230201/DerivativesTemporal/MetadataMDDerivativesTemporal/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-derx-mod;DerivativesTemporalModule">
-		<rdf:type rdf:resource="&sm;Module"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>Derivatives Temporal</rdfs:label>
 		<dct:abstract>This module covers time-dependent concepts related to derivative instruments, such as the various derivatives-related greeks and other analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/ETOptionsTemporal/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/FuturesTemporal/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>FIBO Market Data - Derivatives Temporal Terms Module</dct:title>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>fibo-md-derx</sm:moduleAbbreviation>
+		<dct:title>FIBO MD Derivatives Temporal Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Market Data (MD) Derivatives Temporal Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/MetadataMD.rdf
+++ b/MD/MetadataMD.rdf
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-md-civx-mod "https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/">
 	<!ENTITY fibo-md-dbtx-mod "https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/">
 	<!ENTITY fibo-md-derx-mod "https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/">
@@ -10,11 +12,12 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-md-civx-mod="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/"
 	xmlns:fibo-md-dbtx-mod="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/"
 	xmlns:fibo-md-derx-mod="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/"
@@ -24,50 +27,38 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) Domain</rdfs:label>
 		<dct:abstract>The Market Data (MD) domain contains ontologies that represent temporally variant concepts for financial instruments, loans and funds. As such this domain covers the concepts represented in market data, such as prices, yields and analytics for debt and for pools of assets.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-md-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataMD.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20201201/MetadataMD/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-mod;MDDomain">
-		<rdf:type rdf:resource="&sm;Module"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>Market Data Domain</rdfs:label>
 		<dct:abstract>The Market Data (MD) domain contains ontologies that represent temporally variant concepts for financial instruments, loans and funds. As such this domain covers the concepts represented in market data, such as prices, yields and analytics for debt and for pools of assets.</dct:abstract>
 		<dct:hasPart rdf:resource="&fibo-md-civx-mod;CIVTemporalModule"/>
 		<dct:hasPart rdf:resource="&fibo-md-dbtx-mod;DebtTemporalModule"/>
 		<dct:hasPart rdf:resource="&fibo-md-derx-mod;DerivativesTemporalModule"/>
 		<dct:hasPart rdf:resource="&fibo-md-temx-mod;TemporalCoreModule"/>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Market Data (MD) Domain</dct:title>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/BEDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/BPDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/DERDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/FBCDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/FNDDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/INDDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/LOANDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/SECDomain"/>
-		<sm:keyword>market data</sm:keyword>
-		<sm:moduleAbbreviation>fibo-md</sm:moduleAbbreviation>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
+		<dct:title>Financial Industry Business Ontology (FIBO) Market Data (MD) Domain</dct:title>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/TemporalCore/MetadataMDTemporalCore.rdf
+++ b/MD/TemporalCore/MetadataMDTemporalCore.rdf
@@ -1,48 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-md-temx-mod "https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-md-temx-mod="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) TemporalCore Module</rdfs:label>
 		<dct:abstract>This module covers time-dependent concepts common to all instruments, funds and loans, such as pricing, yields and analytics.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-md-temx-mod</sm:fileAbbreviation>
-		<sm:filename>MetadataMDTemporalCore.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20200401/TemporalCore/MetadataMDTemporalCore/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20230201/TemporalCore/MetadataMDTemporalCore/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-temx-mod;TemporalCoreModule">
-		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Temporal Core</rdfs:label>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
+		<rdfs:label>temporal core module</rdfs:label>
 		<dct:abstract>This module covers time-dependent concepts common to all instruments, funds and loans, such as pricing, yields and analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityCreditStatuses/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>FIBO Market Data - Core Temporal Terms Module</dct:title>
-		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>fibo-md-temx</sm:moduleAbbreviation>
+		<dct:title>FIBO MD Temporal Core Module</dct:title>
+		<dct:title>Financial Industry Business Ontology (FIBO) Market Data (MD) Temporal Core Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/TemporalCore/SecurityCreditStatuses.rdf
+++ b/MD/TemporalCore/SecurityCreditStatuses.rdf
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -9,11 +11,12 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityCreditStatuses/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -22,20 +25,21 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityCreditStatuses/">
 		<rdfs:label xml:lang="en">SecurityCreditStatuses</rdfs:label>
 		<dct:abstract>This ontology extends the credit status ontology to define credit status concepts that are specific to issued securities. These include cashflow status and the basic credit statuses of being OK or in default. 
 		Note that in application data models these concepts would be represented as one or more selectable code lists or enumerations.</dct:abstract>
-		<sm:fileAbbreviation>fibo-md-temx-crs</sm:fileAbbreviation>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityCreditStatuses/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-md-temx-crs;CreditOK">
@@ -64,7 +68,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">security credit status</rdfs:label>

--- a/MD/TemporalCore/SecurityTradingStatuses.rdf
+++ b/MD/TemporalCore/SecurityTradingStatuses.rdf
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -12,11 +14,12 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -28,22 +31,23 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/">
 		<rdfs:label xml:lang="en">SecurityTradingStatuses</rdfs:label>
 		<dct:abstract>This ontology defines the various kinds of trading status that a security may be in at any given point in time. These includes such terms as active and halted, inactive and so on, along with their qualifying terms.</dct:abstract>
-		<sm:fileAbbreviation>fibo-md-temx-trs</sm:fileAbbreviation>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-md-temx-trs;Active">
@@ -88,7 +92,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">security lifecycle status</rdfs:label>
@@ -100,7 +104,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">security trading status</rdfs:label>
@@ -129,7 +133,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
 		<rdfs:label xml:lang="en">worthless</rdfs:label>
 		<skos:definition xml:lang="en">Announcement by the regulator that the security has become worthless.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">e.g. bankruptcy hearings - might result in this being said.</fibo-fnd-utl-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">e.g. bankruptcy hearings - might result in this being said.</cmns-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/MetadataFIBO.rdf
+++ b/MetadataFIBO.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-mod "https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/">
 	<!ENTITY fibo-bp-mod "https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/">
@@ -7,6 +8,7 @@
 	<!ENTITY fibo-der-mod "https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/">
 	<!ENTITY fibo-fbc-mod "https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/">
 	<!ENTITY fibo-fnd-mod "https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-mod "https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/">
 	<!ENTITY fibo-loan-mod "https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/">
 	<!ENTITY fibo-md-mod "https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/">
@@ -16,10 +18,10 @@
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-mod="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/"
 	xmlns:fibo-bp-mod="https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/"
@@ -27,6 +29,7 @@
 	xmlns:fibo-der-mod="https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/"
 	xmlns:fibo-fbc-mod="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/"
 	xmlns:fibo-fnd-mod="https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-mod="https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/"
 	xmlns:fibo-loan-mod="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/"
 	xmlns:fibo-md-mod="https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/"
@@ -36,34 +39,33 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/">
 		<rdfs:label>Metadata for the EDMC-FIBO Specification</rdfs:label>
 		<dct:abstract>This is the metadata ontology used to describe the FIBO Specification.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
-		<sm:fileAbbreviation>fibo-spec</sm:fileAbbreviation>
-		<sm:filename>MetadataFIBO.rdf</sm:filename>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20201201/MetadataFIBO/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230201/MetadataFIBO/"/>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-spec;FIBOSpecification">
-		<rdf:type rdf:resource="&sm;Specification"/>
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>Financial Industry Business Ontology</rdfs:label>
 		<dct:abstract>The Financial Industry Business Ontology (FIBO) is a collaborative effort among industry practitioners, semantic technology experts and information scientists to standardize the language used to precisely define the terms, conditions, and characteristics of financial instruments; the legal and relationship structure of business entities; the content and time dimensions of market data; and the legal obligations and process aspects of corporate actions.  The definitions and relationships that comprise the FIBO specification have been modularized into a number of domains, which in turn include a number of modules, each of which is further modularized into one or more constituent ontologies. 
 
@@ -78,19 +80,13 @@ The FIBO ontologies are available as OWL 2 ontologies from the EDM Council site,
 		<dct:hasPart rdf:resource="&fibo-loan-mod;LOANDomain"/>
 		<dct:hasPart rdf:resource="&fibo-md-mod;MDDomain"/>
 		<dct:hasPart rdf:resource="&fibo-sec-mod;SECDomain"/>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-13T18:00:00</dct:modified>
 		<dct:title>Financial Industry Business Ontology (FIBO)</dct:title>
-		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
-		<sm:keyword>FIBO</sm:keyword>
-		<sm:keyword>Financial Industry Business Ontology</sm:keyword>
-		<sm:specificationAbbreviation>FIBO</sm:specificationAbbreviation>
-		<sm:specificationURL rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</sm:specificationURL>
-		<sm:technologyArea>formal semantics</sm:technologyArea>
-		<sm:topicArea>finance</sm:topicArea>
+		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised all of the MD ontologies and metadata to replace specfication metadata with the Commons annotation vocabulary and eliminate technical debt in a few places

Fixes: #1886 / FND-372


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


