### PR TITLE
FND-375 - Revise the FND ontologies to reuse concepts from the Commons ontologies rather than from LCC Country Representation ontology

### DIFF
--- a/BE/FunctionalEntities/FunctionalEntities.rdf
+++ b/BE/FunctionalEntities/FunctionalEntities.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -16,7 +17,6 @@
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -26,6 +26,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -40,7 +41,6 @@
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -61,10 +61,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/FunctionalEntities/FunctionalEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20150201/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.1 RTF report. Changes include deprecation of the SoleProprietorship class and making it equivalent to the class with the same name in the Sole Proprietorships ontology. This version also introduces a new FunctionalEntity class, as the parent of FunctionalBusinessEntity in this ontology and as the parent of Government in the GovernmentEntities ontology.</skos:changeNote>
@@ -142,14 +142,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;MerchantIdentifier"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;MerchantCategoryCode"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;MerchantCategoryCode"/>
+				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;MerchantIdentifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>merchant</rdfs:label>
@@ -181,7 +181,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;Merchant"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf
@@ -8,7 +8,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -24,7 +23,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -40,13 +38,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to remove the UK from coverage by the EU jurisdiction and replace references to the Czech Republic with Czechia.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190101/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to remove the unnecessary imports.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220201/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220801/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>

--- a/BE/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf
@@ -13,7 +13,6 @@
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-3166-2 "https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/">
 	<!ENTITY lcc-3166-2-gb "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-GB/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -34,7 +33,6 @@
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-3166-2="https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/"
 	xmlns:lcc-3166-2-gb="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-GB/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -52,13 +50,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-GB/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200201/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to add devolved government entities for Scotland, Wales, and Northern Ireland.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200701/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>

--- a/BE/GovernmentEntities/GovernmentEntities.rdf
+++ b/BE/GovernmentEntities/GovernmentEntities.rdf
@@ -178,19 +178,19 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;hasPart"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasPart"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;BranchOfGovernment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;hasPart"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasPart"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;GovernmentAgency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;hasPart"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasPart"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;GovernmentDepartment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -313,7 +313,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;BranchOfGovernment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;hasPart"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasPart"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-cor;CourtOfLaw"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/BE/GovernmentEntities/LatinAmericanJurisdiction/CentralAmericanGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/LatinAmericanJurisdiction/CentralAmericanGovernmentEntitiesAndJurisdictions.rdf
@@ -11,7 +11,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ge-ge-ctlaj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/LatinAmericanJurisdiction/CentralAmericanGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -30,7 +29,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ge-ge-ctlaj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/LatinAmericanJurisdiction/CentralAmericanGovernmentEntitiesAndJurisdictions/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -49,10 +47,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/LatinAmericanJurisdiction/CentralAmericanGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/GovernmentEntities/LatinAmericanJurisdiction/CentralAmericanGovernmentEntitiesAndJurisdictions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201101/GovernmentEntities/LatinAmericanJurisdiction/CentralAmericanGovernmentEntitiesAndJurisdictions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/LatinAmericanJurisdiction/CentralAmericanGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:scopeNote>The initial version of this ontology reflects the highest national level only.</skos:scopeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>

--- a/BE/GovernmentEntities/LatinAmericanJurisdiction/SouthAmericanGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/LatinAmericanJurisdiction/SouthAmericanGovernmentEntitiesAndJurisdictions.rdf
@@ -11,7 +11,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ge-ge-saj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/LatinAmericanJurisdiction/SouthAmericanGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -30,7 +29,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ge-ge-saj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/LatinAmericanJurisdiction/SouthAmericanGovernmentEntitiesAndJurisdictions/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -49,10 +47,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/LatinAmericanJurisdiction/SouthAmericanGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/GovernmentEntities/LatinAmericanJurisdiction/SouthAmericanGovernmentEntitiesAndJurisdictions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201101/GovernmentEntities/LatinAmericanJurisdiction/SouthAmericanGovernmentEntitiesAndJurisdictions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/LatinAmericanJurisdiction/SouthAmericanGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:scopeNote>The initial version of this ontology reflects the highest national level only.</skos:scopeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>

--- a/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions.rdf
@@ -12,7 +12,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-3166-2-ca "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -32,7 +31,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-3166-2-ca="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -51,12 +49,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200201/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to replace &apos;hasPartialSovereigntyOver&apos; with &apos;hasSharedSovereigntyOver&apos;.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>

--- a/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf
@@ -11,7 +11,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -30,7 +29,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -49,12 +47,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200701/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to correct the ontology prefix and address language-specific diacritical marks.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20210201/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to correct spelling issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20211201/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/NorthAmericanJurisdiction/CaribbeanGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:scopeNote>The initial version of this ontology reflects the highest national or regional level (for British Commonwealth members) only.</skos:scopeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>

--- a/BE/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions.rdf
@@ -12,7 +12,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-3166-2-mx "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-MX/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -32,7 +31,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-3166-2-mx="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-MX/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -51,12 +49,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-MX/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200701/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to replace &apos;hasPartialSovereigntyOver&apos; with &apos;hasSharedSovereigntyOver&apos;.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210201/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/NorthAmericanJurisdiction/MXGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>

--- a/BE/LegalEntities/FormalBusinessOrganizations.rdf
+++ b/BE/LegalEntities/FormalBusinessOrganizations.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -18,7 +19,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -27,6 +27,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -44,7 +45,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -60,7 +60,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
@@ -71,7 +70,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/LegalEntities/FormalBusinessOrganizations/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was modified per the FIBO 2.0 RFC to address minor bug fixes.</skos:changeNote>
@@ -209,7 +208,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fnd-arr-cls;IndustrySectorClassifier"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/BE/LegalEntities/LEIEntities.rdf
+++ b/BE/LegalEntities/LEIEntities.rdf
@@ -21,7 +21,6 @@
 	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -50,7 +49,6 @@
 	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -80,7 +78,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/LegalEntities/LEIEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/LegalEntities/LEIEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20150201/LegalEntities/LEIEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.1 RTF report. Changes include deprecation of the MunicipalEntity, Sovereign, and SupranationalEntity classes and making them equivalent to classes in the Government Entities ontology.</skos:changeNote>

--- a/BE/OwnershipAndControl/OwnershipParties.rdf
+++ b/BE/OwnershipAndControl/OwnershipParties.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
@@ -15,7 +16,6 @@
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -24,6 +24,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
@@ -38,7 +39,6 @@
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -48,7 +48,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 		<rdfs:label>Ownership Parties Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts relating to types of organization owning parties. The concepts defined here are party in role concepts, which define the nature of some entity such as an organization or a legal person, in some role such as that of owning equity in the entity. These roles are defined in terms of the ownership enjoyed by the party, with distinctions between constitutional ownership i.e. ownership defined in terms of stockholder equity, and investment ownership more generally.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
@@ -62,8 +62,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230101/OwnershipAndControl/OwnershipParties/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/OwnershipAndControl/OwnershipParties/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified per the FIBO 2.0 RFC to address missing labels and comments, and revise terminology related to shareholders&apos; equity due to requirements for SEC/Equities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to support GLEIF LEI Level 2 ownership relationships.</skos:changeNote>
@@ -76,6 +76,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/OwnershipParties.rdf version of this ontology was revised to add a restriction on entity ownership for the ownership percentage.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210401/OwnershipAndControl/OwnershipParties.rdf version of this ontology was revised to eliminate a dead link that was not necessary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220801/OwnershipAndControl/OwnershipParties.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -169,7 +170,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-be-le-lei;RelationshipStatus"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/BP/SecuritiesIssuance/IssuanceProcess.rdf
+++ b/BP/SecuritiesIssuance/IssuanceProcess.rdf
@@ -20,7 +20,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -48,7 +47,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -78,7 +76,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/IssuanceProcess/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -322,7 +319,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Document"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isPartOf"/>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;IssuedSecurityIssueInformation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
+++ b/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-bp-iss-ambs "https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/AgencyMBSIssuance/">
 	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/">
@@ -24,7 +25,6 @@
 	<!ENTITY fibo-sec-dbt-mbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/">
 	<!ENTITY fibo-sec-dbt-pbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -33,6 +33,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-bp-iss-ambs="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/AgencyMBSIssuance/"
 	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/"
@@ -56,7 +57,6 @@
 	xmlns:fibo-sec-dbt-mbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"
 	xmlns:fibo-sec-dbt-pbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -91,7 +91,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -697,14 +697,14 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasContent">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;hasPart"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasPart"/>
 		<rdfs:label xml:lang="en">has content</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSProspectusOutline"/>
 		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheStructure"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasContent.1">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;hasPart"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasPart"/>
 		<rdfs:label xml:lang="en">has content</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSProspectusOutline"/>
 		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheTermsheet"/>

--- a/CAE/CorporateEvents/CorporateActions.rdf
+++ b/CAE/CorporateEvents/CorporateActions.rdf
@@ -2,18 +2,17 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -23,18 +22,17 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -47,16 +45,15 @@
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20230301/CorporateEvents/CorporateActions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20220301/CorporateEvents/CorporateActions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20230201/CorporateEvents/CorporateActions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
@@ -84,7 +81,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;ActionClassifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -95,7 +92,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;ActionClassificationScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;ClassificationScheme"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -115,8 +112,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;ActionClassifier">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
@@ -139,7 +136,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -158,7 +155,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-cae-ce-GLEIF "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/">
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -18,15 +17,14 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-cae-ce-GLEIF="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -39,12 +37,11 @@
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -68,7 +65,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-GLEIF;ActionGroup">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
@@ -77,7 +74,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -10,7 +11,6 @@
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -19,6 +19,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -28,7 +29,6 @@
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -45,9 +45,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -58,9 +58,9 @@
 		<rdfs:label xml:lang="en">BIDS</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>BIDS</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;RepurchaseOffer"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RepurchaseOffer"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BONU">
@@ -68,9 +68,9 @@
 		<rdfs:label xml:lang="en">BONU</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>BONU</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;BonusIssue"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;BonusIssue"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BPUT">
@@ -78,9 +78,9 @@
 		<rdfs:label xml:lang="en">BPUT</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>BPUT</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;PutRedemptionAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PutRedemptionAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CAPD">
@@ -88,9 +88,9 @@
 		<rdfs:label xml:lang="en">CAPD</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>CAPD</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;CapitalDistribution"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CapitalDistribution"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CAPG">
@@ -98,9 +98,9 @@
 		<rdfs:label xml:lang="en">CAPG</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that distribute profits resulting from the sale of company assets to shareholders</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>CAPG</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;CapitalGainsDistribution"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CapitalGainsDistribution"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CHAN">
@@ -108,9 +108,9 @@
 		<rdfs:label xml:lang="en">CHAN</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that disseminate information regarding a change further described in the corporate action details</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>CHAN</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-act;ChangeAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;ChangeAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CLSA">
@@ -118,9 +118,9 @@
 		<rdfs:label xml:lang="en">CLSA</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving a situation where interested parties seek restitution for financial loss</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>CLSA</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-act;ClassAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;ClassAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CONS">
@@ -128,9 +128,9 @@
 		<rdfs:label xml:lang="en">CONS</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve procedures aiming to obtain consent of holder to a proposal by the issuer or a third party without convening a meeting</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>CONS</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-act;ConsentSolicitation"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;ConsentSolicitation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;CONV">
@@ -138,9 +138,9 @@
 		<rdfs:label xml:lang="en">CONV</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve conversion of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price/ratio</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>CONV</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;ConversionAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ConversionAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DECR">
@@ -148,9 +148,9 @@
 		<rdfs:label xml:lang="en">DECR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that reduce the face value of a share or the value of fund assets</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DECR</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;DecreaseInValueAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DecreaseInValueAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DFLT">
@@ -158,9 +158,9 @@
 		<rdfs:label xml:lang="en">DFLT</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that indicate a failure by the issuer to perform obligations defined as default events under the bond agreement and that have not been remedied</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DFLT</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;BondDefaultAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;BondDefaultAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DRIP">
@@ -168,9 +168,9 @@
 		<rdfs:label xml:lang="en">DRIP</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DRIP</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;DividendReinvestmentAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DividendReinvestmentAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DSCL">
@@ -178,9 +178,9 @@
 		<rdfs:label xml:lang="en">DSCL</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DSCL</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-act;DisclosureAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;DisclosureAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DTCH">
@@ -188,9 +188,9 @@
 		<rdfs:label xml:lang="en">DTCH</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving parties wishing to acquire a security</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DTCH</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;DutchAuction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DutchAuction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DVCA">
@@ -198,9 +198,9 @@
 		<rdfs:label xml:lang="en">DVCA</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that distribute cash to shareholders in proportion to their equity holding</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DVCA</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;CashDividendAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CashDividendAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DVOP">
@@ -208,9 +208,9 @@
 		<rdfs:label xml:lang="en">DVOP</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DVOP</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;DividendOptionAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;DividendOptionAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;DVSE">
@@ -218,9 +218,9 @@
 		<rdfs:label xml:lang="en">DVSE</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders in the form of equities of the issuing corporation</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DVSE</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;StockDividendAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;StockDividendAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXOF">
@@ -228,9 +228,9 @@
 		<rdfs:label xml:lang="en">EXOF</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that reflect an exchange of holdings for other securities and/or cash</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>EXOF</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;ExchangeAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ExchangeAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXRI">
@@ -238,9 +238,9 @@
 		<rdfs:label xml:lang="en">EXRI</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>EXRI</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;CallOnIntermediateSecurities"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;CallOnIntermediateSecurities"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXTM">
@@ -248,9 +248,9 @@
 		<rdfs:label xml:lang="en">EXTM</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve prolonging the maturity date of a bond</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>EXTM</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-fbc-dae-cre;MaturityExtension"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-fbc-dae-cre;MaturityExtension"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;EXWA">
@@ -259,9 +259,9 @@
 		<rdfs:label xml:lang="en">EXWA</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that offer holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>EXWA</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;WarrantExerciseAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;WarrantExerciseAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;INFO">
@@ -269,9 +269,9 @@
 		<rdfs:label xml:lang="en">INFO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>INFO</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-act;Notification"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;Notification"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;INTR">
@@ -279,9 +279,9 @@
 		<rdfs:label xml:lang="en">INTR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a regular interest payment to holders of an interest-bearing asset</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>INTR</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;InterestPaymentAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;InterestPaymentAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme">
@@ -295,9 +295,9 @@
 		<rdfs:label xml:lang="en">LIQU</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>LIQU</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-act;Liquidation"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;Liquidation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;MCAL">
@@ -305,9 +305,9 @@
 		<rdfs:label xml:lang="en">MCAL</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MCAL</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;FullCallEarlyRedemptionAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;FullCallEarlyRedemptionAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;MRGR">
@@ -315,9 +315,9 @@
 		<rdfs:label xml:lang="en">MRGR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve the exchange of outstanding securities, initiated by the issuer which may include options, as the result of two or more companies combining assets, that is, an external, third party company</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MRGR</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;PostMergerSecuritiesExchange"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PostMergerSecuritiesExchange"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PARI">
@@ -325,9 +325,9 @@
 		<rdfs:label xml:lang="en">PARI</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that occur when securities with different characteristics become identical in all respects</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>PARI</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;PariPassuAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PariPassuAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PCAL">
@@ -335,9 +335,9 @@
 		<rdfs:label xml:lang="en">PCAL</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>PCAL</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithReductionOfNominalValueAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithReductionOfNominalValueAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PRED">
@@ -345,9 +345,9 @@
 		<rdfs:label xml:lang="en">PRED</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>PRED</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithoutReductionOfNominalValueAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;PartialRedemptionWithoutReductionOfNominalValueAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;PRIO">
@@ -355,9 +355,9 @@
 		<rdfs:label xml:lang="en">PRIO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a public offer where priority is given to existing shareholders</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>PRIO</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-act;PriorityIssue"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;PriorityIssue"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;REDM">
@@ -365,9 +365,9 @@
 		<rdfs:label xml:lang="en">REDM</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities at final maturity</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>REDM</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;RedemptionAtMaturityAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RedemptionAtMaturityAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;REDO">
@@ -375,9 +375,9 @@
 		<rdfs:label xml:lang="en">REDO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions by which the unit (currency and/or nominal) of a security is restated</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>REDO</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;RedenominationAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;RedenominationAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;RHDI">
@@ -385,9 +385,9 @@
 		<rdfs:label xml:lang="en">RHDI</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>RHDI</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;IntermediateSecuritiesDistribution"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SHPR">
@@ -395,9 +395,9 @@
 		<rdfs:label xml:lang="en">SHPR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the shares premium reserve</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>SHPR</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;SharesPremiumDividendAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;SharesPremiumDividendAction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SOFF">
@@ -405,9 +405,9 @@
 		<rdfs:label xml:lang="en">SOFF</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>SOFF</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-act;SpinOff"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-act;SpinOff"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SPLF">
@@ -415,9 +415,9 @@
 		<rdfs:label xml:lang="en">SPLF</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve an increase in a corporation&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>SPLF</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;StockSplit"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;StockSplit"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;SPLR">
@@ -425,9 +425,9 @@
 		<rdfs:label xml:lang="en">SPLR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>SPLR</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;ReverseStockSplit"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;ReverseStockSplit"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;TEND">
@@ -435,9 +435,9 @@
 		<rdfs:label xml:lang="en">TEND</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>TEND</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;TenderOffer"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;TenderOffer"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;WRTH">
@@ -446,9 +446,9 @@
 		<rdfs:label xml:lang="en">WRTH</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve booking out of valueless securities</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>WRTH</fibo-fnd-rel-rel:hasTag>
+		<cmns-cls:classifies rdf:resource="&fibo-cae-ce-srca;WorthlessSecurityAction"/>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
-		<lcc-cr:classifies rdf:resource="&fibo-cae-ce-srca;WorthlessSecurityAction"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/CommoditiesContracts.rdf
+++ b/DER/DerivativesContracts/CommoditiesContracts.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
@@ -12,7 +13,6 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -24,6 +24,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
@@ -35,7 +36,6 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -57,11 +57,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230301/DerivativesContracts/CommoditiesContracts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20210901/DerivativesContracts/CommoditiesContracts.rdf version of this ontology was modified to fix spelling errors.</skos:changeNote>
@@ -318,7 +318,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-comm;OilGrade">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label xml:lang="en">oil grade</rdfs:label>
 		<skos:definition xml:lang="en">measure of the viscosity of oil during operation</skos:definition>
 	</owl:Class>

--- a/DER/DerivativesContracts/CurrencyContracts.rdf
+++ b/DER/DerivativesContracts/CurrencyContracts.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-cur "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/">
@@ -14,7 +15,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-fx-fx "https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -23,6 +23,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-cur="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"
@@ -36,7 +37,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-fx-fx="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -46,7 +46,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/">
 		<rdfs:label xml:lang="en">Currency Contracts Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts common to currency spot contracts and foreign exchange derivatives (forwards, options and swaps).</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/FuturesAndForwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
@@ -59,10 +59,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230201/DerivativesContracts/CurrencyContracts/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230301/DerivativesContracts/CurrencyContracts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20210701/DerivativesContracts/CurrencyContracts/ version of this ontology was modified to reflect the addition of the concept of a rates swap and the corresponding rate-based leg to the Swaps ontology, as well as the concept of a spot forward currency swap, to facilitate mapping to the CFI standard.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220301/DerivativesContracts/CurrencyContracts.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/DerivativesContracts/CurrencyContracts.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -117,13 +118,13 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-cur;CurrencyForward"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;hasPart"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasPart"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-cur;CurrencySpotContract"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;hasPart"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasPart"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-cur;CurrencySwap"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/DER/DerivativesContracts/ExoticOptions.rdf
+++ b/DER/DerivativesContracts/ExoticOptions.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
@@ -20,7 +21,6 @@
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
 	<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/">
 	<!ENTITY fibo-sec-sec-cls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -29,6 +29,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
@@ -48,7 +49,6 @@
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
 	xmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"
 	xmlns:fibo-sec-sec-cls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -76,6 +76,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230301/DerivativesContracts/ExoticOptions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/ExoticOptions/ version of this ontology was modified to rephrase definitions on knock-in and knock-out options.</skos:changeNote>
@@ -97,14 +98,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-opt;ExoticOption"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-der-drc-exo;AsianOptionClassifier"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-der-drc-exo;AveragingStrategy"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -149,7 +150,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;AsianOption"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -173,7 +174,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-exo;AsianOption"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -14,7 +15,6 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
@@ -30,7 +30,6 @@
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
 	<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -39,6 +38,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -52,7 +52,6 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
@@ -68,7 +67,6 @@
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -89,7 +87,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
@@ -106,8 +103,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230301/DerivativesContracts/Options/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/Options.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/DerivativesContracts/Options.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
@@ -413,10 +410,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-opt;Moneyness">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -767,7 +764,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-opt;hasExerciseStyle">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isClassifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has exercise style</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-ex;ExerciseConvention"/>

--- a/DER/DerivativesContracts/SwapsIndividuals.rdf
+++ b/DER/DerivativesContracts/SwapsIndividuals.rdf
@@ -26,7 +26,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-3166-2-us "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -60,7 +59,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-3166-2-us="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -93,7 +91,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>

--- a/FBC/DebtAndEquities/CreditRatings.rdf
+++ b/FBC/DebtAndEquities/CreditRatings.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -8,9 +9,7 @@
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
-	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
 	<!ENTITY fibo-fnd-arr-rt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
@@ -23,7 +22,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -32,6 +30,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -39,9 +38,7 @@
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
-	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
 	xmlns:fibo-fnd-arr-rt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
@@ -54,7 +51,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -69,9 +65,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
@@ -85,9 +79,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -123,7 +117,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crt;CreditInquiryType"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -132,7 +126,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditInquiryType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>credit inquiry type</rdfs:label>
 		<skos:definition>classifier indicating whether a credit inquiry is a result of a borrower&apos;s direct authorization or by some indirect means</skos:definition>
 	</owl:Class>
@@ -141,7 +135,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Notice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crt;CreditMessageType"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -150,7 +144,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditMessageType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>credit message type</rdfs:label>
 		<skos:definition>classifier that categorizes credit messages</skos:definition>
 	</owl:Class>
@@ -216,7 +210,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crt;CreditRatingModelType"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -226,7 +220,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditRatingModelType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>credit score model type</rdfs:label>
 		<skos:definition>a type corresonding to a family of credit scoring algorithms sharing common characteristics</skos:definition>
 	</owl:Class>
@@ -309,6 +303,12 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crt;CreditReportCategory"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crt;CreditMessage"/>
 			</owl:Restriction>
@@ -319,19 +319,13 @@
 				<owl:someValuesFrom rdf:resource="&cmns-id;Identifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crt;CreditReportCategory"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>credit report</rdfs:label>
 		<skos:definition>report describing the creditworthiness and related credit attributes of a borrower</skos:definition>
 		<cmns-av:explanatoryNote>This is typically provided by a credit rating agency but could be produced by an internal proprietary model as well.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditReportCategory">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>credit report category</rdfs:label>
 		<skos:definition>classifier for credit reports, often available from multiple vendors</skos:definition>
 	</owl:Class>
@@ -369,7 +363,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-crt;CreditWatchDirection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label xml:lang="en">credit watch direction</rdfs:label>
 	</owl:Class>
 	

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
@@ -17,7 +18,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -27,6 +27,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
@@ -42,7 +43,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -68,7 +68,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FinancialInstruments/InstrumentPricing/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, to add adjusted price and to create a more general hasLotSize property that can be used in various contexts.</skos:changeNote>
@@ -617,7 +617,7 @@
 	<owl:Class rdf:about="&fibo-fnd-acc-cur;CalculatedPrice">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;uses"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fi-ip;PricingModel"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -9,7 +9,6 @@
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
@@ -35,7 +34,6 @@
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
@@ -60,7 +58,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>

--- a/FBC/FunctionalEntities/BusinessCenters.rdf
+++ b/FBC/FunctionalEntities/BusinessCenters.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -19,6 +20,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -42,6 +44,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
@@ -98,7 +101,7 @@
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;Municipality">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isPartOf"/>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
 				<owl:someValuesFrom rdf:resource="&lcc-cr;GeopoliticalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/FunctionalEntities/BusinessCentersIndividuals.rdf
+++ b/FBC/FunctionalEntities/BusinessCentersIndividuals.rdf
@@ -15,7 +15,6 @@
 	<!ENTITY lcc-3166-2 "https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/">
 	<!ENTITY lcc-3166-2-ch "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CH/">
 	<!ENTITY lcc-3166-2-us "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -38,7 +37,6 @@
 	xmlns:lcc-3166-2="https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/"
 	xmlns:lcc-3166-2-ch="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CH/"
 	xmlns:lcc-3166-2-us="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -61,7 +59,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CH/"/>
@@ -221,186 +218,186 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Aabenraa">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Aabenraa</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Aalborg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Aalborg</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Abha">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Abha</rdfs:label>
 		<dct:description>the international business center of Abha</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;SaudiArabia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;SaudiArabia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Abidjan">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Abidjan</rdfs:label>
 		<dct:description>the international business center of Abidjan</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;CoteDIvoire"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;CoteDIvoire"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Abu_Dhabi">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Abu Dhabi</rdfs:label>
 		<dct:description>the international business center of Abu Dhabi</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedArabEmirates"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedArabEmirates"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Abuja">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Abuja</rdfs:label>
 		<dct:description>the international business center of Abuja</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Nigeria"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Nigeria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Accra">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Accra</rdfs:label>
 		<dct:description>the international business center of Accra</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Ghana"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Ghana"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Addis_Ababa">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Addis Ababa</rdfs:label>
 		<dct:description>the international business center of Addis Ababa</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Ethiopia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Ethiopia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Adelaide">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Adelaide</rdfs:label>
 		<dct:description>the international business center of Adelaide</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Aden">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Aden</rdfs:label>
 		<dct:description>the international business center of Aden</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Yemen"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Yemen"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Ahmedabad">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Ahmedabad</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Aichi">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Aichi</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Alberta">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Alberta</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Algiers">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Algiers</rdfs:label>
 		<dct:description>the international business center of Algiers</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Algeria"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Algeria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Alma-ata">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<owl:sameAs rdf:resource="&fibo-fbc-fct-bci;Almaty"/>
 		<rdfs:label>Alma-ata</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Kazakhstan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Kazakhstan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Almaty">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Almaty</rdfs:label>
 		<dct:description>the international business center of Almaty</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Kazakhstan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Kazakhstan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Amman">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Amman</rdfs:label>
 		<dct:description>the international business center of Amman</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Jordan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Jordan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Amsterdam">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Amsterdam</rdfs:label>
 		<dct:description>the international business center of Amsterdam</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Ankara">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Ankara</rdfs:label>
 		<dct:description>the international business center of Ankara</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Turkey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Turkey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Antananarivo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Antananarivo</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Madagascar"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Madagascar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Antwerpen">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Antwerpen</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Belgium"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Belgium"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Astana">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Astana</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Kazakhstan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Kazakhstan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Asti">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Asti</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Asuncion">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Asuncion</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Paraguay"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Paraguay"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Athens">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Athens</rdfs:label>
 		<dct:description>the international business center of Athens</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Greece"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Greece"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Atlanta">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Atlanta</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Georgia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Georgia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Auckland">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Auckland</rdfs:label>
 		<dct:description>the international business center of Auckland</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;NewZealand"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;NewZealand"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Aylesbury">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Aylesbury</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;BBBR">
@@ -556,190 +553,190 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Baghdad">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Baghdad</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Iraq"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Iraq"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Baku">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Baku</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Azerbaijan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Azerbaijan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bandar_Seri_Begawan">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Bandar Seri Begawan</rdfs:label>
 		<dct:description>the international business center of Bandar Seri Begawan</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;BruneiDarussalam"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;BruneiDarussalam"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bangalore">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Bangalore</rdfs:label>
 		<dct:description>the international business center of Bangalore</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bangkok">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Bangkok</rdfs:label>
 		<dct:description>the international business center of Bangkok</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Thailand"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Thailand"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Banja_Luka">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Banja Luka</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;BosniaAndHerzegovina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;BosniaAndHerzegovina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Barcelona">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Barcelona</rdfs:label>
 		<dct:description>the international business center of Barcelona</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Basel">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Basel</rdfs:label>
 		<dct:description>the international business center of Basel</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Basseterre">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Basseterre</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;SaintKittsAndNevis"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;SaintKittsAndNevis"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bedminster">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bedminster</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Beijing">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Beijing</rdfs:label>
 		<dct:description>the international business center of Beijing</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;China"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;China"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Beirut">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Beirut</rdfs:label>
 		<dct:description>the international business center of Beirut</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Lebanon"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Lebanon"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Belgrade">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Belgrade</rdfs:label>
 		<dct:description>the international business center of Belgrade</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Serbia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Serbia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bergamo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bergamo</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bergen">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bergen</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Berlin">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Berlin</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bermuda">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bermuda</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Bermuda"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Bermuda"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bern">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bern</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Biella">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Biella</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bilbao">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bilbao</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bishkek">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bishkek</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Kyrgyzstan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Kyrgyzstan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Blantyre">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Blantyre</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Malawi"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Malawi"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;BocaRaton">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Boca Raton</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Florida"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Florida"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bogota">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Bogota</rdfs:label>
 		<dct:description>the international business center of Bogota</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Colombia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Colombia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bologna">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bologna</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Boston">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Boston</rdfs:label>
 		<dct:description>the international business center of Boston</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Massachusetts"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Massachusetts"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bradford">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bradford</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Brasilia">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Brasilia</rdfs:label>
 		<dct:description>the international business center of Brasilia</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bratislava">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Bratislava</rdfs:label>
 		<dct:description>the international business center of Bratislava</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Slovakia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Slovakia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;BrazilBusinessDay">
@@ -754,67 +751,67 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bremen">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bremen</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bridgetown">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Bridgetown</rdfs:label>
 		<dct:description>the international business center of Bridgetown</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Barbados"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Barbados"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Brisbane">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Brisbane</rdfs:label>
 		<dct:description>the international business center of Brisbane</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Brussels">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Brussels</rdfs:label>
 		<dct:description>the international business center of Brussels</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Belgium"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Belgium"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;BryanstonSandton">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bryanston, Sandton</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;SouthAfrica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;SouthAfrica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bucarest">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Bucarest</rdfs:label>
 		<dct:description>the international business center of Bucarest</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Romania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Romania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Bucharest">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Bucharest</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Romania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Romania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Budaors">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Budaors</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Hungary"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Hungary"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Budapest">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Budapest</rdfs:label>
 		<dct:description>the international business center of Budapest</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Hungary"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Hungary"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Buenos_Aires">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Buenos Aires</rdfs:label>
 		<dct:description>the international business center of Buenos Aires</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;CACL">
@@ -991,134 +988,134 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Cairo</rdfs:label>
 		<dct:description>the international business center of Cairo</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Egypt"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Egypt"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Calcutta">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Calcutta</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Calgary">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Calgary</rdfs:label>
 		<dct:description>the international business center of Calgary</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Canberra">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Canberra</rdfs:label>
 		<dct:description>the international business center of Canberra</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Caracas">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Caracas</rdfs:label>
 		<dct:description>the international business center of Caracas</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Venezuela"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Venezuela"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Casablanca">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Casablanca</rdfs:label>
 		<dct:description>the international business center of Casablanca</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Morocco"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Morocco"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Charlotte">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Charlotte</rdfs:label>
 		<dct:description>the international business center of Charlotte</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Chatham">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Chatham</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Massachusetts"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Massachusetts"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Chennai">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Chennai</rdfs:label>
 		<dct:description>the international business center of Chennai</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Chicago">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Chicago</rdfs:label>
 		<dct:description>the international business center of Chicago</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Illinois"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Illinois"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Chisinau">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Chisinau</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Moldova"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Moldova"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Chittagong">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Chittagong</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Bangladesh"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Bangladesh"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Chiyoda-ku">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Chiyoda-ku</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;ClujNapoca">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Cluj Napoca</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Romania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Romania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Cologne">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Cologne</rdfs:label>
 		<dct:description>the international business center of Cologne</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Colombo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Colombo</rdfs:label>
 		<dct:description>the international business center of Colombo</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;SriLanka"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;SriLanka"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Copenhagen">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Copenhagen</rdfs:label>
 		<dct:description>the international business center of Copenhagen</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Cordoba">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Cordoba</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Corrientes">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Corrientes</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Curitiba">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Curitiba</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;DECO">
@@ -1225,116 +1222,116 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Dakar</rdfs:label>
 		<dct:description>the international business center of Dakar</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Senegal"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Senegal"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Dalian">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Dalian</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;China"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;China"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Damascus">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Damascus</rdfs:label>
 		<dct:description>the municipality of Damascus</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;SyrianArabRepublic"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;SyrianArabRepublic"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Dar_es_Salaam">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Dar es Salaam</rdfs:label>
 		<dct:description>the international business center of Dar es Salaam</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Tanzania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Tanzania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Darwin">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Darwin</rdfs:label>
 		<dct:description>the international business center of Darwin</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Davos_Platz">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Davos Platz</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Denver">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Denver</rdfs:label>
 		<dct:description>the international business center of Denver</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Colorado"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Colorado"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Detroit">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Detroit</rdfs:label>
 		<dct:description>the international business center of Detroit</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Michigan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Michigan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Dhaka">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Dhaka</rdfs:label>
 		<dct:description>the international business center of Dhaka</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Bangladesh"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Bangladesh"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Dnipropetrovsk">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Dnipropetrovsk</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Ukraine"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Ukraine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Dodoma">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Dodoma</rdfs:label>
 		<dct:description>the international business center of Dodoma</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Tanzania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Tanzania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Doha">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Doha</rdfs:label>
 		<dct:description>the international business center of Doha</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Qatar"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Qatar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Douala">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Douala</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Cameroon"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Cameroon"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Dubai">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Dubai</rdfs:label>
 		<dct:description>the international business center of Dubai</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedArabEmirates"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedArabEmirates"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Dublin">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Dublin</rdfs:label>
 		<dct:description>the international business center of Dublin</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Ireland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Ireland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Duesseldorf">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Duesseldorf</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Dusseldorf">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Dusseldorf</rdfs:label>
 		<dct:description>the international business center of Dusseldorf</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;EETA">
@@ -1420,62 +1417,62 @@
 		<rdfs:label>Ebene</rdfs:label>
 		<cmns-av:synonym>Cybercity</cmns-av:synonym>
 		<cmns-av:synonym>Ebene Cybercity</cmns-av:synonym>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Mauritius"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Mauritius"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Eden_Island">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Eden Island</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Seychelles"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Seychelles"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Edinburgh">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Edinburgh</rdfs:label>
 		<dct:description>the international business center of Edinburgh</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Ekaterinburg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Ekaterinburg</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;El_Salvador">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>El Salvador</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;ElSalvador"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;ElSalvador"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Esch-sur-alzette">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Esch-sur-alzette</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Luxembourg"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Luxembourg"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Eschborn">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Eschborn</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Eschenz">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Eschenz</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Espirito_Santo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Espirito Santo</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Espoo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Espoo</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Finland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Finland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;FIHE">
@@ -1501,19 +1498,19 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Fiac">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Fiac</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;France"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;France"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Firenze">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Firenze</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Florence">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Florence</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme">
@@ -1527,13 +1524,13 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Frankfurt</rdfs:label>
 		<dct:description>the international business center of Frankfurt</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Fukuoka">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Fukuoka</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;GBED">
@@ -1590,7 +1587,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>GIFT City</rdfs:label>
 		<cmns-av:synonym>Gujarat International Finance Tec-City</cmns-av:synonym>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;GRAT">
@@ -1607,97 +1604,97 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Gaborone</rdfs:label>
 		<dct:description>the international business center of Gaborone</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Botswana"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Botswana"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Gandhinagar">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Gandhinagar</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Geneva">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Geneva</rdfs:label>
 		<dct:description>the international business center of Geneva</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Genova">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Genova</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;George_Town">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>George Town</rdfs:label>
 		<dct:description>the international business center of George Town</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;CaymanIslands"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;CaymanIslands"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Georgetown">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Georgetown</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Guyana"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Guyana"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Gibraltar">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Gibraltar</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Gibraltar"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Gibraltar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Glenview">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Glenview</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Illinois"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Illinois"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Great_Neck">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Great Neck</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewYork"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Greenwich">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Greenwich</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Connecticut"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Connecticut"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Grindsted">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Grindsted</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Guatemala">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Guatemala</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Guatemala"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Guatemala"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Guayaquil">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Guayaquil</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Ecuador"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Ecuador"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Guaynabo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Guaynabo</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;PuertoRico"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;PuertoRico"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Guildford">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Guildford</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;HKHK">
@@ -1743,102 +1740,102 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Hamburg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Hamburg</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Hamilton">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Hamilton</rdfs:label>
 		<dct:description>the international business center of Hamilton</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Bermuda"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Bermuda"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Hannover">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Hannover</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Hanoi">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Hanoi</rdfs:label>
 		<dct:description>the international business center of Hanoi</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;VietNam"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;VietNam"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Harare">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Harare</rdfs:label>
 		<dct:description>the international business center of Harare</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Zimbabwe"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Zimbabwe"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Helsinki">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Helsinki</rdfs:label>
 		<dct:description>the international business center of Helsinki</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Finland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Finland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Hiroshima">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Hiroshima</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Ho_Chi_Minh">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Ho Chi Minh (formerly Saigon)</rdfs:label>
 		<dct:description>the international business center of Ho Chi Minh (formerly Saigon)</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;VietNam"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;VietNam"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Ho_Chi_Minh_City">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Ho Chi Minh City</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;VietNam"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;VietNam"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Hong_Kong">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Hong Kong</rdfs:label>
 		<dct:description>the international business center of Hong Kong</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;HongKong"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;HongKong"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Honolulu">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Honolulu</rdfs:label>
 		<dct:description>the international business center of Honolulu</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Hawaii"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Hawaii"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Horsens">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Horsens</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Houston">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Houston</rdfs:label>
 		<dct:description>the international business center of Houston</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Texas"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Texas"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Hove">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Hove</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Hyderabad">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Hyderabad</rdfs:label>
 		<dct:description>the international business center of Hyderabad</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;IDJA">
@@ -1994,26 +1991,26 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Indore_Madhya_Pradesh">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Indore Madhya Pradesh</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Islamabad">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Islamabad</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Pakistan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Pakistan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Istanbul">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Istanbul</rdfs:label>
 		<dct:description>the international business center of Istanbul</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Turkey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Turkey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Izmir">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Izmir</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Turkey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Turkey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;JESH">
@@ -2059,42 +2056,42 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Jaen">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Jaen</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Jakarta">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Jakarta</rdfs:label>
 		<dct:description>the international business center of Jakarta</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Indonesia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Indonesia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Jeddah">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Jeddah</rdfs:label>
 		<dct:description>the international business center of Jeddah</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;SaudiArabia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;SaudiArabia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Jersey_City">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Jersey City</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Jerusalem">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Jerusalem</rdfs:label>
 		<dct:description>the international business center of Jerusalem</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Israel"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Israel"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Johannesburg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Johannesburg</rdfs:label>
 		<dct:description>the international business center of Johannesburg</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;SouthAfrica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;SouthAfrica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;KENA">
@@ -2151,123 +2148,123 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Kampala</rdfs:label>
 		<dct:description>the international business center of Kampala</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Uganda"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Uganda"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kansas_City">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Kansas City</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Missouri"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Missouri"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Karachi">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Karachi</rdfs:label>
 		<dct:description>the international business center of Karachi</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Pakistan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Pakistan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kathmandu">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Kathmandu</rdfs:label>
 		<dct:description>the international business center of Kathmandu</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Nepal"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Nepal"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kharkov">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Kharkov</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Ukraine"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Ukraine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Khartoum">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Khartoum</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Sudan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Sudan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kiel">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Kiel</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kiev">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Kiev</rdfs:label>
 		<dct:description>the international business center of Kiev</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Ukraine"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Ukraine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kigali">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Kigali</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Rwanda"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Rwanda"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kingston">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Kingston</rdfs:label>
 		<dct:description>the international business center of Kingston</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Jamaica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Jamaica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kingstown">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Kingstown</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;SaintVincentAndTheGrenadines"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;SaintVincentAndTheGrenadines"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Klagenfurt_am_Woerthersee">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Klagenfurt Am Woerthersee</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Austria"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Austria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kobe">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Kobe</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kolkata">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Kolkata</rdfs:label>
 		<dct:description>the international business center of Kolkata</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kongsvinger">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Kongsvinger</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Krakow">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Krakow</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Poland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Poland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kuala_Lumpur">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Kuala Lumpur</rdfs:label>
 		<dct:description>the international business center of Kuala Lumpur</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Malaysia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Malaysia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kuwait_City">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Kuwait City</rdfs:label>
 		<dct:description>the international business center of Kuwait City</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Kuwait"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Kuwait"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Kyoto">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Kyoto</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;LBBE">
@@ -2314,158 +2311,158 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>La Paz</rdfs:label>
 		<dct:description>the international business center of La Paz</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Bolivia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Bolivia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Labuan">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Labuan</rdfs:label>
 		<dct:description>the international business center of Labuan</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Malaysia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Malaysia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lagos">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Lagos</rdfs:label>
 		<dct:description>the international business center of Lagos</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Nigeria"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Nigeria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lahore">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Lahore</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Pakistan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Pakistan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lane_Cove">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Lane Cove</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lao">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Lao</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;LaoPeoplesDemocraticRepublic"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;LaoPeoplesDemocraticRepublic"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Larnaca">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Larnaca</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Cyprus"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Cyprus"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Leipzig">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Leipzig</rdfs:label>
 		<dct:description>the international business center of Leipzig</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lenexa">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Lenexa</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Leuven">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Leuven</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Belgium"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Belgium"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lilongwe">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Lilongwe</rdfs:label>
 		<dct:description>the international business center of Lilongwe</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Malawi"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Malawi"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lima">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Lima</rdfs:label>
 		<dct:description>the international business center of Lima</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Peru"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Peru"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Limassol">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Limassol</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Cyprus"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Cyprus"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Linz">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Linz</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Austria"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Austria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lisboa">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Lisboa</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Portugal"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Portugal"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lisbon">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Lisbon</rdfs:label>
 		<dct:description>the international business center of Lisbon</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Portugal"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Portugal"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Ljubljana">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Ljubljana</rdfs:label>
 		<dct:description>the international business center of Ljubljana</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Slovenia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Slovenia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;London">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>London</rdfs:label>
 		<dct:description>the international business center of London</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Los_Angeles">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Los Angeles</rdfs:label>
 		<dct:description>the international business center of Los Angeles</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;California"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Luanda">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Luanda</rdfs:label>
 		<dct:description>the international business center of Luanda</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Angola"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Angola"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lugano">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Lugano</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Lusaka">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Lusaka</rdfs:label>
 		<dct:description>the international business center of Lusaka</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Zambia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Zambia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Luxembourg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Luxembourg</rdfs:label>
 		<dct:description>the international business center of Luxembourg</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Luxembourg"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Luxembourg"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Luzern">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Luzern</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;MACA">
@@ -2582,222 +2579,222 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Macau</rdfs:label>
 		<dct:description>the international business center of Macau</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Macao"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Macao"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Madras">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Madras</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Madrid">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Madrid</rdfs:label>
 		<dct:description>the international business center of Madrid</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Mainz">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Mainz</rdfs:label>
 		<dct:description>the international business center of Mainz</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Makati">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Makati</rdfs:label>
 		<dct:description>the international business center of Makati</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Philippines"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Philippines"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Makati_City">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Makati City</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Philippines"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Philippines"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Male">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Male</rdfs:label>
 		<dct:description>the international business center of Male</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Maldives"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Maldives"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Managua">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Managua</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Nicaragua"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Nicaragua"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Manama">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Manama</rdfs:label>
 		<dct:description>the international business center of Manama</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Bahrain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Bahrain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Manila">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Manila</rdfs:label>
 		<dct:description>the international business center of Manila</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Philippines"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Philippines"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Maputo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Maputo</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Mozambique"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Mozambique"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Maringa">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Maringa</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Mbabane">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Mbabane</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Eswatini"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Eswatini"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Melbourne">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Melbourne</rdfs:label>
 		<dct:description>the international business center of Melbourne</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Mendoza">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Mendoza</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Mexico_City">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Mexico City</rdfs:label>
 		<dct:description>the international business center of Mexico City</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Mexico"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Mexico"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Miami">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Miami</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Florida"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Florida"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Milan">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Milan</rdfs:label>
 		<dct:description>the international business center of Milan</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Minneapolis">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Minneapolis</rdfs:label>
 		<dct:description>the international business center of Minneapolis</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Minnesota"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Minnesota"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Minsk">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Minsk</rdfs:label>
 		<dct:description>the international business center of Minsk</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Belarus"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Belarus"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Mobile">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Mobile</rdfs:label>
 		<dct:description>the international business center of Mobile</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Alabama"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Alabama"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Moka">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Moka</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Mauritius"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Mauritius"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Monaco">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Monaco</rdfs:label>
 		<dct:description>the international business center of Monaco</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Monaco"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Monaco"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Montenegro">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Montenegro</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Montenegro"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Montenegro"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Montevideo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Montevideo</rdfs:label>
 		<dct:description>the international business center of Montevideo</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Uruguay"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Uruguay"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Montreal">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Montreal</rdfs:label>
 		<dct:description>the international business center of Montreal</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Moorpark">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Moorpark</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Moscow">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Moscow</rdfs:label>
 		<dct:description>the international business center of Moscow</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Mount_Pleasant">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Mount Pleasant</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;SouthCarolina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;SouthCarolina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Muenchen">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Muenchen</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Mumbai">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Mumbai</rdfs:label>
 		<dct:description>the international business center of Mumbai</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Munich">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Munich</rdfs:label>
 		<dct:description>the international business center of Munich</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Muscat">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Muscat</rdfs:label>
 		<dct:description>the international business center of Muscat</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Oman"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Oman"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;NAWI">
@@ -2913,46 +2910,46 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Nablus">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Nablus</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Palestine"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Palestine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Nacka">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Nacka</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Sweden"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Sweden"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Nagoya">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Nagoya</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Nairobi">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Nairobi</rdfs:label>
 		<dct:description>the international business center of Nairobi</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Kenya"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Kenya"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Narberth">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Narberth</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Nasau">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Nasau</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Bahamas"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Bahamas"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Nassau">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Nassau</rdfs:label>
 		<dct:description>the international business center of Nassau</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Bahamas"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Bahamas"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;NewYorkFederalReserveBusinessDay">
@@ -2973,7 +2970,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>New Delhi</rdfs:label>
 		<dct:description>the international business center of New Delhi</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;India"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;New_York">
@@ -2981,52 +2978,52 @@
 		<rdfs:label>New York</rdfs:label>
 		<dct:description>the international business center of New York</dct:description>
 		<cmns-av:synonym>New York City</cmns-av:synonym>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewYork"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Newcastle">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Newcastle</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Nicosia">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Nicosia</rdfs:label>
 		<dct:description>the international business center of Nicosia</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Cyprus"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Cyprus"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Nigita">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Nigita</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;NizhniyNovgorod">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Nizhniy Novgorod</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;North_Bergen">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>North Bergen</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Novosibirsk">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Novosibirsk</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Nyon">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Nyon</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;OMMU">
@@ -3042,39 +3039,39 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Odessa">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Odessa</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Ukraine"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Ukraine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Oldenburg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Oldenburg</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Osaka">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Osaka</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Oslo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Oslo</rdfs:label>
 		<dct:description>the international business center of Oslo</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Oststeinbek">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Oststeinbek</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Ottawa">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Ottawa</rdfs:label>
 		<dct:description>the international business center of Ottawa</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;PAPC">
@@ -3160,132 +3157,132 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Padova">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Padova</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;PalmaDeMallorca">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Palma de Mallorca</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Panama_City">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Panama City</rdfs:label>
 		<dct:description>the international business center of Panama City</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Panama"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Panama"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Paris">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Paris</rdfs:label>
 		<dct:description>the international business center of Paris</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;France"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;France"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Pasig_City">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Pasig City</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Philippines"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Philippines"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Perth">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Perth</rdfs:label>
 		<dct:description>the international business center of Perth</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Pfaffikon_SZ">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Pfäffikon SZ</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-ch;CH-SZ"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-ch;CH-SZ"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Philadelphia">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Philadelphia</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Phnom_Penh">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Phnom Penh</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Cambodia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Cambodia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Phoenix">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Phoenix</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Port_Louis">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Port Louis</rdfs:label>
 		<dct:description>the international business center of Port Louis</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Mauritius"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Mauritius"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Port_Moresby">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Port Moresby</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;PapuaNewGuinea"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;PapuaNewGuinea"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Port_Vila">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Port Vila</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Vanuatu"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Vanuatu"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Port_of_Spain">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Port of Spain</rdfs:label>
 		<dct:description>the international business center of Port of Spain</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;TrinidadAndTobago"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;TrinidadAndTobago"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Portland">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Portland</rdfs:label>
 		<dct:description>the international business center of Portland</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Oregon"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Oregon"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Porto">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Porto</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Portugal"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Portugal"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Prague">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Prague</rdfs:label>
 		<dct:description>the international business center of Prague</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Czechia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Czechia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Praia">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Praia</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;CaboVerde"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;CaboVerde"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Princeton">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Princeton</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Purchase">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Purchase</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewYork"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;QADO">
@@ -3301,7 +3298,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Quito">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Quito</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Ecuador"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Ecuador"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;ROBU">
@@ -3338,105 +3335,105 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Rabat</rdfs:label>
 		<dct:description>the international business center of Rabat</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Morocco"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Morocco"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Randers">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Randers</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Red_Bank">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Red Bank</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Regensburg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Regensburg</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Reggio_Emilia">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Reggio Emilia</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Reykjavik">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Reykjavik</rdfs:label>
 		<dct:description>the international business center of Reykjavik</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Iceland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Iceland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Riga">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Riga</rdfs:label>
 		<dct:description>the international business center of Riga</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Latvia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Latvia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Rio_de_Janeiro">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Rio de Janeiro</rdfs:label>
 		<dct:description>the international business center of Rio de Janeiro</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Riyadh">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Riyadh</rdfs:label>
 		<dct:description>the international business center of Riyadh</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;SaudiArabia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;SaudiArabia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Road_Town">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Road Town</rdfs:label>
 		<dct:description>the international business center of Road Town</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;VirginIslandsBritish"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;VirginIslandsBritish"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Rodgau">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Rodgau</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Roma">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Roma</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Rome">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Rome</rdfs:label>
 		<dct:description>the international business center of Rome</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Rosario">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Rosario</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Rostov">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Rostov</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Rotterdam">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Rotterdam</rdfs:label>
 		<dct:description>the international business center of Rotterdam</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;SAAB">
@@ -3532,22 +3529,22 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Sabadell">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Sabadell</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Sacramento">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Sacramento</rdfs:label>
 		<dct:description>the international business center of Sacramento</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;California"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Saint-Petersburg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Saint Petersburg</rdfs:label>
 		<cmns-av:synonym>St. Petersburg</cmns-av:synonym>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Saint_Peter_Port">
@@ -3555,261 +3552,261 @@
 		<rdfs:label>Saint Peter Port</rdfs:label>
 		<dct:description>the international business center of Saint Peter Port</dct:description>
 		<cmns-av:synonym>St. Peter Port</cmns-av:synonym>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Guernsey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Guernsey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Salzburg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Salzburg</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Austria"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Austria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Samara">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Samara</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;SanPedroSula">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>San Pedro Sula</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Honduras"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Honduras"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;San_Carlos">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>San Carlos</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;California"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;San_Francisco">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>San Francisco</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;California"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;San_Jose">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>San Jose</rdfs:label>
 		<dct:description>the international business center of San Jose</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;CostaRica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;CostaRica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;San_Juan">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>San Juan</rdfs:label>
 		<dct:description>the international business center of San Juan</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;PuertoRico"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;PuertoRico"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;San_Salvador">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>San Salvador</rdfs:label>
 		<dct:description>the international business center of San Salvador</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;ElSalvador"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;ElSalvador"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Santa_Fe">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Santa Fe</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Santander">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Santander</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Santiago">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Santiago</rdfs:label>
 		<dct:description>the international business center of Santiago</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Chile"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Chile"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Santo_Domingo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Santo Domingo</rdfs:label>
 		<dct:description>the international business center of Santo Domingo</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;DominicanRepublic"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;DominicanRepublic"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Sao_Paulo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Sao Paulo</rdfs:label>
 		<dct:description>the international business center of Sao Paulo</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Brazil"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Sapporo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Sapporo</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Sarajevo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Sarajevo</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;BosniaAndHerzegovina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;BosniaAndHerzegovina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Schwerin">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Schwerin</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;SeaGirt">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Sea Girt</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Seattle">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Seattle</rdfs:label>
 		<dct:description>the international business center of Seattle</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Washington"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Washington"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Seoul">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Seoul</rdfs:label>
 		<dct:description>the international business center of Seoul</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;KoreaRepublicOf"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;KoreaRepublicOf"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Shanghai">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Shanghai</rdfs:label>
 		<dct:description>the international business center of Shanghai</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;China"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;China"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Shenzhen">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Shenzhen</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;China"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;China"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Shimonoseki">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Shimonoseki</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Sibiu">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Sibiu</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Romania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Romania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Silkeborg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Silkeborg</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Denmark"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Singapore">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Singapore</rdfs:label>
 		<dct:description>the international business center of Singapore</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Singapore"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Singapore"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Skopje">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Skopje</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Macedonia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Macedonia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Sliema">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Sliema</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Malta"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Malta"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Sofia">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Sofia</rdfs:label>
 		<dct:description>the international business center of Sofia</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Bulgaria"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Bulgaria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Split">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Split</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Croatia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Croatia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;St_Albans">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>St. Albans</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;St_Helier">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>St. Helier</rdfs:label>
 		<dct:description>the international business center of St. Helier</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Jersey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Jersey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;St_John">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>St. John</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;AntiguaAndBarbuda"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;AntiguaAndBarbuda"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Stamford">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Stamford</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Connecticut"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Connecticut"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Stockholm">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Stockholm</rdfs:label>
 		<dct:description>the international business center of Stockholm</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Sweden"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Sweden"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Stuttgart">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Stuttgart</rdfs:label>
 		<dct:description>the international business center of Stuttgart</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Summit">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Summit</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewJersey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Surabaya">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Surabaya</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Indonesia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Indonesia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Suva">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Suva</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Fiji"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Fiji"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Sydney">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Sydney</rdfs:label>
 		<dct:description>the international business center of Sydney</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Australia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;TARGETSettlementDay">
@@ -3915,137 +3912,137 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Taipei</rdfs:label>
 		<dct:description>the international business center of Taipei</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Taiwan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Taiwan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Taiwan">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Taiwan</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Taiwan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Taiwan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tallinn">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Tallinn</rdfs:label>
 		<dct:description>the international business center of Tallinn</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Estonia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Estonia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tashkent">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Tashkent</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Uzbekistan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Uzbekistan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tbilisi">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Tbilisi</rdfs:label>
 		<dct:description>the international business center of Tbilisi</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Georgia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Georgia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tegucigalpa">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Tegucigalpa</rdfs:label>
 		<dct:description>the international business center of Tegucigalpa</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Honduras"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Honduras"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tehran">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Tehran</rdfs:label>
 		<dct:description>the international business center of Tehran</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Iran"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Iran"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tel_Aviv">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Tel Aviv</rdfs:label>
 		<dct:description>the international business center of Tel Aviv</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Israel"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Israel"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;TheWoodlands">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>The Woodlands</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Texas"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Texas"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;The_Hague">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>The Hague</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tirana">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Tirana</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Albania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Albania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tokyo">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Tokyo</rdfs:label>
 		<dct:description>the international business center of Tokyo</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Toronto">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Toronto</rdfs:label>
 		<dct:description>the international business center of Toronto</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Torshavn">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Torshavn</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;FaroeIslands"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;FaroeIslands"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Triesen">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Triesen</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Liechtenstein"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Liechtenstein"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tripoli">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Tripoli</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Libya"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Libya"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tromso">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Tromso</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Trondheim">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Trondheim</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Norway"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tucuman">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Tucuman</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Argentina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Tunis">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Tunis</rdfs:label>
 		<dct:description>the international business center of Tunis</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Tunisia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Tunisia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Turin">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Turin</rdfs:label>
 		<dct:description>the international business center of Turin</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Italy"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;UAKI">
@@ -4258,19 +4255,19 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Ulaan_Baatar">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Ulaan Baatar</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Mongolia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Mongolia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Unterschleisshem">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Unterschleisshem</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Germany"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Utrecht">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Utrecht</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;VECA">
@@ -4316,158 +4313,158 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Vaduz">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Vaduz</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Liechtenstein"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Liechtenstein"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Valencia">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Valencia</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Valletta">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Valletta</rdfs:label>
 		<dct:description>the international business center of Valletta</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Malta"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Malta"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Valparaiso">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Valparaiso</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Chile"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Chile"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Vancouver">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Vancouver</rdfs:label>
 		<dct:description>the international business center of Vancouver</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Varazdin">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Varazdin</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Croatia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Croatia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Victoria">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Victoria</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Seychelles"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Seychelles"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Victoria_Falls">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Victoria Falls</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Zimbabwe"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Zimbabwe"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Vienna">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Vienna</rdfs:label>
 		<dct:description>the international business center of Vienna</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Austria"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Austria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Vilnius">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Vilnius</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Lithuania"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Lithuania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Vladivostok">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Vladivostok</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Warsaw">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Warsaw</rdfs:label>
 		<dct:description>the international business center of Warsaw</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Poland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Poland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Warszawa">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Warszawa</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Poland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Poland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Washington">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Washington</rdfs:label>
 		<dct:description>the international business center of Washington</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;DistrictOfColumbia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;DistrictOfColumbia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Washington_New_York">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Washington, New York</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;NewYork"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Wellington">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Wellington</rdfs:label>
 		<dct:description>the international business center of Wellington</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;NewZealand"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;NewZealand"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Wichita">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Wichita</rdfs:label>
 		<dct:description>the international business center of Wichita</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Kansas"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Kansas"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Willemstad">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Willemstad</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Curacao"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Curacao"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Wilmington">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Wilmington</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-2-us;Delaware"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-2-us;Delaware"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Windhoek">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Windhoek</rdfs:label>
 		<dct:description>the international business center of Windhoek</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Namibia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Namibia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Winnipeg">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Winnipeg</rdfs:label>
 		<dct:description>the international business center of Winnipeg</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Canada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;WinterPark">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Winter Park</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Wroclaw">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Wroclaw</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Poland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Poland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Wuxi">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Wuxi</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;China"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;China"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;YEAD">
@@ -4484,7 +4481,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Yerevan</rdfs:label>
 		<dct:description>the international business center of Yerevan</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Armenia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Armenia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;ZAJO">
@@ -4521,38 +4518,38 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Zagreb</rdfs:label>
 		<dct:description>the international business center of Zagreb</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Croatia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Croatia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Zaragoza">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Zaragoza</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Zhengzhou">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Zhengzhou</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;China"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;China"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Zilina">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>Zilina</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Slovakia"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Slovakia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;Zurich">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;BusinessCenter"/>
 		<rdfs:label>Zurich</rdfs:label>
 		<dct:description>the international business center of Zurich</dct:description>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-bci;s-Hertogenbosch">
 		<rdf:type rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<rdfs:label>s&apos;-Hertogenbosch</rdfs:label>
-		<lcc-cr:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
+		<cmns-col:isPartOf rdf:resource="&lcc-3166-1;Netherlands"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FBC/FunctionalEntities/BusinessRegistries.rdf
+++ b/FBC/FunctionalEntities/BusinessRegistries.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
@@ -16,7 +17,6 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
-	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
@@ -25,7 +25,6 @@
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -35,6 +34,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
@@ -49,7 +49,6 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
-	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
@@ -58,7 +57,6 @@
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -78,7 +76,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
@@ -88,11 +85,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/BusinessRegistries/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.1 RTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified per FIBO 2.0 RFC primarily to loosen the constraints on address properties and better support standards including ISO 9362 (BIC codes), ISO 13616 (IBAN and BBAN codes), and ISO 17442 (the GLIEF LEI standard).</skos:changeNote>
@@ -152,14 +149,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;NorthAmericanIndustryClassificationSystemCode"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;StandardIndustrialClassificationCode"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -528,7 +525,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -628,7 +625,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -817,14 +814,14 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 	<owl:Class rdf:about="&fibo-fnd-org-fm;FormalOrganization">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;NorthAmericanIndustryClassificationSystemCode"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;StandardIndustrialClassificationCode"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
@@ -21,7 +21,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -50,7 +49,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -79,7 +77,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20230101/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>

--- a/FBC/FunctionalEntities/Markets.rdf
+++ b/FBC/FunctionalEntities/Markets.rdf
@@ -692,7 +692,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isPartOf"/>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-mkt;OperatingLevelMarket"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/FunctionalEntities/Markets.rdf
+++ b/FBC/FunctionalEntities/Markets.rdf
@@ -118,7 +118,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-ATSS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -133,7 +133,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;DataReportingServicesProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-APPA"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -151,7 +151,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;DataReportingServicesProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-ARMS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -173,7 +173,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;DataReportingServicesProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-CTPS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -190,7 +190,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-CASP"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -293,7 +293,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-DCMS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -416,7 +416,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-IDQS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -442,7 +442,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -644,7 +644,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -686,7 +686,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketLevelClassifier-SGMT"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -722,7 +722,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;AlternativeTradingSystem"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-MLTF"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -746,7 +746,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketLevelClassifier-OPRT"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -781,7 +781,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-OTFS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -816,7 +816,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-RMOS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -858,7 +858,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-RMKT"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -887,7 +887,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-SEFS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -902,7 +902,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-SINT"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -918,7 +918,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-fac;Facility"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier-TRFS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -29,7 +29,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-3166-2-ca "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -66,7 +65,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-3166-2-ca="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -101,7 +99,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
@@ -143,7 +140,7 @@
 		<cmns-av:explanatoryNote>The Bank of Canada&apos;s overall goal is to promote a stable and efficient financial system in Canada. The focus on the financial system as a whole parallels the Bank&apos;s approach to monetary policy, which focuses on the entire economy.
  
  The Bank provides liquidity to the financial system, gives policy advice to the federal government on the design and development of the system, oversees major clearing and settlement systems, and provides banking services to these systems and their participants.</cmns-av:explanatoryNote>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;BankOfCanadaHeadOfficeAddress">
@@ -233,7 +230,7 @@
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="en">Canada Revenue Agency</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>This agency administers tax laws for the Canadian government and for several of the provinces and territories of Canada.</cmns-av:explanatoryNote>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CanadaRevenueAgencyHeadOfficeAddress">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
@@ -35,7 +35,6 @@
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-3166-2-ca "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/">
 	<!ENTITY lcc-3166-2-us "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -78,7 +77,6 @@
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-3166-2-ca="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"
 	xmlns:lcc-3166-2-us="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -120,7 +118,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
@@ -28,7 +29,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-3166-2-us "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -37,6 +37,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
@@ -64,7 +65,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-3166-2-us="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -98,8 +98,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"/>
@@ -209,7 +209,7 @@
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/markets/american-options</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>NYSE American Options</fibo-fnd-rel-rel:hasFormalName>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEAmericanOptionsAsServiceProvider"/>
-		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;NYSEAmericanOptionsAsServiceProvider">
@@ -260,7 +260,7 @@
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>NYSE Arca</fibo-fnd-rel-rel:hasFormalName>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEArcaAsServiceProvider"/>
-		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;NYSEArcaAsServiceProvider">
@@ -365,7 +365,7 @@
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>NYSE Dark</fibo-fnd-rel-rel:hasFormalName>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchange"/>
-		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;NYSEGroup">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -329,7 +329,7 @@
 		<skos:definition>regulatory agency and registration authority for the overall Federal Reserve System</skos:definition>
 		<fibo-fnd-rel-rel:hasIdentity rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveBoard"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.federalreserve.gov/faqs/about_12591.htm</cmns-av:adaptedFrom>
-		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveRegulatoryAgencyAndCentralBank"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveRegulatoryAgencyAndCentralBank"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CFTCIndustryFilingsRepository">
@@ -370,7 +370,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of California, Secretary of State, Business Programs Division</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sos.ca.gov/business-programs/</fibo-fnd-plc-vrt:hasWebsite>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrar">
@@ -410,7 +410,7 @@
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://dbo.ca.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:explanatoryNote>The Department of Business Oversight (DBO) protects consumers and oversees financial service providers and products. The DBO supervises the operations of state-licensed financial institutions, including banks, credit unions and money transmitters. Additionally, the DBO licenses and regulates a variety of financial service providers, including securities brokers and dealers, investment advisers, payday lenders and other consumer finance lenders.</cmns-av:explanatoryNote>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaRegistrationAuthorityCode">
@@ -442,7 +442,7 @@
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.cftc.gov/index.htm</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>CFTC</cmns-av:abbreviation>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;ConsumerFinanceRegulator">
@@ -463,7 +463,7 @@
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.consumerfinance.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>CFPB</cmns-av:abbreviation>
-		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CorporationServiceCompany">
@@ -606,7 +606,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of Delaware&apos;s Division of Corporations</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://corp.delaware.gov/</fibo-fnd-plc-vrt:hasWebsite>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfDelawareGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfDelawareGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;DelawareRegistrationAuthorityCode">
@@ -765,7 +765,7 @@
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://fca.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FCA</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The FCS is the largest agricultural lender in the United States. It is a nationwide network of lending institutions that are owned by their borrowers. It serves all 50 States and Puerto Rico.</cmns-av:explanatoryNote>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FarmCreditRegulator">
@@ -819,7 +819,7 @@
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveBoard"/>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;NationalCreditUnionAdministration"/>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalFinancialInstitutionsExaminationRegulator">
@@ -869,7 +869,7 @@
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.fhfa.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FHFA</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The FHFA is an independent regulatory agency responsible for the oversight of vital components of the secondary mortgage markets - the housing government sponsored enterprises of Fannie Mae, Freddie Mac and the Federal Home Loan Bank System. Combined these entities provide more than $5.5 trillion in funding for the U.S. mortgage markets and financial institutions. Additionally, FHFA is the conservator of Fannie Mae and Freddie Mac.</cmns-av:explanatoryNote>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalHousingFinanceRegulator">
@@ -1029,7 +1029,7 @@ Once appointed, Governors may not be removed from office for their policy views.
 
 In addition to serving as members of the Board, the Chairman and Vice Chairman of the Board serve terms of four years, and they may be reappointed to those roles and serve until their terms as Governors expire. The Chairman serves as public spokesperson and representative of the Board and manager of the Board&apos;s staff. The Chairman also presides at Board meetings. Affirming the apolitical nature of the Board, recent Presidents of both major political parties have selected the same person as Board Chairman.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>Federal Reserve Board of Governors</cmns-av:synonym>
-		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSystem"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSystem"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FederalReserveDistrict">
@@ -1046,7 +1046,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usjrga;FRSMemberBank"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isPartOf"/>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveRegulatoryAgencyAndCentralBank"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1307,7 +1307,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<cmns-av:explanatoryNote>The Federal Reserve, the central bank of the United States, provides the nation with a safe, flexible, and stable monetary and financial system.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>Fed</cmns-av:synonym>
 		<cmns-av:synonym>Federal Reserve</cmns-av:synonym>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveTenthDistrict">
@@ -1432,7 +1432,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;NationalCreditUnionAdministration"/>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeCommission"/>
-		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;IssuerIdentificationNumber">
@@ -1519,7 +1519,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Commonwealth of Massachusetts, Secretary of State, Corporations Division</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sec.state.ma.us/cor/coridx.htm</fibo-fnd-plc-vrt:hasWebsite>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfMassachusettsGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfMassachusettsGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;MassachusettsRegistrationAuthorityCode">
@@ -1579,7 +1579,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ncua.gov/Pages/default.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>NCUA</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>An independent agency of the federal government, the NCUA operates and manages the National Credit Union Share Insurance Fund (NCUSIF), insuring the deposits of more than 98 million account holders in all federal credit unions and the overwhelming majority of state-chartered credit unions.</cmns-av:explanatoryNote>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NationalCreditUnionInsurerAndRegulator">
@@ -1650,7 +1650,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>New York State (NYS) Department of State&apos;s Division of Corporations</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.dos.ny.gov/corps/index.html</fibo-fnd-plc-vrt:hasWebsite>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfNewYorkGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfNewYorkGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NewYorkRegistrationAuthorityCode">
@@ -1672,7 +1672,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>OCC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The mission of the OCC is to ensure that national banks and federal savings associations operate in a safe and sound manner, provide fair access to financial services, treat customers fairly, and comply with applicable laws and regulations.</cmns-av:explanatoryNote>
-		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OfficeOfThriftSupervision">
@@ -1684,7 +1684,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>OTS</cmns-av:abbreviation>
-		<lcc-cr:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal">
@@ -1734,7 +1734,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Ohio Secretary of State, Business Services Division</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.sos.state.oh.us/businesses/</fibo-fnd-plc-vrt:hasWebsite>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfOhioGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfOhioGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OhioRegistrationAuthorityCode">
@@ -1855,7 +1855,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
  Crucial to the SEC&apos;s effectiveness in each of these areas is its enforcement authority. Each year the SEC brings hundreds of civil enforcement actions against individuals and companies for violation of the securities laws. Typical infractions include insider trading, accounting fraud, and providing false or misleading information about securities and the companies that issue them.
  One of the major sources of information on which the SEC relies to bring enforcement action is investors themselves - another reason that educated and careful investors are so critical to the functioning of efficient markets. To help support investor education, the SEC offers the public a wealth of educational information on this Internet website, which also includes the EDGAR database of disclosure documents that public companies are required to file with the Commission.
  Though it is the primary overseer and regulator of the U.S. securities markets, the SEC works closely with many other institutions, including Congress, other federal departments and agencies, the self-regulatory organizations (e.g. the stock exchanges), state securities regulators, and various private sector organizations. In particular, the Chairman of the SEC, together with the Chairman of the Federal Reserve, the Secretary of the Treasury, and the Chairman of the Commodity Futures Trading Commission, serves as a member of the President&apos;s Working Group on Financial Markets.</cmns-av:explanatoryNote>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator">
@@ -1903,7 +1903,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of South Dakota&apos;s Corporations Division</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://sosenterprise.sd.gov/businessservices/</fibo-fnd-plc-vrt:hasWebsite>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfSouthDakotaGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfSouthDakotaGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsRegulator">
@@ -2031,7 +2031,7 @@ A TIN must be on a withholding certificate if the beneficial owner is claiming a
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.treasury.gov/Pages/default.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:explanatoryNote>The Department is responsible for a wide range of activities such as advising the President on economic and financial issues, encouraging sustainable economic growth, and fostering improved governance in financial institutions. The Department of the Treasury operates and maintains systems that are critical to the nation&apos;s financial infrastructure, such as the production of coin and currency, the disbursement of payments to the American public, revenue collection, and the borrowing of funds necessary to run the federal government. The Department works with other federal agencies, foreign governments, and international financial institutions to encourage global economic growth, raise standards of living, and to the extent possible, predict and prevent economic and financial crises. The Treasury Department also performs a critical and far-reaching role in enhancing national security by implementing economic sanctions against foreign threats to the U.S., identifying and targeting the financial support networks of national security threats, and improving the safeguards of our financial systems.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>Treasury Department</cmns-av:synonym>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;UniformBankPerformanceReportRepository">

--- a/FBC/ProductsAndServices/CardAccounts.rdf
+++ b/FBC/ProductsAndServices/CardAccounts.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -32,6 +33,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -78,6 +80,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
@@ -644,7 +647,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;usesCurrency">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;uses"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;uses"/>
 		<rdfs:label>uses currency</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<skos:definition>indicates the currency defined for the credit card product</skos:definition>

--- a/FBC/ProductsAndServices/CardAccounts.rdf
+++ b/FBC/ProductsAndServices/CardAccounts.rdf
@@ -13,7 +13,6 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
@@ -43,7 +42,6 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
@@ -69,7 +67,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
@@ -315,7 +312,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -387,7 +384,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardNetwork">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
@@ -396,7 +393,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -422,7 +419,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -441,7 +438,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -477,7 +474,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -633,14 +633,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionCategory"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionSubcategory"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
@@ -30,7 +31,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -39,6 +39,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
@@ -68,7 +69,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -103,11 +103,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/ProductsAndServices/FinancialProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified by the FIBO 2.0 RFC, including, but not limited to, the addition of lifecycle events, concepts related to trade settlement, and the definition of a unique transaction identifier (UTI).</skos:changeNote>
@@ -587,6 +587,12 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Product"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ProductLifecycleEvent"/>
 			</owl:Restriction>
@@ -595,12 +601,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ProductLifecycle"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Product"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product lifecycle stage</rdfs:label>
@@ -893,6 +893,12 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;Trade"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleEvent"/>
 			</owl:Restriction>
@@ -901,12 +907,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycle"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;Trade"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle stage</rdfs:label>

--- a/FND/Accounting/CurrencyAmount.rdf
+++ b/FND/Accounting/CurrencyAmount.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
@@ -23,6 +24,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
@@ -52,6 +54,7 @@ The definition of currency provided herein is compliant with the definitions giv
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
@@ -131,7 +134,7 @@ The definition of currency provided herein is compliant with the definitions giv
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isUsedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isUsedBy"/>
 				<owl:someValuesFrom rdf:resource="&lcc-cr;GeopoliticalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -488,7 +491,7 @@ The definition of currency provided herein is compliant with the definitions giv
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-acc-cur;isTenderIn">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<owl:equivalentProperty rdf:resource="&lcc-cr;isUsedBy"/>
+		<owl:equivalentProperty rdf:resource="&cmns-cxtdsg;isUsedBy"/>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/FND/Accounting/ISO4217-CurrencyCodes.rdf
+++ b/FND/Accounting/ISO4217-CurrencyCodes.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -11,7 +12,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -22,6 +22,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -30,7 +31,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -42,16 +42,16 @@
 		<dct:abstract>This ontology represents the subset of the ISO 4217 standard that include the actual currency codes.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2023-01-01T00:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-03-08T00:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-03-11T00:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Accounting/ISO4217-CurrencyCodes/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to replace Swaziland with Eswatini, which was revised by the LCC 1.1 RTF to reflect the change to the country name per the U.N.</skos:changeNote>
@@ -188,7 +188,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>971</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Afghani</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Afghanistan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Afghanistan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AlgerianDinar">
@@ -198,7 +198,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>012</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Algerian Dinar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Algeria"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Algeria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ArgentinePeso">
@@ -208,7 +208,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>032</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Argentine Peso</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Argentina"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Argentina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ArmenianDram">
@@ -218,7 +218,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>051</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Armenian Dram</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Armenia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Armenia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ArubanFlorin">
@@ -228,7 +228,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>533</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Aruban Florin</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Aruba"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Aruba"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AustralianDollar">
@@ -238,14 +238,14 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>036</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Australian Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Australia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;ChristmasIsland"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CocosKeelingIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;HeardIslandAndMcDonaldIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Kiribati"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Nauru"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;NorfolkIsland"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tuvalu"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Australia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;ChristmasIsland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;CocosKeelingIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;HeardIslandAndMcDonaldIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Kiribati"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Nauru"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;NorfolkIsland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Tuvalu"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AzerbaijanManat">
@@ -255,7 +255,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>944</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Azerbaijan Manat</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Azerbaijan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Azerbaijan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BAM">
@@ -425,7 +425,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>044</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Bahamian Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bahamas"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bahamas"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BahrainiDinar">
@@ -435,7 +435,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>048</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Bahraini Dinar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bahrain"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bahrain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Baht">
@@ -445,7 +445,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>764</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Baht</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Thailand"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Thailand"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Balboa">
@@ -455,7 +455,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>590</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Balboa</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Panama"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Panama"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BarbadosDollar">
@@ -465,7 +465,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>052</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Barbados Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Barbados"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Barbados"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BelarusianRuble">
@@ -475,7 +475,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>933</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Belarusian Ruble</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Belarus"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Belarus"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BelizeDollar">
@@ -485,7 +485,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>084</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Belize Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Belize"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Belize"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BermudianDollar">
@@ -495,7 +495,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>060</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Bermudian Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bermuda"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bermuda"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Boliviano">
@@ -505,7 +505,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>068</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Boliviano</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bolivia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bolivia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BolívarSoberano">
@@ -517,7 +517,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>926</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-acc-cur:hasNumericCode>928</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Bolívar Soberano</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Venezuela"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Venezuela"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanCompositeUnit_EURCO">
@@ -559,7 +559,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>986</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Brazilian Real</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Brazil"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Brazil"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BruneiDollar">
@@ -569,7 +569,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>096</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Brunei Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;BruneiDarussalam"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;BruneiDarussalam"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BulgarianLev">
@@ -579,7 +579,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>975</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Bulgarian Lev</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bulgaria"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bulgaria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BurundiFranc">
@@ -589,7 +589,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>108</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Burundi Franc</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Burundi"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Burundi"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CAD">
@@ -619,14 +619,14 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>952</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>CFA Franc BCEAO</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Benin"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;BurkinaFaso"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CoteDIvoire"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guinea-Bissau"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mali"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Niger"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Senegal"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Togo"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Benin"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;BurkinaFaso"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;CoteDIvoire"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Guinea-Bissau"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Mali"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Niger"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Senegal"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Togo"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CFAFrancBEAC">
@@ -636,12 +636,12 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>950</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>CFA Franc BEAC</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Cameroon"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CentralAfricanRepublic"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Chad"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Congo"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;EquatorialGuinea"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Gabon"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Cameroon"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;CentralAfricanRepublic"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Chad"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Congo"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;EquatorialGuinea"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Gabon"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CFPFranc">
@@ -651,9 +651,9 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>953</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>CFP Franc</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;FrenchPolynesia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;NewCaledonia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;WallisAndFutuna"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;FrenchPolynesia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;NewCaledonia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;WallisAndFutuna"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CHE">
@@ -793,7 +793,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>132</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Cabo Verde Escudo</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CaboVerde"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;CaboVerde"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CanadianDollar">
@@ -803,7 +803,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>124</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Canadian Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CaymanIslandsDollar">
@@ -813,7 +813,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>136</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Cayman Islands Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CaymanIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;CaymanIslands"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ChileanPeso">
@@ -823,7 +823,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>152</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Chilean Peso</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Chile"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Chile"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ColombianPeso">
@@ -833,7 +833,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>170</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Colombian Peso</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Colombia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Colombia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ComorianFranc">
@@ -843,7 +843,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>174</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Comorian Franc</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Comoros"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Comoros"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CongoleseFranc">
@@ -853,7 +853,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>976</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Congolese Franc</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CongoDemocraticRepublicOf"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;CongoDemocraticRepublicOf"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ConvertibleMark">
@@ -863,7 +863,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>977</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Convertible Mark</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;BosniaAndHerzegovina"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;BosniaAndHerzegovina"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CordobaOro">
@@ -873,7 +873,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>558</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Cordoba Oro</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Nicaragua"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Nicaragua"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CostaRicanColon">
@@ -883,7 +883,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>188</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Costa Rican Colon</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CostaRica"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;CostaRica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CubanPeso">
@@ -893,7 +893,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>192</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Cuban Peso</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Cuba"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Cuba"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CzechKoruna">
@@ -903,7 +903,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>203</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Czech Koruna</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Czechia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Czechia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DJF">
@@ -953,7 +953,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>270</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Dalasi</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Gambia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Gambia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DanishKrone">
@@ -963,9 +963,9 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>208</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Danish Krone</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Denmark"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;FaroeIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Greenland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Denmark"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;FaroeIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Greenland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Denar">
@@ -975,7 +975,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>807</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Denar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;NorthMacedonia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;NorthMacedonia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DjiboutiFranc">
@@ -985,7 +985,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>262</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Djibouti Franc</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Djibouti"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Djibouti"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Dobra">
@@ -995,7 +995,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>930</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Dobra</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaoTomeAndPrincipe"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SaoTomeAndPrincipe"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DominicanPeso">
@@ -1005,7 +1005,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>214</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Dominican Peso</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;DominicanRepublic"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;DominicanRepublic"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Dong">
@@ -1015,7 +1015,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>704</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Dong</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;VietNam"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;VietNam"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;EGP">
@@ -1065,14 +1065,14 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>951</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>East Caribbean Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Anguilla"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;AntiguaAndBarbuda"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Dominica"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Grenada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Montserrat"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaintKittsAndNevis"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaintLucia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaintVincentAndTheGrenadines"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Anguilla"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;AntiguaAndBarbuda"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Dominica"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Grenada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Montserrat"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SaintKittsAndNevis"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SaintLucia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SaintVincentAndTheGrenadines"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;EgyptianPound">
@@ -1082,7 +1082,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>818</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Egyptian Pound</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Egypt"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Egypt"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ElSalvadorColon">
@@ -1092,7 +1092,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>222</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>El Salvador Colon</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;ElSalvador"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;ElSalvador"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;EthiopianBirr">
@@ -1102,7 +1102,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>230</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Ethiopian Birr</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Ethiopia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Ethiopia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Euro">
@@ -1112,41 +1112,41 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>978</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Euro</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;AlandIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Andorra"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Austria"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Belgium"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Croatia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Cyprus"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Estonia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Finland"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;France"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;FrenchGuiana"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;FrenchSouthernTerritories"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Germany"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Greece"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guadeloupe"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;HolySee"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Ireland"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Italy"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Latvia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Lithuania"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Luxembourg"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Malta"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Martinique"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mayotte"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Monaco"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Montenegro"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Netherlands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Portugal"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Reunion"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaintBarthelemy"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaintMartin"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaintPierreAndMiquelon"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SanMarino"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Slovakia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Slovenia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Spain"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;AlandIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Andorra"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Austria"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Belgium"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Croatia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Cyprus"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Estonia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Finland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;France"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;FrenchGuiana"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;FrenchSouthernTerritories"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Germany"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Greece"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Guadeloupe"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;HolySee"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Ireland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Italy"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Latvia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Lithuania"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Luxembourg"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Malta"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Martinique"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Mayotte"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Monaco"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Montenegro"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Netherlands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Portugal"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Reunion"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SaintBarthelemy"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SaintMartin"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SaintPierreAndMiquelon"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SanMarino"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Slovakia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Slovenia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Spain"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;FJD">
@@ -1176,7 +1176,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>238</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Falkland Islands Pound</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;FalklandIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;FalklandIslands"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;FijiDollar">
@@ -1186,7 +1186,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>242</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Fiji Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Fiji"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Fiji"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Forint">
@@ -1196,7 +1196,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>348</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Forint</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Hungary"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Hungary"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GBP">
@@ -1286,7 +1286,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>936</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Ghana Cedi</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Ghana"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Ghana"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GibraltarPound">
@@ -1296,7 +1296,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>292</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Gibraltar Pound</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Gibraltar"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Gibraltar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Gold">
@@ -1314,7 +1314,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>332</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Gourde</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Haiti"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Haiti"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Guarani">
@@ -1324,7 +1324,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>600</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Guarani</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Paraguay"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Paraguay"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GuineanFranc">
@@ -1334,7 +1334,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>324</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Guinean Franc</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guinea"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Guinea"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GuyanaDollar">
@@ -1344,7 +1344,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>328</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Guyana Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guyana"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Guyana"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;HKD">
@@ -1405,7 +1405,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>344</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Hong Kong Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;HongKong"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;HongKong"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Hryvnia">
@@ -1415,7 +1415,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>980</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Hryvnia</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Ukraine"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Ukraine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IDR">
@@ -1492,7 +1492,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>352</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Iceland Krona</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Iceland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Iceland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IndianRupee">
@@ -1502,8 +1502,8 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>356</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Indian Rupee</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bhutan"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;India"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bhutan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;India"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IranianRial">
@@ -1513,7 +1513,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>364</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Iranian Rial</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Iran"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Iran"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IraqiDinar">
@@ -1523,7 +1523,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>368</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Iraqi Dinar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Iraq"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Iraq"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;JMD">
@@ -1563,7 +1563,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>388</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Jamaican Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Jamaica"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Jamaica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;JordanianDinar">
@@ -1573,7 +1573,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>400</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Jordanian Dinar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Jordan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Jordan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KES">
@@ -1673,7 +1673,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>404</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Kenyan Shilling</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Kenya"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Kenya"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Kina">
@@ -1683,7 +1683,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>598</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Kina</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;PapuaNewGuinea"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;PapuaNewGuinea"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Kuna">
@@ -1696,7 +1696,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>191</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Kuna</fibo-fnd-rel-rel:hasTextualName>
 		<cmns-av:explanatoryNote>The Kuna (HRK) will be retained in FIBO at least through 2023 due to the possibility of dual listing and to support instrument pricing that predated this change.</cmns-av:explanatoryNote>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Croatia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Croatia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KuwaitiDinar">
@@ -1706,7 +1706,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>414</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Kuwaiti Dinar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Kuwait"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Kuwait"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Kwanza">
@@ -1716,7 +1716,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>973</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Kwanza</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Angola"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Angola"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Kyat">
@@ -1726,7 +1726,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>104</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Kyat</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Myanmar"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Myanmar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LAK">
@@ -1796,7 +1796,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>418</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Lao Kip</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;LaoPeoplesDemocraticRepublic"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;LaoPeoplesDemocraticRepublic"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Lari">
@@ -1806,7 +1806,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>981</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Lari</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Georgia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Georgia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LebanesePound">
@@ -1816,7 +1816,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>422</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Lebanese Pound</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Lebanon"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Lebanon"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Lek">
@@ -1826,7 +1826,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>008</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Lek</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Albania"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Albania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Lempira">
@@ -1836,7 +1836,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>340</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Lempira</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Honduras"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Honduras"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Leone">
@@ -1848,7 +1848,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>694</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-acc-cur:hasNumericCode>925</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Leone</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SierraLeone"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SierraLeone"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LiberianDollar">
@@ -1858,7 +1858,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>430</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Liberian Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Liberia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Liberia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LibyanDinar">
@@ -1868,7 +1868,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>434</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Libyan Dinar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Libya"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Libya"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Lilangeni">
@@ -1878,7 +1878,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>748</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Lilangeni</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Eswatini"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Eswatini"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Loti">
@@ -1888,7 +1888,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>426</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Loti</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Lesotho"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Lesotho"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MAD">
@@ -2048,7 +2048,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>969</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Malagasy Ariary</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Madagascar"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Madagascar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MalawiKwacha">
@@ -2058,7 +2058,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>454</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Malawi Kwacha</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Malawi"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Malawi"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MalaysianRinggit">
@@ -2068,7 +2068,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>458</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Malaysian Ringgit</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Malaysia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Malaysia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MauritiusRupee">
@@ -2078,7 +2078,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>480</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Mauritius Rupee</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mauritius"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Mauritius"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MexicanPeso">
@@ -2088,7 +2088,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>484</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Mexican Peso</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mexico"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Mexico"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MexicanUnidaddeInversion_UDI">
@@ -2100,7 +2100,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>979</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Mexican Unidad de Inversion (UDI)</fibo-fnd-rel-rel:hasTextualName>
 		<cmns-av:explanatoryNote>The UDI is an inflation adjusted mechanism set by the Central Bank of Mexico according to the variation in the Mexican Consumer Price Index. The value of the UDI is expressed in terms of Mexican Pesos per UDI. It is used to denominate mortgage loans, some bank deposits with maturities of 3 month or more and Government bonds (UDIBONOS).</cmns-av:explanatoryNote>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mexico"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Mexico"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MoldovanLeu">
@@ -2110,7 +2110,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>498</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Moldovan Leu</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Moldova"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Moldova"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MoroccanDirham">
@@ -2120,8 +2120,8 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>504</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Moroccan Dirham</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Morocco"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;WesternSahara"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Morocco"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;WesternSahara"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MozambiqueMetical">
@@ -2131,7 +2131,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>943</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Mozambique Metical</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mozambique"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Mozambique"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Mvdol">
@@ -2143,7 +2143,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>984</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Mvdol</fibo-fnd-rel-rel:hasTextualName>
 		<cmns-av:explanatoryNote>For indexation purposes and denomination of certain financial instruments (e.g. treasury bills). The Mvdol is set daily by the Central Bank of Bolivia based on the official USD/BOB rate.</cmns-av:explanatoryNote>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bolivia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bolivia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NAD">
@@ -2213,7 +2213,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>566</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Naira</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Nigeria"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Nigeria"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Nakfa">
@@ -2223,7 +2223,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>232</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Nakfa</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Eritrea"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Eritrea"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NamibiaDollar">
@@ -2233,7 +2233,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>516</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Namibia Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Namibia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Namibia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NepaleseRupee">
@@ -2243,7 +2243,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>524</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Nepalese Rupee</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Nepal"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Nepal"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NetherlandsAntilleanGuilder">
@@ -2253,8 +2253,8 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>532</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Netherlands Antillean Guilder</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Curacao"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SintMaarten"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Curacao"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SintMaarten"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NewIsraeliSheqel">
@@ -2264,7 +2264,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>376</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>New Israeli Sheqel</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Israel"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Israel"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NewTaiwanDollar">
@@ -2274,7 +2274,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>901</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>New Taiwan Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Taiwan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Taiwan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NewZealandDollar">
@@ -2284,11 +2284,11 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>554</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>New Zealand Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CookIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;NewZealand"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Niue"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Pitcairn"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tokelau"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;CookIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;NewZealand"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Niue"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Pitcairn"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Tokelau"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Ngultrum">
@@ -2298,7 +2298,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>064</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Ngultrum</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bhutan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bhutan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NorthKoreanWon">
@@ -2308,7 +2308,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>408</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>North Korean Won</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;KoreaDemocraticPeoplesRepublicOf"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;KoreaDemocraticPeoplesRepublicOf"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NorwegianKrone">
@@ -2318,9 +2318,9 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>578</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Norwegian Krone</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;BouvetIsland"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Norway"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SvalbardAndJanMayen"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;BouvetIsland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Norway"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SvalbardAndJanMayen"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;OMR">
@@ -2340,7 +2340,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>929</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Ouguiya</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mauritania"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Mauritania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PAB">
@@ -2420,7 +2420,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>776</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Paʻanga</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tonga"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Tonga"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PakistanRupee">
@@ -2430,7 +2430,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>586</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Pakistan Rupee</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Pakistan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Pakistan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Palladium">
@@ -2448,7 +2448,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>446</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Pataca</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Macao"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Macao"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PesoConvertible">
@@ -2458,7 +2458,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>931</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Peso Convertible</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Cuba"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Cuba"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PesoUruguayo">
@@ -2468,7 +2468,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>858</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Peso Uruguayo</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uruguay"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Uruguay"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PhilippinePeso">
@@ -2478,7 +2478,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>608</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Philippine Peso</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Philippines"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Philippines"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Platinum">
@@ -2496,10 +2496,10 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>826</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Pound Sterling</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guernsey"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;IsleOfMan"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Jersey"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Guernsey"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;IsleOfMan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Jersey"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Pula">
@@ -2509,7 +2509,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>072</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Pula</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Botswana"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Botswana"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;QAR">
@@ -2529,7 +2529,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>634</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Qatari Rial</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Qatar"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Qatar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Quetzal">
@@ -2539,7 +2539,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>320</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Quetzal</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guatemala"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Guatemala"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RON">
@@ -2589,9 +2589,9 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>710</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Rand</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Lesotho"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Namibia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SouthAfrica"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Lesotho"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Namibia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SouthAfrica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RialOmani">
@@ -2601,7 +2601,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>512</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Rial Omani</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Oman"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Oman"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Riel">
@@ -2611,7 +2611,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>116</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Riel</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Cambodia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Cambodia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RomanianLeu">
@@ -2621,7 +2621,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>946</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Romanian Leu</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Romania"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Romania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Rufiyaa">
@@ -2631,7 +2631,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>462</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Rufiyaa</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Maldives"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Maldives"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Rupiah">
@@ -2641,7 +2641,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>360</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Rupiah</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Indonesia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Indonesia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RussianRuble">
@@ -2651,7 +2651,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>643</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Russian Ruble</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;RussianFederation"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;RussianFederation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RwandaFranc">
@@ -2661,7 +2661,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>646</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Rwanda Franc</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Rwanda"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Rwanda"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SAR">
@@ -2840,7 +2840,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>654</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Saint Helena Pound</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaintHelena"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SaintHelena"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SaudiRiyal">
@@ -2850,7 +2850,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>682</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Saudi Riyal</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaudiArabia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SaudiArabia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SerbianDinar">
@@ -2860,7 +2860,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>941</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Serbian Dinar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Serbia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Serbia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SeychellesRupee">
@@ -2870,7 +2870,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>690</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Seychelles Rupee</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Seychelles"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Seychelles"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Silver">
@@ -2888,7 +2888,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>702</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Singapore Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Singapore"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Singapore"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Sol">
@@ -2898,7 +2898,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>604</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Sol</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Peru"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Peru"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SolomonIslandsDollar">
@@ -2908,7 +2908,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>090</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Solomon Islands Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SolomonIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SolomonIslands"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Som">
@@ -2918,7 +2918,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>417</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Som</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Kyrgyzstan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Kyrgyzstan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SomaliShilling">
@@ -2928,7 +2928,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>706</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Somali Shilling</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Somalia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Somalia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Somoni">
@@ -2938,7 +2938,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>972</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Somoni</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tajikistan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Tajikistan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SouthSudanesePound">
@@ -2948,7 +2948,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>728</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>South Sudanese Pound</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SouthSudan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SouthSudan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SriLankaRupee">
@@ -2958,7 +2958,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>144</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Sri Lanka Rupee</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SriLanka"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SriLanka"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Sucre">
@@ -2976,7 +2976,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>938</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Sudanese Pound</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Sudan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Sudan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SurinamDollar">
@@ -2986,7 +2986,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>968</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Surinam Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Suriname"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Suriname"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SwedishKrona">
@@ -2996,7 +2996,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>752</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Swedish Krona</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Sweden"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Sweden"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SwissFranc">
@@ -3006,8 +3006,8 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>756</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Swiss Franc</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Liechtenstein"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Liechtenstein"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SyrianPound">
@@ -3017,7 +3017,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>760</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Syrian Pound</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SyrianArabRepublic"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;SyrianArabRepublic"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;THB">
@@ -3117,7 +3117,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>050</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Taka</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bangladesh"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bangladesh"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Tala">
@@ -3127,7 +3127,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>882</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Tala</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Samoa"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Samoa"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TanzanianShilling">
@@ -3137,7 +3137,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>834</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Tanzanian Shilling</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tanzania"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Tanzania"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Tenge">
@@ -3147,7 +3147,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>398</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Tenge</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Kazakhstan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Kazakhstan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TrinidadandTobagoDollar">
@@ -3157,7 +3157,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>780</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Trinidad and Tobago Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;TrinidadAndTobago"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;TrinidadAndTobago"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Tugrik">
@@ -3167,7 +3167,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>496</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Tugrik</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mongolia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Mongolia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TunisianDinar">
@@ -3177,7 +3177,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>788</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Tunisian Dinar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tunisia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Tunisia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TurkishLira">
@@ -3187,7 +3187,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>949</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Turkish Lira</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Turkey"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Turkey"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TurkmenistanNewManat">
@@ -3197,7 +3197,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>934</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Turkmenistan New Manat</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Turkmenistan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Turkmenistan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UAEDirham">
@@ -3207,7 +3207,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>784</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>UAE Dirham</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedArabEmirates"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedArabEmirates"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UAH">
@@ -3247,25 +3247,25 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>840</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>US Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;AmericanSamoa"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bonaire"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;BritishIndianOceanTerritory"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Ecuador"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;ElSalvador"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guam"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Haiti"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;MarshallIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Micronesia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;NorthernMarianaIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Palau"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Panama"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;PuertoRico"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Timor-Leste"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;TurksAndCaicosIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesMinorOutlyingIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;VirginIslandsBritish"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;VirginIslandsUS"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;AmericanSamoa"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Bonaire"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;BritishIndianOceanTerritory"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Ecuador"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;ElSalvador"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Guam"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Haiti"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;MarshallIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Micronesia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;NorthernMarianaIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Palau"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Panama"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;PuertoRico"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Timor-Leste"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;TurksAndCaicosIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesMinorOutlyingIslands"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;VirginIslandsBritish"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;VirginIslandsUS"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;USDollar_Nextday">
@@ -3277,7 +3277,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>997</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>US Dollar (Next day)</fibo-fnd-rel-rel:hasTextualName>
 		<cmns-av:explanatoryNote>&quot;Next day&quot; funds are immediately available for transfer in like funds, and, subject to settlement, available the next business day for same day funds transfer or withdrawal in cash.</cmns-av:explanatoryNote>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;USN">
@@ -3337,7 +3337,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>800</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Uganda Shilling</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uganda"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Uganda"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UnidadPrevisional">
@@ -3349,7 +3349,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>4</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>927</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Unidad Previsional</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uruguay"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Uruguay"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UnidaddeFomento">
@@ -3361,7 +3361,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>990</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Unidad de Fomento</fibo-fnd-rel-rel:hasTextualName>
 		<cmns-av:explanatoryNote>The CLF is a daily economically-financial unit calculated by the Central Bank of Chile according to inflation (as measured by the Chilean Consumer Price Index of the previous month). The value of the CLF is expressed in terms of Chilean Pesos per CLF. The use of CLF has been widely extended to all types of bank loans, financial investments (time deposits, mortgages and other public or private indexed instruments), contracts and fees in some cases.</cmns-av:explanatoryNote>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Chile"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Chile"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UnidaddeValorReal">
@@ -3373,7 +3373,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>970</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Unidad de Valor Real</fibo-fnd-rel-rel:hasTextualName>
 		<cmns-av:explanatoryNote>The UVR is a daily account unit set by the Central Bank of Colombia according to the variation in the Consumer Price Index of Colombia. The value of UVR is expressed in terms of Colombian Pesos per UVR. It is used to denominate and update mortgage loans and some public debt bonds.</cmns-av:explanatoryNote>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Colombia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Colombia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UruguayPesoenUnidadesIndexadas_UI">
@@ -3385,7 +3385,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>940</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Uruguay Peso en Unidades Indexadas (UI)</fibo-fnd-rel-rel:hasTextualName>
 		<cmns-av:explanatoryNote>The UYI (URUIURUI) is used for issuance of debt instruments by the Uruguayan government in the international global bond market. It is calculated based on an established methodology using underlying inflationary statistics in the Uruguayan market. (Introduced in 2002).</cmns-av:explanatoryNote>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uruguay"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Uruguay"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UzbekistanSum">
@@ -3395,7 +3395,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>860</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Uzbekistan Sum</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uzbekistan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Uzbekistan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;VED">
@@ -3447,7 +3447,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>548</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Vatu</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Vanuatu"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Vanuatu"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;WIREuro">
@@ -3459,7 +3459,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>947</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>WIR Euro</fibo-fnd-rel-rel:hasTextualName>
 		<cmns-av:explanatoryNote>WIR Euro - WIR Bank for use with the EFTPOS system with their own WIR-card and the Electronic Banking Services</cmns-av:explanatoryNote>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;WIRFranc">
@@ -3471,7 +3471,7 @@
 		<fibo-fnd-acc-cur:hasNumericCode>948</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>WIR Franc</fibo-fnd-rel-rel:hasTextualName>
 		<cmns-av:explanatoryNote>WIR Franc - WIR Bank for use with the EFTPOS system with their own WIR-card and the Electronic Banking Services.</cmns-av:explanatoryNote>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Switzerland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Switzerland"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;WST">
@@ -3491,7 +3491,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>410</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Won</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;KoreaRepublicOf"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;KoreaRepublicOf"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XAF">
@@ -3677,7 +3677,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>886</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Yemeni Rial</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Yemen"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Yemen"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Yen">
@@ -3687,7 +3687,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>392</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Yen</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Japan"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Japan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;YuanRenminbi">
@@ -3697,7 +3697,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>156</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Yuan Renminbi</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;China"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;China"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ZAR">
@@ -3737,7 +3737,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>967</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Zambian Kwacha</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Zambia"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Zambia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ZimbabweDollar">
@@ -3747,7 +3747,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>932</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Zimbabwe Dollar</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Zimbabwe"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Zimbabwe"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Zloty">
@@ -3757,7 +3757,7 @@
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>985</fibo-fnd-acc-cur:hasNumericCode>
 		<fibo-fnd-rel-rel:hasTextualName>Zloty</fibo-fnd-rel-rel:hasTextualName>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Poland"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Poland"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -15,7 +15,6 @@
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -38,7 +37,6 @@
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -62,7 +60,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Agreements/Contracts/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Agreements/Contracts.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 		(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
@@ -265,7 +262,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;hasPart"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasPart"/>
 				<owl:allValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Arrangements/ClassificationSchemes.rdf
+++ b/FND/Arrangements/ClassificationSchemes.rdf
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -16,13 +15,12 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -34,11 +32,10 @@
 		<dct:abstract>This ontology defines abstract concepts for representation of classification schemes that themselves are intended to permit the classification of arbitrary concepts into hierarchies (or partial orders) for use in other FIBO ontology elements.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Arrangements/ClassificationSchemes/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20150501/Arrangements/ClassificationSchemes.rdf version of this ontology was introduced as a part of the initial FIBO FBC RFC and revised due to changes introduced in the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Arrangements/ClassificationSchemes.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
@@ -53,40 +50,17 @@
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-cls;ClassificationScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-arr;Scheme"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>classification scheme</rdfs:label>
-		<skos:definition>system for allocating classifiers to objects</skos:definition>
-		<cmns-av:adaptedFrom>ISO/IEC 11179-3 Information technology - Metadata registries (MDR) - Part 3: Registry metamodel and basic attributes, Third edition, 2013-02-15</cmns-av:adaptedFrom>
-		<cmns-av:explanatoryNote>A classification scheme may be a taxonomy, a network, an ontology, or any other terminological system. Such classification schemes are intended to permit the classification of arbitrary objects into hierarchies, or partial orders, as appropriate. The classification may also be just a list of controlled vocabulary of property words (or terms). The list might be taken from the &apos;leaf level&apos; of a taxonomy.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-cls;ClassificationScheme"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-cls;Classifier">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
-				<owl:onClass rdf:resource="&fibo-fnd-arr-cls;ClassificationScheme"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>classifier</rdfs:label>
-		<skos:definition>standardized classification or delineation for something, per some scheme for such delineation, within a specified context</skos:definition>
-		<cmns-av:adaptedFrom>ISO/IEC 11179-3 Information technology - Metadata registries (MDR) - Part 3: Registry metamodel and basic attributes, Third edition, 2013-02-15</cmns-av:adaptedFrom>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-cls;Classifier"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-cls;IndustrySectorClassificationScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;ClassificationScheme"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
@@ -99,7 +73,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-cls;IndustrySectorClassifier">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
@@ -109,6 +83,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label>industry sector classifier</rdfs:label>
 		<skos:definition>standardized classification or delineation for an organization, or possibly for a security representing an interest in a given organization, per some scheme for such delineation, by industry</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-cls;ClassificationScheme">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-arr;Scheme"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
+				<owl:allValuesFrom rdf:resource="&cmns-cls;Classifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 	</owl:Class>
 
 </rdf:RDF>

--- a/FND/Arrangements/Lifecycles.rdf
+++ b/FND/Arrangements/Lifecycles.rdf
@@ -11,7 +11,6 @@
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -30,7 +29,6 @@
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -208,7 +206,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-lif;hasStage">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;hasPart"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasPart"/>
 		<rdfs:label>has stage</rdfs:label>
 		<rdfs:range>
 			<owl:Class>
@@ -232,7 +230,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-lif;isStageOf">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isPartOf"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;isPartOf"/>
 		<rdfs:label>is stage of</rdfs:label>
 		<rdfs:domain>
 			<owl:Class>

--- a/FND/Arrangements/Lifecycles.rdf
+++ b/FND/Arrangements/Lifecycles.rdf
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
@@ -20,10 +20,10 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
@@ -41,14 +41,13 @@
 		<rdfs:label>Lifecycles Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a set of basic concepts for lifecycles, including the various stages and events that make up a given lifecycle, for use in describing product, trade, instrument, production, and other lifecycles in FIBO.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Arrangements/Lifecycles/"/>
@@ -140,7 +139,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-lif;LifecycleStage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-lif;isStageOf"/>
@@ -190,7 +189,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-lif;LifecycleStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-lif;hasStage"/>

--- a/FND/Arrangements/Ratings.rdf
+++ b/FND/Arrangements/Ratings.rdf
@@ -17,7 +17,6 @@
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -42,7 +41,6 @@
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -68,7 +66,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Arrangements/Ratings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190601/Arrangements/Ratings.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Arrangements/Ratings.rdf version of this ontology was revised to add properties indicating the &apos;best&apos; and &apos;worst&apos; scores on a given scale.</skos:changeNote>
@@ -334,7 +331,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-rt;hasRating">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isClassifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has rating</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-arr-rt;Rating"/>
 		<owl:inverseOf rdf:resource="&fibo-fnd-arr-rt;rates"/>
@@ -342,7 +339,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-rt;hasRatingScore">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isClassifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has rating score</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-arr-rt;Rating"/>
 		<rdfs:range rdf:resource="&fibo-fnd-arr-rt;RatingScore"/>
@@ -367,7 +364,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-rt;rates">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;classifies"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;classifies"/>
 		<rdfs:label>rates</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-arr-rt;Rating"/>
 		<skos:definition>indicates the instrument, party or something else to which a rating applies</skos:definition>

--- a/FND/DatesAndTimes/Occurrences.rdf
+++ b/FND/DatesAndTimes/Occurrences.rdf
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
@@ -20,10 +19,9 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
@@ -41,14 +39,13 @@
 		<rdfs:label>Occurrences Ontology</rdfs:label>
 		<dct:abstract>This ontology extends definitions of date and schedule concepts from the FinancialDates ontology with concepts defining occurrences (i.e., event-related concepts) for use in other FIBO ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/DatesAndTimes/Occurrences/"/>
@@ -184,10 +181,10 @@ They are modularized this way to minimize the ontological committments that are 
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-oc;OccurrenceKind">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Organizations/Organizations.rdf
+++ b/FND/Organizations/Organizations.rdf
@@ -14,7 +14,6 @@
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -36,7 +35,6 @@
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -60,7 +58,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Organizations/Organizations/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20160201/Organizations/Organizations.rdf version of this ontology was modified per the FIBO 2.0 RFC, to revise the definition of Organization per ISO 6523.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Organizations/Organizations.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
@@ -124,7 +121,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;hasPart"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasPart"/>
 				<owl:allValuesFrom rdf:resource="&fibo-fnd-org-org;Organization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -241,7 +238,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;Organization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isPartOf"/>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
 				<owl:allValuesFrom rdf:resource="&fibo-fnd-org-org;Organization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -274,7 +271,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-org;hasSubUnit">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;hasPart"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasPart"/>
 		<rdfs:label>has sub-unit</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-org-org;Organization"/>
 		<rdfs:range rdf:resource="&fibo-fnd-org-org;OrganizationalSubUnit"/>
@@ -301,7 +298,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-org;isSubUnitOf">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isPartOf"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;isPartOf"/>
 		<rdfs:label>is sub-unit of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-org-org;OrganizationalSubUnit"/>
 		<rdfs:range rdf:resource="&fibo-fnd-org-org;Organization"/>

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -678,7 +678,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressComponent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
@@ -26,6 +27,7 @@
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
@@ -57,6 +59,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
@@ -465,7 +468,7 @@
 		<rdfs:subClassOf rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isUsedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isUsedBy"/>
 				<owl:someValuesFrom rdf:resource="&lcc-cr;GeopoliticalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -21,6 +22,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -51,6 +53,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
@@ -200,8 +204,8 @@
 		<rdf:type rdf:resource="&lcc-cr;CountrySubdivision"/>
 		<rdfs:label>Armed Forces Americas</rdfs:label>
 		<skos:definition>state designation for Armed Forces Americas, excluding Canada</skos:definition>
+		<cmns-cls:isClassifiedBy rdf:resource="&lcc-3166-2-us;State"/>
 		<lcc-cr:hasEnglishShortName xml:lang="en">Armed Forces Americas</lcc-cr:hasEnglishShortName>
-		<lcc-cr:isClassifiedBy rdf:resource="&lcc-3166-2-us;State"/>
 		<lcc-cr:isSubregionOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
@@ -209,8 +213,8 @@
 		<rdf:type rdf:resource="&lcc-cr;CountrySubdivision"/>
 		<rdfs:label>Armed Forces Europe</rdfs:label>
 		<skos:definition>state designation for Armed Forces Europe, the Middle East, and Canada</skos:definition>
+		<cmns-cls:isClassifiedBy rdf:resource="&lcc-3166-2-us;State"/>
 		<lcc-cr:hasEnglishShortName xml:lang="en">Armed Forces Europe, the Middle East, and Canada</lcc-cr:hasEnglishShortName>
-		<lcc-cr:isClassifiedBy rdf:resource="&lcc-3166-2-us;State"/>
 		<lcc-cr:isSubregionOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
@@ -218,8 +222,8 @@
 		<rdf:type rdf:resource="&lcc-cr;CountrySubdivision"/>
 		<rdfs:label>Armed Forces Pacific</rdfs:label>
 		<skos:definition>state designation for Armed Forces Pacific</skos:definition>
+		<cmns-cls:isClassifiedBy rdf:resource="&lcc-3166-2-us;State"/>
 		<lcc-cr:hasEnglishShortName xml:lang="en">Armed Forces Pacific</lcc-cr:hasEnglishShortName>
-		<lcc-cr:isClassifiedBy rdf:resource="&lcc-3166-2-us;State"/>
 		<lcc-cr:isSubregionOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	

--- a/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -23,6 +24,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -54,6 +56,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
@@ -75,9 +78,9 @@
 		<skos:definition>US-specific code for the state designation for Armed Forces Americas, excluding Canada</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>AA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AA</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AB">
@@ -86,10 +89,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Alberta</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>AB</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AB</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Alberta"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Alberta"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AE">
@@ -98,9 +101,9 @@
 		<skos:definition>US-specific code for the state designation for Armed Forces Europe, the Middle East, and Canada</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>AE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AE</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AK">
@@ -109,9 +112,9 @@
 		<skos:definition>US-specific code for the designation for Alaska</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>AK</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AK</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Alaska"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Alaska"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AL">
@@ -120,9 +123,9 @@
 		<skos:definition>US-specific code for the designation for Alabama</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>AL</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AL</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Alabama"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Alabama"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AP">
@@ -131,9 +134,9 @@
 		<skos:definition>US-specific code for the state designation for Armed Forces Pacific</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>AP</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AP</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AR">
@@ -142,9 +145,9 @@
 		<skos:definition>US-specific code for the designation for Arkansas</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>AR</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AR</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Arkansas"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Arkansas"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AS">
@@ -153,9 +156,9 @@
 		<skos:definition>US-specific code for the designation for American Samoa</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>AS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AS</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;AmericanSamoa"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;AmericanSamoa"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AZ">
@@ -164,9 +167,9 @@
 		<skos:definition>US-specific code for the designation for Arizona</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>AZ</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AZ</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Arizona"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Arizona"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Alley">
@@ -247,10 +250,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for British Columbia</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>BC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>BC</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;BritishColumbia"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;BritishColumbia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Bayou">
@@ -391,9 +394,9 @@
 		<skos:definition>US-specific code for the designation for California</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>CA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>CA</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;California"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;California"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;CO">
@@ -402,9 +405,9 @@
 		<skos:definition>US-specific code for the designation for Colorado</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>CO</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>CO</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Colorado"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Colorado"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;CT">
@@ -413,9 +416,9 @@
 		<skos:definition>US-specific code for the designation for Connecticut</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>CT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>CT</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Connecticut"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Connecticut"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Camp">
@@ -647,9 +650,9 @@
 		<skos:definition>US-specific code for the designation for the District of Colombia</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>DC</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;DistrictOfColumbia"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;DistrictOfColumbia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;DE">
@@ -658,9 +661,9 @@
 		<skos:definition>US-specific code for the designation for Delaware</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>DE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>DE</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Delaware"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Delaware"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Dale">
@@ -757,9 +760,9 @@
 		<skos:definition>US-specific code for the designation for Florida</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>FL</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>FL</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Florida"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Florida"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Fall">
@@ -900,9 +903,9 @@
 		<skos:definition>US-specific code for the designation for Georgia</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>GA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>GA</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Georgia"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Georgia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;GU">
@@ -911,9 +914,9 @@
 		<skos:definition>US-specific code for the designation for Guam</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>GU</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>GU</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Guam"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Guam"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Garden">
@@ -998,9 +1001,9 @@
 		<skos:definition>US-specific code for the designation for Hawaii</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>HI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>HI</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Hawaii"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Hawaii"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Harbor">
@@ -1082,9 +1085,9 @@
 		<skos:definition>US-specific code for the designation for Iowa</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>IA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>IA</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Iowa"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Iowa"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ID">
@@ -1093,9 +1096,9 @@
 		<skos:definition>US-specific code for the designation for Idaho</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ID</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>ID</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Idaho"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Idaho"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;IL">
@@ -1104,9 +1107,9 @@
 		<skos:definition>US-specific code for the designation for Illinois</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>IL</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>IL</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Illinois"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Illinois"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;IN">
@@ -1115,9 +1118,9 @@
 		<skos:definition>US-specific code for the designation for Indiana</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>IN</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>IN</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Indiana"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Indiana"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Inlet">
@@ -1180,9 +1183,9 @@
 		<skos:definition>US-specific code for the designation for Kansas</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>KS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>KS</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Kansas"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Kansas"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;KY">
@@ -1191,9 +1194,9 @@
 		<skos:definition>US-specific code for the designation for Kentucky</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>KY</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>KY</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Kentucky"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Kentucky"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Key">
@@ -1235,9 +1238,9 @@
 		<skos:definition>US-specific code for the designation for Louisiana</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>LA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>LA</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Louisiana"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Louisiana"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Lake">
@@ -1343,9 +1346,9 @@
 		<skos:definition>US-specific code for the designation for Massachusetts</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MA</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Massachusetts"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Massachusetts"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MB">
@@ -1354,10 +1357,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Manitoba</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MB</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MB</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Manitoba"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Manitoba"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MD">
@@ -1366,9 +1369,9 @@
 		<skos:definition>US-specific code for the designation for Maryland</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MD</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MD</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Maryland"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Maryland"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ME">
@@ -1377,9 +1380,9 @@
 		<skos:definition>US-specific code for the designation for Maine</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ME</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>ME</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Maine"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Maine"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MI">
@@ -1388,9 +1391,9 @@
 		<skos:definition>US-specific code for the designation for Michigan</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MI</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Michigan"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Michigan"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MN">
@@ -1399,9 +1402,9 @@
 		<skos:definition>US-specific code for the designation for Minnesota</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MN</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MN</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Minnesota"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Minnesota"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MO">
@@ -1410,9 +1413,9 @@
 		<skos:definition>US-specific code for the designation for Missouri</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MO</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MO</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Missouri"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Missouri"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MP">
@@ -1421,9 +1424,9 @@
 		<skos:definition>US-specific code for the designation for the outlying area of Northern Mariana Islands</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MP</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MP</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NorthernMarianaIslands"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NorthernMarianaIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MS">
@@ -1432,9 +1435,9 @@
 		<skos:definition>US-specific code for the designation for Mississippi</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MS</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Mississippi"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Mississippi"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MT">
@@ -1443,9 +1446,9 @@
 		<skos:definition>US-specific code for the designation for Montana</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>MT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MT</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Montana"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Montana"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mall">
@@ -1559,10 +1562,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for New Brunswick</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NB</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NB</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;NewBrunswick"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;NewBrunswick"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NC">
@@ -1571,9 +1574,9 @@
 		<skos:definition>US-specific code for the designation for North Carolina</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NC</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ND">
@@ -1582,9 +1585,9 @@
 		<skos:definition>US-specific code for the designation for North Dakota</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ND</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>ND</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NorthDakota"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NorthDakota"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NE">
@@ -1593,9 +1596,9 @@
 		<skos:definition>US-specific code for the designation for Nebraska</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NE</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Nebraska"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Nebraska"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NH">
@@ -1604,9 +1607,9 @@
 		<skos:definition>US-specific code for the designation for New Hampshire</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NH</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NH</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NewHampshire"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NewHampshire"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NJ">
@@ -1615,9 +1618,9 @@
 		<skos:definition>US-specific code for the designation for New Jersey</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NJ</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NJ</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NewJersey"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NewJersey"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NL">
@@ -1626,10 +1629,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Newfoundland and Labrador</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NL</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NL</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;NewfoundlandAndLabrador"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;NewfoundlandAndLabrador"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NM">
@@ -1638,9 +1641,9 @@
 		<skos:definition>US-specific code for the designation for New Mexico</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NM</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NM</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NewMexico"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NewMexico"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NS">
@@ -1649,10 +1652,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Nova Scotia</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NS</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;NovaScotia"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;NovaScotia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NT">
@@ -1661,10 +1664,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Northwest Territories</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NT</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;NorthwestTerritories"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;NorthwestTerritories"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NU">
@@ -1673,10 +1676,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Nunavut</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NU</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NU</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Nunavut"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Nunavut"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NV">
@@ -1685,9 +1688,9 @@
 		<skos:definition>US-specific code for the designation for Nevada</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NV</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NV</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Nevada"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Nevada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NY">
@@ -1696,9 +1699,9 @@
 		<skos:definition>US-specific code for the designation for New York</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>NY</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NY</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NewYork"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NewYork"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Neck">
@@ -1715,9 +1718,9 @@
 		<skos:definition>US-specific code for the designation for Ohio</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>OH</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>OH</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Ohio"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Ohio"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;OK">
@@ -1726,9 +1729,9 @@
 		<skos:definition>US-specific code for the designation for Oklahoma</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>OK</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>OK</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Oklahoma"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Oklahoma"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ON">
@@ -1737,10 +1740,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Ontario</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ON</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>ON</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Ontario"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Ontario"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;OR">
@@ -1749,9 +1752,9 @@
 		<skos:definition>US-specific code for the designation for Oregon</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>OR</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>OR</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Oregon"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Oregon"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Orchard">
@@ -1784,9 +1787,9 @@
 		<skos:definition>US-specific code for the designation for Pennsylvania</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>PA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>PA</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;PE">
@@ -1795,10 +1798,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Prince Edward Island</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>PE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>PE</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;PrinceEdwardIsland"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;PrinceEdwardIsland"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;PR">
@@ -1807,9 +1810,9 @@
 		<skos:definition>US-specific code for the designation for Puerto Rico</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>PR</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>PR</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;PuertoRico"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;PuertoRico"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Park">
@@ -1970,10 +1973,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Quebec</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>QC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>QC</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Quebec"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Quebec"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;RI">
@@ -1982,9 +1985,9 @@
 		<skos:definition>US-specific code for the designation for Rhode Island</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>RI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>RI</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;RhodeIsland"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;RhodeIsland"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Radial">
@@ -2115,9 +2118,9 @@
 		<skos:definition>US-specific code for the designation for South Carolina</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>SC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>SC</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;SouthCarolina"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;SouthCarolina"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;SD">
@@ -2126,9 +2129,9 @@
 		<skos:definition>US-specific code for the designation for South Dakota</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>SD</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>SD</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;SouthDakota"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;SouthDakota"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;SK">
@@ -2137,10 +2140,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Saskatchewan</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>SK</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>SK</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Saskatchewan"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Saskatchewan"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Shoal">
@@ -2302,9 +2305,9 @@
 		<skos:definition>US-specific code for the designation for Tennessee</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>TN</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>TN</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Tennessee"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Tennessee"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;TX">
@@ -2313,9 +2316,9 @@
 		<skos:definition>US-specific code for the designation for Texas</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>TX</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>TX</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Texas"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Texas"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Terrace">
@@ -2407,9 +2410,9 @@
 		<skos:definition>US-specific code for the designation for the United States Minor Outlying Islands</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>UM</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>UM</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;UnitedStatesMinorOutlyingIslands"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;UnitedStatesMinorOutlyingIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;US-AA">
@@ -2448,9 +2451,9 @@
 		<skos:definition>US-specific code for the designation for Utah</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>UT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>UT</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Utah"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Utah"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Underpass">
@@ -2481,9 +2484,9 @@
 		<skos:definition>US-specific code for the designation for Virginia</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>VA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>VA</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Virginia"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Virginia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;VI">
@@ -2492,9 +2495,9 @@
 		<skos:definition>US-specific code for the designation for the U.S. Virgin Islands</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>VI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>VI</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;VirginIslands"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;VirginIslands"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;VT">
@@ -2503,9 +2506,9 @@
 		<skos:definition>US-specific code for the designation for Vermont</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>VT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>VT</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Vermont"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Vermont"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Valley">
@@ -2597,9 +2600,9 @@
 		<skos:definition>US-specific code for the designation for Washington</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>WA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>WA</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Washington"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Washington"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;WI">
@@ -2608,9 +2611,9 @@
 		<skos:definition>US-specific code for the designation for Wisconsin</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>WI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>WI</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Wisconsin"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Wisconsin"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;WV">
@@ -2619,9 +2622,9 @@
 		<skos:definition>US-specific code for the designation for West Virginia</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>WV</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>WV</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;WestVirginia"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;WestVirginia"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;WY">
@@ -2630,9 +2633,9 @@
 		<skos:definition>US-specific code for the designation for Wyoming</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>WY</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>WY</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Wyoming"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Wyoming"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Walk">
@@ -2692,10 +2695,10 @@
 		<skos:definition>Canadian and US-specific code for the designation for Yukon</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>YT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>YT</fibo-fnd-utl-av:preferredDesignation>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Yukon"/>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Yukon"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
-		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-1;FM">

--- a/FND/Quantities/QuantitiesAndUnits.rdf
+++ b/FND/Quantities/QuantitiesAndUnits.rdf
@@ -3,12 +3,12 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -19,12 +19,12 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -40,8 +40,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Quantities/QuantitiesAndUnits/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Quantities/QuantitiesAndUnits/ was modified to untangle this ontology from analytics, untangle quantity values (measurements) from measures and add refinements from SysML and ISO 11179, including dimensionality.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Quantities/QuantitiesAndUnits/ was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
@@ -264,7 +264,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;uses"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
 				<owl:onClass rdf:resource="&fibo-fnd-qt-qtu;SystemOfQuantities"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -301,7 +301,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;uses"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
 				<owl:onClass rdf:resource="&fibo-fnd-qt-qtu;SystemOfUnits"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
@@ -12,10 +13,8 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
-	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
@@ -30,7 +29,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -39,6 +37,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
@@ -50,10 +49,8 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
-	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
@@ -68,7 +65,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -88,10 +84,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
@@ -106,8 +100,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230301/EconomicIndicators/EconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
@@ -513,14 +507,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;Establishment"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-cls;IndustrySectorClassifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-cls;IndustrySectorClassifier"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;Establishment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>enterprise</rdfs:label>

--- a/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf
+++ b/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf
@@ -16,7 +16,6 @@
 	<!ENTITY fibo-ind-ei-caei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/">
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -40,7 +39,6 @@
 	xmlns:fibo-ind-ei-caei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -64,7 +62,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230301/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf version of this ontology was added to the IND specification per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
@@ -218,7 +215,7 @@
 		<fibo-fnd-plc-loc:hasCoverageArea rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-av:abbreviation>StatCan</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/eng/about/mandate</cmns-av:adaptedFrom>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf
+++ b/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf
@@ -17,7 +17,6 @@
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY fibo-ind-ei-usei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -42,7 +41,6 @@
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:fibo-ind-ei-usei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -67,7 +65,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230301/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was added to the IND specification per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
@@ -99,7 +96,7 @@
 		<cmns-av:abbreviation>BLS</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/bls/infohome.htm</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Its mission is to collect, analyze, and disseminate essential economic information to support public and private decision-making. As an independent statistical agency, BLS serves its diverse user communities by providing products and services that are objective, timely, accurate, and relevant.</cmns-av:explanatoryNote>
-		<lcc-cr:isPartOf rdf:resource="&fibo-ind-ei-usei;UnitedStatesDepartmentOfLabor"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-ind-ei-usei;UnitedStatesDepartmentOfLabor"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;ConsumerExpenditureSurvey">
@@ -207,7 +204,7 @@
 		<fibo-fnd-plc-loc:hasCoverageArea rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-av:abbreviation>DOL</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.dol.gov/general/aboutdol</cmns-av:adaptedFrom>
-		<lcc-cr:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;UrbanConsumerPriceIndex">

--- a/IND/InterestRates/InterestRates.rdf
+++ b/IND/InterestRates/InterestRates.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -8,14 +9,12 @@
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
 	<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -24,6 +23,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -31,14 +31,12 @@
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
 	xmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -54,15 +52,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230301/InterestRates/InterestRates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/InterestRates/InterestRates.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/InterestRates/InterestRates.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 2 report.</skos:changeNote>
@@ -210,7 +207,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ir-ir;ReferenceInterestRate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -220,7 +217,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ir-ir;InterestRateBenchmarkClassificationScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;ClassificationScheme"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>

--- a/IND/MarketIndices/BasketIndices.rdf
+++ b/IND/MarketIndices/BasketIndices.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
@@ -20,7 +21,6 @@
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
 	<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/">
 	<!ENTITY fibo-sec-sec-cls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -29,6 +29,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
@@ -48,7 +49,6 @@
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"
 	xmlns:fibo-sec-sec-cls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -76,8 +76,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230301/MarketIndices/BasketIndices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200901/MarketIndices/BasketIndices.rdf version of this ontology was revised to add the details needed to calculate market cap for a capitalization-based weighting function.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/MarketIndices/BasketIndices.rdf version of this ontology was revised to eliminate the restriction on reference index that it has an index value - the restriction should be on the quantity value such that the value refers to the indicator it represents.</skos:changeNote>
@@ -239,7 +239,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fnd-arr-cls;IndustrySectorClassifier"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -253,7 +253,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-sec-sec-cls;AssetClass"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/IND/MarketIndices/EquityIndexExampleIndividuals.rdf
+++ b/IND/MarketIndices/EquityIndexExampleIndividuals.rdf
@@ -14,7 +14,6 @@
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
@@ -49,7 +48,6 @@
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
@@ -84,7 +82,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>

--- a/LOAN/LoansGeneral/LoanApplications.rdf
+++ b/LOAN/LoansGeneral/LoanApplications.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-crt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/">
@@ -10,7 +11,6 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
@@ -22,7 +22,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-app "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -31,6 +30,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-crt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditRatings/"
@@ -40,7 +40,6 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
@@ -52,7 +51,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-app="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -70,7 +68,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
@@ -81,8 +78,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -447,7 +444,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-app;PublicRecordCategory"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -457,7 +454,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-app;PublicRecordCategory">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>public record category</rdfs:label>
 		<skos:definition>classifier of public records relevant to a loan application, e.g. tax lien, wage garnishment, foreclosure</skos:definition>
 	</owl:Class>
@@ -510,13 +507,13 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-app;UnderwritingAutomation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>underwriting automation</rdfs:label>
 		<skos:definition>classifier indicating whether a loan was underwritten manually or using an automated underwriting system</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-app;UnderwritingDecision">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>underwriting decision</rdfs:label>
 		<skos:definition>classifier providing a loan approval recommendation determined either manually or by an automated underwriting system</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -23,7 +23,6 @@
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -54,7 +53,6 @@
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -87,7 +85,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230301/LoansGeneral/Loans/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/LoansGeneral/Loans.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20230201/LoansGeneral/Loans.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
@@ -550,7 +547,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isPartOf"/>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;Loan"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -12,9 +13,7 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
@@ -33,6 +32,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -44,9 +44,7 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
@@ -76,9 +74,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
@@ -89,6 +85,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230301/LoansGeneral/Loans/"/>
@@ -236,7 +233,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;LenderLienPosition">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>lender lien position</rdfs:label>
 		<skos:definition>classifier indicating whether the lender has the primary lien position with respect to an asset used as collateral for the loan</skos:definition>
 	</owl:Class>
@@ -281,7 +278,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-loan-ln-ln;LenderLienPosition"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -461,10 +458,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;OwnershipInterest">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Ownership"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -541,13 +538,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;LenderLienPosition"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;OwnershipInterest"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/LOAN/LoansSpecific/LoanProducts.rdf
+++ b/LOAN/LoansSpecific/LoanProducts.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
@@ -8,7 +9,6 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
@@ -21,7 +21,6 @@
 	<!ENTITY fibo-loan-ln-reg "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/">
 	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
 	<!ENTITY fibo-loan-spc-prod "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -30,6 +29,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
@@ -37,7 +37,6 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
@@ -50,7 +49,6 @@
 	xmlns:fibo-loan-ln-reg="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"
 	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
 	xmlns:fibo-loan-spc-prod="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -66,7 +64,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
@@ -79,8 +76,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -89,7 +86,7 @@
 	<owl:Class rdf:about="&fibo-loan-ln-ln;Loan">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-prod;LoanMarketCategory"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/LOAN/RealEstateLoans/ConstructionLoans.rdf
+++ b/LOAN/RealEstateLoans/ConstructionLoans.rdf
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ev "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 	<!ENTITY fibo-loan-reln-cnst "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -21,18 +20,17 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ev="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:fibo-loan-reln-cnst="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -46,14 +44,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -62,7 +59,7 @@
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;RealEstate">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-cnst;ConstructionType"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -107,7 +104,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-cnst;ConstructionType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>construction type</rdfs:label>
 		<skos:definition>particular kind of construction</skos:definition>
 	</owl:Class>

--- a/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
+++ b/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
@@ -17,7 +17,6 @@
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 	<!ENTITY fibo-loan-reln-hmda "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/">
 	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -26,10 +25,10 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
@@ -42,7 +41,6 @@
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:fibo-loan-reln-hmda="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"
 	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -55,7 +53,6 @@
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
@@ -67,7 +64,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -75,10 +72,10 @@
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;Ethnicity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -90,7 +87,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-hmda;HowSubmitted"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -100,7 +97,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;HMDA-Disposition">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>HMDA disposition</rdfs:label>
 		<skos:definition>a type of action taken regarding an application for a HMDA covered loan</skos:definition>
 	</owl:Class>
@@ -187,7 +184,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;HowSubmitted">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>how submitted</rdfs:label>
 		<skos:definition>category indicating whether the applicant or borrower submitted the application for the covered loan directly to the reporting financial institution</skos:definition>
 		<cmns-av:adaptedFrom>2015 Revised HMDA regulation</cmns-av:adaptedFrom>
@@ -202,7 +199,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;Race">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&skos;broaderTransitive"/>
@@ -211,7 +208,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/LOAN/RealEstateLoans/MortgageLoans.rdf
+++ b/LOAN/RealEstateLoans/MortgageLoans.rdf
@@ -29,7 +29,6 @@
 	<!ENTITY fibo-loan-ln-app "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -66,7 +65,6 @@
 	xmlns:fibo-loan-ln-app="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -104,7 +102,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -147,13 +144,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;DwellingCapacity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/MD/TemporalCore/SecurityTradingStatuses.rdf
+++ b/MD/TemporalCore/SecurityTradingStatuses.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
@@ -9,7 +10,6 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-md-temx-trs "https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -18,6 +18,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
@@ -26,7 +27,6 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-md-temx-trs="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -44,7 +44,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -68,7 +68,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStatus"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;Listing"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -91,7 +91,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStatus"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -103,7 +103,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStatus"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Debt/ExerciseConventions.rdf
+++ b/SEC/Debt/ExerciseConventions.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -9,7 +10,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -18,6 +18,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -26,7 +27,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -44,14 +44,15 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/ExerciseConventions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/ExerciseConventions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20211001/Debt/ExerciseConventions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190101/Debt/ExerciseConventions.rdf version of this ontology was added to support integration of Bonds and Options in SEC and DER, respectively.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190101/Debt/ExerciseConventions.rdf version of this ontology was modified to add the hasExerciseTerms property.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/ExerciseConventions.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Debt/ExerciseConventions.rdf version of this ontology was modified to revise the definition of American exercise terms to say that an option with such terms may be exercised on or before the expiration date of the contract.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210901/Debt/ExerciseConventions.rdf version of this ontology was modified to loosen the domain of hasExerciseTerms to allow for entitlements to have such terms.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/ExerciseConventions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -67,7 +68,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;uses"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
 				<owl:hasValue rdf:resource="&fibo-sec-dbt-ex;AmericanExerciseConvention"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -88,7 +89,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;uses"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
 				<owl:hasValue rdf:resource="&fibo-sec-dbt-ex;BermudanExerciseConvention"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -120,7 +121,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ex;BermudanExerciseTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;uses"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
 				<owl:hasValue rdf:resource="&fibo-sec-dbt-ex;CanaryExerciseConvention"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -138,7 +139,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ex;ExerciseTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;uses"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
 				<owl:hasValue rdf:resource="&fibo-sec-dbt-ex;EuropeanExerciseConvention"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -163,7 +164,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;uses"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ex;ExerciseConvention"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Debt/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/MortgageBackedSecurities.rdf
@@ -29,7 +29,6 @@
 	<!ENTITY fibo-sec-fund-fund "https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-pls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -66,7 +65,6 @@
 	xmlns:fibo-sec-fund-fund="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-pls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -104,7 +102,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -636,7 +633,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mbs;hasNote">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;hasPart"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasPart"/>
 		<rdfs:label xml:lang="en">has note</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-mbs;MortgageBackedSecurity"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
@@ -661,7 +658,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mbs;isSliceOf">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isPartOf"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;isPartOf"/>
 		<rdfs:label xml:lang="en">is slice of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-mbs;MortgageBackedSecurity"/>

--- a/SEC/Equities/DepositaryReceipts.rdf
+++ b/SEC/Equities/DepositaryReceipts.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-easj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/AsianJurisdiction/EasternAsiaGovernmentEntitiesAndJurisdictions/">
@@ -15,7 +16,6 @@
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
 	<!ENTITY fibo-sec-sec-cls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
 	<!ENTITY fibo-sec-sec-rst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -24,6 +24,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-easj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/AsianJurisdiction/EasternAsiaGovernmentEntitiesAndJurisdictions/"
@@ -38,7 +39,6 @@
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:fibo-sec-sec-cls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"
 	xmlns:fibo-sec-sec-rst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -61,8 +61,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/DepositaryReceipts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20221001/Equities/DepositaryReceipts.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Equities/DepositaryReceipts.rdf version of this ontology was modified to expand the definition of a depositary receipt to cover a broader range of securities.</skos:changeNote>
@@ -85,7 +85,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceiptLevel"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -101,14 +101,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceiptLevelScheme"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceipt"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceipt"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceiptLevelScheme"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">American depositary receipt level</rdfs:label>
@@ -328,7 +328,7 @@ jurisdictions other than the one where the original debt instruments were issued
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-dr;AmericanDepositaryReceipt"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-dr;LevelIAmericanDepositaryReceipt"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-usj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/">
@@ -23,7 +24,6 @@
 	<!ENTITY fibo-sec-sec-idind "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -32,6 +32,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-usj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"
@@ -54,7 +55,6 @@
 	xmlns:fibo-sec-sec-idind="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -84,8 +84,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquitiesExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was modified to add CFI codes to the example equity instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
@@ -117,7 +117,7 @@
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Facility-XNAS"/>
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNAS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNASListedAlphabetIncClassACommonStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassAFinancialInstrumentShortName">
@@ -148,7 +148,7 @@
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Facility-XNAS"/>
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNAS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNASListedAlphabetIncClassCCapitalStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESNUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESNUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassCFinancialInstrumentShortName">
@@ -187,7 +187,7 @@
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNAS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XLOMListedAppleIncCommonStock"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNASListedAppleIncCommonStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AppleIncCommonStockFinancialInstrumentShortName">
@@ -474,7 +474,7 @@
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedCitigroupIncCommonStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;CitigroupIncCommonStockFinancialInstrumentShortName">
@@ -592,7 +592,7 @@
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedInternationalBusinessMachinesCorporationCommonStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStockFinancialInstrumentShortName">
@@ -631,7 +631,7 @@
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedJPMorganChaseAndCoCommonStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStockFinancialInstrumentShortName">
@@ -677,7 +677,7 @@
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheCoca-ColaCompanyCommonStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStockFinancialInstrumentShortName">
@@ -716,7 +716,7 @@
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNAS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheHomeDepotIncCommonStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStockFinancialInstrumentShortName">
@@ -754,7 +754,7 @@
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheProctorAndGambleCompanyCommonStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStockFinancialInstrumentShortName">
@@ -892,7 +892,7 @@
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:hasOriginalPlaceOfListing rdf:resource="&fibo-fbc-fct-mkti;Facility-XNYS"/>
 		<fibo-sec-sec-lst:isListedVia rdf:resource="&fibo-sec-eq-eqind;XNYSListedWellsFargoCommonStock"/>
-		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;XLOMListedAppleIncCommonStock">

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-eq-10962 "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
@@ -11,7 +11,6 @@
 	<!ENTITY fibo-sec-sec-cls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -20,9 +19,9 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-eq-10962="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
@@ -30,7 +29,6 @@
 	xmlns:fibo-sec-sec-cls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -49,8 +47,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquityCFIClassificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form, eliminate embedded restrictions, and build out additional classes representing the various feature-based descriptions supported by the CFI standard.</skos:changeNote>
@@ -72,7 +70,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -88,7 +86,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -104,7 +102,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESETPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -120,7 +118,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -136,7 +134,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -152,7 +150,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESEUPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -168,7 +166,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -184,7 +182,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -200,7 +198,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNTPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -216,7 +214,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -232,7 +230,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -248,7 +246,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESNUPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -264,7 +262,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -280,7 +278,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -296,7 +294,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRTPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -312,7 +310,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -328,7 +326,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -344,7 +342,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESRUPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -360,7 +358,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -376,7 +374,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -392,7 +390,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVTPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -408,7 +406,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -424,7 +422,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUOR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -440,7 +438,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:hasValue rdf:resource="&fibo-sec-eq-10962;ESVUPR"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -16,7 +16,6 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
@@ -34,7 +33,6 @@
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
 	<!ENTITY fibo-sec-sec-sch "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -58,7 +56,6 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
@@ -76,7 +73,6 @@
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
 	xmlns:fibo-sec-sec-sch="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -100,7 +96,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
@@ -118,7 +113,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
@@ -956,7 +950,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStatus"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1195,7 +1189,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasSharePaymentStatus">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isClassifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label xml:lang="en">has share payment status</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:range rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -870,7 +870,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-rst;SecuritiesRestriction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isPartOf"/>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundProspectus"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -18,7 +19,6 @@
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-arr-rt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/">
@@ -52,6 +52,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -69,7 +70,6 @@
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-arr-rt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/"
@@ -119,7 +119,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/"/>
@@ -145,6 +144,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
@@ -364,10 +364,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundClassification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-fund;CollectiveInvestmentVehicle"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -376,7 +376,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundClassificationScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;ClassificationScheme"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
@@ -1073,7 +1073,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;RiskLevel">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label xml:lang="en">risk level</rdfs:label>
 	</owl:Class>
 	

--- a/SEC/Funds/Funds.rdf
+++ b/SEC/Funds/Funds.rdf
@@ -19,7 +19,6 @@
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
 	<!ENTITY fibo-sec-fund-fund "https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/">
 	<!ENTITY fibo-sec-sec-pls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -46,7 +45,6 @@
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:fibo-sec-fund-fund="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"
 	xmlns:fibo-sec-sec-pls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -76,7 +74,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Funds/Funds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Funds/Funds.rdf version of this ontology was modified to replace the original fibo-sec-fnd-fnd prefix with fibo-sec-fund-fund for the sake of clarity and to change the restriction on LegalFundStructure from an equivalence to a subclass relationship to address a reasoning error as well as adding a missing restriction on jurisdiction.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Funds/Funds.rdf version of this ontology was modified to move the definition of SpecialPurposeVehicle to the Pools ontology to make it available for use more generally.</skos:changeNote>
@@ -264,7 +261,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-fund;hasSubFund">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;hasPart"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasPart"/>
 		<rdfs:label xml:lang="en">has sub-fund</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;PooledFund"/>
 		<rdfs:range rdf:resource="&fibo-sec-sec-pls;PooledFund"/>
@@ -279,7 +276,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-fund;isSubFundOf">
-		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isPartOf"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;isPartOf"/>
 		<rdfs:label xml:lang="en">is sub-fund of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;PooledFund"/>
 		<rdfs:range rdf:resource="&fibo-sec-sec-pls;PooledFund"/>

--- a/SEC/Securities/SecurityAssets.rdf
+++ b/SEC/Securities/SecurityAssets.rdf
@@ -12,7 +12,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-ast "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/">
-	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -32,7 +31,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-ast="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"
-	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -54,7 +52,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/SecurityAssets/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecurityAssets.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecurityAssets.rdf version of this ontology was revised to simplify the contract party hierarchy and eliminate complexity introduced by &apos;security holding&apos;.</skos:changeNote>
@@ -138,7 +135,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isPartOf"/>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/etc/testing/hygiene_parameterized/testHygiene_triples_untyped_object.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene_triples_untyped_object.sparql
@@ -6,7 +6,7 @@ prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
-prefix lcc-cr: <https://www.omg.org/spec/LCC/Countries/CountryRepresentation/>
+prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/>
 
 ##
 # banner If we refer to something, it should have a type
@@ -19,7 +19,7 @@ WHERE {
   FILTER regex(str(?object), <HYGIENE_TESTS_FILTER_PARAMETER>)
   FILTER NOT EXISTS {?object a []}
   FILTER (! (?property IN (owl:versionIRI, sm:dependsOn , owl:imports , sm:specificationVersionURL,
-                    rdfs:seeAlso, dct:isPartOf, lcc-cr:isPartOf, lcc-cr:hasPart, dct:hasPart))) 
+                    rdfs:seeAlso, dct:isPartOf, cmns-col:isPartOf, cmns-col:hasPart, dct:hasPart))) 
   BIND (
     concat ("ERROR:", xsd:string (?object), " is referenced by ", afn:localname (?property), " but has no type.")
 	  AS ?error

--- a/etc/testing/hygiene_parameterized/testHygiene_triples_untyped_property.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene_triples_untyped_property.sparql
@@ -6,7 +6,7 @@ prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
-prefix lcc-cr: <https://www.omg.org/spec/LCC/Countries/CountryRepresentation/>
+prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/>
 
 ##
 # banner If we refer to something, it should have a type
@@ -18,6 +18,6 @@ WHERE {
   FILTER regex(str(?property), <HYGIENE_TESTS_FILTER_PARAMETER>)
   FILTER NOT EXISTS {?property a []}
   FILTER (! (?property IN (owl:versionIRI, sm:dependsOn , owl:imports , sm:specificationVersionURL,
-                    rdfs:seeAlso, dct:isPartOf, lcc-cr:isPartOf, lcc-cr:hasPart, dct:hasPart))) 
+                    rdfs:seeAlso, dct:isPartOf, cmns-col:isPartOf, cmns-col:hasPart, dct:hasPart))) 
   BIND (concat ("ERROR: Property ", xsd:string (?property), " is used but has no type.") AS ?error)
 }

--- a/etc/testing/hygiene_parameterized/testHygiene_triples_untyped_subject.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene_triples_untyped_subject.sparql
@@ -6,7 +6,7 @@ prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
-prefix lcc-cr: <https://www.omg.org/spec/LCC/Countries/CountryRepresentation/>
+prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/>
 
 ##
 # banner If we refer to something, it should have a type
@@ -18,7 +18,7 @@ WHERE {
   FILTER regex(str(?s), <HYGIENE_TESTS_FILTER_PARAMETER>)
   FILTER NOT EXISTS {?s a []}
   FILTER (! (?p IN (owl:versionIRI, sm:dependsOn , owl:imports , sm:specificationVersionURL,
-                    rdfs:seeAlso, dct:isPartOf, lcc-cr:isPartOf, lcc-cr:hasPart, dct:hasPart))) 
+                    rdfs:seeAlso, dct:isPartOf, cmns-col:isPartOf, cmns-col:hasPart, dct:hasPart))) 
   BIND (
     concat ("ERROR:", xsd:string (?s), " is referenced by ", afn:localname (?p), " but has no type.")
 	  AS ?error


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

1. Eliminate unused references to the Country Representation ontology
2. Replace elements including LCC classifies and isClassifiedBy as well as FIBO Classifier and ClassificationScheme with the corresponding concepts in the Commons Classifiers Ontology
3. Replace elements including LCC hasPart and isPartOf with the corresponding concepts in the Commons Collections ontology
4. Replace remaining LCC uses and isUsedBy elements with the corresponding concepts from Commons

Fixes: #1897 / FND-375


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


