### PR TITLE
SEC-196 - Revise the definition of ticker-symbol to broaden its scope

### DIFF
--- a/IND/InterestRates/MarketDataProviders.rdf
+++ b/IND/InterestRates/MarketDataProviders.rdf
@@ -108,7 +108,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20240101/InterestRates/MarketDataProviders/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20240401/InterestRates/MarketDataProviders/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200301/InterestRates/MarketDataProviders.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200701/InterestRates/MarketDataProviders.rdf version of this ontology was revised to update the LEI URIs to the new form published by the GLEIF on data.world.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20201201/InterestRates/MarketDataProviders.rdf version of this ontology was revised to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
@@ -117,6 +117,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20221001/InterestRates/MarketDataProviders.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230201/InterestRates/MarketDataProviders.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230301/InterestRates/MarketDataProviders.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20240101/InterestRates/MarketDataProviders.rdf version of this ontology was modified to clarify the definition of ticker symbol and revise the role of Thomson Reuters&apos; market data division to reflect it&apos;s history as (1) a subsidiary called Refinitiv, and (2) its acquisition by the London Stock Exchange Group (SEC-196).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -143,7 +144,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;ThomsonReuters">
-		<rdf:type rdf:resource="&fibo-be-fct-pub;MarketDataProvider"/>
+		<cmns-av:explanatoryNote>Note that in 2018, the market data subsidiary of Thomson Reuters became Refinitiv, which then sold a 55% stake to Blackstone Group LP in August 2018. In October 2019, Blackstone and Thomson Reuters announced the sale of the company to London Stock Exchange Group. LSEG completed the US$27 billion purchase from the two previous owners in late January 2021, and Refinitiv is now a subsidiary of LSEG. The well-known financial instrument identifier called a &apos;RIC code&apos; has been a Refinitiv branded code since its founding.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem">
@@ -232,6 +233,13 @@
 		<skos:definition>the ICE Benchmark Administration functional entity that is an international financial information publisher, responsible for the publication of ICE LIBOR, ICE Swap Rate, LBMA Gold Price and ISDA SIMM benchmarks</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.theice.com/index</cmns-av:adaptedFrom>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usfsind;ICEBenchmarkAdministration"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-ind-ir-mdp;LSEGFinancialSolutionsAsMarketDataProvider">
+		<rdf:type rdf:resource="&fibo-be-fct-pub;MarketDataProvider"/>
+		<rdfs:label>LSEG Financial Solutions as market data provider</rdfs:label>
+		<skos:definition>financial market data provider role of the London Stock Exchange Group (LSEG)&apos;s subsidiary, LSEG Financial Solutions</skos:definition>
+		<cmns-av:explanatoryNote>Note that LSEG Financial Group was formerly known as Refinitiv, and before that, the market data division of Thomson Reuters.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-mdp;ReferenceBanks">

--- a/SEC/Securities/SecuritiesIdentification.rdf
+++ b/SEC/Securities/SecuritiesIdentification.rdf
@@ -401,6 +401,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>ticker symbol</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/t/tickersymbol.asp"/>
+		<rdfs:seeAlso rdf:resource="https://www.omg.org/spec/FIGI"/>
 		<skos:definition>reassignable identifier of relatively short character string length that is unique within an exchange for a particular financial instrument or listing for that instrument</skos:definition>
 		<cmns-av:explanatoryNote>Every listed security has at least one unique ticker symbol, facilitating the vast array of trade orders that flow through the financial markets every day. However, in some countries this relationship may be indirect, through the listing, rather than direct, as is the case in the United States. In the US, the relationship between a ticker symbol and the listed security is one-to-one. This is not, however, the case in Singapore, where there may be unique ticker symbols for the same security based on the lot size. Some well-known ticker symbols are commonly used by multiple exchanges for the same instrument, such as &apos;IBM&apos;, though exchanges attempt to coordinate to limit duplication.</cmns-av:explanatoryNote>
 		<cmns-av:usageNote>Ticker symbols are reusable, assigned to a given instrument by an exchange for some period of time.</cmns-av:usageNote>

--- a/SEC/Securities/SecuritiesIdentification.rdf
+++ b/SEC/Securities/SecuritiesIdentification.rdf
@@ -78,7 +78,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/SecuritiesIdentification/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240401/Securities/SecuritiesIdentification/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20180801/Securities/SecuritiesIdentification.rdf version of this ontology was modified to use the hasCoverageArea property rather than hasJurisdiction for coverage of national numbering agencies, and eliminate redundant subclass relationships for two of the schemes defined herein.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20181101/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was modified to add the concept of a ticker symbol and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
@@ -89,9 +89,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Securities/SecuritiesIdentification.rdf version of this ontology was revised to leverage the notion of a composite identifier and address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/SecuritiesIdentification.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecuritiesIdentification.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/SecuritiesIdentification.rdf version of this ontology was modified to clarify the definition of ticker symbol (SEC-196).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;FinancialInstrumentIdentificationScheme">
@@ -400,8 +401,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>ticker symbol</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/t/tickersymbol.asp"/>
-		<skos:definition>exchange-specific identifier for a particular security or listing for that security, depending on the country</skos:definition>
-		<cmns-av:explanatoryNote>Every listed security has at least one unique ticker symbol, facilitating the vast array of trade orders that flow through the financial markets every day. However, in some countries this relationship may be indirect, through the listing, rather than direct, as is the case in the United States. In the US, the relationship between a ticker symbol and the listed security is one-to-one. This is not, however, the case in Singapore, where there may be unique ticker symbols for the same security based on the lot size.</cmns-av:explanatoryNote>
+		<skos:definition>reassignable identifier of relatively short character string length that is unique within an exchange for a particular financial instrument or listing for that instrument</skos:definition>
+		<cmns-av:explanatoryNote>Every listed security has at least one unique ticker symbol, facilitating the vast array of trade orders that flow through the financial markets every day. However, in some countries this relationship may be indirect, through the listing, rather than direct, as is the case in the United States. In the US, the relationship between a ticker symbol and the listed security is one-to-one. This is not, however, the case in Singapore, where there may be unique ticker symbols for the same security based on the lot size. Some well-known ticker symbols are commonly used by multiple exchanges for the same instrument, such as &apos;IBM&apos;, though exchanges attempt to coordinate to limit duplication.</cmns-av:explanatoryNote>
 		<cmns-av:usageNote>Ticker symbols are reusable, assigned to a given instrument by an exchange for some period of time.</cmns-av:usageNote>
 	</owl:Class>
 	

--- a/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
+++ b/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
@@ -20,6 +20,7 @@
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-ind-ir-mdp "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/">
 	<!ENTITY fibo-sec-sec-id "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/">
 	<!ENTITY fibo-sec-sec-idind "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
@@ -50,6 +51,7 @@
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-ind-ir-mdp="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"
 	xmlns:fibo-sec-sec-id="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"
 	xmlns:fibo-sec-sec-idind="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
@@ -76,6 +78,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -84,7 +87,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241201/Securities/SecuritiesIdentificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240401/Securities/SecuritiesIdentificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was updated to represent identifiers as classes rather than individuals and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
@@ -97,6 +100,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to address text formatting hygiene issues and clean up dead or irrelevant links.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was revised to replace &apos;financial information publisher&apos; with &apos;publisher&apos;.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20221001/Securities/SecuritiesIdentificationIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/202301201/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was modified to revise the representation of a RIC code to reflect that it is now published by the London Stock Exchange and is branded using their Refinitiv brand (SEC-196).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
@@ -203,6 +207,7 @@
 		<rdfs:label>CUSIP International Numbering System (CINS) scheme</rdfs:label>
 		<skos:definition>security identification scheme that extends the CUSIP scheme, used to identify securities outside of the United States and Canada for the purposes of facilitating clearing and settlement of trades</skos:definition>
 		<cmns-av:abbreviation>CINS scheme</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.cusip.com/cusip/about-cgs-identifiers.htm</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber">
@@ -277,6 +282,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>common code registry entry</rdfs:label>
+		<rdfs:seeAlso rdf:resource="http://www.isin.net/common-code-isin/"/>
 		<skos:definition>entry in a common code registry</skos:definition>
 	</owl:Class>
 	
@@ -351,6 +357,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
 		<rdfs:label>Euroclear Clearstream common code scheme</rdfs:label>
 		<skos:definition>nine-digit security identification scheme, defined originally by Euroclear and CEDEL (now Clearstream) that is used to identify securities in Europe for the purposes of facilitating clearing and settlement of trades</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.isin.net/common-code-isin/</cmns-av:adaptedFrom>
 		<cmns-av:synonym>common code scheme</cmns-av:synonym>
 		<cmns-dsg:describes rdf:resource="&fibo-sec-sec-idind;CommonCodeRepository"/>
 	</owl:NamedIndividual>
@@ -399,7 +406,8 @@
 		<rdfs:label>financial instrument global identifier</rdfs:label>
 		<skos:definition>financial instrument identifier that is defined as specified in the Object Management Group (OMG) Financial Instrument Global Identifier (FIGI) Specification</skos:definition>
 		<cmns-av:abbreviation>FIGI</cmns-av:abbreviation>
-		<cmns-av:explanatoryNote>While in most cases, a FIGI uniquely identifies a security, there are situations outside of the U.S. where it instead identifies a listing for a security, similarly to a ticker symbol.</cmns-av:explanatoryNote>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/FIGI</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The development of the Financial Instrument Global Identifier (FIGI) originated from a need for a standard methodology to bridge across multiple identification systems for financial instruments. Without prejudice against any existing symbol-based solutions, or any question of the validity of one system over the other, the FIGI standard utilizes a metadata driven approach to enable the unique and persistent identification of financial instruments. While in most cases, a FIGI uniquely identifies a security, there are situations outside of the U.S. where it instead identifies a listing for a security, similar to a ticker symbol.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry">
@@ -409,6 +417,7 @@
 		<skos:definition>open, OMG standards-based registry used by the FIGI registration authority to manage the financial instrument identifiers and related information that it registers according to the Financial Instrument Global Identifier (FIGI) standard</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<cmns-av:abbreviation>FIGI Registry</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/FIGI</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistryEntry">
@@ -443,6 +452,7 @@
 		<rdfs:label>Financial Instrument Global Identifier (FIGI) registry entry</rdfs:label>
 		<skos:definition>entry in a Financial Instrument Global Identifier (FIGI) registry</skos:definition>
 		<cmns-av:abbreviation>FIGI registry entry</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/FIGI</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierScheme">
@@ -451,6 +461,7 @@
 		<rdfs:label>financial instrument global identifier scheme</rdfs:label>
 		<skos:definition>standard identification scheme for financial instrument identifiers (not limited to securities) and, in some cases, related listings, published by the Object Management Group (OMG)</skos:definition>
 		<cmns-av:abbreviation>FIGI scheme</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/FIGI</cmns-av:adaptedFrom>
 		<cmns-dsg:describes rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry"/>
 	</owl:NamedIndividual>
 	
@@ -461,42 +472,63 @@
 		<cmns-av:abbreviation>FTID scheme</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-sec-sec-idind;ReutersInstrumentCode">
+	<owl:Class rdf:about="&fibo-sec-sec-idind;RefinitivInstrumentCode">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;isRegisteredBy"/>
-				<owl:hasValue rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
+				<owl:hasValue rdf:resource="&fibo-ind-ir-mdp;LSEGFinancialSolutionsAsMarketDataProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
-				<owl:hasValue rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
+				<owl:hasValue rdf:resource="&fibo-ind-ir-mdp;LSEGFinancialSolutionsAsMarketDataProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
-				<owl:hasValue rdf:resource="&fibo-sec-sec-idind;ReutersInstrumentCodeScheme"/>
+				<owl:hasValue rdf:resource="&fibo-sec-sec-idind;RefinitivInstrumentCodeScheme"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>Reuters instrument code</rdfs:label>
-		<skos:definition>ticker-like identifier to identify financial instruments and indices owned, managed, and distributed by Thomson Reuters</skos:definition>
+		<rdfs:label>Refinitiv instrument code</rdfs:label>
+		<skos:definition>proprietary code for financial instruments and indices owned, managed, and distributed by the London Stock Exchange Group&apos;s LSEG Financial Solutions (branded as Refinitiv)</skos:definition>
+		<skos:note>A Refinitiv Instrument Code (RIC), previously known as the Reuters Instrument Code, is a proprietary identifier used by Refinitiv (now LSEG Financial Solutions) to represent financial instrument related data. The composition of a RIC is dependent on the type of instrument.
+
+- Instrument code : Can be based on the exchange ticker code, ISIN or local code, currency code, and so on
+- Period or time interval : Can be an expiry month code for example
+- Delimiter : Usually a full stop used to separate the instrument code from the exchange code or a = sign for money securities.
+- Source code : Usually a single or double alpha-character capital unique to an exchange
+
+An equity RIC has several components: the Equity RIC root is in upper case, brokerage characters in lower case (if applicable), and finally an exchange identifier. These codes facilitate information lookup across various financial networks. The concept of RICs traces back to the Quotron service, which Thomson Reuters acquired in the 1980s. The division was spun out as Refinitiv in 2018. Refinitiv was acquired by the London Stock Exchange Group in 2021, and the organization was rebranded as LSEG Financial Solutions in 2023, though the name of the code and certain other branded concepts were retained.</skos:note>
 		<cmns-av:abbreviation>RIC</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://community.developers.refinitiv.com/questions/28938/ric-code-understandingidentificaiton.html</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;RefinitivInstrumentCodeScheme">
+		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
+		<rdfs:label>Refinitiv instrument code scheme</rdfs:label>
+		<skos:definition>proprietary identification scheme for securities identifiers managed by the London Stock Exchange Group&apos;s LSEG Financial Solutions</skos:definition>
+		<cmns-av:abbreviation>RIC scheme</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://community.developers.refinitiv.com/questions/28938/ric-code-understandingidentificaiton.html</cmns-av:adaptedFrom>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-sec-sec-idind;ReutersInstrumentCode">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-sec-sec-idind;RefinitivInstrumentCode"/>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;ReutersInstrumentCodeScheme">
-		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
-		<rdfs:label>Reuters instrument code scheme</rdfs:label>
-		<skos:definition>proprietary identification scheme for securities identifiers managed by Thomson Reuters</skos:definition>
-		<cmns-av:abbreviation>RIC scheme</cmns-av:abbreviation>
+		<owl:sameAs rdf:resource="&fibo-sec-sec-idind;RefinitivInstrumentCodeScheme"/>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;SEDOLMasterFile">
 		<rdf:type rdf:resource="&fibo-sec-sec-id;NationalSecuritiesIdentifyingNumberRegistry"/>
 		<rdf:type rdf:resource="&fibo-sec-sec-id;SecurityRegistry"/>
 		<rdfs:label>SEDOL Master File</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.isin.net/sedol/"/>
 		<skos:definition>repository of security identifiers, issued by the London Stock Exchange, that is the National Securities Identifying Number (NSIN) for securities issued in the United Kingdom, which is also part of the ISIN for the security it identifies</skos:definition>
 		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchange"/>
 	</owl:NamedIndividual>
@@ -530,6 +562,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>Stock Exchange Daily Official List (SEDOL) code</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.isin.net/sedol/"/>
 		<skos:definition>seven-character security identifier, issued by the London Stock Exchange, that is the National Securities Identifying Number (NSIN) for securities issued in the United Kingdom, which is also part of the ISIN for the security it identifies</skos:definition>
 		<cmns-av:abbreviation>SEDOL code</cmns-av:abbreviation>
 	</owl:Class>
@@ -539,6 +572,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
 		<rdf:type rdf:resource="&fibo-sec-sec-id;SecurityIdentificationScheme"/>
 		<rdfs:label>Stock Exchange Daily Official List (SEDOL) scheme</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.isin.net/sedol/"/>
 		<skos:definition>national security identification scheme used to identify all stocks and registered bonds in the United Kingdom for the purposes of facilitating clearing and settlement of trades</skos:definition>
 		<cmns-av:abbreviation>SEDOL scheme</cmns-av:abbreviation>
 		<cmns-dsg:describes rdf:resource="&fibo-sec-sec-idind;SEDOLMasterFile"/>


### PR DESCRIPTION
 
## Description

Revised the definition of ticker symbol per the FIGI 1.2 revision task force at OMG, with some adjustments based on a more expansive definition, and updated the reference individuals related to Thomson Reuters to reflect its sale of the market data subsidiary (rebranded as Refinitiv) to the London Stock Exchange Group. Also added provenance for some securities identifiers where they were lacking.

Fixes: #2009 / SEC-196


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


