### PR TITLE
SEC-191 - Eliminate the class WACBondCoupon as redundant

### DIFF
--- a/SEC/Debt/AssetBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities.rdf
@@ -265,10 +265,5 @@
 		<rdfs:label xml:lang="en">student loan pool</rdfs:label>
 		<skos:definition xml:lang="en">debt pool consisting of student loans</skos:definition>
 	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-abs;WACBondCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;BondVariableCoupon"/>
-		<rdfs:label>w a c bond coupon</rdfs:label>
-	</owl:Class>
 
 </rdf:RDF>


### PR DESCRIPTION

## Description

Eliminated the duplicative WACBondCoupon class from the ABS ontology

Fixes: #1959 / SEC-191


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


