### PR TITLE
SEC-184 - Add common pooled securities statistics

### DIFF
--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -63,7 +63,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Utilities/Analytics/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230501/Utilities/Analytics/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20140501/Utilities/Analytics.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Utilities/Analytics.rdf version of this ontology was modified to address issue FIBOFND11-20, which added the definition of Calculation and corrected a reasoning issue related to the use of a custom datatype.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/Utilities/Analytics.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
@@ -82,6 +82,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220101/Utilities/Analytics.rdf version of this ontology was modified to eliminate hygiene issues related to text formatting and eliminate dead or outdated references.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/Utilities/Analytics.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Utilities/Analytics.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Utilities/Analytics.rdf version of this ontology was modified to add a synonym of &apos;average&apos; to arithmetic mean.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -111,6 +112,7 @@
 		<rdfs:label>arithmetic mean</rdfs:label>
 		<skos:definition>sum of a collection of numbers divided by the number of numbers in the collection</skos:definition>
 		<cmns-av:explanatoryNote>While the arithmetic mean is often used to report central tendencies, it is not a robust statistic, meaning that it is greatly influenced by outliers (values that are very much larger or smaller than most of the values). Notably, for skewed distributions, such as the distribution of income for which a few people&apos;s incomes are substantially greater than most people&apos;s, the arithmetic mean may not accord with one&apos;s notion of &apos;middle&apos;, and robust statistics, such as the median, may be a better description of central tendency.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>average</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-utl-alx;Aspect">

--- a/MD/DebtTemporal/DebtAnalytics.rdf
+++ b/MD/DebtTemporal/DebtAnalytics.rdf
@@ -83,49 +83,10 @@
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;AbsolutePrepaymentRate">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;AbsolutePrepaymentRateFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">absolute prepayment rate</rdfs:label>
-		<skos:definition xml:lang="en">The absolute prepayment rate (for ABS) is the standard measure of prepayment rates in the auto-loan sector. ABS measures the monthly rate of loan prepayments as a percentage of the original pool balance. ABS is defined by the following formula where SMM refers to Single Monthly Mortality, which measures the percentage of dollars prepaid in a given month expressed as a percentage of the scheduled loan balance. ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">The ABS measurement differs from conditional prepayment rate (CPR) used in the mortgage industry, which measures prepayment as an annualized percentage of the current pool balance.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;AbsolutePrepaymentRateFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Formula"/>
-		<rdfs:label xml:lang="en">absolute prepayment rate formula</rdfs:label>
-		<skos:definition xml:lang="en">ABS is defined by the following formula where SMM refers to Single Monthly Mortality, which measures the percentage of dollars prepaid in a given month expressed as a percentage of the scheduled loan balance. ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;AccruedInterestAmount">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Interest"/>
 		<rdfs:label xml:lang="en">accrued interest amount</rdfs:label>
 		<skos:definition xml:lang="en">The interest accrued on the bond or debt instrument at the time that the price is quoted. If this is a dirty price, this is the amount of accrued interest that is included in the price. This is therefore passed on to the purchaser of the bond or debt instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;AverageLife">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;LifeAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">average life</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
-		<skos:definition xml:lang="en">An estimate of the number of terms to maturity, taking the possibility of early payments into account. Average life is calculated using the weighted average time to the receipt of all future cash flows.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">Where it refers to pre-payment above, if the bond does not include prepayment then this is not included. However, analytics that refer to this e.g. Yield to Average Life, then this figure is relevant. It is not relevant for other types of bond where e.g. you would use yield to next call, yield to worst etc. Average Life used in place of Maturity for Yield Calculation. This is not only used for Yield calculations though. It is referred to as an analytic figure in its own right. Average Life uses one of a number of standard pre-payment models (for structured finance at least). For MBS, the average life includes some calculations to take account of pre-payments on the underlying mortgages. This takes account of the possibillity of borrowers paying early. This has to be modeled or forecast (not given) as it&apos;s a function of market conditions and interest rate. You would not see this in a market data feed. When you model MBS you calculate Average Life as part of the model i.e. you estimate the percentage of prepayment in the next x length of time and factor this into the Average Life. Refers to Weighted Average Time to receipt of future cash flows. For MBS, early payments will shorten the Average Life. For Student Loans, Credit Card, Loan etc, i.e. all Pool Backed (any bond that has securitized debt). Other bonds: Sinking Funds etc., also Early Payment - partial Call for a corporate / regular bond. Early Payment for pass through has the same effect. Sinking Fund: Each payment is part principal and part interest, this is implicit in the overall definition of &quot;Early payment&quot;.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;AverageLifeAtIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
-		<rdfs:label xml:lang="en">average life at issue</rdfs:label>
-		<skos:definition xml:lang="en">The Average Life analytic at the time the security was issued.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;BondEquivalentYield">
@@ -217,24 +178,6 @@
 		<skos:definition xml:lang="en">The second derivative of a security&apos;s price with respect to its yield, divided by the security&apos;s price. A security exhibits positive convexity when its price rises more for a downward move in its yield than its price declines for an equal upward move in its yield. Further notes: A measure of the change in price for a given change in Modified Duration. This always (necessarily) refers to Modified Duration. This is used as another risk measurement. Numerator is always (a) duration - either MacCaulays or Modified. Always rate of change of (one of the) Duration against some other parameter. The other paramater can be characterised as a Yield (it may be the Price, but that has a relationship to the Yield in any case). REVIEW: Inconsistency in the above - is it always necessarily Modified Duration that is referred to, or &quot;any&quot; Duration measure (Macaulays and.or Modified)? notes 9 Dec A measure of the sensitivity of the price with reference to interest rates. This is normally determined with reference to maturity, but since there are different maturity dates, this figure gives an estimate of the equitvalent if you had a homogenous portfolio, i.e. this is an estimate based on a pure equivalent, homogenous portfolio. Convexity of instrument versus portfolio. Sees instrument in terms of the set of cashflows. The term Convexity can be applied either to a bond or to a portfolio. More notes: When you get Convexit in MD, it will tell you what Duration it is refrfering to, along with Redemption Date (logically). Also if there is Option Adjusted Yield, there is a third set of analytics. What are they? i.e. OA Convexity, Duration Yield and the rest. Conclusions: Agreed to revisit this in OTC.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;ScopedMeasure"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasApplicableDatePeriod"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;DatePeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-pls;DebtPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt instrument analytical parameter</rdfs:label>
-		<skos:definition xml:lang="en">parameter describing some aspect of the behavior of one or more debt instrument(s) that may vary over time</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtInstrumentYield">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;Yield"/>
 		<rdfs:subClassOf>
@@ -275,24 +218,6 @@
 		<cmns-av:explanatoryNote xml:lang="en">Yield has a relationship to the price.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;ScopedMeasure"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasApplicableDatePeriod"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;DatePeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;CollectionOfDebtPools"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt pool analytical parameter</rdfs:label>
-		<skos:definition xml:lang="en">measure of some aspect of some pool or pools of debt, such as a pool of loans or a pool of securitized debt products</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtPriceSpread">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ind-ind;MarketSpread"/>
 		<rdfs:subClassOf>
@@ -323,7 +248,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasOutlookPeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageLife"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">debt yield to average life</rdfs:label>
@@ -385,12 +310,6 @@
 		<skos:definition xml:lang="en">Yield to the worst case of when the instrument might be called.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DefaultRate">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:label xml:lang="en">default rate</rdfs:label>
-		<skos:definition xml:lang="en">The rate at which holders of loans in the pool default on those loans.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DerivedPrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:label xml:lang="en">derived price</rdfs:label>
@@ -418,7 +337,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DurationAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
@@ -456,6 +375,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">equivalent life analytic</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageLife"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;EquivalentYieldCalculationMethod">
@@ -470,14 +390,14 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;FFIECDown300PrepaySpeed">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;PrepaymentSpeed"/>
 		<rdfs:label xml:lang="en">f f i e c down 300 prepay speed</rdfs:label>
 		<skos:definition xml:lang="en">Public Securities Association (PSA) speed used for the underlying collateral for cash-flow calculations in the &quot;down 300&quot; scenario.</skos:definition>
 		<skos:editorialNote xml:lang="en">Detailed parameters to follow, but basically these three PSA terms are differentiated by the fact that they reference 3 different prepayment models, so each of these will refer to a sub-type of the term &quot;Loan Pool Prepayment Model&quot;. For now the semantics are defined only in this written definition. Add model variants and terms in a future version.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;FFIECUp300PrepaySpeed">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;PrepaymentSpeed"/>
 		<rdfs:label xml:lang="en">f f i e c up 300 prepay speed</rdfs:label>
 		<skos:definition xml:lang="en">Public Securities Association (PSA) speed used for the underlying collateral for cash-flow calculations in the &quot;up 300&quot; scenario.</skos:definition>
 		<skos:editorialNote xml:lang="en">Detailed parameters to follow, but basically these three PSA terms are differentiated by the fact that they reference 3 different prepayment models, so each of these will refer to a sub-type of the term &quot;Loan Pool Prepayment Model&quot;. For now the semantics are defined only in this written definition. Add model variants and terms in a future version.</skos:editorialNote>
@@ -493,31 +413,6 @@
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;ImpliedForwardRate">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;RatioValue"/>
 		<rdfs:label xml:lang="en">implied forward rate</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;aggregateOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageLoanAge"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">instrument weighted average loan age</rdfs:label>
-		<skos:definition xml:lang="en">A dollar-weighted average measuring the age of the individual loans in a mortgage pass-through or pooled security, such as Ginnie Mae or a Freddie Mac security. The WALA is measured as the time in months since the origination of the loans, with the weighting based on each loan&apos;s size in proportion to the aggregate total of the pool.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">This is defined by the issuer. WALA is more official, not an analysis from a vendor. This changes but the values are relayed by the issuer on an ongoing basis. Investopedia explains Weighted Average Loan Age - WALA The weighted average age will change over time as some mortgages get paid off faster than others. Based on the issuer of the mortgage-backed securities (MBS), the WALA may be weighted on the remaining principal balance dollar figure, or the beginning notional value of the loan. The flip side of the WALA is the weighted average maturity (WAM), which is a dollar-weighted measure of the months remaining until the principal amounts are completely repaid on each loan in the pool.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;aggregateOf.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageRemainingMaturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">instrument weighted average remaining maturity</rdfs:label>
-		<skos:definition xml:lang="en">The weighted average of the time until all maturities on loans in a mortgage-backed or asset backed security. The higher the weighted average to maturity of the loans, the longer the loans in the security have until maturity.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;InternallyDeterminedPriceSpread">
@@ -551,7 +446,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;LifeAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
 		<rdfs:label xml:lang="en">life analytic</rdfs:label>
 		<skos:definition xml:lang="en">Some measure of the life of a security, other than the actual time to maturity itself. This is a derived figure, based on certain parameters as appropriate to that type of instrument, to give a figure that is equivalent to and similar to the basic maturity of the instrument, for the purposes of analysing that security.</skos:definition>
 	</owl:Class>
@@ -588,7 +483,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;MaturityEquivalentPSA">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;PrepaymentSpeed"/>
 		<rdfs:label xml:lang="en">maturity equivalent p s a</rdfs:label>
 		<skos:definition xml:lang="en">Prepayment speed that results in the same average life as that computed for the Collateralized Mortgage Obligation (CMO), Asset Backed Securities (ABS) or Mortgage Backed Securities (MBS) using the Maturity Prepay Model.</skos:definition>
 		<skos:editorialNote xml:lang="en">Detailed parameters to follow, but basically these three PSA terms are differentiated by the fact that they reference 3 different prepayment models, so each of these will refer to a sub-type of the term &quot;Loan Pool Prepayment Model&quot;. For now the semantics are defined only in this written definition. Add model variants and terms in a future version.</skos:editorialNote>
@@ -606,13 +501,6 @@
 		<owl:disjointWith rdf:resource="&fibo-md-dbtx-aly;MacCaulaysDurationAnalytic"/>
 		<skos:definition xml:lang="en">The percentage price change of a security for a given change in yield. The higher the modified duration of a security, the higher its risk. Ad/ModDuration = [duration / {1 + (IRR/M)}]; where IRR is the internal rate of return and M is the number of compounding periods per year.</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">The higher the MD the greater the change in price for a given change in yield.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
-		<rdfs:label xml:lang="en">mortgage instrument weighted average remaining maturity</rdfs:label>
-		<skos:definition xml:lang="en">The weighted average of the time until all maturities on mortgages in a mortgage-backed security (MBS). The higher the weighted average to maturity, the longer the mortgages in the security have until maturity.</skos:definition>
-		<skos:editorialNote xml:lang="en">Synonym (if this is the same term): Also known as &quot;average effective maturity&quot;. Investopedia explains Weighted Average Maturity - WAM The measure is calculated by totaling each mortgage value represented by the MBS. The weights of each mortgage is found by dividing the value of each into the total of all. To arrive at the WAM number the weight of each security is multiplied by the time until maturity of each mortgage, and then all the values are added together. For example say an MBS has three mortgages valued at $1,000, $2,000 and $3,000 (a total of $6,000) and mature in one, two and three years respectively. The weights of these are 1/6 (1,000/6,000), 1/3 (2,000/6,000) and 1/2 (3,000/6,000). The WAM is 2 1/3 years (1/6 x 1 year + 1/3 x 2 years + 1/2 x 3 years). Analysis: this investopedia decription does not take account of there being more than one Pool behind the MBS.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;NativeYield">
@@ -708,45 +596,8 @@
 		<skos:definition xml:lang="en">The rate at which the pool is paying down. This is based on observed factor. CPR, SMM, etc. etc. Measured differently for different kinds of security. CBO might have a prepayment rate for example if the underlying bond is callable. with a non agency mortgge dela, defualts will effect this. so for instance there is principal is no lnger inthe pool because the mortgagee defaults. With agency these are not taken out in the case of default but for non agency these mortgages are removed from the pool if and when a mortgagee defualts.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolWeightedAverageLoanAge">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:label xml:lang="en">pool weighted average loan age</rdfs:label>
-		<skos:definition xml:lang="en">A dollar-weighted average measuring the age of the individual loans in a mortgage pass-through or pooled security, such as Ginnie Mae or a Freddie Mac security. The WALA is measured as the time in months since the origination of the loans, with the weighting based on each loan&apos;s size in proportion to the aggregate total of the pool.</skos:definition>
-		<skos:editorialNote xml:lang="en">Adaptation taken from the instrument level figure. This definition looks as though it may already be defined with reference to the Loan Pool. Note also that this figure is specific to Pass Through securities. These are mutually exclusive with Tranched securities (static model update to come).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolWeightedAverageRemainingMaturity">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isBasedOn"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasMaturityDate"/>
-						<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool weighted average remaining maturity</rdfs:label>
-		<skos:definition xml:lang="en">The weighted average of the time until all maturities on loans in a pool. The higher the weighted average to maturity of the loans, the longer the loans in the pool have until maturity. REVIEW: Adapted from instrument specific definition from Investopedia. Review of 23 September identified that certain figures exist for pool and for instrument, whereas Investopedia definition was for Instrument (tranche, class etc.).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PrepaymentSpeed">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isBasedOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;LoanPoolPrepaymentModel"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">prepayment speed</rdfs:label>
-		<skos:definition xml:lang="en">The rate at which the pool is paying down.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is a model. Includes other factors such as homogeniety. Earlier notes: Same as Payment. Curtailment. Paydown is normally scheduled payments of the mortgage. Prepayment is when someone pays off the mortgage early I may send in 1500 when my monthly amount is 1000 a month. So the 500 is a prepayment. Scheduled principal payment. More notes 25 nov: Also factor in changes to the pool constituents where this is allowed for that kind of MBS. So we make estimates of how face value will will change. face value won&apos;t change but the underlying value of the Pf changes, so eg. the current mortgage factor. Model update note June 2010: Detailed types of &quot;Prepayment Speed&quot; analytic received from thomson Reuters, now modeled as sub types of this term. So term origin is PSA by extension, since this is the common super class of 3 specific prepayment speed analytic types defined by PSA. PSA stands for Public Securities Association. Type: PSA gives this as numeric, however definitions imply percentage, so defined as dated percentage for now. Many data models use numbers which are interpreted later as percentages so this may be the case here.</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;PriceValueOfBasisPoint">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
@@ -841,13 +692,6 @@
 		<skos:definition xml:lang="en">No definition.Term put here from memory.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;WeightedAverageCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:label xml:lang="en">weighted average coupon</rdfs:label>
-		<skos:definition xml:lang="en">The weighted-average gross interest rates of the pool of mortgages that underlie a mortgage-backed security (MBS) at the time the securities were issued. A mortgage-backed security&apos;s current WAC can differ from its original WAC as the underlying mortgages pay down at different speeds. In the weighted-average calculation, the principal balance of each underlying mortgage is used as the weighting factor</skos:definition>
-		<skos:editorialNote xml:lang="en">Provided by the Issuer (loan servicer?) along with the WALA etc. If you know the underlying loans you can calculate this yourself. For ABS you don&apos;t know this so you have to get this information from the loan servicer. Investopedia explains Weighted Average Coupon - WAC For example, suppose a MBS is composed of two different pools of mortgages: $6 million worth of mortgages that yield 7.5% and a pool of $4 million mortgages that yield 5%. The WAC would be 6.5%. The WAC on a mortgage-backed security is an important piece of information used by analysts to estimate the pre-pay characteristics of that security. It is an important relative value tool in MBS portfolio management and analysis.</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;WeightedAverageTimeToReceiptOfCashflows">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Formula"/>
 		<rdfs:label xml:lang="en">weighted average time to receipt of cashflows</rdfs:label>
@@ -912,20 +756,6 @@
 		<rdfs:label xml:lang="en">yield to next put</rdfs:label>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;aggregateOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-aly;isAggregateOf"/>
-		<rdfs:label xml:lang="en">aggregate of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageLoanAge"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;aggregateOf.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-aly;isAggregateOf"/>
-		<rdfs:label xml:lang="en">aggregate of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageRemainingMaturity"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;calculationFollowing">
 		<rdfs:label xml:lang="en">calculation following</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentYield"/>
@@ -948,7 +778,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;defaultRateValue">
 		<rdfs:label xml:lang="en">default rate value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DefaultRate"/>
+		<rdfs:domain rdf:resource="&fibo-sec-dbt-pbs;DefaultRate"/>
 		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
 	</owl:ObjectProperty>
 	
@@ -965,23 +795,16 @@
 		<skos:definition xml:lang="en">The Equivalent Life in years at the stated date.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-aly;expressedAs">
-		<rdfs:label xml:lang="en">expressed as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;AbsolutePrepaymentRateFormula"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasAnalytic">
 		<rdfs:label xml:lang="en">has analytic</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;DebtPool"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
+		<rdfs:range rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasDefaultRate">
 		<rdfs:label xml:lang="en">has default rate</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;DebtPool"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;DefaultRate"/>
+		<rdfs:range rdf:resource="&fibo-sec-dbt-pbs;DefaultRate"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasFactor">
@@ -993,7 +816,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasMeasure">
 		<rdfs:label xml:lang="en">has measure</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;DebtPool"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+		<rdfs:range rdf:resource="&fibo-sec-dbt-pbs;PrepaymentSpeed"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasOutlookPeriod">
@@ -1020,7 +843,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasWac">
 		<rdfs:label xml:lang="en">has wac</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-mbs;MortgageBackedSecurity"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;WeightedAverageCoupon"/>
+		<rdfs:range rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageCoupon"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasYield">
@@ -1031,8 +854,8 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;isAggregateOf">
 		<rdfs:label xml:lang="en">is aggregate of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
+		<rdfs:domain rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:range rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-aly;isCompounded">
@@ -1102,37 +925,38 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasWac"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;WeightedAverageCoupon"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageCoupon"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-pbs;PoolBackedSecurity">
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;PrepaymentSpeed">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isBasedOn"/>
+				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;LoanPoolPrepaymentModel"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<skos:editorialNote xml:lang="en">This is a model. Includes other factors such as homogeniety. Earlier notes: Same as Payment. Curtailment. Paydown is normally scheduled payments of the mortgage. Prepayment is when someone pays off the mortgage early I may send in 1500 when my monthly amount is 1000 a month. So the 500 is a prepayment. Scheduled principal payment. More notes 25 nov: Also factor in changes to the pool constituents where this is allowed for that kind of MBS. So we make estimates of how face value will will change. face value won&apos;t change but the underlying value of the Pf changes, so eg. the current mortgage factor. Model update note June 2010: Detailed types of &quot;Prepayment Speed&quot; analytic received from thomson Reuters, now modeled as sub types of this term. So term origin is PSA by extension, since this is the common super class of 3 specific prepayment speed analytic types defined by PSA. PSA stands for Public Securities Association. Type: PSA gives this as numeric, however definitions imply percentage, so defined as dated percentage for now. Many data models use numbers which are interpreted later as percentages so this may be the case here.</skos:editorialNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;WeightedAverageLifeAtIssue">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageLife"/>
+		<rdfs:label xml:lang="en">average life at issue</rdfs:label>
+		<skos:definition xml:lang="en">The Average Life analytic at the time the security was issued.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-pls;DebtPool">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasAnalytic"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasDefaultRate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;DefaultRate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;DefaultRate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -1144,7 +968,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasMeasure"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;PrepaymentSpeed"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>

--- a/SEC/Debt/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/MortgageBackedSecurities.rdf
@@ -21,7 +21,6 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
-	<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/">
 	<!ENTITY fibo-sec-dbt-abs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/">
 	<!ENTITY fibo-sec-dbt-cdo "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
@@ -58,7 +57,6 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
-	xmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"
 	xmlns:fibo-sec-dbt-abs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"
 	xmlns:fibo-sec-dbt-cdo="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
@@ -94,7 +92,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
@@ -292,7 +289,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageRemainingTerm"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">mortgage-backed security</rdfs:label>

--- a/SEC/Debt/PoolBackedSecurities.rdf
+++ b/SEC/Debt/PoolBackedSecurities.rdf
@@ -118,6 +118,13 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:onClass rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-pbs;isPassThrough"/>
 				<owl:onDataRange rdf:resource="&xsd;boolean"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
@@ -127,18 +134,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isBasedOn"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-pls;InstrumentPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageLoanAge"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageRemainingTerm"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">pool-backed security</rdfs:label>
@@ -160,6 +155,15 @@
 		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01.</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote xml:lang="en">There are one or more reference entities underlying the product. Redemption is made at least in the amount of the conditional capital protection at maturity, provided that no credit event by the reference entity has occurred. Conditional capital protection only applies to the nominal amount and not to the purchase price. The general functioning of a capital guaranteed structured instrument is as follows: the notional amount is split into a zero bond, that will deliver the capital guarantee at maturity, and the difference between the zero bond&apos;s value (= present value of the guarantee level at maturity) and the notional amount is used for structuring the performance component with options which deliver the agreed pay-off profile of the structured instrument.</cmns-av:explanatoryNote>
 		<cmns-av:synonym xml:lang="en">capital protected note</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;SingleMonthlyMortality">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Percentage"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:label xml:lang="en">single monthly mortality</rdfs:label>
+		<skos:definition xml:lang="en">estimated per-month percentage of mortgages in an MBS pool that will be paid off early</skos:definition>
+		<cmns-av:abbreviation xml:lang="en">SMM</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">Single monthly mortality (SMM) is a way to gauge the prepayment risk of a mortgage-backed security.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;StructuredFinanceInstrument">

--- a/SEC/Debt/PoolBackedSecurities.rdf
+++ b/SEC/Debt/PoolBackedSecurities.rdf
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
 	<!ENTITY fibo-sec-dbt-pbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/">
@@ -19,12 +23,16 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
 	xmlns:fibo-sec-dbt-pbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"
@@ -43,18 +51,32 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/PoolBackedSecurities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230501/Debt/PoolBackedSecurities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Debt/PoolBackedSecurities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/PoolBackedSecurities.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate, and added an explanatory note to ABS.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/PoolBackedSecurities.rdf version of this ontology was modified add a number of commonly used pool-backed security related statistical measures.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;AbsolutePrepaymentRate">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:label xml:lang="en">absolute prepayment rate</rdfs:label>
+		<skos:definition xml:lang="en">measure of the monthly rate of loan prepayments as a percentage of the original pool balance</skos:definition>
+		<cmns-av:abbreviation xml:lang="en">ABS</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">ABS is defined by the following formula where SMM refers to Single Monthly Mortality, which measures the percentage of dollars prepaid in a given month expressed as a percentage of the scheduled loan balance. ABS = (100 * SMM)/100 + (SMM X (Age - 1).</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The ABS measurement differs from conditional prepayment rate (CPR) used in the mortgage industry, which measures prepayment as an annualized percentage of the current pool balance.</cmns-av:explanatoryNote>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;AssetBackedSecurity">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;PoolBackedSecurity"/>
@@ -64,6 +86,32 @@
 		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10-01</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote xml:lang="en">An asset-backed security (ABS) is a type of financial investment that is collateralized by an underlying pool of assets—usually ones that generate a cash flow from debt, such as loans, leases, credit card balances, or receivables. It takes the form of a bond or note, paying income at a fixed rate for a set amount of time, until maturity. ABS are financial securities backed by income-generating assets such as credit card receivables, home equity loans, student loans, and auto loans. Pooling assets into an ABS is a process called securitization. One difference between an ABS and a collateralized debt obligation (CDO) is that the CDO issuer is generally a special purpose vehicle (SPV) or trust.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote xml:lang="en">Asset-backed securities, for example home equity loans (HEL), credit cards, and so forth are backed by receivables [payments] that are either secured (such as HEL) or unsecured (for example, credit cards). They are typically tranched based on default risk.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;QualifiedMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasApplicableDatePeriod"/>
+				<owl:onClass rdf:resource="&cmns-dt;DatePeriod"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-pls;DebtPool"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">debt pool statistical measure</rdfs:label>
+		<skos:definition xml:lang="en">qualified measure of some aspect of the behavior of one or more debt instrument(s) that may vary over time</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;DefaultRate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Ratio"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:label xml:lang="en">default rate</rdfs:label>
+		<skos:definition xml:lang="en">qualified measure of the rate at which holders of the debt instruments in the pool default on those instruments</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;PoolBackedSecurity">
@@ -81,9 +129,28 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-pls;InstrumentPool"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageLoanAge"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-pbs;WeightedAverageRemainingTerm"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">pool-backed security</rdfs:label>
 		<skos:definition xml:lang="en">debt instrument that derives its cashflow from an underlying pool of mortgage loans or other receivables</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">If the security is a component of a collateralized debt obligation, then the underlying pool is typically segmented into various tranches, each of which provides cash flows to hedge particular risks, or that offset other gains by time to maturity or other factors.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;PrepaymentSpeed">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:label xml:lang="en">prepayment speed</rdfs:label>
+		<skos:definition xml:lang="en">estimated rate at which a debt or part of a debt is paid off ahead of schedule</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">A prepayment model is used to estimate the level of prepayments (speed) on a loan portfolio that will occur in a set period of time, given possible changes in interest rates. Understanding prepayment speed is critical in assessing the value of mortgage pass-through securities. Prepayment models are based on mathematical equations and usually involve the analysis of historical prepayment trends to predict what will happen in the future. Prepayment models are often used to value mortgage pools such as GNMA securities or other securitized debt products, including mortgage-backed securities (MBS).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-pbs;PrincipalProtectedNote">
@@ -143,6 +210,65 @@
 		<rdfs:label xml:lang="en">tranche</rdfs:label>
 		<skos:definition xml:lang="en">segment of a pool of securities, typically debt instruments</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">A tranche is one of a number of related securities in the same offering that represents a partition of a debt pool whose cash flow is derived from the combined cash flows of the instruments in that partition.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;WeightedAverageCoupon">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;ArithmeticMean"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:label xml:lang="en">weighted average coupon</rdfs:label>
+		<skos:definition xml:lang="en">weighted-average gross interest rates of the pool of mortgages that underlie a mortgage-backed security (MBS) weighed by their balances at the time the securities were issued</skos:definition>
+		<skos:editorialNote xml:lang="en">Provided by the Issuer (loan servicer?) along with the WALA etc. If you know the underlying loans you can calculate this yourself. For ABS you don&apos;t know this so you have to get this information from the loan servicer. Investopedia explains Weighted Average Coupon - WAC For example, suppose a MBS is composed of two different pools of mortgages: $6 million worth of mortgages that yield 7.5% and a pool of $4 million mortgages that yield 5%. The WAC would be 6.5%. The WAC on a mortgage-backed security is an important piece of information used by analysts to estimate the pre-pay characteristics of that security. It is an important relative value tool in MBS portfolio management and analysis.</skos:editorialNote>
+		<cmns-av:abbreviation xml:lang="en">WAC</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">The weighted average coupon (WAC) is calculated by taking the gross of the interest rates owed on the underlying mortgages of the MBS and weighting them according to the percentage of the security that each mortgage represents. The WAC represents the average interest rate of different pools of mortgages with varying interest rates. In the weighted average calculation, the principal balance of each underlying mortgage is used as the weighting factor. To calculate the WAC, the coupon rate of each mortgage or MBS is multiplied by its remaining principal balance. The results are added together, and the sum total is divided by the remaining balance. A mortgage-backed security&apos;s current WAC can differ from its original WAC as the underlying mortgages pay down at different speeds. In the weighted-average calculation, the principal balance of each underlying mortgage is used as the weighting factor.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;WeightedAverageLife">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;ArithmeticMean"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
+				<owl:onClass rdf:resource="&fibo-sec-dbt-pbs;PrepaymentSpeed"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">weighted average life</rdfs:label>
+		<skos:definition xml:lang="en">weighted average of the times of the principal repayments Average life is calculated using the weighted average time to the receipt of all future cash flows.</skos:definition>
+		<cmns-av:abbreviation xml:lang="en">WAL</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">Average life is calculated using the weighted average time to the receipt of all future cash flows of an amortizing loan or amortizing bond. it&apos;s the average time until a dollar of principal is repaid.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The time weightings used in weighted average life calculations are based on payments to the principal. In many loans, such as mortgages, each payment consists of payments to principal and payments to interest. In WAL, only the principal payments are considered and these payments tend to get larger over time, with early payments of a mortgage going mostly to interest, while payments made towards the end of the loan are applied mostly to the principal balance of the loan.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Where it refers to pre-payment above, if the bond does not include prepayment then this is not included. However, analytics that refer to this e.g. Yield to Average Life, then this figure is relevant. It is not relevant for other types of bond where e.g. you would use yield to next call, yield to worst etc. Average Life used in place of Maturity for Yield Calculation. This is not only used for Yield calculations though. It is referred to as an analytic figure in its own right. Average Life uses one of a number of standard pre-payment models (for structured finance at least). For MBS, the average life includes some calculations to take account of pre-payments on the underlying mortgages. This takes account of the possibillity of borrowers paying early. This has to be modeled or forecast (not given) as it&apos;s a function of market conditions and interest rate. You would not see this in a market data feed. When you model MBS you calculate Average Life as part of the model i.e. you estimate the percentage of prepayment in the next x length of time and factor this into the Average Life. Refers to Weighted Average Time to receipt of future cash flows. For MBS, early payments will shorten the Average Life. For Student Loans, Credit Card, Loan etc, i.e. all Pool Backed (any bond that has securitized debt). Other bonds: Sinking Funds etc., also Early Payment - partial Call for a corporate / regular bond. Early Payment for pass through has the same effect. Sinking Fund: Each payment is part principal and part interest, this is implicit in the overall definition of &quot;Early payment&quot;.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">average life</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;WeightedAverageLoanAge">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;ArithmeticMean"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:label xml:lang="en">weighted average loan age</rdfs:label>
+		<skos:definition xml:lang="en">dollar-weighted average measuring the age of the individual loans in a mortgage pass-through or pooled security</skos:definition>
+		<cmns-av:abbreviation xml:lang="en">WALA</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">A weighted average loan age (WALA) may apply to pool-backed securities such as Ginnie Mae or Freddie Mac securities. The WALA is measured as the time in months since the origination of the loans, with the weighting based on each loan&apos;s size in proportion to the aggregate total of the pool.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This is defined by the issuer. WALA is more official, not an analysis from a vendor. This changes but the values are relayed by the issuer on an ongoing basis. Investopedia explains Weighted Average Loan Age - WALA The weighted average age will change over time as some mortgages get paid off faster than others. Based on the issuer of the mortgage-backed securities (MBS), the WALA may be weighted on the remaining principal balance dollar figure, or the beginning notional value of the loan. The flip side of the WALA is the weighted average maturity (WAM), which is a dollar-weighted measure of the months remaining until the principal amounts are completely repaid on each loan in the pool.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;WeightedAverageMaturity">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;ArithmeticMean"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:label xml:lang="en">weighted average maturity</rdfs:label>
+		<skos:definition xml:lang="en">weighted average amount of time until the maturities on mortgages in a mortgage-backed security (MBS)</skos:definition>
+		<cmns-av:abbreviation xml:lang="en">WAM</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">The measure is calculated by totaling each mortgage value represented by the MBS. The weights of each mortgage is found by dividing the value of each into the total of all. To arrive at the WAM number the weight of each security is multiplied by the time until maturity of each mortgage, and then all the values are added together. For example say an MBS has three mortgages valued at $1,000, $2,000 and $3,000 (a total of $6,000) and mature in one, two and three years respectively. The weights of these are 1/6 (1,000/6,000), 1/3 (2,000/6,000) and 1/2 (3,000/6,000). The WAM is 2 1/3 years (1/6 x 1 year + 1/3 x 2 years + 1/2 x 3 years). Note that this calculation would need to be adjusted if there are multiple pools behind the MBS.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This term is used more broadly to describe maturities in a portfolio of debt securities, including corporate debt and municipal bonds. The higher the WAM, the longer it takes for all of the mortgages or bonds in the portfolio to mature. WAM is used to manage debt portfolios and to assess the performance of debt portfolio managers.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-pbs;WeightedAverageRemainingTerm">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;ArithmeticMean"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-pbs;DebtPoolStatisticalMeasure"/>
+		<rdfs:label xml:lang="en">weighted average remaining term</rdfs:label>
+		<skos:definition xml:lang="en">weighted average time to maturity of a portfolio of asset-backed securities (ABS) or mortgage-backed (MBS) securities</skos:definition>
+		<cmns-av:abbreviation xml:lang="en">WART</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">The longer the WART, the longer the portfolio&apos;s assets will take to mature, on average. WART is often used in relation to mortgage-backed securities (MBS) but can also be applied to any portfolio of fixed-income securities. WART is closely related to weighted average loan age (WALA), which is its inverse.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">weighted average remaining maturity</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-pbs;isPassThrough">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall [ekendall@thematix.com](mailto:ekendall@thematix.com)

## Description

1. Added a synonym of 'average' to 'arithmetic mean'
2. Moved a number of pool-specific analytical statistics from the provisional debt analytics ontology to the pool-backed securities ontology, including but not limited to: absolute prepayment rate, default rate, weighted average loan age, weighted average remaining maturity, prepayment speed, and weighted average coupon
3. Added single monthly mortality to the set of possible statistics since it was mentioned

Fixes: #1921 / SEC-184


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


