### PR TITLE
DER-140 - Wording of the definition of AuctionMethod in CDS is clumsy

### DIFF
--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -93,10 +93,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20231001/CreditDerivatives/CreditDefaultSwaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20231101/CreditDerivatives/CreditDefaultSwaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20221201/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/CreditDerivatives/CreditDefaultSwaps.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230301/CreditDerivatives/CreditDefaultSwaps.rdf version of this ontology was modified to add the concept of a credit default swap index.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231001/CreditDerivatives/CreditDefaultSwaps.rdf version of this ontology was modified to move the nominal for auction market from CDS to the pricing ontology (its IRI was that of the instrument pricing ontology but it was mistakenly in the CDS ontology) and simplify the definition (DER-140).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -411,12 +412,6 @@
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationSpecificCreditEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
 	</owl:Class>
-	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-ip;AuctionMethod">
-		<rdf:type rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">auction method</rdfs:label>
-		<skos:definition xml:lang="en">method for determining a price that represents use of an independently administered synthetic auction in order to set a price</skos:definition>
-	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-stl;CashSettlementTerms">
 		<rdfs:subClassOf>

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -72,7 +72,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FinancialInstruments/InstrumentPricing/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20231101/FinancialInstruments/InstrumentPricing/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, to add adjusted price and to create a more general hasLotSize property that can be used in various contexts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize.</skos:changeNote>
@@ -81,6 +81,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to eliminate a redundant restriction on CollectionOfSecurityPrices, better integrate pricing methods, loosen the domain restriction on hasPricingSource and add dealer to the set of possible sources for prices.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FinancialInstruments/InstrumentPricing.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to move the nominal for auction market from CDS to the pricing ontology (its IRI was that of this instrument pricing ontology but it was mistakenly in the CDS ontology) and simplify the definition (DER-140).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -92,6 +93,13 @@
 		<skos:definition xml:lang="en">amended closing price to reflect a security&apos;s value after accounting for any corporate actions, such as stock splits, dividends, and rights offerings</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">A particularly dramatic change in price occurs when a company announces a stock split. When the change is made, the price displayed will immediately reflect the split. For example, if a company splits its stock 2-for-1, the last closing price will be cut in half. That&apos;s the adjusted closing price.</cmns-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fi-ip;AuctionMethod">
+		<rdf:type rdf:resource="&fibo-fbc-fi-ip;PriceDeterminationMethod"/>
+		<rdfs:label xml:lang="en">auction method</rdfs:label>
+		<skos:definition xml:lang="en">method for determining a price that represents use of an independently administered synthetic auction</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Auction method refers to a process where buyers enter competitive bids and sellers submit competitive offers at the same time. The price at which a security trades represents the highest price that a buyer is willing to pay and the lowest price that a seller is willing to accept. Matching bids and offers are then paired together, and the orders are executed.</cmns-av:explanatoryNote>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;BestBid">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;BidPrice"/>


### PR DESCRIPTION

## Description

Moved the nominal representing auction method from CDS to instrument pricing (it's IRI was for the instrument pricing ontology already) and revised its metadata to simplify the definition and add an explanatory note

Fixes: #1977 / DER-140


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


