### PR TITLE
issue-1950: add separate references to england and wales

### DIFF
--- a/BE/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf
@@ -53,10 +53,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-GB/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230701/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200201/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to add devolved government entities for Scotland, Wales, and Northern Ireland.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200701/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230701/GovernmentEntities/EuropeanJurisdiction/UKGovernmentEntitiesAndJurisdictions.rdf version of this ontology was modified to include separate references to England and Wales in reach of the EnglandAndWalesJurisdiction.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -69,7 +70,8 @@
 		<rdfs:seeAlso rdf:resource="https://law.gov.wales/"/>
 		<skos:definition>jurisdiction of the Courts of England and Wales</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-ukj;NationalAssemblyForWales"/>
-		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-gb;EnglandAndWales"/>
+		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-gb;GB-ENG-Subdivision"/>
+		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-2-gb;GB-WLS-Subdivision"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-ukj;GovernmentOfGuernsey">


### PR DESCRIPTION
## Description

fibo-be-ge-ukj:EnglandAndWalesJurisdiction declares fibo-fnd-law-jur:hasReach
lcc-3166-2-gb:EnglandAndWales, which I could not find. So in this branch I replaced it with two references to both England and Wales individually.

Fixes: #1950 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


