### PR TITLE
DER-117 - The Rights and Warrants ontology is missing the concept of a mini-future certificate

### DIFF
--- a/DER/DerivativesContracts/RightsAndWarrants.rdf
+++ b/DER/DerivativesContracts/RightsAndWarrants.rdf
@@ -84,7 +84,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230701/DerivativesContracts/RightsAndWarrants/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230801/DerivativesContracts/RightsAndWarrants/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20211101/DerivativesContracts/RightsAndWarrants.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary, to move the definition of an underlier and the related property, has underlier, to financial instruments so that these concepts are also available for use in relation to pool-backed securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/DerivativesContracts/RightsAndWarrants.rdf version of this ontology was modified to add concepts including mini-future certificate and constant leverage certificate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
@@ -113,6 +113,20 @@
 		<rdfs:label xml:lang="en">allotment right formula</rdfs:label>
 		<skos:definition xml:lang="en">rule applied to calculate the number of securities for an allotment right, typically based on the number of these instruments that the holder holds</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">Note that there may be a combination of a rule expressed in text as well as an expression or more complex formula embedded in a contract for making this determination.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-raw;BarrierInstrumentBasedMiniFutureCertificate">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;MiniFutureCertificate"/>
+		<rdfs:label xml:lang="en">barrier instrument-based mini-future certificate</rdfs:label>
+		<skos:definition xml:lang="en">mini-future certificate that immediately expires if the barrier instrument trading price level is breached during product lifetime</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-raw;BarrierUnderlyingMiniFutureCertificate">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;MiniFutureCertificate"/>
+		<rdfs:label xml:lang="en">barrier underlying mini-future certificate</rdfs:label>
+		<skos:definition xml:lang="en">mini-future certificate that immediately expires if the barrier underlying level is breached during product lifetime</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;BasketWarrant">
@@ -376,6 +390,13 @@
 		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-raw;LongMiniFutureCertificate">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;MiniFutureCertificate"/>
+		<rdfs:label xml:lang="en">long mini-future certificate</rdfs:label>
+		<skos:definition xml:lang="en">mini-future certificate that typically entitles the holder to acquire specific underlying assets during a specified period at a specified price</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-raw;MiniFutureCertificate">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;SecurityBasedDerivative"/>
@@ -507,6 +528,13 @@
 		<rdfs:label xml:lang="en">put warrant</rdfs:label>
 		<skos:definition xml:lang="en">warrant giving the buyer (holder) the right, but not the obligation, to sell the assets specified (i.e., acquire cash in exchange for the underlying assets) back to the issuer at a fixed price or formula, on or before a specified date</skos:definition>
 		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, 2019.</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-raw;ShortMiniFutureCertificate">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;MiniFutureCertificate"/>
+		<rdfs:label xml:lang="en">short mini-future certificate</rdfs:label>
+		<skos:definition xml:lang="en">mini-future certificate that entitles the holder to acquire cash in exchange for specific underlying assets</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;SubscriptionRight">

--- a/DER/DerivativesContracts/RightsAndWarrants.rdf
+++ b/DER/DerivativesContracts/RightsAndWarrants.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-comm "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/">
 	<!ENTITY fibo-der-drc-cur "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/">
+	<!ENTITY fibo-der-drc-exo "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/">
 	<!ENTITY fibo-der-drc-raw "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
@@ -35,6 +36,7 @@
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-comm="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"
 	xmlns:fibo-der-drc-cur="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"
+	xmlns:fibo-der-drc-exo="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"
 	xmlns:fibo-der-drc-raw="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
@@ -60,11 +62,12 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/">
 		<rdfs:label xml:lang="en">Rights and Warrants Ontology</rdfs:label>
 		<dct:abstract>The Rights and Warrants ontology covers a range of financial instruments providing the holder with the privilege to subscribe to or receive specific assets on terms specified. These include rights (privileges) extended to existing security holders to make new securities available to them at reduced prices or for free, and warrants whereby the holder can purchase or sell back a given quantity of the instrument, commodity or currency during a specified period at a pre-defined price.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/CurrencyContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ExoticOptions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
@@ -81,8 +84,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230201/DerivativesContracts/RightsAndWarrants/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230701/DerivativesContracts/RightsAndWarrants/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20211101/DerivativesContracts/RightsAndWarrants.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary, to move the definition of an underlier and the related property, has underlier, to financial instruments so that these concepts are also available for use in relation to pool-backed securities.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/DerivativesContracts/RightsAndWarrants.rdf version of this ontology was modified to add concepts including mini-future certificate and constant leverage certificate.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -289,6 +293,15 @@
 		<skos:definition xml:lang="en">equity warrant to purchase shares of capital stock issued by the corporation whose equity is the underlying asset</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-raw;ConstantLeverageCertificate">
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;SecurityBasedDerivative"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
+		<rdfs:label xml:lang="en">constant leverage certificate</rdfs:label>
+		<skos:definition xml:lang="en">entitlement that combines the structure of an open-end certificate with a leverage option with no fixed term, making leverage available without a term restriction, without a knock-out barrier dependency</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-der-drc-raw;CoveredWarrant">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
 		<rdfs:subClassOf>
@@ -361,6 +374,16 @@
 		<rdfs:label xml:lang="en">index warrant</rdfs:label>
 		<skos:definition xml:lang="en">warrant that permits the holder to acquire a specified amount based on the performance of an index during a specified period at a specified price</skos:definition>
 		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-raw;MiniFutureCertificate">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-exo;BarrierOption"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;SecurityBasedDerivative"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
+		<rdfs:label xml:lang="en">mini-future certificate</rdfs:label>
+		<skos:definition xml:lang="en">entitlement that combines the structure of an open-end certificate with a leverage option with no fixed term, making leverage available without a term restriction, and whose payoff depends on whether or not the underlying asset has reached or exceeded a predetermined price</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">The price of a mini-future always corresponds to its intrinsic value, i.e. the capital outlay, plus the bid-ask spread. The financing costs associated with building up the leverage effect are offset against the capital outlay on a daily basis, thereby eliminating the need for a premium. Investors have to pay only financing costs they actually utilize. In contrast to options, factors like volatility have no influence at all on the price of mini-futures.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;NakedWarrant">


### PR DESCRIPTION
## Description

Added classes for mini-future certificate and constant leverage option to rights and warrants, including 4 subclasses to mini-future per the CFI standard

Fixes: #1946 / DER-117


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


