### PR TITLE
issue-1949 - change resource name from Syria to SyrianArabRepublic

### DIFF
--- a/BE/GovernmentEntities/AsianJurisdiction/WesternAsiaGovernmentEntitiesAndJurisdictions.rdf
+++ b/BE/GovernmentEntities/AsianJurisdiction/WesternAsiaGovernmentEntitiesAndJurisdictions.rdf
@@ -200,7 +200,7 @@
 		<rdfs:label xml:lang="ar">ٱلْجُمْهُورِيَّةُ ٱلْعَرَبِيَّةُ ٱلسُّورِيَّةُ</rdfs:label>
 		<skos:definition>unitary dominant-party semi-presidential Ba&apos;athist republic bordering Lebanon to the southwest, the Mediterranean Sea to the west, Turkey to the north, Iraq to the east, Jordan to the south, and Israel to the southwest</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-wasj;JurisdictionOfTheSyrianArabRepublic"/>
-		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;Syria"/>
+		<fibo-fnd-rel-rel:governs rdf:resource="&lcc-3166-1;SyrianArabRepublic"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-wasj;GovernmentOfTheUnitedArabEmirates">
@@ -345,7 +345,7 @@
 		<rdfs:label>jurisdiction of the Syrian Arab Republic</rdfs:label>
 		<skos:definition>jurisdiction of the judiciary of Syria, which is the system of courts that interprets and applies the law in Syria</skos:definition>
 		<fibo-be-ge-ge:isJurisdictionOf rdf:resource="&fibo-be-ge-wasj;GovernmentOfTheSyrianArabRepublic"/>
-		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;Syria"/>
+		<fibo-fnd-law-jur:hasReach rdf:resource="&lcc-3166-1;SyrianArabRepublic"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-ge-wasj;JurisdictionOfTheUnitedArabEmirates">
@@ -473,7 +473,7 @@
 		<rdf:type rdf:resource="&fibo-be-ge-ge;SovereignState"/>
 		<rdfs:label>State of Syria</rdfs:label>
 		<skos:definition>sovereign state and polity that is Syria</skos:definition>
-		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;Syria"/>
+		<fibo-be-ge-ge:hasFullSovereigntyOver rdf:resource="&lcc-3166-1;SyrianArabRepublic"/>
 		<fibo-be-ge-ge:isRepresentedBy rdf:resource="&fibo-be-ge-wasj;GovernmentOfTheSyrianArabRepublic"/>
 	</owl:NamedIndividual>
 	


### PR DESCRIPTION
## Description

There was a reference to lcc-3166-1:Syria which was changed to lcc-3166-1:SyrianArabRepublic.

Fixes: #1949 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


