### PR TITLE
GitHub-2041 - fibo-fbc-fct-usnic:NationalInformationCenterClassificationSchemeAndCodeSet is used as an object of owl:hasValue

### DIFF
--- a/FBC/FunctionalEntities/NorthAmericanEntities/USNationalInformationCenterControlledVocabularies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USNationalInformationCenterControlledVocabularies.rdf
@@ -712,26 +712,27 @@
 		<cmns-txt:hasTextValue>USB</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
-	<cmns-cls:ClassificationScheme rdf:about="&fibo-fbc-fct-usnic;NationalInformationCenterClassificationSchemeAndCodeSet">
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeSet"/>
+	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usnic;NationalInformationCenterClassificationSchemeAndCodeSet">
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>National Information Center (NIC) Classification Scheme And Code Set</rdfs:label>
 		<rdfs:isDefinedBy rdf:datatype="&xsd;anyURI">https://www.ffiec.gov/nicpubweb/Content/DataDownload/NPW%20Data%20Dictionary.pdf</rdfs:isDefinedBy>
 		<skos:definition>set of controlled vocabularies and codes for describing content managed in the National Information Center (NIC) repository</skos:definition>
-	</cmns-cls:ClassificationScheme>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usnic;NationalInformationCenterControlledVocabulary">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
+				<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
 				<owl:hasValue rdf:resource="&fibo-fbc-fct-usnic;NationalInformationCenterClassificationSchemeAndCodeSet"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-usnic;NationalInformationCenterClassificationSchemeAndCodeSet"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
+				<owl:hasValue rdf:resource="&fibo-fbc-fct-usnic;NationalInformationCenterClassificationSchemeAndCodeSet"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>National Information Center (NIC) controlled vocabulary</rdfs:label>


### PR DESCRIPTION
## Description

address misclassification of the scheme for the NIC repository and related axioms (was a class, is now a named individual)

Fixes: #2041 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


