### PR TITLE
Fix to report from testHygiene_performance_multiple_different_individuals

### DIFF
--- a/etc/testing/hygiene_parameterized/testHygiene_performance_multiple_different_individuals.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene_performance_multiple_different_individuals.sparql
@@ -24,5 +24,5 @@ WHERE
     {
         ?individual1 owl:differentFrom/owl:differentFrom/owl:differentFrom/owl:differentFrom/owl:differentFrom/owl:differentFrom/owl:differentFrom/owl:differentFrom ?individual2.
     }
-    BIND (concat ("An ontology contains more than seven different individuals") AS ?warning)
+    BIND (concat ("WARN: An ontology contains more than seven different individuals") AS ?warning)
 }


### PR DESCRIPTION
Fix to hygiene test reporting

## Description

This fixes the reporter from the hygiene test testHygiene_performance_multiple_different_individuals.sparql

Fixes: #1988 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


