### PR TITLE
Update equivalent property name from hasRole to hasObjectRole (WIP)

### DIFF
--- a/FND/Parties/Parties.rdf
+++ b/FND/Parties/Parties.rdf
@@ -257,7 +257,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pty-pty;hasThingInRole">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<owl:equivalentProperty rdf:resource="&cmns-pts;hasRole"/>
+		<owl:equivalentProperty rdf:resource="&cmns-pts;hasObjectRole"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pty-pty;hasUndergoer">


### PR DESCRIPTION
## Description

https://github.com/edmcouncil/fibo/blob/fc3e59cb178e3ba23aa98e74cf6dd9d5e3c39916/FND/Parties/Parties.rdf#L260

When this property was deprecated for the cmns-pts ontology the owl:equivalentProperty asserted was cmns-pts:hasRole, which could not be found in the ontology. The closest match I think is cmns-pts:hasObjectRole. 

Fixes: #2015 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


