### PR TITLE
Fix to fractional seconds trailing zeros

### DIFF
--- a/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
@@ -288,7 +288,7 @@
 		<rdfs:label>Clearstream Banking S.A. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier Global LEI Index registry entry for Clearstream Banking S.A.</skos:definition>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2015-01-09T22:33:24.097</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-06-07T16:35:00.470</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-06-07T16:35:00.47</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
 		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-06-07T00:00:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
@@ -499,7 +499,7 @@
 		<rdfs:label>LuxCSD S.A. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier Global LEI Index registry entry for LuxCSD S.A.</skos:definition>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2014-06-03T01:45:01.523</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-03-09T13:03:09.110</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-03-09T13:03:09.11</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
 		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-03-13T00:00:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>

--- a/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
@@ -246,10 +246,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Business Entity Data (BED) B.V. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier Global LEI Index registry entry for Business Entity Data (BED) B.V.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:54:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-15T15:32:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:54:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-15T15:32:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-05T19:16:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-05T19:16:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-EVK05KS7XY1DEII3R011-LEI"/>
 	</owl:NamedIndividual>
@@ -344,10 +344,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Euroclear SA/NV legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier Global LEI Index registry entry for Euroclear SA/NV</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2014-01-07T03:04:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-02-09T07:33:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2014-01-07T03:04:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-02-09T07:33:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-02-09T07:38:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-02-09T07:38:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-549300CBNW05DILT6870-LEI"/>
 	</owl:NamedIndividual>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -169,10 +169,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Bank of Canada legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier for the Bank of Canada</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2014-03-28T01:39:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2020-12-23T00:19:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2014-03-28T01:39:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2020-12-23T00:19:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-12-22T19:31:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-12-22T19:31:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelEntitySuppliedOnly"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-549300PN6MKI0CLP4T28-LEI"/>
 	</owl:NamedIndividual>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -373,10 +373,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Alphabet Inc. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for Alphabet Inc.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2015-08-31T16:16:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-29T23:17:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2015-08-31T16:16:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-29T23:17:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-29T17:57:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-29T17:57:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-5493006MHB84DD0ZWV18-LEI"/>
 	</owl:NamedIndividual>
@@ -396,10 +396,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Apple Inc. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for for Apple Inc.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-08-19T21:31:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-08-19T21:31:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-09T17:42:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-09T17:42:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-HWUPKR0MPOU8FGXBT394-LEI"/>
 	</owl:NamedIndividual>
@@ -506,10 +506,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>BNY Mellon, National Association legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for BNY Mellon, National Association</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-26T13:54:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-04-27T13:02:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-26T13:54:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-04-27T13:02:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-04-27T13:06:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-04-27T13:06:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-4EP6JBYBTPTQ47LZOB67-LEI"/>
 	</owl:NamedIndividual>
@@ -586,10 +586,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Bank of New York Mellon Corporation legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for The Bank of New York Mellon Corporation</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-01T15:31:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-01T15:31:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-03T23:22:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-03T23:22:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-WFLLPEPC7FZXENRZV188-LEI"/>
 	</owl:NamedIndividual>
@@ -777,10 +777,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Citibank, N.A. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for Citibank, N.A.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-05-27T19:56:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-05-27T19:56:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-27T20:19:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-27T20:19:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-E57ODZWZ7FF32TWEFA76-LEI"/>
 	</owl:NamedIndividual>
@@ -848,10 +848,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Citicorp LLC legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for Citicorp LLC</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2016-05-05T01:54:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-06-09T15:32:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2016-05-05T01:54:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-06-09T15:32:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-27T20:19:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-27T20:19:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-549300PSHWOM1D1JVL23-LEI"/>
 	</owl:NamedIndividual>
@@ -940,10 +940,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Citigroup Inc. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for Citigroup Inc.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-06-17T15:33:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-06-17T15:33:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-27T20:19:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-27T20:19:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-6SHGI4ZSSLCXXQSBB395-LEI"/>
 	</owl:NamedIndividual>
@@ -1009,10 +1009,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>FMR LLC legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for FMR LLC</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:52:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-06-28T12:47:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:52:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-06-28T12:47:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-06-28T12:51:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-06-28T12:51:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-6X064LF7Y6B4DKF2GZ26-LEI"/>
 	</owl:NamedIndividual>
@@ -1069,10 +1069,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>International Business Machines Corporation legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for International Business Machines Corporation</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-27T11:47:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-05-27T21:33:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-27T11:47:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-05-27T21:33:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-10T21:00:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-10T21:00:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-VGRQXHF3J8VDLUA7XE92-LEI"/>
 	</owl:NamedIndividual>
@@ -1160,10 +1160,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for JPMorgan Chase &amp; Co.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-01-07T23:26:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-01-07T23:26:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-01-07T23:27:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-01-07T23:27:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-8I5DZWZKVSZI1NUHU748-LEI"/>
 	</owl:NamedIndividual>
@@ -1279,10 +1279,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-08-24T20:52:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-08-24T20:52:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-01-07T23:30:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-01-07T23:30:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-7H6GLXDRUGQFU57RNE97-LEI"/>
 	</owl:NamedIndividual>
@@ -1508,10 +1508,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>State Street Bank and Trust Company legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for State Street Bank and Trust Company</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-10-22T15:33:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-10-22T15:33:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-26T18:01:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-26T18:01:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-571474TGEMMWANRLN572-LEI"/>
 	</owl:NamedIndividual>
@@ -1595,10 +1595,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>State Street Corporation legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for State Street Corporation</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-12-11T21:45:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-06T15:31:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-12-11T21:45:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-06T15:31:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-26T18:01:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-26T18:01:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-549300ZFEEJ2IP5VME73-LEI"/>
 	</owl:NamedIndividual>
@@ -1655,10 +1655,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>The Coca-Cola Company legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for The Coca-Cola Company</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-10-19T18:57:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-04-26T14:19:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-10-19T18:57:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-04-26T14:19:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-04-27T13:14:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-04-27T13:14:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-UWJKFUJFZ02DKWI3RY53-LEI"/>
 	</owl:NamedIndividual>
@@ -1678,10 +1678,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>The Home Depot, Inc. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for The Home Depot, Inc.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-28T21:32:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-28T21:32:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-09-02T16:53:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-09-02T16:53:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-QEKMOTMBBKA8I816DO57-LEI"/>
 	</owl:NamedIndividual>
@@ -1736,10 +1736,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>The Proctor &amp; Gamble Company legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-11-28T20:59:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-08-12T15:32:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-11-28T20:59:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-08-12T15:32:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-02T07:54:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-02T07:54:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-2572IBTT8CCZW6AU4141-LEI"/>
 	</owl:NamedIndividual>
@@ -1800,10 +1800,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>WFC Holdings, LLC legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for WFC Holdings, LLC</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-10-06T19:01:53.589</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-10-24T00:30:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-10-24T00:30:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelPartiallyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-OT19FZZ6Z7A27CCLDY33-LEI"/>
 	</owl:NamedIndividual>
@@ -1876,10 +1876,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Wells Fargo &amp; Company legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for Wells Fargo &amp; Company</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:52:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:52:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-10-06T19:01:52.884</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-10-11T00:31:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-10-11T00:31:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelPartiallyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-PBLD0EJDB5FWOLXP3B76-LEI"/>
 	</owl:NamedIndividual>
@@ -1992,10 +1992,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Wells Fargo Bank, National Association legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:53:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-08-18T14:04:54.256</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-27T20:07:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-08-27T20:07:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-KB1H1DSPRFMYMCUFXT09-LEI"/>
 	</owl:NamedIndividual>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
@@ -288,7 +288,7 @@
 		<rdfs:label>Bloomberg Finance L.P. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for Bloomberg Finance L.P.</skos:definition>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-12-06T20:55:22.718</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-07-20T17:18:41.850</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-07-20T17:18:41.85</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
 		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-01-25T16:50:02.081</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
@@ -353,7 +353,7 @@
 		<rdfs:label>Bloomberg L.P. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier Global LEI Index registry entry for Bloomberg L.P.</skos:definition>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-12-06T21:00:04.761</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-07-20T17:18:41.850</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-07-20T17:18:41.85</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
 		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-01-25T16:50:01.379</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
@@ -549,9 +549,9 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>Federal Reserve Bank of New York legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier for the Federal Reserve Bank of New York</skos:definition>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2017-10-05T21:46:14.433</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-07-20T17:18:41.850</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-07-20T17:18:41.85</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-06-28T20:23:33.650</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-06-28T20:23:33.65</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelEntitySuppliedOnly"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-254900Y8NKGV541U8Q32-LEI"/>
 	</owl:NamedIndividual>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
@@ -374,10 +374,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Corporation Service Company legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier for Corporation Service Company</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2013-08-14T02:34:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-29T21:32:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2013-08-14T02:34:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-29T21:32:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-09-09T12:59:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-09-09T12:59:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-549300NOPSIMGJNT8J31-LEI"/>
 	</owl:NamedIndividual>
@@ -446,10 +446,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>The Depository Trust &amp; Clearing Corporation legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for The Depository Trust &amp; Clearing Corporation</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:50:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-15T15:32:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:50:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-15T15:32:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-02T18:50:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-02T18:50:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-MLDY5N6PZ58ZE60QU102-LEI"/>
 	</owl:NamedIndividual>
@@ -479,10 +479,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>DTC legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for The Depository Trust &amp; Clearing Corporation</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2017-12-29T15:32:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-16T15:33:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2017-12-29T15:32:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-16T15:33:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-02T18:50:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-02T18:50:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelEntitySuppliedOnly"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-549300HBJLRO8YFMI370-LEI"/>
 	</owl:NamedIndividual>
@@ -648,10 +648,10 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Intercontinental Exchange legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for Intercontinental Exchange</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2013-12-10T03:07:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-30T23:23:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2013-12-10T03:07:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-30T23:23:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-30T20:13:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-30T20:13:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-5493000F4ZO33MV32P92-LEI"/>
 	</owl:NamedIndividual>
@@ -712,10 +712,10 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>S&amp;P Global legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for S&amp;P Global, Inc.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-23T02:31:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:51:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-09-23T02:31:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;LapsedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-09-23T00:46:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2021-09-23T00:46:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-Y6X4K52KMJMZE7I7MY94-LEI"/>
 	</owl:NamedIndividual>
@@ -795,10 +795,10 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>Thomson Reuters Corporation legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for Thomson Reuters Corporation</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2013-03-01T16:35:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-17T23:23:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2013-03-01T16:35:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-11-17T23:23:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-17T18:01:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-11-17T18:01:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-549300561UZND4C7B569-LEI"/>
 	</owl:NamedIndividual>

--- a/IND/InterestRates/MarketDataProviders.rdf
+++ b/IND/InterestRates/MarketDataProviders.rdf
@@ -193,10 +193,10 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistryEntry"/>
 		<rdfs:label>BGC Partners, Inc. legal entity identifier registry entry</rdfs:label>
 		<skos:definition>legal entity identifier registry entry for BGC Partners, Inc.</skos:definition>
-		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:55:00.000</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-05-17T15:24:00.000</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
+		<fibo-fbc-fct-breg:hasInitialRegistrationDate rdf:datatype="&xsd;dateTime">2012-06-06T15:55:00</fibo-fbc-fct-breg:hasInitialRegistrationDate>
+		<fibo-fbc-fct-breg:hasRegistrationRevisionDate rdf:datatype="&xsd;dateTime">2021-05-17T15:24:00</fibo-fbc-fct-breg:hasRegistrationRevisionDate>
 		<fibo-fbc-fct-breg:hasRegistrationStatus rdf:resource="&fibo-fbc-fct-breg;IssuedStatus"/>
-		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-17T15:31:00.000</fibo-fbc-fct-breg:hasRenewalDate>
+		<fibo-fbc-fct-breg:hasRenewalDate rdf:datatype="&xsd;dateTime">2022-05-17T15:31:00</fibo-fbc-fct-breg:hasRenewalDate>
 		<fibo-fbc-fct-breg:hasValidationLevel rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated"/>
 		<cmns-col:comprises rdf:resource="https://rdf.gleif.org/L1/L-TF1LXM1YNB81WKUH5G19-LEI"/>
 	</owl:NamedIndividual>


### PR DESCRIPTION
## Description

This removes the fractional second part of xsd:dataTime values as required by the spec.

Fixes: #1993


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


