### PR TITLE
FBC-311 - Move the provisional credit cards ontology to loans and release it

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -26,7 +26,7 @@
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the very latest version of every FIBO ontology (released, provisional, and informative) based on the contents of GitHub, for use in particular while working on revisions. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-04-14T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-06-27T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
@@ -183,7 +183,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 
@@ -295,6 +294,7 @@
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
 		
+	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"/>
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/"/>
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"/>

--- a/AboutFIBOProd-IncludingReferenceData.rdf
+++ b/AboutFIBOProd-IncludingReferenceData.rdf
@@ -26,7 +26,7 @@
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, including reference data but excluding examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. By reference data we mean ISO currency codes and USPS individuals in FND, juridictions and governments in BE, regulatory agencies and related financial services entities as well as business centers and MIC codes in FBC, FpML interest rates in IND, CFI codes in SEC (incomplete but planned for extension in subsequent releases), and so forth. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-04-14T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-06-27T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
@@ -344,7 +344,8 @@
 	-->
 
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
-
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"/>
+		
 	<!-- 
 	///////////////////////////////////////////////////////////////////////////////////////
 	//
@@ -376,7 +377,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230401/AboutFIBOProd-IncludingReferenceData/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230601/AboutFIBOProd-IncludingReferenceData/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBOProd-TBoxOnly.rdf
+++ b/AboutFIBOProd-TBoxOnly.rdf
@@ -26,7 +26,7 @@
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, excluding reference data and examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-04-14T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-06-27T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
@@ -218,6 +218,7 @@
 	-->
 
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"/>
 
 	<!-- 
 	///////////////////////////////////////////////////////////////////////////////////////
@@ -246,7 +247,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230401/AboutFIBOProd-TBoxOnly/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230601/AboutFIBOProd-TBoxOnly/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -26,7 +26,7 @@
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-04-14T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-06-27T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>	
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
@@ -256,7 +256,8 @@
 	-->
 
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
-
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"/>
+		
 	<!-- 
 	///////////////////////////////////////////////////////////////////////////////////////
 	//
@@ -289,7 +290,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230401/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20230601/AboutFIBOProd/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/FBC/ProductsAndServices/MetadataFBCProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/MetadataFBCProductsAndServices.rdf
@@ -25,11 +25,11 @@
 		<rdfs:label>Metadata about the EDMC-FIBO Financial Business and Commerce(FBC) Products and Services Module</rdfs:label>
 		<dct:abstract>The FBC Products and Services module extends the FND Products and Services module via ontologies defining financial products, financial services, financial service providers, and product catalogs as well as customer/client accounts.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-06-27T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/ProductsAndServices/MetadataFBCProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230601/ProductsAndServices/MetadataFBCProductsAndServices/"/>
 		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
@@ -38,10 +38,9 @@
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>products and services module</rdfs:label>
 		<dct:abstract>The products and services module extends the FND Products and Services module via ontologies defining financial products, financial services, financial service providers, and product catalogs as well as customer/client accounts.</dct:abstract>
-		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO FBC Products and Services Module</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Products and Services Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>

--- a/LOAN/AllLOAN.rdf
+++ b/LOAN/AllLOAN.rdf
@@ -56,6 +56,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>

--- a/LOAN/LoansSpecific/CardAccounts.rdf
+++ b/LOAN/LoansSpecific/CardAccounts.rdf
@@ -140,7 +140,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-crd;CardAuthenticationValue">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeValue"/>
 		<rdfs:label>card authentication value</rdfs:label>
 		<skos:definition>card verification value specifically for JCB payment cards</skos:definition>
 		<cmns-av:abbreviation>CAV</cmns-av:abbreviation>
@@ -148,7 +148,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-crd;CardAuthenticationValue2">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeValue"/>
 		<rdfs:label>card authentication value 2</rdfs:label>
 		<skos:definition>card verification value specifically for JCB payment cards</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
@@ -162,7 +162,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-crd;CardIdentificationNumber">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeValue"/>
 		<rdfs:label>card identification number</rdfs:label>
 		<skos:definition>card verification value specifically for American Express and Discover payment cards</skos:definition>
 		<cmns-av:abbreviation>CID</cmns-av:abbreviation>
@@ -210,7 +210,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-crd;CardSecurityCode">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeValue"/>
 		<rdfs:label>card security code</rdfs:label>
 		<skos:definition>card verification value specifically for American Express payment cards</skos:definition>
 		<cmns-av:abbreviation>CSC</cmns-av:abbreviation>
@@ -218,7 +218,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-crd;CardValidationCode">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeValue"/>
 		<rdfs:label>card validation code</rdfs:label>
 		<skos:definition>card verification code specifically for Mastercard payment cards</skos:definition>
 		<cmns-av:abbreviation>PAN CVC</cmns-av:abbreviation>
@@ -226,14 +226,14 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-crd;CardValidationCode2">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeValue"/>
 		<rdfs:label>card validation code 2</rdfs:label>
 		<skos:definition>card verification value specifically for Mastercard payment cards</skos:definition>
 		<cmns-av:abbreviation>PAN CVC2</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-loan-spc-crd;CardVerificationCodeOrValue">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardVerificationCodeValue">
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -254,7 +254,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-crd;CardVerificationValue">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeValue"/>
 		<rdfs:label>card verification value</rdfs:label>
 		<skos:definition>card verification value specifically for Visa and Discover payment cards</skos:definition>
 		<cmns-av:abbreviation>CVV</cmns-av:abbreviation>
@@ -262,7 +262,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-crd;CardVerificationValue2">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeValue"/>
 		<rdfs:label>card verification value 2</rdfs:label>
 		<skos:definition>card verification value specifically for Visa payment cards</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
@@ -507,8 +507,8 @@
 		<cmns-av:explanatoryNote>JCB Co., Ltd., (formerly Japan Credit Bureau) is a credit card company based in Tokyo, Japan. As of 2020, it operates in 23 countries with over 130 million customers. In the United States, it is not a primary credit card network but has an association with the Discover Network to enable use of JCB cards.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;MagneticStripeVerificationCodeValue">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeValue"/>
 		<rdfs:label>magnetic stripe verification code or value</rdfs:label>
 		<skos:definition>card verification code on a card&apos;s magnetic stripe that uses secure cryptographic processes to protect data integrity on the stripe, and reveals any alteration or counterfeiting</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
@@ -532,7 +532,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-loan-spc-crd;hasCardVerificationCode"/>
-				<owl:onClass rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeOrValue"/>
+				<owl:onClass rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeValue"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -611,8 +611,8 @@
 		<cmns-av:explanatoryNote>The circuits, also referred to as the &apos;chip,&apos; contain payment card data including but not limited to data equivalent to the magnetic-stripe data.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;ThreeDigitVerificationCodeValue">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeValue"/>
 		<rdfs:label>three-digit verification code or value</rdfs:label>
 		<skos:definition>card verification code that is the rightmost three-digit value printed in the signature panel area on the back of the card</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
@@ -627,7 +627,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-loan-spc-crd;hasCardVerificationCode">
 		<rdfs:label>has card verification code</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-loan-spc-crd;PaymentCard"/>
-		<rdfs:range rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeOrValue"/>
+		<rdfs:range rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeValue"/>
 		<skos:definition>links a credit card to either: (1) magnetic-stripe data, or (2) printed security features that are used to protect data integrity and limit alteration, counterfeiting and fraud generally</skos:definition>
 	</owl:ObjectProperty>
 	

--- a/LOAN/LoansSpecific/CardAccounts.rdf
+++ b/LOAN/LoansSpecific/CardAccounts.rdf
@@ -11,7 +11,6 @@
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
-	<!ENTITY fibo-fbc-pas-crd "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -22,6 +21,7 @@
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-loan-spc-crd "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -29,7 +29,7 @@
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
@@ -41,7 +41,6 @@
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
-	xmlns:fibo-fbc-pas-crd="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -52,6 +51,7 @@
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-loan-spc-crd="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -59,9 +59,9 @@
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/">
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/">
 		<rdfs:label>Card Accounts Ontology</rdfs:label>
-		<dct:abstract>This ontology defines account-related concepts that are specific to credit and debit cards.</dct:abstract>
+		<dct:abstract>This ontology defines revolving credit account-related concepts that are specific to credit and debit cards. Note that it does not differentiate between consumer and commercial/corporate cards and is capable of representing either.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -84,19 +84,19 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230601/LoansSpecific/CardAccounts/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;AmericanExpressNetwork">
-		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-spc-crd;AmericanExpressNetwork">
+		<rdf:type rdf:resource="&fibo-loan-spc-crd;CreditCardNetwork"/>
 		<rdfs:label>American Express network</rdfs:label>
 		<skos:definition>credit card network and card issuer that both issues credit cards and processes payments for cards bearing its logo, as well as offering cardholder benefits like travel insurance</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardAccount">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardAccount">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -108,73 +108,73 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasPrimaryAccountHolder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;Cardholder"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;Cardholder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;PaymentCardAgreement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;PaymentCardAgreement"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;PaymentCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;PrimaryCardAccountNumber"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;PrimaryCardAccountNumber"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>card account</rdfs:label>
 		<skos:definition>account whose terms and conditions are defined in a card agreement that is represented by a payment card</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardAuthenticationValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardAuthenticationValue">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue"/>
 		<rdfs:label>card authentication value</rdfs:label>
 		<skos:definition>card verification value specifically for JCB payment cards</skos:definition>
 		<cmns-av:abbreviation>CAV</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardAuthenticationValue2">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardAuthenticationValue2">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue"/>
 		<rdfs:label>card authentication value 2</rdfs:label>
 		<skos:definition>card verification value specifically for JCB payment cards</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 		<cmns-av:synonym>CAV2</cmns-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardExpirationDate">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardExpirationDate">
 		<rdfs:subClassOf rdf:resource="&cmns-dt;ExplicitDate"/>
 		<rdfs:label>card expiration date</rdfs:label>
 		<skos:definition>date on which a given payment card expires</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardIdentificationNumber">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardIdentificationNumber">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue"/>
 		<rdfs:label>card identification number</rdfs:label>
 		<skos:definition>card verification value specifically for American Express and Discover payment cards</skos:definition>
 		<cmns-av:abbreviation>CID</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardProduct">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardProduct">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialProduct"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCreditCardNetwork"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+				<owl:onProperty rdf:resource="&fibo-loan-spc-crd;hasCreditCardNetwork"/>
+				<owl:onClass rdf:resource="&fibo-loan-spc-crd;CreditCardNetwork"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -187,7 +187,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;usesCurrency"/>
+				<owl:onProperty rdf:resource="&fibo-loan-spc-crd;usesCurrency"/>
 				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -202,38 +202,38 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>card product</rdfs:label>
-		<skos:definition>financial product involving the issuance of payment cards</skos:definition>
+		<skos:definition>financial product involving the issuance of credit, debit, or other payment cards</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardSecurityCode">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardSecurityCode">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue"/>
 		<rdfs:label>card security code</rdfs:label>
 		<skos:definition>card verification value specifically for American Express payment cards</skos:definition>
 		<cmns-av:abbreviation>CSC</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardValidationCode">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardValidationCode">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue"/>
 		<rdfs:label>card validation code</rdfs:label>
 		<skos:definition>card verification code specifically for Mastercard payment cards</skos:definition>
 		<cmns-av:abbreviation>PAN CVC</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardValidationCode2">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardValidationCode2">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue"/>
 		<rdfs:label>card validation code 2</rdfs:label>
 		<skos:definition>card verification value specifically for Mastercard payment cards</skos:definition>
 		<cmns-av:abbreviation>PAN CVC2</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardVerificationCodeOrValue">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardVerificationCodeOrValue">
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -245,7 +245,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;PaymentCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>card verification code or value</rdfs:label>
@@ -253,23 +253,23 @@
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardVerificationValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardVerificationValue">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue"/>
 		<rdfs:label>card verification value</rdfs:label>
 		<skos:definition>card verification value specifically for Visa and Discover payment cards</skos:definition>
 		<cmns-av:abbreviation>CVV</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardVerificationValue2">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CardVerificationValue2">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue"/>
 		<rdfs:label>card verification value 2</rdfs:label>
 		<skos:definition>card verification value specifically for Visa payment cards</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 		<cmns-av:synonym>CVV2</cmns-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;Cardholder">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;Cardholder">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;CustomerAccountHolder"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -277,7 +277,7 @@
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fnd-oac-own;owns"/>
-						<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+						<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardAccount"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
 			</owl:Restriction>
@@ -288,7 +288,7 @@
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fnd-pty-pty;isAPartyTo"/>
-						<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+						<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardAccount"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
 			</owl:Restriction>
@@ -296,7 +296,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>cardholder</rdfs:label>
@@ -304,19 +304,19 @@
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCard">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CreditCard">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;PaymentCard"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidenceFor"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardAccount"/>
+				<owl:onClass rdf:resource="&fibo-loan-spc-crd;CreditCardAccount"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCardProduct"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CreditCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>credit card</rdfs:label>
@@ -324,9 +324,9 @@
 		<cmns-av:explanatoryNote>Issuance of credit cards has the condition that the cardholder will pay back the original, borrowed amount plus any additional agreed-upon charges. The credit company provider may also grant a line of credit (LOC) to the cardholder which allows the holder to borrow money in the form of a cash advance. The issuer pre-sets borrowing limits which have a basis on the individual&apos;s credit rating.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CreditCardAccount">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;LoanOrCreditAccount"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardAccount"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasPaymentDueDate"/>
@@ -336,57 +336,57 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCardProduct"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CreditCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCardAgreement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CreditCardAgreement"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCard"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CreditCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>credit card account</rdfs:label>
 		<skos:definition>card account whose terms and conditions are defined in a credit card agreement that is represented by a credit card</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardAgreement">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CreditCardAgreement">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CommittedCreditFacility"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;PaymentCardAgreement"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;PaymentCardAgreement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasBorrower"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;Cardholder"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;Cardholder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasLender"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;IssuingFinancialInstitution"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;IssuingFinancialInstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidencedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCard"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CreditCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCardAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CreditCardAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>credit card agreement</rdfs:label>
 		<skos:definition>account-specific credit facility that specifies the terms and conditions under which the credit card is offered to the cardholder by the issuer</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardNetwork">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CreditCardNetwork">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -397,7 +397,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>credit card network</rdfs:label>
@@ -405,93 +405,93 @@
 		<skos:example>Mastercard, Visa, American Express, Discover</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardProduct">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;CreditCardProduct">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardProduct"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCreditCardNetwork"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+				<owl:onProperty rdf:resource="&fibo-loan-spc-crd;hasCreditCardNetwork"/>
+				<owl:onClass rdf:resource="&fibo-loan-spc-crd;CreditCardNetwork"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCardAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CreditCardAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCard"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CreditCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>credit card product</rdfs:label>
 		<skos:definition>card product allowing the holder to purchase goods or services on credit</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;DebitCard">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;DebitCard">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;PaymentCard"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidenceFor"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;DebitCardAccount"/>
+				<owl:onClass rdf:resource="&fibo-loan-spc-crd;DebitCardAccount"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCardProduct"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;DebitCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>debit card</rdfs:label>
 		<skos:definition>payment card issued by a financial service provider that enables the cardholder to access funds in a demand deposit account</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;DebitCardAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;DebitCardAccount">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardAccount"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCardProduct"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;DebitCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCard"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;DebitCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>debit card account</rdfs:label>
 		<skos:definition>card account that is represented by a one or more debit cards</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;DebitCardProduct">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;DebitCardProduct">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardProduct"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCardAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;DebitCardAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCard"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;DebitCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>debit card product</rdfs:label>
 		<skos:definition>card product card typically provided by a depository institution allowing the holder to transfer money electronically to another account when making a purchase</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;DiscoverNetwork">
-		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-spc-crd;DiscoverNetwork">
+		<rdf:type rdf:resource="&fibo-loan-spc-crd;CreditCardNetwork"/>
 		<rdfs:label>Discover network</rdfs:label>
 		<skos:definition>credit card network and card issuer offering benefits like secondary rental car collision insurance</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;IssuingFinancialInstitution">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;IssuingFinancialInstitution">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:label>issuing financial institution</rdfs:label>
@@ -500,53 +500,53 @@
 		<cmns-av:synonym>issuing bank</cmns-av:synonym>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;JCBNetwork">
-		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-spc-crd;JCBNetwork">
+		<rdf:type rdf:resource="&fibo-loan-spc-crd;CreditCardNetwork"/>
 		<rdfs:label>JCB network</rdfs:label>
 		<skos:definition>credit card network based in Japan, with coverage throughout Asia, with strategic partners worldwide</skos:definition>
 		<cmns-av:explanatoryNote>JCB Co., Ltd., (formerly Japan Credit Bureau) is a credit card company based in Tokyo, Japan. As of 2020, it operates in 23 countries with over 130 million customers. In the United States, it is not a primary credit card network but has an association with the Discover Network to enable use of JCB cards.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;MagneticStripeVerificationCodeOrValue">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeOrValue"/>
 		<rdfs:label>magnetic stripe verification code or value</rdfs:label>
 		<skos:definition>card verification code on a card&apos;s magnetic stripe that uses secure cryptographic processes to protect data integrity on the stripe, and reveals any alteration or counterfeiting</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;MastercardNetwork">
-		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-spc-crd;MastercardNetwork">
+		<rdf:type rdf:resource="&fibo-loan-spc-crd;CreditCardNetwork"/>
 		<rdfs:label>Mastercard network</rdfs:label>
 		<skos:definition>credit card network that has its own suite of card protections and benefits, such as identity theft protection and extended warranties</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;PaymentCard">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;PaymentCard">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;LegalDocument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-doc;hasExpirationDate"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CardExpirationDate"/>
+				<owl:onClass rdf:resource="&fibo-loan-spc-crd;CardExpirationDate"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCardVerificationCode"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
+				<owl:onProperty rdf:resource="&fibo-loan-spc-crd;hasCardVerificationCode"/>
+				<owl:onClass rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeOrValue"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasPrimaryAccountNumber"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;PrimaryCardAccountNumber"/>
+				<owl:onProperty rdf:resource="&fibo-loan-spc-crd;hasPrimaryAccountNumber"/>
+				<owl:onClass rdf:resource="&fibo-loan-spc-crd;PrimaryCardAccountNumber"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidenceFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>payment card</rdfs:label>
@@ -556,43 +556,43 @@
 		<cmns-av:explanatoryNote>The term payment card includes credit cards, debit cards, and stored-value cards, as well as payment through any distinctive marks of a payment card (such as a credit card number). A payment card is issued under an agreement that provides standards and mechanisms for settling the transactions between a merchant acquiring bank or similar entity and the providers who accept the cards as payment.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;PaymentCardAgreement">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;PaymentCardAgreement">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;AccountSpecificServiceAgreement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;Cardholder"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;Cardholder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;IssuingFinancialInstitution"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;IssuingFinancialInstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidencedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;PaymentCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>payment card agreement</rdfs:label>
 		<skos:definition>account-specific credit agreement that specifies the terms and conditions under which the payment card is offered to the cardholder by the issuer</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;PrimaryCardAccountNumber">
+	<owl:Class rdf:about="&fibo-loan-spc-crd;PrimaryCardAccountNumber">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;AccountIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+				<owl:onClass rdf:resource="&fibo-loan-spc-crd;CardAccount"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -603,50 +603,50 @@
 		<cmns-av:synonym>primary account number</cmns-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;SmartCard">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;SmartCard">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;PaymentCard"/>
 		<rdfs:label>smart card</rdfs:label>
 		<skos:definition>payment card that has integrated circuits embedded within it</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>The circuits, also referred to as the &apos;chip,&apos; contain payment card data including but not limited to data equivalent to the magnetic-stripe data.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
+	<owl:Class rdf:about="&fibo-loan-spc-crd;ThreeDigitVerificationCodeOrValue">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeOrValue"/>
 		<rdfs:label>three-digit verification code or value</rdfs:label>
 		<skos:definition>card verification code that is the rightmost three-digit value printed in the signature panel area on the back of the card</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;VisaNetwork">
-		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-spc-crd;VisaNetwork">
+		<rdf:type rdf:resource="&fibo-loan-spc-crd;CreditCardNetwork"/>
 		<rdfs:label>Visa network</rdfs:label>
 		<skos:definition>credit card network that oversees the Visa Signature benefits associated with certain credit cards, such as premium rental car privileges and hotel perks</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasCardVerificationCode">
+	<owl:ObjectProperty rdf:about="&fibo-loan-spc-crd;hasCardVerificationCode">
 		<rdfs:label>has card verification code</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
+		<rdfs:domain rdf:resource="&fibo-loan-spc-crd;PaymentCard"/>
+		<rdfs:range rdf:resource="&fibo-loan-spc-crd;CardVerificationCodeOrValue"/>
 		<skos:definition>links a credit card to either: (1) magnetic-stripe data, or (2) printed security features that are used to protect data integrity and limit alteration, counterfeiting and fraud generally</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasCreditCardNetwork">
+	<owl:ObjectProperty rdf:about="&fibo-loan-spc-crd;hasCreditCardNetwork">
 		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has credit card network</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+		<rdfs:range rdf:resource="&fibo-loan-spc-crd;CreditCardNetwork"/>
 		<skos:definition>indicates the underlying network for credit card product</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasPrimaryAccountNumber">
+	<owl:ObjectProperty rdf:about="&fibo-loan-spc-crd;hasPrimaryAccountNumber">
 		<rdfs:label>has primary account number</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-crd;PrimaryCardAccountNumber"/>
+		<rdfs:domain rdf:resource="&fibo-loan-spc-crd;PaymentCard"/>
+		<rdfs:range rdf:resource="&fibo-loan-spc-crd;PrimaryCardAccountNumber"/>
 		<skos:definition>specifies the account number displayed on the face of the card</skos:definition>
 		<skos:editorialNote>modeled independently of &apos;identifies&apos; in order to circumvent circular reasoning challenges</skos:editorialNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;usesCurrency">
+	<owl:ObjectProperty rdf:about="&fibo-loan-spc-crd;usesCurrency">
 		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;uses"/>
 		<rdfs:label>uses currency</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>

--- a/LOAN/LoansSpecific/MetadataLOANLoansSpecific.rdf
+++ b/LOAN/LoansSpecific/MetadataLOANLoansSpecific.rdf
@@ -26,10 +26,10 @@
 		<dct:abstract>This module contains ontologies of concepts descriptive of a range of loans, excluding real estate, including commercial and consumer, loans differentiated by purpose, and their differentiating characteristics.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-03-31T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-06-27T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230301/LoansSpecific/MetadataLOANLoansSpecific/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230601/LoansSpecific/MetadataLOANLoansSpecific/"/>
 		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
@@ -37,7 +37,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-loan-spc-mod;LoansSpecificModule">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>loans specific module</rdfs:label>
-		<dct:abstract>This module contains ontologies of concepts descriptive of a range of loans, excluding real estate, including commercial and consumer, loans differentiated by purpose, and their differentiating characteristics.</dct:abstract>
+		<dct:abstract>This module contains ontologies of concepts descriptive of a range of loans, excluding real estate, including commercial and consumer loans differentiated by purpose.</dct:abstract>
 		<dct:contributor>Adaptive, Inc.</dct:contributor>
 		<dct:contributor>Federated Knowledge LLC</dct:contributor>
 		<dct:contributor>Hypercube Ltd.</dct:contributor>
@@ -48,6 +48,7 @@
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
 		<dct:contributor>Wells Fargo</dct:contributor>
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -135,7 +135,6 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/" uri="./FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/" uri="./FBC/FunctionalEntities/RegistrationAuthorities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/" uri="./FBC/FunctionalEntities/RegulatoryAgencies.rdf"/>
-	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/" uri="./FBC/ProductsAndServices/CardAccounts.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/" uri="./FBC/ProductsAndServices/ClientsAndAccounts.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/" uri="./FBC/ProductsAndServices/FinancialProductsAndServices.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/" uri="./FBC/ProductsAndServices/MetadataFBCProductsAndServices.rdf"/>
@@ -228,6 +227,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/" uri="./LOAN/LoansGeneral/Loans.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/" uri="./LOAN/LoansGeneral/LoansRegulatory.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/" uri="./LOAN/LoansGeneral/MetadataLOANLoansGeneral.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/" uri="./LOAN/LoansSpecific/CardAccounts.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/" uri="./LOAN/LoansSpecific/CommercialLoans.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/" uri="./LOAN/LoansSpecific/ConsumerLoans.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/" uri="./LOAN/LoansSpecific/LoanProducts.rdf"/>


### PR DESCRIPTION
## Description

1. Moved the credit cards ontology to loans specific and revised related metadata as a precursor to releasing additional ABS-related ontologies
2. Revised top level FIBO load files to include the card accounts ontology

Fixes: #1924 / FBC-311


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


