### PR TITLE
SEC-185 - Several terms in the DebtAnalytics ontology should be included in the InstrumentPricing ontology

### DIFF
--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -105,7 +105,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240301/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240701/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away, to support collateral agreements such as deeds of trust, UCC filings and the like, to add the concept of a rate reset time of day, to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations.</skos:changeNote>
@@ -121,6 +121,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230901/DebtAndEquities/Debt.rdf version of this ontology was modified to add the starting point value of some collateral when it was acquired (DER-138) and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/DebtAndEquities/Debt.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/Debt.rdf version of this ontology was modified to incorporate certain general debt schedule terms that were previously in more specific ontologies (FBC-317).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240301/DebtAndEquities/Debt.rdf version of this ontology was modified to include a definition for accrued interest, needed for pricing, and correct certain process (methodology) issues in the class hierarchy (SEC-185).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -139,6 +140,19 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>the process of accumulating interest or other income that has been earned but not paid</skos:definition>
 		<cmns-av:explanatoryNote>There are legal contractual terms for the accrual of interest, as distinct from the payment of interest.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;AccruedInterest">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Interest"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasAsOfDate"/>
+				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">accrued interest</rdfs:label>
+		<skos:definition>amount of interest that has been incurred, as of a specific date, on a loan or other financial obligation but has not yet been paid out</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Accrued interest refers to the interest that has accumulated on a bond or other financial obligation since the last interest payment up to, but not including, the settlement date. This interest is earned over time but not yet paid out to the bondholder, for example. If this is a dirty price, this is the amount of accrued interest that is included in the price. This is therefore passed on to the purchaser of the bond or debt instrument.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Amortization">

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -8,6 +8,7 @@
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
+	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
@@ -33,6 +34,7 @@
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
+	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
@@ -54,6 +56,7 @@
 		<dct:abstract>This ontology provides a basic set of definitions related to pricing, yield, and spread that are extended in other instrument-specific ontologies.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -69,7 +72,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/FinancialInstruments/InstrumentPricing/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240701/FinancialInstruments/InstrumentPricing/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200601/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to reflect the move of dated collection from arrangements to financial dates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to add trading day and trading session, to address ambiguity in some definitions, to add adjusted price and to create a more general hasLotSize property that can be used in various contexts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20201201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to replace a redundant concept, calculation formula with formula, add a general price determination class needed for options, add a restriction on SecurityPrice to point to the security, and add hasRoundLotSize.</skos:changeNote>
@@ -79,9 +82,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FinancialInstruments/InstrumentPricing.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FinancialInstruments/InstrumentPricing.rdf version of this ontology was modified to move the nominal for auction market from CDS to the pricing ontology (its IRI was that of this instrument pricing ontology but it was mistakenly in the CDS ontology) and simplify the definition (DER-140), and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/FinancialInstruments/InstrumentPricing.rdf version of this ontology was enhanced to incorporate additional definitions for pricing terminology (SEC-185).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;AdjustedClosingPrice">
@@ -148,6 +152,13 @@
 		<cmns-av:explanatoryNote xml:lang="en">The term &apos;bid price&apos; is used by traders / market makers with respect to a given security, and that are prepared to buy or sell round lots at publicly quoted prices, and by specialists in certain instruments that perform similar functions on an exchange.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-fi-ip;CleanPrice">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
+		<rdfs:label xml:lang="en">clean price</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-fbc-fi-ip;DirtyPrice"/>
+		<skos:definition xml:lang="en">debt instrument price that does not include accrued interest</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;ClosingPrice">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
 		<rdfs:label xml:lang="en">closing price</rdfs:label>
@@ -184,6 +195,27 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">composite market</rdfs:label>
 		<skos:definition xml:lang="en">group of exchanges and trading venues referenced for pricing purposes</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fi-ip;DerivedPrice">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
+		<rdfs:label xml:lang="en">derived price</rdfs:label>
+		<skos:definition xml:lang="en">price that stems from another source or calculation rather than being quoted or based on actual trading data</skos:definition>
+		<skos:example xml:lang="en">For example, a product&apos;s price can be derived from another pricing source, such as an asset or product, using various contributing factors. Derived prices can also be calculated within a firm using published price spreads or other market data. An interpolated price is determined by interpolation between available price figures, using some algorithm or curve, such as between bid and offer (among others). It also includes yield curves and implied forward curves. That is, interpolation may either be linear (straight line interpolation between two values) or may be expressed as a non linear curve such as a yield curve or an implied forward curve.</skos:example>
+		<cmns-av:explanatoryNote xml:lang="en">There are evaluated prices in which an independent source evaluates a price they have derived, and there are prices which are derived within a firm, from supplied, published end of day price spreads or other market data.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">interpolated price</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fi-ip;DirtyPrice">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;AccruedInterest"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">dirty price</rdfs:label>
+		<skos:definition xml:lang="en">debt instrument price that includes accrued interest</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;HighPrice">
@@ -566,6 +598,13 @@
 		<skos:definition xml:lang="en">magnitude of an item (i.e., total quantity)</skos:definition>
 		<skos:example xml:lang="en">For example, with respect to corn, 5000 bushels is a typical contract size. For some oil commodities trades, 1000 barrels is considered a single contract. For equity options, the lot size is typically 100 shares of the underlying.</skos:example>
 		<cmns-av:explanatoryNote xml:lang="en">The lot size, referenced in offerings, listings, orders, and trades, typically refers to the number of shares or units in a single contract.</cmns-av:explanatoryNote>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-fi-ip;hasNumberOfDaysAccrued">
+		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasNumericValue"/>
+		<rdfs:label xml:lang="en">has number of days accrued</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;integer"/>
+		<skos:definition xml:lang="en">indicates the number of days for which interest has accrued and has not yet been received</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-ip;hasPriceDeterminationMethod">

--- a/FBC/FinancialInstruments/InstrumentPricing.rdf
+++ b/FBC/FinancialInstruments/InstrumentPricing.rdf
@@ -153,7 +153,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;CleanPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:label xml:lang="en">clean price</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fi-ip;DirtyPrice"/>
 		<skos:definition xml:lang="en">debt instrument price that does not include accrued interest</skos:definition>
@@ -198,16 +198,18 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;DerivedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;CalculatedPrice"/>
 		<rdfs:label xml:lang="en">derived price</rdfs:label>
 		<skos:definition xml:lang="en">price that stems from another source or calculation rather than being quoted or based on actual trading data</skos:definition>
 		<skos:example xml:lang="en">For example, a product&apos;s price can be derived from another pricing source, such as an asset or product, using various contributing factors. Derived prices can also be calculated within a firm using published price spreads or other market data. An interpolated price is determined by interpolation between available price figures, using some algorithm or curve, such as between bid and offer (among others). It also includes yield curves and implied forward curves. That is, interpolation may either be linear (straight line interpolation between two values) or may be expressed as a non linear curve such as a yield curve or an implied forward curve.</skos:example>
 		<cmns-av:explanatoryNote xml:lang="en">There are evaluated prices in which an independent source evaluates a price they have derived, and there are prices which are derived within a firm, from supplied, published end of day price spreads or other market data.</cmns-av:explanatoryNote>
 		<cmns-av:synonym xml:lang="en">interpolated price</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en">matrix price</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-ip;DirtyPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;MarketPrice"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>

--- a/MD/DebtTemporal/DebtAnalytics.rdf
+++ b/MD/DebtTemporal/DebtAnalytics.rdf
@@ -86,14 +86,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;AccruedInterestAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Interest"/>
-		<rdfs:label xml:lang="en">accrued interest amount</rdfs:label>
-		<skos:definition xml:lang="en">The interest accrued on the bond or debt instrument at the time that the price is quoted. If this is a dirty price, this is the amount of accrued interest that is included in the price. This is therefore passed on to the purchaser of the bond or debt instrument.</skos:definition>
-	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;BondEquivalentYield">
 		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;RelativelyDefinedDebtInstrumentYield"/>
@@ -328,7 +322,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;AccruedInterestAmount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;AccruedInterest"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">dirty price</rdfs:label>

--- a/MD/DebtTemporal/DebtAnalytics.rdf
+++ b/MD/DebtTemporal/DebtAnalytics.rdf
@@ -102,25 +102,6 @@
 		<cmns-av:explanatoryNote xml:lang="en">For example when comparing Treasury with Corp it&apos;s called a Corp Bond Equivalent Yield; when comparing other kinds of yields this would be labelled differently. Treasury bills typically in discount rates - that&apos;s one of the ways you would compare TB or MM or RePo to BEQ - by changing the day count. Detailed implementation of this: This term refers to the type of bond that it is equivalent to, that is the type of bond whose yield is normally determined according to the yield calculation method that is used in determining this Bond Equivalent Yield figure. The type of bond in this instance is defined in relation to the market on which that bond trades, for example the US Corporate Bond Market.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;CashStructuredFinanceInstrumentPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
-		<rdfs:label xml:lang="en">cash structured finance instrument price</rdfs:label>
-		<skos:definition xml:lang="en">When the price is above a certain level (70), you get a quote in reference to an index e.g. LIBOR+50bp i.e. the yield. When you get below a certain price you get a quote such as 65c to a dollar. Percentage? not seen. Would be a whole number, interpreted as c/$</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">This might be a Price, a Spread or a Yield, i.e. &quot;here&apos;s the price., the current Yield is this, and here&apos;s the Spread&quot;.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;CollectionOfDebtPools">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;Pool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-pls;DebtPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">collection of debt pools</rdfs:label>
-		<skos:definition xml:lang="en">pool consisting of one or more pools of debt instrument(s)</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;CreditSpread">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;YieldSpread"/>
 		<rdfs:subClassOf>

--- a/MD/DebtTemporal/DebtAnalytics.rdf
+++ b/MD/DebtTemporal/DebtAnalytics.rdf
@@ -109,13 +109,6 @@
 		<cmns-av:explanatoryNote xml:lang="en">This might be a Price, a Spread or a Yield, i.e. &quot;here&apos;s the price., the current Yield is this, and here&apos;s the Spread&quot;.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;CleanPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
-		<rdfs:label xml:lang="en">clean price</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-aly;DirtyPrice"/>
-		<skos:definition xml:lang="en">A bond or debt instrument price that does not include accrued interest.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;CollectionOfDebtPools">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;Pool"/>
 		<rdfs:subClassOf>
@@ -146,7 +139,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;CleanPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-ip;CleanPrice"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">current yield calculation method</rdfs:label>
@@ -310,25 +303,6 @@
 		<skos:definition xml:lang="en">Yield to the worst case of when the instrument might be called.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DerivedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
-		<rdfs:label xml:lang="en">derived price</rdfs:label>
-		<skos:definition xml:lang="en">price that stems from another source or calculation rather than being quoted or based on actual trading data</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">There are evaluated prices in which an independent source evaluates a price they have derived, and there are prices which are derived within a firm, from supplied, published end of day price spreads or other market data.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DirtyPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-ip;SecurityPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;AccruedInterest"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dirty price</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-ind-ind-ind;QuotedPrice"/>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DiscountedInstrumentYield">
 		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentYield"/>
 		<rdfs:label xml:lang="en">discounted instrument yield</rdfs:label>
@@ -419,13 +393,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPriceSpread"/>
 		<rdfs:label xml:lang="en">internally determined price spread</rdfs:label>
 		<skos:definition xml:lang="en">The spread determined internally within the organisation from information available at their own trading desks. Further Notes Internal prices within a bank would be determined by surveying their own traders. So e.g. corporate desk trades these 30 bonds, get the daily spreads on those at the end of the day and calculate the price. The traders determine the pricing during the based on market movements. (this is all for OTC traded bonds, not exchange traded bonds).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;InterpolatedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DerivedPrice"/>
-		<rdfs:label xml:lang="en">interpolated price</rdfs:label>
-		<skos:definition xml:lang="en">A price determined by interpolation between available price figures, using some algorithm or curve.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">Uses an algorithm to interpolate a price from two observed prices. Examples include price derived by interpolation between prices e.g. between Bid and Offer (among others). also includes Yield Curves and implied forward curves. That is, interpolation may either be linear (straight line interpolation between two values) or may be expressed as a non linear curve such as a yield curve or an implied forward curve.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;JapaneseCompoundYieldCalculationMethod">
@@ -650,7 +617,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;DirtyPrice"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-ip;DirtyPrice"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">simple yield calculation method</rdfs:label>
@@ -768,13 +735,6 @@
 		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentYield"/>
 		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;YieldCalculationMethod"/>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-aly;daysAccrued">
-		<rdfs:label xml:lang="en">days accrued</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DirtyPrice"/>
-		<rdfs:range rdf:resource="&xsd;integer"/>
-		<skos:definition xml:lang="en">The number of days that interest has accrued, as reflected in the price.</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-aly;decimalPlaces">
 		<rdfs:label xml:lang="en">decimal places</rdfs:label>


### PR DESCRIPTION
## Description

1. Added a definition for accrued interest to the debt ontology and removed it from debt analytics
2. Moved clean price, dirty price, derived price and related property to the pricing ontology

Fixes: #2033 / SEC-185


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


