### PR TITLE
SEC-73 - Augment the equities concepts with their CFI classification

### DIFF
--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -99,7 +99,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230601/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away, to support collateral agreements such as deeds of trust, UCC filings and the like, to add the concept of a rate reset time of day, to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations.</skos:changeNote>
@@ -110,6 +110,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220601/DebtAndEquities/Debt/ version of this ontology was modified to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/Debt.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/DebtAndEquities/Debt.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/DebtAndEquities/Debt.rdf version of this ontology was modified to address a punning issue due to the use of hasMethod as the parent property for hasAccrualBasis that was not detected before the latest Commons ontologies were posted to the OMG site.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -942,7 +943,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasAccrualBasis">
-		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasMethod"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-bd;hasBusinessRecurrenceIntervalConvention"/>
 		<rdfs:label>has accrual basis</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -49,7 +49,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquityCFIClassificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230601/Equities/EquityCFIClassificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form, eliminate embedded restrictions, and build out additional classes representing the various feature-based descriptions supported by the CFI standard.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to complete the set of possible common share representations corresponding to the CFI standard, complete the set of corresponding codes for common shares (non-convertible), and add the set of possible combinations for preferred shares (non-convertible).</skos:changeNote>
@@ -57,6 +57,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityCFIClassificationIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was modified to add a parent class of extendable preferred share where appropriate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -711,6 +712,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableAdjustableIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -729,6 +731,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableAuctionRateIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -748,6 +751,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -768,6 +772,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -787,6 +792,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableFixedIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -807,6 +813,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -825,6 +832,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExtendableParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -1073,6 +1081,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableAdjustableIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -1092,6 +1101,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableAuctionRateIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -1112,6 +1122,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -1133,6 +1144,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -1153,6 +1165,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableFixedIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -1174,6 +1187,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -1193,6 +1207,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExchangeableExtendableParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -1273,6 +1288,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableAdjustableIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -1291,6 +1307,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableAuctionRateIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -1310,6 +1327,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -1330,6 +1348,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -1349,6 +1368,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableFixedIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -1369,6 +1389,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Class>
@@ -1386,6 +1407,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingRedeemableExtendableParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;EnhancedVotingShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -1533,6 +1555,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -1551,6 +1574,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -1570,6 +1594,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -1590,6 +1615,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -1609,6 +1635,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
@@ -1629,6 +1656,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -1647,6 +1675,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
@@ -1895,6 +1924,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableAdjustableIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -1914,6 +1944,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableAuctionRateIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -1934,6 +1965,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -1955,6 +1987,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -1975,6 +2008,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableFixedIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
@@ -1996,6 +2030,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2015,6 +2050,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExchangeableExtendableParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
@@ -2095,6 +2131,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2113,6 +2150,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2132,6 +2170,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -2152,6 +2191,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -2171,6 +2211,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
@@ -2191,6 +2232,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -2208,6 +2250,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredNonVotingRedeemableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
@@ -2356,6 +2399,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2374,6 +2418,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2393,6 +2438,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
@@ -2413,6 +2459,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
@@ -2432,6 +2479,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -2452,6 +2500,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2470,6 +2519,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -2718,6 +2768,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableAdjustableIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2737,6 +2788,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableAuctionRateIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2757,6 +2809,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
@@ -2778,6 +2831,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
@@ -2798,6 +2852,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableFixedIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -2819,6 +2874,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2838,6 +2894,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExchangeableExtendableParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -2918,6 +2975,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2936,6 +2994,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -2955,6 +3014,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
@@ -2975,6 +3035,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
@@ -2994,6 +3055,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -3014,6 +3076,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;RestrictedVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -3031,6 +3094,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredRestrictedVotingRedeemableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -3179,6 +3243,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -3197,6 +3262,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -3216,6 +3282,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
@@ -3236,6 +3303,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
@@ -3255,6 +3323,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -3275,6 +3344,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -3293,6 +3363,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -3541,6 +3612,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableAdjustableIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -3560,6 +3632,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableAuctionRateIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -3580,6 +3653,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
@@ -3601,6 +3675,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
@@ -3621,6 +3696,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableFixedIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -3642,6 +3718,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableNormalIncomeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -3661,6 +3738,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExchangeableExtendableParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExchangeablePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -3741,6 +3819,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableAdjustableIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAdjustableRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -3759,6 +3838,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableAuctionRateIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithAuctionRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
@@ -3778,6 +3858,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableCumulativeParticipatingRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
@@ -3798,6 +3879,7 @@
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableCumulativeRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CumulativePreferredShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
@@ -3817,6 +3899,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableFixedIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>
@@ -3837,6 +3920,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableNormalIncomeRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
@@ -3854,6 +3938,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredVotingRedeemableExtendableParticipatingRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ExtendablePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;NonCumulativePreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ParticipatingPreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShareWithFixedRateDividend"/>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -116,7 +116,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230601/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
@@ -132,7 +132,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityInstruments.rdf version of this ontology was revised to add the notion of a VIE share and integrate dividend distribution method with strategy.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20221001/Equities/EquityInstruments.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/EquityInstruments.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquityInstruments.rdf version of this ontology was modified to clarify a restriction on perpetual preferred share.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquityInstruments.rdf version of this ontology was modified to clarify a restriction on perpetual preferred share, add extendible preferred share, and add the CFI definition for limited partnership unit.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -429,6 +429,15 @@
 		<skos:definition>preferred share that may be exchanged for a security of another issuer</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;ExtendablePreferredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
+		<rdfs:label>extendable preferred share</rdfs:label>
+		<skos:definition>preferred share whose redemption date can be extended at the issuer or holder option</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>An extendable preferred share may be redeemed at the option of the issuer and/or of the shareholder with an extendable redemption (meturity) date.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>extendible preferred share</cmns-av:synonym>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;FixedRateDividend">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredDividend"/>
 		<rdfs:subClassOf>
@@ -472,20 +481,13 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-ptr-ptr;GeneralPartner">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-ptr-ptr;LimitedPartner">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:someValuesFrom rdf:resource="&fibo-be-ptr-ptr;LimitedPartnership"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">limited partnership unit</rdfs:label>
-		<skos:definition xml:lang="en">share in a limited partnership</skos:definition>
+		<skos:definition xml:lang="en">share in a form of partnership similar to a general partnership, except that in addition to one or more general partners (GPs), there are one or more limited partners (LPs)</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Like shareholders in a corporation, the LPs have limited liability, i.e., they are  only liable on debts incurred by the firm to the extent of their registered investment and they have no management authority. The GPs pay the LPs the equivalent of a dividend on their investment, the nature and extent of which is usually defined in the partnership agreement.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ListedShare">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall [ekendall@thematix.com](mailto:ekendall@thematix.com)

## Description

Added the concept of an extendable preferred share to equity instruments and updated the definition of limited partnership unit per the CFI standard.

Fixes: #1929 / SEC-73


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


