### PR TITLE
FBC-317 - The concepts related to interest rate schedules, rate resets and related events needs to be cleaned up

### DIFF
--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -105,7 +105,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/Swaps/ version of this ontology was modified to make a total return swap a kind of credit derivative.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20221001/DerivativesContracts/Swaps.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary, to move the definition of an underlier and the related property, has underlier, to financial instruments so that these concepts are also available for use in relation to pool-backed securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230301/DerivativesContracts/Swaps.rdf version of the ontology was modified to tease out the distinction between the nominal and notional amount, which were confused and augment the definition of notional for swaps to properly reflect variations from the CFI (DER-127), and replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/DerivativesContracts/Swaps.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1 (FND-380) and to revise definitions related to swap leg-specific events.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/DerivativesContracts/Swaps.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1 (FND-380) and to revise definitions related to swap leg-specific events (FBC-317).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -497,7 +497,18 @@
 		<rdfs:label>swap leg</rdfs:label>
 		<skos:definition>terms defining and the commitment to fulfill cashflow requirements (e.g., interest payments, coupon payments, etc.) for one side of a swap</skos:definition>
 		<skos:editorialNote>For some swaps this may be a commitment to net up the difference between a strike and an outcome, rather than to make a series of cashflows over time. For credit default swaps there are conditional commitments, contingent on the occurrence of a credit event.</skos:editorialNote>
-		<cmns-av:synonym>swap stream terms</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-swp;SwapLegEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLifecycleEvent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-swp;SwapLeg"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>swap leg event</rdfs:label>
+		<skos:definition>swap lifecycle event, such as a payment or rate reset event, that applies to one leg of a swap</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;SwapLifecycleEvent">
@@ -577,10 +588,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;SwapStreamEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLifecycleEvent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentEvent"/>
-		<rdfs:label>swap stream event</rdfs:label>
-		<skos:definition>payment event (e.g., interest payment, coupon payment, etc.) against one leg of a swap stream</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-der-drc-swp;SwapLegEvent"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;SwapTerms">
@@ -641,8 +650,7 @@
 		<rdfs:label>has leg</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-swp;Swap"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-swp;SwapLeg"/>
-		<skos:definition>relates a swap to the legs (swap streams) that comprise the swap</skos:definition>
-		<cmns-av:synonym>has swap stream</cmns-av:synonym>
+		<skos:definition>relates a swap contract to a leg that is part of that swap</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-swp;hasReturnLeg">

--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -20,6 +20,7 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
+	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
@@ -53,6 +54,7 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
+	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
@@ -78,6 +80,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
@@ -512,7 +515,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;SwapLifecycleEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;TransactionEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>

--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -105,10 +105,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20220801/DerivativesContracts/Swaps/ version of this ontology was modified to make a total return swap a kind of credit derivative.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20221001/DerivativesContracts/Swaps.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary, to move the definition of an underlier and the related property, has underlier, to financial instruments so that these concepts are also available for use in relation to pool-backed securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230301/DerivativesContracts/Swaps.rdf version of the ontology was modified to tease out the distinction between the nominal and notional amount, which were confused and augment the definition of notional for swaps to properly reflect variations from the CFI (DER-127), and replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/DerivativesContracts/Swaps.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/DerivativesContracts/Swaps.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1 (FND-380) and to revise definitions related to swap leg-specific events.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;BasisSwap">

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -10,13 +10,13 @@
 	<!ENTITY fibo-der-rtd-irswp "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/">
 	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
-	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
@@ -42,13 +42,13 @@
 	xmlns:fibo-der-rtd-irswp="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"
 	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
-	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
@@ -72,12 +72,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
@@ -112,7 +112,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateSwap"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
 				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -122,10 +122,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;ExplicitInterestAmountCalculationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;ScheduledCalculationPeriodEndEvent"/>
-		<rdfs:label>explicit interest amount calculation event</rdfs:label>
-		<skos:definition>the explicit representation of the calculation event in a given period, in which an interest payment is calculated based on the rate (fixed or floating) and the notional amount (in the payment currency, and factored for Fx if necessary), on a given date</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-der-rtd-irswp;InterestCalculation"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;FixedFixedInterestRateSwap">
@@ -311,25 +309,29 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-rtd-irswp;hasInterestCalculationSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestCalculationSchedule"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;InterestCalculationSchedule"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;InterestRateReset"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-rtd-irswp;hasInterestRateResetSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestRateResetSchedule"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;InterestRateResetSchedule"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestRateReset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestRateSettingEvent"/>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;InterestRateSettingEvent"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>floating interest rate leg</rdfs:label>
@@ -425,7 +427,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;RateBasedLeg"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
+				<owl:onClass rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
 				<owl:onClass rdf:resource="&fibo-der-rtd-irswp;NotionalStepChangeEvent"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -439,39 +448,30 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestCalculation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestPayment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-bd;hasBusinessRecurrenceIntervalConvention"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;InterestCalculationSchedule"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pas-psch;hasPaymentSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentSchedule"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentSchedule"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>interest rate swap leg</rdfs:label>
@@ -515,6 +515,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;NotionalStepChangeEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Calculation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dt;hasDate"/>
@@ -533,17 +534,17 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;NotionalStepSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;ParametricSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;NotionalStepAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestCalculationSchedule"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;NotionalStepAmount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>notional step schedule</rdfs:label>
@@ -592,7 +593,7 @@
 				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+						<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
 						<owl:onClass rdf:resource="&fibo-der-rtd-irswp;NotionalStepChangeEvent"/>
 						<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:maxQualifiedCardinality>
 					</owl:Restriction>
@@ -619,7 +620,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateSwap"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
 				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -633,7 +634,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;isRelativeTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestRateResetSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestRateResetSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>swap leg calculation relative date</rdfs:label>
@@ -667,40 +668,23 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestRateReset">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
-		<rdfs:label>swap stream interest rate reset</rdfs:label>
-		<skos:definition>event in which an interest rate for a given swap stream changes (resets)</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestRateReset"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestRateResetSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;ParametricSchedule"/>
-		<rdfs:label>swapstream interest rate reset schedule</rdfs:label>
-		<skos:definition>parametric schedule of reset dates</skos:definition>
-		<cmns-av:explanatoryNote>These may more commonly be expressed as an offset of the calculation dates, however the creation of a schedule specifically for reset dates is allowed for.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestRateResetSchedule"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestRateSettingEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dt;hasDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestSettingRelativeDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>swap stream interest rate setting event</rdfs:label>
-		<skos:definition>event in which an interest rate for a given swap stream is determined</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestRateSettingEvent"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestSettingRelativeDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;isRelativeTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestRateReset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>swap stream interest setting relative date</rdfs:label>
-		<skos:definition>date on which an interest rate is revised if that date is relative to a rate reset event</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;ZeroCouponInterestRateSwap">

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -311,7 +311,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-rtd-irswp;hasInterestCalculationSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestCalculationSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestCalculationSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -453,13 +453,13 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestCalculation"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestCalculation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestPayment"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestPayment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -543,7 +543,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestCalculationSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestCalculationSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>notional step schedule</rdfs:label>

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -24,7 +24,6 @@
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
-	<!ENTITY fibo-sec-sec-sch "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -56,7 +55,6 @@
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
-	xmlns:fibo-sec-sec-sch="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -85,7 +83,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -90,7 +90,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20240101/RateDerivatives/IRSwaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20240301/RateDerivatives/IRSwaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/RateDerivatives/IRSwaps.rdf version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20190501/RateDerivatives/IRSwaps/ version of this ontology was modified to eliminate the property &apos;hasPaymentSchedule&apos; from the Swaps ontology in favor of the equivalent property with the same name from FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200701/RateDerivatives/IRSwaps/ version of this ontology was modified take advantage of basic fixed and floating legs as higher level concepts common to many swaps, and to refine definitions to eliminate ambiguity and conform with ISO 704.</skos:changeNote>
@@ -471,7 +471,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pas-psch;hasPaymentSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestPaymentSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>interest rate swap leg</rdfs:label>
@@ -647,29 +647,23 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestCalculation">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
-		<rdfs:label>swapstream interest calculation</rdfs:label>
-		<skos:definition>expression that specifies the formula for calculation of interest</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestCalculation"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestCalculationSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;ParametricSchedule"/>
-		<rdfs:label>swap stream interest calculation schedule</rdfs:label>
-		<skos:definition>parametric schedule that represents the dates on which interest is calculated</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestCalculationSchedule"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;Payment"/>
-		<rdfs:label>swap stream interest payment</rdfs:label>
-		<skos:definition>event involving the payment of interest for a given swap leg</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestPayment"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestPaymentSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;ParametricSchedule"/>
-		<rdfs:label>swap stream interest payment schedule</rdfs:label>
-		<skos:definition>parametric schedule that represents the dates on which interest is due to be paid</skos:definition>
-		<cmns-av:explanatoryNote>These may more commonly be expressed as an offset of the calculation dates, however the creation of a schedule specifically for payment dates is allowed for.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentSchedule"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestRateReset">

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -102,7 +102,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/RateDerivatives/IRSwaps.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230301/RateDerivatives/IRSwaps.rdf version of this ontology was modified to clarify restrictions on a plain vanilla IR swap.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230501/RateDerivatives/IRSwaps.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/RateDerivatives/IRSwaps.rdf version of this ontology was modified to simplify the class hierarchy and add a definition for fixed-fixed interest rate swap (DER-126).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/RateDerivatives/IRSwaps.rdf version of this ontology was modified to simplify the class hierarchy, add a definition for fixed-fixed interest rate swap (DER-126), and to revise definitions related to swap leg-specific events (FBC-317).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -122,7 +122,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;ExplicitInterestAmountCalculationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateStreamEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;ScheduledCalculationPeriodEndEvent"/>
 		<rdfs:label>explicit interest amount calculation event</rdfs:label>
 		<skos:definition>the explicit representation of the calculation event in a given period, in which an interest payment is calculated based on the rate (fixed or floating) and the notional amount (in the payment currency, and factored for Fx if necessary), on a given date</skos:definition>
@@ -236,8 +236,8 @@
 			</owl:Class>
 		</owl:equivalentClass>
 		<skos:definition>fixed leg that specifies fixed interest amounts and terms for the payment of that interest</skos:definition>
-		<cmns-av:explanatoryNote>This may be the funding leg of some swaps (i.e. one party agrees to pay fixed interest amounts in exchange for whatever is the other leg) or it may be one or both sides of an interest rate swap, where the two parties exchange different interest streams.</cmns-av:explanatoryNote>
-		<cmns-av:synonym>fixed interest rate swap stream</cmns-av:synonym>
+		<cmns-av:explanatoryNote>This may be the funding leg of some swaps (i.e. one party agrees to pay fixed interest amounts in exchange for whatever is the other leg) or it may be one or both sides of an interest rate swap, where the two parties exchange different interest payment streams.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>fixed interest rate payment stream</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;FloatFloatCrossCurrencyInterestRateSwap">
@@ -383,10 +383,15 @@
 		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateStreamEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapStreamEvent"/>
-		<rdfs:label>interest rate stream event</rdfs:label>
+	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateLegEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLegEvent"/>
+		<rdfs:label>interest rate leg event</rdfs:label>
 		<skos:definition>interest-rate specific event occurring with respect to one leg of a swap</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateStreamEvent">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateSwap">
@@ -442,7 +447,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;InterestRateStreamEvent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -509,7 +514,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;NotionalStepChangeEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateStreamEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dt;hasDate"/>
@@ -517,7 +522,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>notional step change event</rdfs:label>
-		<skos:definition>event in which a step change in the notional amount of the swap stream occurs</skos:definition>
+		<skos:definition>event in which a step change in the notional amount for a given swap leg occurs</skos:definition>
 		<cmns-av:explanatoryNote>This always occurs on a calculation date (that is, one of the calculation period end dates). Therefore the frequency / period length of the steps in the step schedule is a multiple of the calculation period or frequency. For example, if the notional is recalculated on every calculation date, applying a new interest rate to the new notional amount, then the two frequencies are the same. If notional is updated every second calculation period, then the step schedule specifies periods that are twice as long, and so on.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -623,7 +628,7 @@
 		<skos:definition>interest rate swap in which the two streams of interest payments are in the same currency</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamCalculationRelativeDate">
+	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapLegCalculationRelativeDate">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -631,8 +636,14 @@
 				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestRateResetSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>swap stream calculation relative date</rdfs:label>
-		<skos:definition>calculation date that is relative to the rate reset schedule</skos:definition>
+		<rdfs:label>swap leg calculation relative date</rdfs:label>
+		<skos:definition>calculation date that is relative to the the rate reset date in a given reset schedule</skos:definition>
+		<skos:note>*** fix the restriction accordingly, and think about moving this up the hierarchy to cover loans, etc. rather than only swap legs ***</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamCalculationRelativeDate">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-der-rtd-irswp;SwapLegCalculationRelativeDate"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestCalculation">
@@ -662,7 +673,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestRateReset">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateStreamEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
 		<rdfs:label>swap stream interest rate reset</rdfs:label>
 		<skos:definition>event in which an interest rate for a given swap stream changes (resets)</skos:definition>
 	</owl:Class>
@@ -675,7 +686,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestRateSettingEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateStreamEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dt;hasDate"/>

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -123,7 +123,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;ExplicitInterestAmountCalculationEvent">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<owl:equivalentClass rdf:resource="&fibo-der-rtd-irswp;InterestCalculation"/>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestCalculation"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;FixedFixedInterestRateSwap">
@@ -308,7 +308,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateSwapLeg"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rtd-irswp;hasInterestCalculationSchedule"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
 				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;InterestCalculationSchedule"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -322,7 +322,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rtd-irswp;hasInterestRateResetSchedule"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
 				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;InterestRateResetSchedule"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -385,15 +385,9 @@
 		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fifth edition, 2021-06-15</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateLegEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLegEvent"/>
-		<rdfs:label>interest rate leg event</rdfs:label>
-		<skos:definition>interest-rate specific event occurring with respect to one leg of a swap</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateStreamEvent">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<owl:equivalentClass rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
+		<owl:equivalentClass rdf:resource="&fibo-der-drc-swp;SwapLegEvent"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;InterestRateSwap">
@@ -427,21 +421,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;RateBasedLeg"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
-				<owl:onClass rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
-				<owl:onClass rdf:resource="&fibo-der-rtd-irswp;NotionalStepChangeEvent"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rtd-irswp;hasNotionalStepSchedule"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
 				<owl:onClass rdf:resource="&fibo-der-rtd-irswp;NotionalStepSchedule"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -478,7 +458,7 @@
 		<owl:equivalentClass>
 			<owl:Class>
 				<owl:intersectionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-drc-swp;SwapLeg">
+					<rdf:Description rdf:about="&fibo-der-drc-swp;RateBasedLeg">
 					</rdf:Description>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasInterestRate"/>
@@ -487,7 +467,7 @@
 				</owl:intersectionOf>
 			</owl:Class>
 		</owl:equivalentClass>
-		<skos:definition>swap leg specifying an interest rate stream, including both a parametric and cashflow representation for the stream of payments</skos:definition>
+		<skos:definition>swap leg that has an interest rate payment stream, including both a parametric and cashflow representation for the stream of payments</skos:definition>
 		<cmns-av:synonym>interest rate swap stream</cmns-av:synonym>
 	</owl:Class>
 	
@@ -514,17 +494,17 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;NotionalStepChangeEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateLegEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEventOccurrence"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Calculation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dt;hasDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;CalculatedDate"/>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;NotionalStepAmount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>notional step change event</rdfs:label>
 		<skos:definition>event in which a step change in the notional amount for a given swap leg occurs</skos:definition>
-		<cmns-av:explanatoryNote>This always occurs on a calculation date (that is, one of the calculation period end dates). Therefore the frequency / period length of the steps in the step schedule is a multiple of the calculation period or frequency. For example, if the notional is recalculated on every calculation date, applying a new interest rate to the new notional amount, then the two frequencies are the same. If notional is updated every second calculation period, then the step schedule specifies periods that are twice as long, and so on.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The frequency / period length of the steps in the step schedule is a multiple of the calculation period or frequency. For example, if the notional is recalculated on every calculation date, applying a new interest rate to the new notional amount, then the two frequencies are the same. If notional is updated every second calculation period, then the step schedule specifies periods that are twice as long, and so on.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;NotionalStepPeriodLength">
@@ -537,14 +517,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestCalculationSchedule"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasRecurrenceInterval"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;NotionalStepPeriodLength"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;NotionalStepAmount"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOccurrence"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;NotionalStepChangeEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>notional step schedule</rdfs:label>
@@ -605,7 +585,7 @@
 				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-der-rtd-irswp;hasNotionalStepSchedule"/>
+						<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
 						<owl:onClass rdf:resource="&fibo-der-rtd-irswp;NotionalStepSchedule"/>
 						<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:maxQualifiedCardinality>
 					</owl:Restriction>
@@ -629,22 +609,9 @@
 		<skos:definition>interest rate swap in which the two streams of interest payments are in the same currency</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapLegCalculationRelativeDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;isRelativeTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestRateResetSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>swap leg calculation relative date</rdfs:label>
-		<skos:definition>calculation date that is relative to the the rate reset date in a given reset schedule</skos:definition>
-		<skos:note>*** fix the restriction accordingly, and think about moving this up the hierarchy to cover loans, etc. rather than only swap legs ***</skos:note>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamCalculationRelativeDate">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<owl:equivalentClass rdf:resource="&fibo-der-rtd-irswp;SwapLegCalculationRelativeDate"/>
+		<owl:equivalentClass rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;SwapStreamInterestCalculation">
@@ -731,17 +698,13 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-rtd-irswp;hasInterestCalculationSchedule">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
-		<rdfs:label>has interest calculation schedule</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-		<skos:definition>links a set of terms to a corresponding schedule for calculating interest</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-rtd-irswp;hasInterestRateResetSchedule">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
-		<rdfs:label>has interest rate reset schedule</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<skos:definition>links a set of terms to a corresponding schedule for resetting the interest rate</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-rtd-irswp;hasLastNotionalStepDate">
@@ -752,10 +715,8 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-rtd-irswp;hasNotionalStepSchedule">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
-		<rdfs:label>has notional step schedule</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<skos:definition>links a set of terms to a corresponding notional step schedule</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-rtd-irswp;hasRateMultiplier">

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -24,6 +24,7 @@
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
+	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -55,6 +56,7 @@
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
+	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -83,6 +85,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
@@ -492,7 +495,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;NotionalStepChangeEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEventOccurrence"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Calculation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;StepEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
@@ -512,6 +515,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;NotionalStepSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;StepSchedule"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasRecurrenceInterval"/>

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -795,6 +795,31 @@
 		<cmns-av:explanatoryNote>Note that in most cases, the dates and payment frequencies for interest will coincide with the dates and payment frequencies related to the principal.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestRateReset">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;InterestCalculation"/>
+		<rdfs:label>interest rate reset</rdfs:label>
+		<skos:definition>event reflecting a potential adjustment to an interest rate, typically corresponding to a change in the underlying benchmark interest rate or index specified in the contract</skos:definition>
+		<cmns-av:explanatoryNote>Note that depending on the contract, a rate reset can occur daily or on some other timetable, and depending on the underlying benchmark, the actual rate may or may not change. Rate resets may be associated with variable interest rate loans, scheduled reset dates for loans and other debt instruments, for example, interest rate swaps, certain kinds of bonds, and the like. The date on which interest is (re)calculated may be an explicit or date relative.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestRateResetSchedule">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOccurrence"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestRateReset"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>interest rate reset schedule</rdfs:label>
+		<skos:definition>regular, contract-specific schedule including the dates on which a rate reset, and corresponding actual rate, is recalculated</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestRateSettingEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;InterestCalculation"/>
+		<rdfs:label>interest rate setting event</rdfs:label>
+		<skos:definition>event on which an initial rate for a given contract is set, which may be relative the the occurrence of some other contract lifecycle event, such as the execution date</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Lease">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreementRepaidPeriodically"/>
 		<rdfs:label>lease</rdfs:label>

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
@@ -37,6 +38,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
@@ -94,6 +96,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
@@ -155,6 +158,20 @@
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;AmortizationSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentSchedule"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;PrincipalPaymentSchedule"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
@@ -559,7 +576,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>debt</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>an obligation to pay something, such as an amount of money, good, service, or instrument</skos:definition>
+		<skos:definition>obligation to pay something, such as an amount of money, good, service, or instrument</skos:definition>
 		<cmns-av:explanatoryNote>In cases where the debtor and payer are the same legal person, then a debt is equivalent to a payment obligation.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -608,7 +625,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;InterestRate"/>
 		<rdfs:label>fixed interest rate</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>an interest rate that does not fluctuate over the lifetime of a loan or other debt instrument</skos:definition>
+		<skos:definition>interest rate that does not fluctuate over the lifetime of a loan or other debt instrument</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;FloatingInterestRate">
@@ -616,7 +633,7 @@
 		<rdfs:label>floating interest rate</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:seeAlso rdf:resource="http://recomparison.com/comparisons/100975/floating-vs-variable-vs-adjustable-interest-rate/"/>
-		<skos:definition>a variable interest rate that is based on a specific index or benchmark rate</skos:definition>
+		<skos:definition>variable interest rate that is based on a specific index or benchmark rate</skos:definition>
 		<skos:example>Certain revolving credit, such as credit-card related debt, may adjust after a specified period of time to an absolute rate stated in the agreement (variable but not floating) rather than based on a benchmark rate (variable, floating).</skos:example>
 		<cmns-av:explanatoryNote>The index used to determine the specific interest rate is generally included in the terms of the loan. In most cases, lenders will also charge a spread, or added percentage points on top of the established index rate. If a loan is billed as prime plus 2.5 percent, for a prime rate of 3.5 percent, the terms of the loan will require the borrower to pay off a 6 percent interest. Floating interest rates typically involve periodic reset dates for the loan, particularly when the index rate changes. Resets may also occur online at market predetermined intervals, with yearly adjustments being a common arrangement.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -656,12 +673,32 @@
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestCalculation">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEventOccurrence"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Calculation"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasInterestRate"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;InterestRate"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>interest calculation</rdfs:label>
 		<skos:definition>event reflecting the calculation of interest</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestCalculationSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOccurrence"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestCalculation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>interest calculation schedule</rdfs:label>
 		<skos:definition>regular, contract-specific schedule including the dates on which interest is calculated</skos:definition>
 		<cmns-av:explanatoryNote>The dates may be fixed, or relative to the corresponding interest payment date. It may be the same as the payment date, in arrears, or forward looking to the next interest payment.</cmns-av:explanatoryNote>
@@ -676,6 +713,12 @@
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestPaymentSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOccurrence"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestPayment"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>interest payment schedule</rdfs:label>
 		<skos:definition>regular, contract-specific schedule including the dates on which interest is due to be paid</skos:definition>
 		<cmns-av:explanatoryNote>The dates may be fixed, or expressed as an offset of the calculation dates. Typically the payment dates are fixed and calculation dates are expressed as an offset, however.</cmns-av:explanatoryNote>
@@ -844,6 +887,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Principal">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Aspect"/>
 		<rdfs:subClassOf>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
@@ -864,6 +908,26 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:seeAlso rdf:resource="http://www.finra.org/investors/bond-glossary#p"/>
 		<skos:definition>with respect to a debt: the value of an obligation, such as a bond or loan, raised and that must be repaid at maturity; for investments: the original amount of money invested, separate from any associated interest, dividends or capital gains</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PrincipalPayment">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;Payment"/>
+		<rdfs:label>principal payment</rdfs:label>
+		<skos:definition>event reflecting the actual payment of some amount of the principal of a debt</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PrincipalPaymentSchedule">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOccurrence"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;PrincipalPayment"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>principal payment schedule</rdfs:label>
+		<skos:definition>regular, contract-specific schedule including the dates on which some percentage or all of the principal is due to be (re)paid</skos:definition>
+		<cmns-av:explanatoryNote>The dates may be fixed, or expressed as an offset of the calculation dates. Typically the payment dates are fixed and calculation dates are expressed as an offset, however.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PrincipalRepaymentTerms">

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -20,6 +20,7 @@
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
@@ -55,6 +56,7 @@
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
@@ -82,6 +84,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
@@ -99,7 +102,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240301/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away, to support collateral agreements such as deeds of trust, UCC filings and the like, to add the concept of a rate reset time of day, to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations.</skos:changeNote>
@@ -114,6 +117,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230601/DebtAndEquities/Debt.rdf version of this ontology was extended to incorporate the concept of a lease.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230901/DebtAndEquities/Debt.rdf version of this ontology was modified to add the starting point value of some collateral when it was acquired (DER-138) and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/DebtAndEquities/Debt.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/Debt.rdf version of this ontology was modified to incorporate certain general debt schedule terms that were previously in more specific ontologies (FBC-317).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -649,6 +653,34 @@
 		<skos:definition>the cost of using credit, or another&apos;s money, expressed as a rate per period of time, payable by a debtor to a creditor in consideration of the credit extended to the debtor</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestCalculation">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEventOccurrence"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Calculation"/>
+		<rdfs:label>interest calculation</rdfs:label>
+		<skos:definition>event reflecting the calculation of interest</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestCalculationSchedule">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
+		<rdfs:label>interest calculation schedule</rdfs:label>
+		<skos:definition>regular, contract-specific schedule including the dates on which interest is calculated</skos:definition>
+		<cmns-av:explanatoryNote>The dates may be fixed, or relative to the corresponding interest payment date. It may be the same as the payment date, in arrears, or forward looking to the next interest payment.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestPayment">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;Payment"/>
+		<rdfs:label>interest payment</rdfs:label>
+		<skos:definition>event reflecting the actual payment of interest</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestPaymentSchedule">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
+		<rdfs:label>interest payment schedule</rdfs:label>
+		<skos:definition>regular, contract-specific schedule including the dates on which interest is due to be paid</skos:definition>
+		<cmns-av:explanatoryNote>The dates may be fixed, or expressed as an offset of the calculation dates. Typically the payment dates are fixed and calculation dates are expressed as an offset, however.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;InterestPaymentTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;DebtTerms"/>
 		<rdfs:subClassOf>
@@ -887,12 +919,20 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasAnticipatedNumberOfPayments"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>projected contract event schedule</rdfs:label>
-		<skos:definition>schedule of events, including but not limited to anticipated payment events, rate reset events and others that are expected to occur over the lifetime of the credit agreement</skos:definition>
-		<cmns-av:explanatoryNote>This is a regular schedule that provides a way of documenting the anchor dates and frequency of occurrences, using rules, rather than an explicit list of dates, that are terms of the contract. This method will project future event dates (transaction event dates), based on the frequencies specified and would be adjusted due to calendar restrictions and other rules to deal with holidays, weekends, and so forth.</cmns-av:explanatoryNote>
+		<skos:definition>schedule of events, including but not limited to anticipated payment events, rate reset events and others that are expected to occur over the lifetime of the contract</skos:definition>
+		<cmns-av:explanatoryNote>A projected schedule is a regular schedule that documents the anchor dates and frequency of occurrences, using rules, rather than providing an explicit list of dates. This method will project future event dates (transaction event dates), based on the frequencies specified and may be adjusted due to calendar restrictions and other rules to deal with holidays, weekends, and so forth in addition to contract-specific events.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PromissoryNote">
@@ -994,6 +1034,13 @@
 		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<skos:definition>identifies the convention that defines how interest accrues on something, that is the number of days in a month and days in a year that are counted when performing interest accrual calculations</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-dbt;hasAnticipatedNumberOfPayments">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasCount"/>
+		<rdfs:label>has anticipated number of payments</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;positiveInteger"/>
+		<skos:definition>specifies the number payments promised per the terms of the contract over the lifetime of the contract assuming all payments are made</skos:definition>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;hasAvailableAmount">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>

--- a/FBC/FinancialInstruments/Settlement.rdf
+++ b/FBC/FinancialInstruments/Settlement.rdf
@@ -62,10 +62,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FinancialInstruments/Settlement/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240201/FinancialInstruments/Settlement/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221001/FinancialInstruments/Settlement.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FinancialInstruments/Settlement.rdf version of this ontology was revised to integrate the notion of a value assessment with a settlement event and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FinancialInstruments/Settlement.rdf version of this ontology was revised to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FinancialInstruments/Settlement.rdf version of this ontology was revised to better integrate settlement with the overall lifecycle of a contract (FBC-317)</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -148,7 +149,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-stl;Settlement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEvent"/>
 		<rdfs:label xml:lang="en">settlement</rdfs:label>
 		<skos:definition>act of finalizing a transaction, including but not limited to finalizing accounting, exchanging consideration, and/or legally recording documents, as applicable</skos:definition>
 	</owl:Class>
@@ -167,7 +168,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-stl;SettlementEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEventOccurrence"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasPrice"/>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -296,6 +296,20 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;succeeds"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEvent"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEventOccurrence"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleStage"/>
 			</owl:Restriction>
@@ -312,6 +326,12 @@
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;exemplifies"/>
 				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEvent"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -347,8 +367,21 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStage"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;succeeds"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleStage"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-lif;isStageOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycle"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -410,6 +443,12 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Exposure">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&cmns-pts;Party"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>exposure</rdfs:label>
 		<skos:definition>the extent to which an individual or organization is unprotected and open to damage, danger, risk of suffering a loss, or uncertainty</skos:definition>
 		<skos:example>Examples include financial exposure, credit exposure, legal exposure, credit rating exposure, reputational exposure, and so forth.</skos:example>
@@ -417,12 +456,7 @@
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;FinancialExposure">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;Exposure"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&cmns-pts;PartyRole"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:label>financial exposure</rdfs:label>
 		<skos:definition>the extent to which an individual or organization is open to risk of suffering a loss in a transaction, or with respect to some investment or set of investments, e.g., some holding; the amount one stands to lose in that transaction or investment</skos:definition>
 		<skos:example>Examples in banking include the total amount of unsecured loans, the amount of loans advanced to a single borrower, group, industry, or country, and the probability of loss from devaluation, revaluation, or foreign exchange fluctuations.</skos:example>
@@ -661,6 +695,20 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;succeeds"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ProductLifecycleEvent"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ProductLifecycleEventOccurrence"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ProductLifecycleStage"/>
 			</owl:Restriction>
@@ -711,8 +759,21 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStage"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;succeeds"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ProductLifecycleStage"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-lif;isStageOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ProductLifecycle"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Product"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -844,7 +905,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Trade">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;TransactionEvent"/>
+		<rdfs:subClassOf rdf:resource="&cmns-pts;Situation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dt;succeeds"/>
@@ -881,6 +942,18 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasBuyer"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Buyer"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;hasSeller"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Seller"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
 				<owl:someValuesFrom>
 					<owl:Class>
@@ -897,7 +970,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trade</rdfs:label>
-		<skos:definition>agreement between parties participating in a voluntary action of buying and selling goods and services</skos:definition>
+		<skos:definition>situation that realizes an agreement between parties participating in a voluntary action of buying and selling goods and services</skos:definition>
 		<cmns-av:adaptedFrom>Deutsche Bank Presentation on the Lifecycle of a Trade, available at http://www.slideshare.net/ahaline/23512555-tradelifecycle</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>The advent of money as a medium of exchange has allowed trade to be conducted in a manner that is much simpler and effective compared to earlier forms of trade, such as bartering. In financial markets, trading also can mean performing a transaction that involves the selling and purchasing of a security.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>The seller must deliver the commodity sold to the buyer; the buyer must pay the agreed purchase price, which could be in the form of other goods or services, on the agreed date.</cmns-av:explanatoryNote>
@@ -939,7 +1012,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle</rdfs:label>
 		<skos:definition>lifecycle that defines the evolution of a trade, from initiation through settlement</skos:definition>
-		<skos:example>The trade life cycle describes the period of time over which a trade is initiated, typically as a part of a broader deal, consumated, processed and executed, settled or closed for other reasons, and reported. Parts of a trade lifecycle may include or overlap with the lifecycle of one or more contracts.</skos:example>
+		<skos:example>The trade life cycle covers the period of time over which a trade is initiated, typically as a part of a broader deal, is consumated, processed and executed, is settled or closed for other reasons, and is reported. Parts of a trade lifecycle may include or overlap with the lifecycle of one or more contracts.</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycleEvent">
@@ -948,6 +1021,13 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dt;succeeds"/>
 				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleEvent"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;TradeLifecycleEventOccurrence"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1154,8 +1234,9 @@
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;facilitates">
+		<rdfs:subPropertyOf rdf:resource="&cmns-pts;playsActivePartyIn"/>
 		<rdfs:label>facilitates</rdfs:label>
-		<skos:definition>provides the context in which an event, a task, a conversation or something else can occur</skos:definition>
+		<skos:definition>acts as an enabler in a situation in which an event, a task, a conversation or something else occurs</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;hasGeneratingEntity">
@@ -1256,6 +1337,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;isFacilitatedBy">
+		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasActiveParty"/>
 		<rdfs:label>is facilitated by</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fbc-pas-fpas;facilitates"/>
 		<skos:definition>identifies someone or something that expedites some event, transaction, conversation or something else in some context</skos:definition>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -108,7 +108,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240201/ProductsAndServices/FinancialProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified by the FIBO 2.0 RFC, including, but not limited to, the addition of lifecycle events, concepts related to trade settlement, and the definition of a unique transaction identifier (UTI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified as a part of organizational hierarchy simplification and to correct a logical inconsistency with respect to the representation of baskets.</skos:changeNote>
@@ -127,6 +127,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/ProductsAndServices/FinancialProductsAndServices.rdf version of this ontology was revised to augment the representation of institutions based on their definitions in the law, and to clarify and extend definitions related to non-bank financial institutions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230401/ProductsAndServices/FinancialProductsAndServices.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/ProductsAndServices/FinancialProductsAndServices.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/ProductsAndServices/FinancialProductsAndServices.rdf version of the ontology was modified to add the concept of a contract lifecycle, as distinct from a product or trade lifecycle (FBC-317).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -142,7 +143,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>agency agreement</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.sos.state.tx.us/corp/registeredagents.shtml"/>
-		<skos:definition>an agreement that designates a party as a registered agent to represent and act on behalf of another party in some, typically legal, financial, or medical capacity</skos:definition>
+		<skos:definition>agreement that designates a party as a registered agent to represent and act on behalf of another party in some, typically legal, financial, or medical capacity</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;AgentForServiceOfProcess">
@@ -150,7 +151,7 @@
 		<rdfs:label>agent for service of process</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.law.cornell.edu/wex/agent_for_service_of_process"/>
 		<rdfs:seeAlso rdf:resource="http://www.sos.state.tx.us/corp/registeredagents.shtml"/>
-		<skos:definition>a registered agent (person or organization) designated by a business entity, such as a corporation, to receive legal correspondence on behalf of the business entity in the jurisdiction in which the agent&apos;s address is located</skos:definition>
+		<skos:definition>registered agent (person or organization) designated by a business entity, such as a corporation, to receive legal correspondence on behalf of the business entity in the jurisdiction in which the agent&apos;s address is located</skos:definition>
 		<cmns-av:explanatoryNote>The person may be an officer of the corporation or a third party, such as the corporation&apos;s attorney, or a company providing such agency services.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -266,6 +267,131 @@
 		<skos:definition>stage in the lifecycle of a trade indicating that the trade has been finalized, and that there is no longer a corresponding open position on the books of the trader, eliminating any exposure</skos:definition>
 	</owl:NamedIndividual>
 	
+	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ContractLifecycle">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;Lifecycle"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-lif;hasStage"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleStage"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-lif;isLifecycleOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleStage"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>contract lifecycle</rdfs:label>
+		<skos:definition>lifecycle of an agreement, including, but not limited to a credit agreement, financial instrument, or other formal contract, from initial stages through retirement</skos:definition>
+		<cmns-av:explanatoryNote>Certain business agreements, such as partnership agreements,may involve planning, drafting/review/revision, execution and management, renewal, and possibly sunsetting phases. Financial contracts, such as loans and other instruments have specific stages and events during the execution and management phase, i.e. from the effective date of the contract through maturity and redemption.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ContractLifecycleEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleEvent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleStage"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>contract lifecycle event</rdfs:label>
+		<skos:definition>kind of event that occurs during one or more stages of the lifecycle of an agreement</skos:definition>
+		<skos:example>a call notification or coupon payment as a part of a bond lifecycle</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ContractLifecycleEventOccurrence">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleEventOccurrence"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;exemplifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEvent"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleStageOccurrence"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>contract lifecycle event occurrence</rdfs:label>
+		<skos:definition>actual occurrence of an event during a specific stage of a specific contract lifecycle</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ContractLifecycleOccurrence">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleOccurrence"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;exemplifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycle"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-lif;hasStage"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleStageOccurrence"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>contract lifecycle occurrence</rdfs:label>
+		<skos:definition>realization of the lifecycle of a specific contract</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ContractLifecycleStage">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStage"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-lif;isStageOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycle"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEvent"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycle"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>contract lifecycle stage</rdfs:label>
+		<skos:definition>phase in the lifecycle of an agreement</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ContractLifecycleStageOccurrence">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStageOccurrence"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;exemplifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleStage"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-lif;isStageOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleOccurrence"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEventOccurrence"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>contract lifecycle stage occurrence</rdfs:label>
+		<skos:definition>realization, from start to finish of a phase in an occurrence of a specific contract lifecycle</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Dealer">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
 		<rdfs:subClassOf>
@@ -331,7 +457,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>financial product catalog</rdfs:label>
-		<skos:definition>a catalog of financial products and/or services available for sale with their description and other product details</skos:definition>
+		<skos:definition>catalog of financial products and/or services available for sale with their description and other product details</skos:definition>
 		<cmns-av:adaptedFrom>Nordea Bank</cmns-av:adaptedFrom>
 	</owl:Class>
 	
@@ -483,7 +609,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>offeror</rdfs:label>
-		<skos:definition>a party that proposes to make something available to someone (i.e., an offeree) based on the terms of the offering</skos:definition>
+		<skos:definition>party that proposes to make something available to someone (i.e., an offeree) based on the terms of the offering</skos:definition>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-fpas;OpenTrade">
@@ -527,7 +653,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product lifecycle</rdfs:label>
-		<skos:definition>a lifecycle specific to a product or product family</skos:definition>
+		<skos:definition>lifecycle specific to a product or product family</skos:definition>
 		<skos:example>The product life cycle describes the period of time over which an item is developed, brought to market and eventually removed from the market. The cycle is broken into four stages: introduction, growth, maturity and decline. The idea of the product life cycle is used in marketing to decide when it is appropriate to advertise, reduce prices, explore new markets or create new packaging.</skos:example>
 	</owl:Class>
 	
@@ -540,8 +666,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product lifecycle event</rdfs:label>
-		<skos:definition>a kind of event that occurs during one or more stages of a product lifecycle</skos:definition>
-		<skos:example>a call notification or coupon payment as a part of a bond lifecycle</skos:example>
+		<skos:definition>kind of event that occurs during one or more stages of a product lifecycle</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ProductLifecycleEventOccurrence">
@@ -560,7 +685,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product lifecycle event occurrence</rdfs:label>
-		<skos:definition>an occurrence of an event that occurs during a specific stage of a specific product lifecycle</skos:definition>
+		<skos:definition>actual occurrence of an event that happens during a specific stage of a specific product lifecycle</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ProductLifecycleOccurrence">
@@ -579,7 +704,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product lifecycle occurrence</rdfs:label>
-		<skos:definition>a realization of a product lifecycle</skos:definition>
+		<skos:definition>realization of the lifecycle of a specific product</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ProductLifecycleStage">
@@ -609,8 +734,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product lifecycle stage</rdfs:label>
-		<skos:definition>a phase in a product lifecycle</skos:definition>
-		<skos:example>a research and development phase of a product lifecycle, the introduction phase in a marketing lifecycle, a growth stage in an economic lifecycle, or the origination phase in the lifecycle of a loan</skos:example>
+		<skos:definition>phase in a product lifecycle</skos:definition>
+		<skos:example>research and development phase of a product lifecycle or the introduction phase in a marketing lifecycle, growth stage in an economic lifecycle for a product</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ProductLifecycleStageOccurrence">
@@ -635,7 +760,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product lifecycle stage occurrence</rdfs:label>
-		<skos:definition>an instance of a phase in an occurrence of a given product lifecycle</skos:definition>
+		<skos:definition>realization of a specific stage in the lifecycle of a given product</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;RegisteredAgent">
@@ -663,7 +788,7 @@
 		<rdfs:label>registered agent</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.sos.state.tx.us/corp/registeredagents.shtml"/>
 		<rdfs:seeAlso rdf:resource="https://thelawdictionary.org/agent/"/>
-		<skos:definition>a legal agent designated by another party (person or organization), to represent and acts on their behalf under a formal agency agreement</skos:definition>
+		<skos:definition>legal agent designated by some party to represent them and act on their behalf under a formal agency agreement</skos:definition>
 		<cmns-av:explanatoryNote>Agency capacity, as specified in an agency agreement, may include power of attorney, the ability to act as an agent in certain kinds of transactions such as real estate, tax, audit or other financial or legal transactions, as a fiduciary, including as a trustee or legal guardian, for service of process, and so forth.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>resident agent</cmns-av:synonym>
 		<cmns-av:synonym>statutory agent</cmns-av:synonym>
@@ -684,7 +809,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>regulated commodity</rdfs:label>
-		<skos:definition>a commodity under the jurisdiction of the regulatory agency, such as the Commodities Futures Trading Commission (CFTF), which includes any commodity traded in an organized contracts market</skos:definition>
+		<skos:definition>commodity under the jurisdiction of the regulatory agency, such as the Commodities Futures Trading Commission (CFTF) in the United States, which includes any commodity traded in an organized contracts market</skos:definition>
 		<cmns-av:explanatoryNote>The CFTC polices matters of information and disclosure, fair trading practices, registration of firms and individuals, protection of customer funds, record keeping, and maintenance of orderly options and futures markets in the United States.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -789,7 +914,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>trade identifier</rdfs:label>
 		<skos:definition>sequence of characters identifying a trade within some context</skos:definition>
-		<skos:note>Note that a given trade may consist of multiple transactions, and thus there may be multiple UTIs associated with a trade.</skos:note>
+		<skos:note>Note that a given trade may consist of multiple transactions, and thus there may be multiple identifiers for such transactions associated with a specific trade.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycle">
@@ -813,8 +938,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle</rdfs:label>
-		<skos:definition>a lifecycle that defines the evolution of a trade, from initiation through settlement</skos:definition>
-		<skos:example>The trade life cycle describes the period of time over which a trade is initiated, typically as a part of a broader deal, consumated, processed and executed, settled or closed for other reasons, and reported.</skos:example>
+		<skos:definition>lifecycle that defines the evolution of a trade, from initiation through settlement</skos:definition>
+		<skos:example>The trade life cycle describes the period of time over which a trade is initiated, typically as a part of a broader deal, consumated, processed and executed, settled or closed for other reasons, and reported. Parts of a trade lifecycle may include or overlap with the lifecycle of one or more contracts.</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycleEvent">
@@ -833,7 +958,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle event</rdfs:label>
-		<skos:definition>a kind of event that occurs during one or more stages of the lifecycle of a trade</skos:definition>
+		<skos:definition>kind of event that occurs during one or more stages of the lifecycle of a trade</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycleEventOccurrence">
@@ -859,7 +984,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle event occurrence</rdfs:label>
-		<skos:definition>an occurrence of an event that occurs during a specific stage of a specific trade lifecycle</skos:definition>
+		<skos:definition>realization of an event that happens during a specific stage of a specific trade lifecycle</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycleOccurrence">
@@ -878,7 +1003,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle occurrence</rdfs:label>
-		<skos:definition>a realization of a trade lifecycle</skos:definition>
+		<skos:definition>realization of the lifecycle for a specific trade</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycleStage">
@@ -915,7 +1040,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle stage</rdfs:label>
-		<skos:definition>a phase in the lifecycle of a trade</skos:definition>
+		<skos:definition>phase in the lifecycle of a trade</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;TradeLifecycleStageOccurrence">
@@ -947,7 +1072,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>trade lifecycle stage occurrence</rdfs:label>
-		<skos:definition>an instance of a phase in an occurrence of a given trade lifecycle</skos:definition>
+		<skos:definition>realization of a phase in the lifecycle of a specific trade</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Trader">
@@ -1049,8 +1174,8 @@
 			<rdf:Description rdf:about="&cmns-id;isIdentifiedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
-		<skos:definition>specifies an identifier for the entity that generated something</skos:definition>
-		<cmns-av:explanatoryNote>Note that the range of is identified by must be that entity&apos;s LEI in the context of a UTI</cmns-av:explanatoryNote>
+		<skos:definition>specifies an identifier for the entity that generated a unique transaction identifier</skos:definition>
+		<cmns-av:explanatoryNote>Note that the range of is identified by must be that entity&apos;s LEI in the context of a UTI.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;hasLegalAgent">

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -1272,6 +1272,14 @@
 		<skos:definition>has a logical or causal connection with</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:Class rdf:about="&fibo-fnd-agr-ctr;BreachOfContract">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEvent"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-agr-ctr;BreachOfCovenant">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;ContractLifecycleEvent"/>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Product">
 		<rdfs:subClassOf>
 			<owl:Restriction>

--- a/FND/DatesAndTimes/FinancialDates.rdf
+++ b/FND/DatesAndTimes/FinancialDates.rdf
@@ -33,7 +33,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240201/DatesAndTimes/FinancialDates/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240301/DatesAndTimes/FinancialDates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/DatesAndTimes/FinancialDates/ version of this ontology was revised by the FIBO FND 1.2 RTF in order to introduce the definition of a time interval, which is a location, to ground some of the concepts such as a date period, and duration as well as to support the definition of business recurrence intervals for use in parametric schedules for securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20170201/DatesAndTimes/FinancialDates/ version of this ontology was revised by the FIBO 2.0 RFC in order to introduce the definition of a time instant, to eliminate a reasoning issue with relative dates, and remove a circular dependency inadvertently incorporated in the ontology with a FIBO FND 1.2 modification.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/DatesAndTimes/FinancialDates/ version of this ontology was revised to introduce a composite date datatype to allow for cases whereby the representation of a date for certain purposes, such as GLEIF LEI data, is inconsistent, and to facilitate mapping FIBO to multiple data sources in user environments.</skos:changeNote>
@@ -316,8 +316,17 @@ Similar points apply to other kinds of calendar periods, such as calendar week, 
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasRecurrenceStartDate"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;Date"/>
+				<owl:onProperty rdf:resource="&cmns-dt;hasStartDate"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fnd-dt-fd;CalculatedDate">
+							</rdf:Description>
+							<rdf:Description rdf:about="&cmns-dt;ExplicitDate">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>regular schedule</rdfs:label>
@@ -569,9 +578,8 @@ The recurrence start date can also be relative to the starting Date of the overa
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-dt-fd;hasRecurrenceStartDate">
-		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasStartDate"/>
-		<rdfs:label>has recurrence start date</rdfs:label>
-		<skos:definition>the starting date of the first recurrence in a regular schedule</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-dt;hasStartDate"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-dt-fd;hasRelativeDuration">

--- a/FND/DatesAndTimes/FinancialDates.rdf
+++ b/FND/DatesAndTimes/FinancialDates.rdf
@@ -33,7 +33,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20231101/DatesAndTimes/FinancialDates/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240201/DatesAndTimes/FinancialDates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/DatesAndTimes/FinancialDates/ version of this ontology was revised by the FIBO FND 1.2 RTF in order to introduce the definition of a time interval, which is a location, to ground some of the concepts such as a date period, and duration as well as to support the definition of business recurrence intervals for use in parametric schedules for securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20170201/DatesAndTimes/FinancialDates/ version of this ontology was revised by the FIBO 2.0 RFC in order to introduce the definition of a time instant, to eliminate a reasoning issue with relative dates, and remove a circular dependency inadvertently incorporated in the ontology with a FIBO FND 1.2 modification.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/DatesAndTimes/FinancialDates/ version of this ontology was revised to introduce a composite date datatype to allow for cases whereby the representation of a date for certain purposes, such as GLEIF LEI data, is inconsistent, and to facilitate mapping FIBO to multiple data sources in user environments.</skos:changeNote>
@@ -48,6 +48,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/DatesAndTimes/FinancialDates.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/DatesAndTimes/FinancialDates.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/DatesAndTimes/FinancialDates.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231101/DatesAndTimes/FinancialDates.rdf version of the ontology was modified to add the general notions of explicit anchor date and calculation period (FBC-317).</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the December 2014 Long Beach meeting in support of the SEC specification. It is also needed to provide temporal relationships for Ownership and Control.
 
 These three ontologies are designed for use together:
@@ -100,12 +101,38 @@ They are modularized this way to minimize the ontological committments that are 
 		<skos:definition>length of time that something or someone has been alive or existed</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fnd-dt-fd;AnchorDate">
+		<rdfs:subClassOf rdf:resource="&cmns-dt;ExplicitDate"/>
+		<rdfs:label>anchor date</rdfs:label>
+		<skos:definition>fixed reference point within a series or timeline</skos:definition>
+		<cmns-av:explanatoryNote>It is an explicit date chosen to provide context or structure for analyzing data or events.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fnd-dt-fd;CalculatedDate">
 		<rdfs:subClassOf rdf:resource="&cmns-dt;Date"/>
 		<rdfs:label>calculated date</rdfs:label>
 		<owl:disjointWith rdf:resource="&cmns-dt;ExplicitDate"/>
 		<skos:definition>date that is or will be determined based on some formula</skos:definition>
 		<cmns-av:explanatoryNote>The hasDateValue property of a CalculatedDate is not set until the Date is calculated. Since the calculation may depend upon future events that may or may not ever happen, the hasDateValue property may never be set.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-dt-fd;CalculationPeriod">
+		<rdfs:subClassOf rdf:resource="&cmns-dt;ExplicitDatePeriod"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasDuration"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;CalculationPeriodLength"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>calculation period</rdfs:label>
+		<skos:definition>explicit period from the start to the end of a specific interval or range within which a computational process or operation occurs</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-dt-fd;CalculationPeriodLength">
+		<rdfs:subClassOf rdf:resource="&cmns-dt;ExplicitDuration"/>
+		<rdfs:label>calculation period length</rdfs:label>
+		<skos:definition>explicit number of days from the adjusted effective or start date to the adjusted termination or end date calculated in accordance with the applicable day count fraction</skos:definition>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-dt-fd;CalendarMonth">
@@ -252,6 +279,14 @@ Similar points apply to other kinds of calendar periods, such as calendar week, 
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-fd;RegularSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+		<rdfs:subClassOf rdf:resource="&cmns-col;StructuredCollection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasAnchorDate"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;AnchorDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasFinalStub"/>
@@ -269,7 +304,8 @@ Similar points apply to other kinds of calendar periods, such as calendar week, 
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasCount"/>
-				<owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
+				<owl:onDataRange rdf:resource="&xsd;positiveInteger"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -353,13 +389,12 @@ The recurrence start date can also be relative to the starting Date of the overa
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasOverallPeriod"/>
-				<owl:onClass rdf:resource="&cmns-dt;DatePeriod"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&cmns-dt;DatePeriod"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>schedule</rdfs:label>
 		<skos:definition>collection of events, observations, or other occurrences and the associated dates and/or times when they will be done</skos:definition>
-		<cmns-av:explanatoryNote>The overall period covers the entire DatePeriod of the Schedule, from the earliest Date to the final Date of the Schedule. Schedules may be ad hoc, essentially a list of dates and events without any consistency in the durations between events, regular, in which case there is a consistently recurring interval between events, or a combination of the two.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The overall period covers the entire DatePeriod of the Schedule, from the earliest Date to the final Date of the Schedule. Schedules may be ad hoc, essentially a list of dates and events without any consistency in the durations between events, regular, in which case there is a consistently recurring interval between events, or a combination of the two. There may be a single overall period, or more than one if the schedule is extended for some reason.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-fd;ScheduleStub">
@@ -434,6 +469,14 @@ The recurrence start date can also be relative to the starting Date of the overa
 		<rdfs:label>has age</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-dt;Duration"/>
 		<skos:definition>relates something to the length of time it has existed</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-dt-fd;hasAnchorDate">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasExplicitDate"/>
+		<rdfs:label>has anchor date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;AnchorDate"/>
+		<skos:definition>specifies a fixed reference point within a series or timeline</skos:definition>
+		<skos:example>With respect to a scoped measure, such as an economic indicator, the anchor date specifies the reference date against which the value of a numeric index for a more recent date is compared (i.e., the starting point from which it stems).</skos:example>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-dt-fd;hasAsOfDate">

--- a/FND/DatesAndTimes/Occurrences.rdf
+++ b/FND/DatesAndTimes/Occurrences.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
+	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
@@ -24,6 +25,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
+	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
@@ -50,6 +52,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240301/DatesAndTimes/Occurrences/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/DatesAndTimes/Occurrences/ version of this ontology was revised to address the issue resolutions in the FIBO 2.0 RFC, primarily to add properties that are relevant to the inputs and outputs from processes, events, systems and the like.</skos:changeNote>
@@ -129,6 +132,27 @@ They are modularized this way to minimize the ontological committments that are 
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-oc;Calculation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasExpression"/>
+				<owl:onClass rdf:resource="&cmns-qtu;Expression"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValueRange"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValueRange"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;exemplifies"/>

--- a/FND/DatesAndTimes/Occurrences.rdf
+++ b/FND/DatesAndTimes/Occurrences.rdf
@@ -51,7 +51,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240201/DatesAndTimes/Occurrences/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240301/DatesAndTimes/Occurrences/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/DatesAndTimes/Occurrences/ version of this ontology was revised to address the issue resolutions in the FIBO 2.0 RFC, primarily to add properties that are relevant to the inputs and outputs from processes, events, systems and the like.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/DatesAndTimes/Occurrences/ version of this ontology was revised to make use of the new composite date type added to Financial Dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190201/DatesAndTimes/Occurrences/ version of this ontology was revised to eliminate duplication of concepts in LCC, and eliminate unnecessary complexity in restrictions.</skos:changeNote>

--- a/FND/DatesAndTimes/Occurrences.rdf
+++ b/FND/DatesAndTimes/Occurrences.rdf
@@ -51,7 +51,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240101/DatesAndTimes/Occurrences/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240201/DatesAndTimes/Occurrences/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/DatesAndTimes/Occurrences/ version of this ontology was revised to address the issue resolutions in the FIBO 2.0 RFC, primarily to add properties that are relevant to the inputs and outputs from processes, events, systems and the like.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/DatesAndTimes/Occurrences/ version of this ontology was revised to make use of the new composite date type added to Financial Dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190201/DatesAndTimes/Occurrences/ version of this ontology was revised to eliminate duplication of concepts in LCC, and eliminate unnecessary complexity in restrictions.</skos:changeNote>
@@ -60,7 +60,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20211201/DatesAndTimes/Occurrences/ version of this ontology was revised to address hygiene errors with respect to text formatting.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/DatesAndTimes/Occurrences.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/DatesAndTimes/Occurrences.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/DatesAndTimes/Occurrences.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380)</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/DatesAndTimes/Occurrences.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to to add the general notion of a calculation event (FBC-317).</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the December 2014 Long Beach meeting in support of the SEC specification. It is also needed to provide temporal relationships for Ownership and Control.
 
 These three ontologies are designed for use together:
@@ -125,6 +125,33 @@ They are modularized this way to minimize the ontological committments that are 
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-fd;SpecifiedDate">
 		<owl:disjointWith rdf:resource="&fibo-fnd-dt-oc;OccurrenceBasedDate"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-dt-oc;Calculation">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;exemplifies"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-oc;CalculationEvent"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>calculation</rdfs:label>
+		<skos:definition>actual occurrence of a calculation that was scheduled or triggered by something</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-dt-oc;CalculationEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-oc;Calculation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>calculation event</rdfs:label>
+		<skos:definition>kind of event that is either scheduled or triggered by something, such as a related financial event, that causes a calculation to be performed</skos:definition>
+		<skos:note>A calculation event may be prescriptive, that occurs within a specified period, or ad hoc.</skos:note>
+		<skos:note>A calculation event related to a debt instrument might be a rate reset event, calculation of interest subsequent to a rate change, an amortization calculation, calculation of interest and/or recalculation of principal due to a late payment, etc. A calculation event related to an investment might involve the adjustment of the number of shares owned, such as a redemption or dividend related event.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-oc;Occurrence">

--- a/FND/DatesAndTimes/Occurrences.rdf
+++ b/FND/DatesAndTimes/Occurrences.rdf
@@ -137,7 +137,7 @@ They are modularized this way to minimize the ontological committments that are 
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>calculation</rdfs:label>
-		<skos:definition>actual occurrence of a calculation that was scheduled or triggered by something</skos:definition>
+		<skos:definition>actual execution of some computation, computational process, or operation that was scheduled or triggered by something</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-dt-oc;CalculationEvent">

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -88,7 +88,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Utilities/Analytics.rdf version of this ontology was modified to add a synonym of &apos;average&apos; to arithmetic mean.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230501/Utilities/Analytics.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231101/Utilities/Analytics.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Utilities/Analytics.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Utilities/Analytics.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to move the concept of an anchor date to Financial Dates (FBC-317).</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
@@ -310,8 +310,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasAnchorDate"/>
-				<owl:onClass rdf:resource="&cmns-dt;ExplicitDate"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasAnchorDate"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;AnchorDate"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -572,10 +572,8 @@
 	</owl:AnnotationProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasAnchorDate">
-		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasExplicitDate"/>
-		<rdfs:label>has anchor date</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-dt;ExplicitDate"/>
-		<skos:definition>specifies the base date against which the value of a numeric index for a more recent date is compared (i.e., the starting point from which it stems)</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&fibo-fnd-dt-fd;hasAnchorDate"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasApplicableDatePeriod">

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -185,18 +185,18 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;AppraisedValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;AppraisedValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;TotalOutstandingPrincipal"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>combined loan-to-value ratio</rdfs:label>
 		<skos:definition>ratio of the total amount of debt that is secured by the asset(s) and the appraised value of the asset(s) securing the financing</skos:definition>
-		<cmns-av:explanatoryNote>This is particularly important for secondary loans, or for refinancing that combines outstanding loans against a given asset.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This is particularly important for secondary loans, or for refinancing that combines outstanding loans against a given asset. Lenders use this ratio to evaluate the risk of extending a loan to a borrower(s) in cases where multiple loans are involved.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-ln;FeeSimpleOwnershipInterest">
@@ -425,7 +425,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;Principal"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -572,6 +572,12 @@
 		<rdfs:label>subordinate lien position</rdfs:label>
 		<skos:definition xml:lang="en">secondary or lower position in the order of seniority in which the law recognizes lenders&apos; claims against a property</skos:definition>
 	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-loan-ln-ln;TotalOutstandingPrincipal">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Principal"/>
+		<rdfs:label>total outstanding principal</rdfs:label>
+		<skos:definition>the principal balance of all loans secured by the property</skos:definition>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;UnsecuredLoan">
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-ln;Loan"/>

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -94,11 +94,12 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20240101/LoansGeneral/Loans/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20240301/LoansGeneral/Loans/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/LoansGeneral/Loans.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20230201/LoansGeneral/Loans.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20230301/LoansGeneral/Loans.rdf version of this ontology was modified to eliminate a subproperty relationship between the principal and notional amount, which may not be appropriate (DER-127) and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20231201/LoansGeneral/Loans.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20240101/LoansGeneral/Loans.rdf version of this ontology was modified to move certain terms athat are general debt schedule terms to the Debt ontology (FBC-317).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -330,11 +331,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;LoanPaymentSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;ProjectedContractEventSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;AmortizationSchedule"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;hasAnticipatedNumberOfPayments"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasAnticipatedNumberOfPayments"/>
 				<owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -581,10 +581,8 @@
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-loan-ln-ln;hasAnticipatedNumberOfPayments">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasCount"/>
-		<rdfs:label>has anticipated number of payments</rdfs:label>
-		<rdfs:range rdf:resource="&xsd;positiveInteger"/>
-		<skos:definition>specifies the number payments promised per the terms of the contract over the lifetime of the contract assuming all payments are made</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&fibo-fbc-dae-dbt;hasAnticipatedNumberOfPayments"/>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-loan-ln-ln;hasBalloonPayment">

--- a/SEC/Debt/Bonds.rdf
+++ b/SEC/Debt/Bonds.rdf
@@ -128,7 +128,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240101/Debt/Bonds/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240301/Debt/Bonds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/Debt/Bonds.rdf version of this ontology was revised to reflect the refactored definition of a listing and improve the definition of corporate bond.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and eliminate a redundant superclass from RegularCouponSchedule.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate a duplicate &apos;isBasedOn&apos; property and replace it with the property of the same name in the debt ontology, to revise the inheritance hierarchy for bond conversion terms to reflect changes in the representation of redemption more generally, to reflect the move of redemption provision from debt to financial instruments, and eliminate circular and ambiguous definitions.</skos:changeNote>
@@ -141,6 +141,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/Bonds.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/Bonds.rdf version of the ontology was modified to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20231201/Debt/Bonds.rdf version of the ontology was modified to replace concepts from additional FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240101/Debt/Bonds.rdf version of this ontology was modified to move details regarding step schedules to the debt instruments ontology for broader use and deprecate the use of a &apos;coupon&apos; schedule in favor of interest payment schedule, which is the more modern terminology, aligning with other uses of the related terms in FIBO (FBC-317).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -400,9 +401,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;CouponPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentEvent"/>
-		<rdfs:label>coupon payment</rdfs:label>
-		<skos:definition>payment event involving an interest payment on a bond</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestPayment"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;CouponPaymentTerms">
@@ -422,7 +422,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;CouponSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>coupon payment terms</rdfs:label>
@@ -430,16 +430,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;CouponSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;CouponPayment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>coupon schedule</rdfs:label>
-		<skos:definition>payment schedule that consists of interest payments on a bond</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentSchedule"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;EquityLinkedBond">
@@ -841,10 +833,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;RegularCouponSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;CouponSchedule"/>
-		<rdfs:label>regular coupon schedule</rdfs:label>
-		<skos:definition>schedule including an interval of regular coupon payment dates</skos:definition>
-		<cmns-av:explanatoryNote>A regular schedule may include an initial and/or final stub period.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentSchedule"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;RegulatoryCall">
@@ -940,27 +930,13 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;StepEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;PrescriptiveEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;FixedCouponTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>step event</rdfs:label>
-		<skos:definition>event whereby a set of fixed coupon terms comes into force as specified in a step schedule</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-sec-dbt-dbti;StepEvent"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;StepSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;StepEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>step schedule</rdfs:label>
-		<skos:definition>schedule specifying the dates and rates relevant to securities that pay an initial interest rate but also have a feature where set rate increases happen at periodic intervals</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-sec-dbt-dbti;StepSchedule"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;StepUpBond">
@@ -983,7 +959,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;StepSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbti;StepSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>stepped coupon terms</rdfs:label>

--- a/SEC/Debt/DebtInstruments.rdf
+++ b/SEC/Debt/DebtInstruments.rdf
@@ -22,6 +22,7 @@
 	<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
+	<!ENTITY fibo-sec-sec-sch "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -51,6 +52,7 @@
 	xmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
+	xmlns:fibo-sec-sec-sch="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -75,13 +77,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/DebtInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240201/Debt/DebtInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Debt/DebtInstruments.rdf version of this ontology was modified to reflect use of actualExpression as an annotation rather than datatype property, to deprecate maturity-related properties which have been moved to financial instruments more generally, and to simplify restrictions on tradable debt instrument.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to support integration of the bonds ontology.</skos:changeNote>
@@ -92,10 +95,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Debt/DebtInstruments.rdf version of this ontology was modified to generalize the definition of fixed income security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Debt/DebtInstruments.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/DebtInstruments.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/DebtInstruments.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to augment the ontology with details regarding schedules for interest rate calculations, payment calculations, rate resets and the like (FBC-713).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;DebtInstrument">

--- a/SEC/Debt/DebtInstruments.rdf
+++ b/SEC/Debt/DebtInstruments.rdf
@@ -21,7 +21,7 @@
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
-	<!ENTITY fibo-sec-sec-sch "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/">
+	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -50,7 +50,7 @@
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
-	xmlns:fibo-sec-sec-sch="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"
+	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -234,7 +234,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;DebtOffering">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/SecuritiesOffering"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecuritiesOffering"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
@@ -368,7 +368,7 @@
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PrescriptiveEvent">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
 		<rdfs:label>prescriptive event</rdfs:label>
-		<skos:definition>an event related to the imposition or enforcement of a rule, method, formula, etc.</skos:definition>
+		<skos:definition>event related to the imposition or enforcement of a rule, method, formula, etc.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PrincipalOnlyStrip">
@@ -479,6 +479,25 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:label>relative price</rdfs:label>
 		<skos:definition>security price specified in comparison with either a stated or market value for a debt instrument at some point in time</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-dbti;StepEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;CalculationEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;PrescriptiveEvent"/>
+		<rdfs:label>step event</rdfs:label>
+		<skos:definition>event that prescribes a change in a contractual term, such as a rate or notional amount, for a given contract</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-dbt-dbti;StepSchedule">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbti;StepEvent"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>step schedule</rdfs:label>
+		<skos:definition>schedule specifying the date(s) and change in a contractual term(s), e.g., rate or notional amount, for a contract that has a feature where stipulated changes occur at specified intervals or on specified dates</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;Strip">

--- a/SEC/Debt/DebtInstruments.rdf
+++ b/SEC/Debt/DebtInstruments.rdf
@@ -21,7 +21,6 @@
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
-	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-sch "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -51,7 +50,6 @@
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
-	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-sch="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -77,14 +75,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240201/Debt/DebtInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240301/Debt/DebtInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Debt/DebtInstruments.rdf version of this ontology was modified to reflect use of actualExpression as an annotation rather than datatype property, to deprecate maturity-related properties which have been moved to financial instruments more generally, and to simplify restrictions on tradable debt instrument.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to support integration of the bonds ontology.</skos:changeNote>
@@ -95,7 +92,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Debt/DebtInstruments.rdf version of this ontology was modified to generalize the definition of fixed income security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Debt/DebtInstruments.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/DebtInstruments.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to augment the ontology with details regarding schedules for interest rate calculations, payment calculations, rate resets and the like (FBC-713).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/DebtInstruments.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to augment the ontology with details regarding schedules for interest rate calculations, payment calculations, rate resets and the like (FBC-317).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -237,7 +234,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;DebtOffering">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecuritiesOffering"/>
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/SecuritiesOffering"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -32,7 +32,6 @@
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
-	<!ENTITY fibo-sec-sec-sch "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -72,7 +71,6 @@
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
-	xmlns:fibo-sec-sec-sch="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -105,7 +103,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -113,7 +110,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240101/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240301/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
@@ -131,7 +128,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/EquityInstruments.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquityInstruments.rdf version of this ontology was modified to clarify a restriction on perpetual preferred share, add extendible preferred share, and add the CFI definition for limited partnership unit.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230601/Equities/EquityInstruments.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20231201/Equities/EquityInstruments.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20231201/Equities/EquityInstruments.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to clean up details related to regular schedules (FBC-317).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -270,8 +267,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;DividendSchedule">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;ParametricSchedule"/>
 		<rdfs:label>dividend schedule</rdfs:label>
 		<skos:definition>payment schedule indicating the dates on which dividends are due to be paid</skos:definition>
 	</owl:Class>

--- a/SEC/Securities/ParametricSchedules.rdf
+++ b/SEC/Securities/ParametricSchedules.rdf
@@ -51,7 +51,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/ParametricSchedules.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/ParametricSchedules.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/ParametricSchedules.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/ParametricSchedules.rdf version of this ontology was modified to integrate concepts related to scheduled interest rate related events that were previously embedded in DER to make them available for broader use.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/ParametricSchedules.rdf version of this ontology was modified to move certain very general concepts related to calculation dates and events to FND and to integrate concepts related to scheduled interest rate related events that were previously embedded in DER to make them available for broader use.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -64,44 +64,18 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;hasApplicablePeriod"/>
-				<owl:onClass rdf:resource="&fibo-sec-sec-sch;CalculationPeriod"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>calculation event</rdfs:label>
-		<skos:definition>event that is either scheduled or triggered by something, such as a related financial event, that causes a calculation to be performed</skos:definition>
-		<skos:note>A calculation event may be prescriptive, that occurs within a specified period, or ad hoc.</skos:note>
-		<skos:note>A calculation event related to a debt instrument might be a rate reset event, calculation of interest subsequent to a rate change, an amortization calculation, calculation of interest and/or recalculation of principal due to a late payment, etc. A calculation event related to an investment might involve the adjustment of the number of shares owned, such as a redemption or dividend related event.</skos:note>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fnd-dt-oc;CalculationEvent"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationPeriod">
-		<rdfs:subClassOf rdf:resource="&cmns-dt;ExplicitDatePeriod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-bd;hasBusinessDayAdjustment"/>
-				<owl:onClass rdf:resource="&fibo-fnd-dt-bd;BusinessDayAdjustment"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dt;hasDuration"/>
-				<owl:onClass rdf:resource="&fibo-sec-sec-sch;CalculationPeriodLength"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>calculation period</rdfs:label>
-		<skos:definition>explicit period from the start to the end of the computation window</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fnd-dt-fd;CalculationPeriod"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationPeriodLength">
-		<rdfs:subClassOf rdf:resource="&cmns-dt;ExplicitDuration"/>
-		<rdfs:label>calculation period length</rdfs:label>
-		<skos:definition>explicit number of days from the adjusted effective or start date to the adjusted termination or end date calculated in accordance with the applicable day count fraction</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fnd-dt-fd;CalculationPeriodLength"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;DateReturnedBySettlementDateRule">
@@ -201,7 +175,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>parametric schedule</rdfs:label>
-		<skos:definition>a regular, parameterized schedule typically used for the calculation of payments for coupons, dividends, and interest</skos:definition>
+		<skos:definition>regular, parameterized schedule typically used for the calculation of payments for coupons, dividends, and interest</skos:definition>
 		<skos:editorialNote>This is a schedule for one of the events that occur in a periodic schedule of interest accruals, interest payments, and (for floating rate swapstreams), changes to the interest rate. These may be specified individually but more commonly the Calculation event is the one scheduled according to this kind of parametric schedule, with the other dates specified as an offset to these. Here we have allowed for each of the related dates to be independently parametrically scheduled. The notional amount step schedule is a separate kind of schedule, with similar terms but without a period length. For calculation schedules (and possibly payments, resets), there is a different end date to the end /start of the period, since events may be specified as being on specific dates - this is where the Roll Convention comes in. This has the same basic concepts as the generic schedule shown as the parent to this. However, where the upper model has Date with various applicable sub types (known i.e. calendar, specified or determined). For example, an ISDA FpML schedule has a Specified Date (via a convention), and then has a date roll rule which is specified for the whole schedule and applies to each of the dates returned by the parametric specification of the schedule. It has: A schedule beginning and end; A set of regular repeating periods: the scheduled event takes place once per period; Optionally one or two stubs (one start and one end); these may be longer than the repeating period, or shorter. The precise parameters used are: Start of the overall Schedule period: Effective Date End of the overall Schedule period: Termination Date Start of first regular period: not specified (assume Effective Date?) Length of each regular period: Frequency (actually a duration) There are generally three ways in which the regular periods of a parametric schedule may be expressed: first plus last first plus period length last plus period length event date plus period length. In FpML, Roll events (the date that something rolls over from the value used in one period to the value used in the next) is defined in a Roll Convention, which may be a day of the month, a day of the week, or some published set of dates, typically the ISDA quarterly dates for these events. This is therefore the date within the regular period (before adjustments) when the event occurs. This is in addition so a date for the start or end of such a period. In general this applies to the Calculation Schedule (i.e. the event is the calculation event) with other dates specified relative to this, however in principle the other related events (payment and reset or refix) are specified relative to this. It is not immediately clear what specification of a date replaces the Roll event convention element when this happens.</skos:editorialNote>
 	</owl:Class>
 	

--- a/SEC/Securities/ParametricSchedules.rdf
+++ b/SEC/Securities/ParametricSchedules.rdf
@@ -45,7 +45,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240201/Securities/ParametricSchedules/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240301/Securities/ParametricSchedules/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/ParametricSchedules.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/ParametricSchedules.rdf version of this ontology was modified to eliminate circular definitions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/ParametricSchedules.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
@@ -60,7 +60,7 @@
 	<owl:Class rdf:about="&fibo-sec-sec-sch;AuctionDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-bd;BusinessRecurrenceIntervalConvention"/>
 		<rdfs:label>auction date rule</rdfs:label>
-		<skos:definition>a business recurrence interval convention that is a published rule for defining the date of some auction event</skos:definition>
+		<skos:definition>business recurrence interval convention that is a published rule for defining the date of some auction event</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationEvent">
@@ -79,7 +79,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;DateReturnedBySettlementDateRule">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;RuleDeterminedDate"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;CalculatedDate"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
@@ -87,11 +87,11 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>date returned by settlement date rule</rdfs:label>
-		<skos:definition>a rule-determined date that is a published rule for defining the date returned by settlement date</skos:definition>
+		<skos:definition>calculated date that is determined via a settlement rule</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;DateReturnedByTradingDateRule">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;RuleDeterminedDate"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;CalculatedDate"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
@@ -99,7 +99,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>date returned by trading date rule</rdfs:label>
-		<skos:definition>a rule-determined date that is a published rule for defining the date returned by trading date</skos:definition>
+		<skos:definition>calculated date that is determined via a trading rule</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;FloatingRateNoteDate">
@@ -112,21 +112,21 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>floating-rate note date</rdfs:label>
-		<skos:definition>a calculated date associated with a floating-rate note, also known as a floater or FRN, which is a debt instrument with a variable interest rate</skos:definition>
+		<skos:definition>calculated date associated with a floating-rate note, also known as a floater or FRN, which is a debt instrument with a variable interest rate</skos:definition>
 		<cmns-av:abbreviation>FRN date</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;FloatingRateNoteDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-bd;BusinessDayAdjustment"/>
 		<rdfs:label>floating-rate note date rule</rdfs:label>
-		<skos:definition>a business day adjustment rule applied to floating-rate note instruments</skos:definition>
+		<skos:definition>business day adjustment rule applied to floating-rate note instruments</skos:definition>
 		<cmns-av:abbreviation>FRN date rule</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;InternationalMoneyMarketAustralianDollarTradingDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;TradingDateRule"/>
 		<rdfs:label>International Money Market (IMM) Australian Dollar (AUD) trading date rule</rdfs:label>
-		<skos:definition>a trading date rule defined as the last trading day of an Australian Stock Exchange (ASX) 90-Day Bank Accepted Futures and Options product, one Sydney business day preceding the second Friday of the relevant settlement month</skos:definition>
+		<skos:definition>trading date rule defined as the last trading day of an Australian Stock Exchange (ASX) 90-Day Bank Accepted Futures and Options product, one Sydney business day preceding the second Friday of the relevant settlement month</skos:definition>
 		<cmns-av:abbreviation>IMM AUD trading date rule</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.asx.com.au/documents/products/90-Day-bank-bill-futures-factsheet.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
@@ -148,63 +148,37 @@
 	<owl:Class rdf:about="&fibo-sec-sec-sch;InternationalMoneyMarketNewZealandDollarTradingDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;TradingDateRule"/>
 		<rdfs:label>International Money Market (IMM) New Zealand Dollar (NZD) trading date rule</rdfs:label>
-		<skos:definition>a trading date rule defined as the last trading day of an Australian Stock Exchange (ASX) New Zealand (NZ) 90-Day Bank Accepted Futures and Options product, the first Wednesday after the ninth day of the relevant settlement month</skos:definition>
+		<skos:definition>trading date rule defined as the last trading day of an Australian Stock Exchange (ASX) New Zealand (NZ) 90-Day Bank Accepted Futures and Options product, the first Wednesday after the ninth day of the relevant settlement month</skos:definition>
 		<cmns-av:abbreviation>IMM NZD trading date rule</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;InternationalMoneyMarketSettlementDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;SettlementDateRule"/>
 		<rdfs:label>International Money Market (IMM) settlement date rule</rdfs:label>
-		<skos:definition>a settlement date rule as defined in the International Money Market (IMM) settlement dates calendar</skos:definition>
+		<skos:definition>settlement date rule as defined in the International Money Market (IMM) settlement dates calendar</skos:definition>
 		<cmns-av:abbreviation>IMM settlement date rule</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The International Money Market (IMM) is a division of the Chicago Mercantile Exchange (CME) that deals with the trading of currency and interest rate futures and options.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;NonRollingDate">
-		<rdfs:subClassOf rdf:resource="&cmns-dt;ExplicitDate"/>
-		<rdfs:label>non-rolling date</rdfs:label>
-		<skos:definition>an explicit date that equates to a calendar date with no adjustments and with no reference to any date specification</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-dt;ExplicitDate"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;ParametricSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasRecurrenceStartDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-sch;PeriodicScheduledEventDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>parametric schedule</rdfs:label>
-		<skos:definition>regular, parameterized schedule typically used for the calculation of payments for coupons, dividends, and interest</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
 		<skos:editorialNote>This is a schedule for one of the events that occur in a periodic schedule of interest accruals, interest payments, and (for floating rate swapstreams), changes to the interest rate. These may be specified individually but more commonly the Calculation event is the one scheduled according to this kind of parametric schedule, with the other dates specified as an offset to these. Here we have allowed for each of the related dates to be independently parametrically scheduled. The notional amount step schedule is a separate kind of schedule, with similar terms but without a period length. For calculation schedules (and possibly payments, resets), there is a different end date to the end /start of the period, since events may be specified as being on specific dates - this is where the Roll Convention comes in. This has the same basic concepts as the generic schedule shown as the parent to this. However, where the upper model has Date with various applicable sub types (known i.e. calendar, specified or determined). For example, an ISDA FpML schedule has a Specified Date (via a convention), and then has a date roll rule which is specified for the whole schedule and applies to each of the dates returned by the parametric specification of the schedule. It has: A schedule beginning and end; A set of regular repeating periods: the scheduled event takes place once per period; Optionally one or two stubs (one start and one end); these may be longer than the repeating period, or shorter. The precise parameters used are: Start of the overall Schedule period: Effective Date End of the overall Schedule period: Termination Date Start of first regular period: not specified (assume Effective Date?) Length of each regular period: Frequency (actually a duration) There are generally three ways in which the regular periods of a parametric schedule may be expressed: first plus last first plus period length last plus period length event date plus period length. In FpML, Roll events (the date that something rolls over from the value used in one period to the value used in the next) is defined in a Roll Convention, which may be a day of the month, a day of the week, or some published set of dates, typically the ISDA quarterly dates for these events. This is therefore the date within the regular period (before adjustments) when the event occurs. This is in addition so a date for the start or end of such a period. In general this applies to the Calculation Schedule (i.e. the event is the calculation event) with other dates specified relative to this, however in principle the other related events (payment and reset or refix) are specified relative to this. It is not immediately clear what specification of a date replaces the Roll event convention element when this happens.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;PeriodicScheduledEventDate">
-		<rdfs:subClassOf rdf:resource="&cmns-dt;Date"/>
-		<rdfs:subClassOf>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-dt-bd;DayOfMonth">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-dt-bd;DayOfWeek">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-dt-bd;EndOfMonth">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-sec-sch;NonRollingDate">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-sec-sch;RuleDeterminedDate">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:subClassOf>
-		<rdfs:label>periodic scheduled event date</rdfs:label>
-		<skos:definition>the date on which a schedule event occurs in some parametric schedule</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-dt;Date"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;RuleDeterminedDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;CalculatedDate"/>
-		<rdfs:label>rule-determined date</rdfs:label>
-		<skos:definition>a date determined by the application of some rule</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fnd-dt-fd;CalculatedDate"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;ScheduledCalculationPeriodEndEvent">
@@ -224,13 +198,13 @@
 	<owl:Class rdf:about="&fibo-sec-sec-sch;SettlementDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-bd;BusinessRecurrenceIntervalConvention"/>
 		<rdfs:label>settlement date rule</rdfs:label>
-		<skos:definition>a rule for determining dates by reference to some calendar or specification of settlement dates</skos:definition>
+		<skos:definition>convention for determining settlement dates by reference to some jurisdiction or as set by a given exchange or similar venue</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;TradingDateRule">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-bd;BusinessRecurrenceIntervalConvention"/>
 		<rdfs:label>trading date rule</rdfs:label>
-		<skos:definition>a rule for dates defined with reference to some trading date calendar published by some trading facility or authority, such as a stock exchange</skos:definition>
+		<skos:definition>convention for determining trading dates defined with reference to some trading date calendar published by some trading facility or exchange</skos:definition>
 		<skos:editorialNote>Corresponds to several ISDA FpML enumeration entries for determining Calculation Date, but refers to other kinds of trading date defined in those calendars. These include Canadian, Australian and New Zealand dates. Note also that some of these have roll rules included within them for when the date determined by the specification returns a non working day, while others explicitly return a business day and require no date roll rule. At least one is silent on this matter.</skos:editorialNote>
 	</owl:Class>
 	
@@ -243,7 +217,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>US Treasury bill auction date rule</rdfs:label>
-		<skos:definition>a rule for setting auction dates for US Treasury bills</skos:definition>
+		<skos:definition>rule for setting auction dates for US Treasury bills</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.treasurydirect.gov/instit/auctfund/work/work.htm</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>To finance the public debt, the U.S. Treasury sells bills, notes, bonds, Floating Rate Notes (FRNs), and Treasury Inflation-Protected Securities (TIPS) to institutional and individual investors through public auctions. Treasury auctions occur regularly and have a set schedule. Rules and other information are available via announcements of pending auctions.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -258,7 +232,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>US Treasury bill date</rdfs:label>
-		<skos:definition>an auction date for US 13 week and 26 week Treasury bills</skos:definition>
+		<skos:definition>auction date for US 13 week and 26 week Treasury bills</skos:definition>
 		<skos:editorialNote>Per FpML notes/definition, this is every Monday except on New York holidays when it will be on a Tuesday.</skos:editorialNote>
 	</owl:Class>
 

--- a/SEC/Securities/ParametricSchedules.rdf
+++ b/SEC/Securities/ParametricSchedules.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -17,6 +18,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -40,17 +42,19 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/ParametricSchedules/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240201/Securities/ParametricSchedules/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/ParametricSchedules.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/ParametricSchedules.rdf version of this ontology was modified to eliminate circular definitions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210201/Securities/ParametricSchedules.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/ParametricSchedules.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/ParametricSchedules.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/ParametricSchedules.rdf version of this ontology was modified to integrate concepts related to scheduled interest rate related events that were previously embedded in DER to make them available for broader use.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;AuctionDateRule">
@@ -59,8 +63,30 @@
 		<skos:definition>a business recurrence interval convention that is a published rule for defining the date of some auction event</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;hasApplicablePeriod"/>
+				<owl:onClass rdf:resource="&fibo-sec-sec-sch;CalculationPeriod"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>calculation event</rdfs:label>
+		<skos:definition>event that is either scheduled or triggered by something, such as a related financial event, that causes a calculation to be performed</skos:definition>
+		<skos:note>A calculation event may be prescriptive, that occurs within a specified period, or ad hoc.</skos:note>
+		<skos:note>A calculation event related to a debt instrument might be a rate reset event, calculation of interest subsequent to a rate change, an amortization calculation, calculation of interest and/or recalculation of principal due to a late payment, etc. A calculation event related to an investment might involve the adjustment of the number of shares owned, such as a redemption or dividend related event.</skos:note>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationPeriod">
 		<rdfs:subClassOf rdf:resource="&cmns-dt;DatePeriod"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-bd;hasBusinessDayAdjustment"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-bd;BusinessDayAdjustment"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dt;hasDuration"/>
@@ -89,7 +115,7 @@
 	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationPeriodLength">
 		<rdfs:subClassOf rdf:resource="&cmns-dt;ExplicitDuration"/>
 		<rdfs:label>calculation period length</rdfs:label>
-		<skos:definition>an explicit duration defined as the number of days from the adjusted effective or start date to the adjusted termination or end date calculated in accordance with the applicable day count fraction</skos:definition>
+		<skos:definition>explicit number of days from the adjusted effective or start date to the adjusted termination or end date calculated in accordance with the applicable day count fraction</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;DateReturnedBySettlementDateRule">

--- a/SEC/Securities/ParametricSchedules.rdf
+++ b/SEC/Securities/ParametricSchedules.rdf
@@ -79,7 +79,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationPeriod">
-		<rdfs:subClassOf rdf:resource="&cmns-dt;DatePeriod"/>
+		<rdfs:subClassOf rdf:resource="&cmns-dt;ExplicitDatePeriod"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-bd;hasBusinessDayAdjustment"/>
@@ -94,22 +94,8 @@
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dt;hasEndDate"/>
-				<owl:onClass rdf:resource="&cmns-dt;Date"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dt;hasStartDate"/>
-				<owl:onClass rdf:resource="&cmns-dt;Date"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>calculation period</rdfs:label>
-		<skos:definition>date period defined as the number of days from the start to the scheduled end of the computation window</skos:definition>
+		<skos:definition>explicit period from the start to the end of the computation window</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-sch;CalculationPeriodLength">


### PR DESCRIPTION
## Description

1. Replaced the term 'swap stream' with 'swap leg' or 'leg' in some cases
2. Moved general concepts related to anchor dates, calculations and calculation periods to financial dates, to enable broader use
3. Moved concepts related to interest rate schedules and calculations to the debt ontology to normalize the pattern used across FIBO
4. Moved concepts related to step schedules to the debt instruments ontology and normalized their usage

Fixes: #1996 / FBC-317


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


