### PR TITLE
GitHub-2038 - Implicit punning of OWL Classes in triples (as subjects) with datatype property

### DIFF
--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -105,7 +105,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20240101/EconomicIndicators/EconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20240901/EconomicIndicators/EconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the FIBO 2.0 RFC. Primary changes include the addition of a number of statistical measures (mean, total, etc.) and their use in existing and new indicators, and the addition of several more economic indicators.</skos:changeNote>
@@ -123,6 +123,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230201/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230301/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20231201/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20240101/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate punning in the use of several indicators and normalize certain definitions to be ISO 704 compliant (GitHub-2038).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2014-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2014-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -137,7 +138,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>average daily earnings</rdfs:label>
-		<skos:definition>a measure of the average daily wage an employee makes over the reporting period</skos:definition>
+		<skos:definition>measure of the average daily wage an employee makes over the reporting period</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
 	</owl:Class>
 	
@@ -152,7 +153,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>average earnings</rdfs:label>
-		<skos:definition>a measure of the average wage an hourly or salaried worker makes in a given period of time</skos:definition>
+		<skos:definition>measure of the average wage an hourly or salaried worker makes in a given period of time</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Average earnings are typically calculated on an hourly, daily, weekly, or monthly basis. They may be expressed as an amount of money or in terms of a percent change with respect to a prior period, depending on the jurisdiction and report.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -166,7 +167,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>average hourly earnings</rdfs:label>
-		<skos:definition>a measure of the average hourly wage an employee makes over the reporting period</skos:definition>
+		<skos:definition>measure of the average hourly wage an employee makes over the reporting period</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
 	</owl:Class>
 	
@@ -179,7 +180,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>average monthly earnings</rdfs:label>
-		<skos:definition>a measure of the average monthly wage an employee makes over the reporting period</skos:definition>
+		<skos:definition>measure of the average monthly wage an employee makes over the reporting period</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
 	</owl:Class>
 	
@@ -192,14 +193,14 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>average weekly earnings</rdfs:label>
-		<skos:definition>a measure of the average weekly wage an employee makes over the reporting period</skos:definition>
+		<skos:definition>measure of the average weekly wage an employee makes over the reporting period</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=4360</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CapitalLaborEnergyMaterialsMultifactorProductivity">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;Productivity"/>
 		<rdfs:label>capital-labor-energy-materials multifactor productivity</rdfs:label>
-		<skos:definition>a ratio of a quantity index of gross output to a quantity index of combined inputs</skos:definition>
+		<skos:definition>ratio of a quantity index of gross output to a quantity index of combined inputs</skos:definition>
 		<cmns-av:abbreviation>KLEMS-MFP</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Shows the time profile of how productively combined inputs are used to generate gross output. Conceptually, the KLEMS productivity measure captures disembodied technical change. In practice, it reflects also efficiency change, economies of scale, variations in capacity utilisation and measurement errors.</cmns-av:explanatoryNote>
@@ -209,7 +210,7 @@
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CapitalLaborMultifactorProductivityValueAdded">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;Productivity"/>
 		<rdfs:label>capital-labor multifactor productivity (MFP), based on value added</rdfs:label>
-		<skos:definition>a ratio of a quantity index of value added to a quantity index of combined labor and capital input</skos:definition>
+		<skos:definition>ratio of a quantity index of value added to a quantity index of combined labor and capital input</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Capital-labour MFP indices show the time profile of how productively combined labour and capital inputs are used to generate value added. Conceptually, capital-labour productivity is not, in general, an accurate measure of technical change. It is, however, an indicator of an industry&apos;s capacity to contribute to economy-wide growth of income per unit of primary input. In practice, the measure reflects the combined effects of disembodied technical change, economies of scale, efficiency change, variations in capacity utilisation and measurement errors.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -217,7 +218,7 @@
 	<owl:Class rdf:about="&fibo-ind-ei-ei;CapitalProductivityValueAdded">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;Productivity"/>
 		<rdfs:label>capital productivity, based on value added</rdfs:label>
-		<skos:definition>a ratio of a quantity index of value added to a quantity index of capital input</skos:definition>
+		<skos:definition>ratio of a quantity index of value added to a quantity index of capital input</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Changes in capital productivity indicate the extent to which output growth can be achieved with lower welfare costs in the form of foregone consumption.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>The capital productivity index shows the time profile of how productively capital is used to generate value added. Capital productivity reflects the joint influence of labour, intermediate inputs, technical change, efficiency change, economies of scale, capacity utilisation and measurement errors.</cmns-av:explanatoryNote>
@@ -226,7 +227,7 @@
 	<owl:Class rdf:about="&fibo-ind-ei-ei;Civilian">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
 		<rdfs:label>civilian</rdfs:label>
-		<skos:definition>a person that is not a member of the military (i.e., that is not on active duty)</skos:definition>
+		<skos:definition>person that is not a member of the military (i.e., that is not on active duty)</skos:definition>
 		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 	</owl:Class>
 	
@@ -243,20 +244,20 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>civilian labor force participation rate</rdfs:label>
@@ -314,20 +315,20 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;FixedBasket"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;FixedBasket"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>consumer price index</rdfs:label>
@@ -336,7 +337,7 @@
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;GrossDomesticProduct"/>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;InflationRate"/>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;UnemploymentRate"/>
-		<skos:definition>economic indicator representing a measure of the change over time in the prices of consumer goods and services that households consume</skos:definition>
+		<skos:definition>economic indicator representing measure of the change over time in the prices of consumer goods and services that households consume</skos:definition>
 		<cmns-av:abbreviation>CPI</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://unstats.un.org/unsd/nationalaccount/docs/SNA2008.pdf</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ilo.org/public/english/bureau/stat/guides/cpi/</cmns-av:adaptedFrom>
@@ -345,7 +346,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-ei;Daily">
 		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitRecurrenceInterval"/>
 		<rdfs:label>daily</rdfs:label>
-		<skos:definition>an explicit recurrence interval of one day, or 24 hours</skos:definition>
+		<skos:definition>explicit recurrence interval of one day, or 24 hours</skos:definition>
 		<cmns-dt:hasDurationValue>P1D</cmns-dt:hasDurationValue>
 	</owl:NamedIndividual>
 	
@@ -406,7 +407,7 @@
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulation">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
 		<rdfs:label>employed population</rdfs:label>
-		<skos:definition>a subset of the civilian labor force considered to be employed during the reporting period</skos:definition>
+		<skos:definition>subset of the civilian labor force considered to be employed during the reporting period</skos:definition>
 		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>There are a number of distinctions with respect to how individuals are counted from country to country, including whether or not they are considered employed if they are on unpaid leave for some reason, and whether or not they are counted multiple times if they have more than one paying job.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -454,19 +455,19 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -523,7 +524,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>enterprise</rdfs:label>
-		<skos:definition>a functional business entity that produces and/or sells goods or services</skos:definition>
+		<skos:definition>functional business entity that produces and/or sells goods or services</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.bls.gov/opub/hom/glossary.htm#E</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>An enterprise (a private firm, government, or nonprofit organization) can consist of a single establishment or multiple establishments. All establishments in an enterprise may be classified in one industry (e.g., a chain), or they may be classified in different industries (e.g., a conglomerate).</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -537,7 +538,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>enterprise population</rdfs:label>
-		<skos:definition>a statistical universe consisting of enterprises designed for the purposes of supporting surveys such as those used as the basis for employment and producer price indices</skos:definition>
+		<skos:definition>statistical universe consisting of enterprises designed for the purposes of supporting surveys such as those used as the basis for employment and producer price indices</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;Establishment">
@@ -569,13 +570,13 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EstablishmentPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EstablishmentPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -691,7 +692,7 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-ei;Hourly">
 		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitRecurrenceInterval"/>
 		<rdfs:label>hourly</rdfs:label>
-		<skos:definition>an explicit recurrence interval of one hour, or 60 minutes</skos:definition>
+		<skos:definition>explicit recurrence interval of one hour, or 60 minutes</skos:definition>
 		<cmns-dt:hasDurationValue>P1H</cmns-dt:hasDurationValue>
 	</owl:NamedIndividual>
 	
@@ -749,7 +750,7 @@ A household may be located in a housing unit or in a set of collective living qu
 	<owl:Class rdf:about="&fibo-ind-ei-ei;InputProducerPriceIndex">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;ProducerPriceIndex"/>
 		<rdfs:label>input producer price index</rdfs:label>
-		<skos:definition>economic indicator representing a measure of the rate of change over time in the prices of inputs of goods and services purchased by the producer</skos:definition>
+		<skos:definition>economic indicator representing measure of the rate of change over time in the prices of inputs of goods and services purchased by the producer</skos:definition>
 		<cmns-av:abbreviation>input PPI</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
@@ -821,21 +822,21 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
 		<rdfs:label>military person</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;Civilian"/>
-		<skos:definition>a person that is a member of the active duty military</skos:definition>
+		<skos:definition>person that is a member of the active duty military</skos:definition>
 		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-ei;Monthly">
 		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitRecurrenceInterval"/>
 		<rdfs:label>monthly</rdfs:label>
-		<skos:definition>an explicit recurrence interval of exactly one (1) month, regardless of the length in days of a given calendar month, but typically 30 days</skos:definition>
+		<skos:definition>explicit recurrence interval of exactly one (1) month, regardless of the length in days of a given calendar month, but typically 30 days</skos:definition>
 		<cmns-dt:hasDurationValue>P1M</cmns-dt:hasDurationValue>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;OutputProducerPriceIndex">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;ProducerPriceIndex"/>
 		<rdfs:label>output producer price index</rdfs:label>
-		<skos:definition>economic indicator representing a measure of the rate of change over time in the prices of products sold as they leave the producer</skos:definition>
+		<skos:definition>economic indicator representing measure of the rate of change over time in the prices of products sold as they leave the producer</skos:definition>
 		<cmns-av:abbreviation>output PPI</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</cmns-av:adaptedFrom>
 	</owl:Class>
@@ -843,7 +844,7 @@ A household may be located in a housing unit or in a set of collective living qu
 	<owl:Class rdf:about="&fibo-ind-ei-ei;PersonalConsumptionExpenditures">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
 		<rdfs:label>personal consumption expenditures</rdfs:label>
-		<skos:definition>economic indicator representing a measure of the value of the goods and services purchased by, or on the behalf of, &apos;persons&apos;</skos:definition>
+		<skos:definition>economic indicator representing measure of the value of the goods and services purchased by, or on the behalf of, &apos;persons&apos;</skos:definition>
 		<cmns-av:abbreviation>PCE</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bea.gov/data/consumer-spending/main</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Personal consumption expenditures consist of purchases of goods and services by households and by nonprofit institutions serving households (NPISHs). These goods and services include imputed expenditures on items such as the services of housing by a homeowner (the equivalent of rent), financial and insurance services for which there is no explicit charge, and medical care provided to individuals and financed by government or by private insurance.</cmns-av:explanatoryNote>
@@ -853,7 +854,7 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 		<rdfs:label>population not in the labor force</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
-		<skos:definition>a subset of the civilian, noninstitutional population, that is considered neither employed nor unemployed by the reporting agency during the reporting period</skos:definition>
+		<skos:definition>subset of the civilian, noninstitutional population, that is considered neither employed nor unemployed by the reporting agency during the reporting period</skos:definition>
 		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>There are a number of distinctions with respect to how individuals are counted from country to country, including whether or not they are considered employed if they are on unpaid leave for some reason, and whether or not they are counted multiple times if they have more than one paying job.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -861,6 +862,29 @@ A household may be located in a housing unit or in a set of collective living qu
 	<owl:Class rdf:about="&fibo-ind-ei-ei;ProducerPriceIndex">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;FixedBasket"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-ind-ei-ei;EnterprisePopulation">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-ind-ei-ei;EstablishmentPopulation">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-ind-ei-ei;FixedBasketPopulation">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
@@ -878,32 +902,9 @@ A household may be located in a housing unit or in a set of collective living qu
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;FixedBasket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;EnterprisePopulation">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;EstablishmentPopulation">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;FixedBasketPopulation">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>producer price index</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;ConsumerPriceIndex"/>
-		<skos:definition>economic indicator representing a measure of the rate of change over time in the prices of goods and services bought and sold by producers</skos:definition>
+		<skos:definition>economic indicator representing measure of the rate of change over time in the prices of goods and services bought and sold by producers</skos:definition>
 		<cmns-av:abbreviation>PPI</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.imf.org/external/pubs/ft/ppi/2010/manual/ppi.pdf</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Statistical agencies implement the Laspeyres index by putting it into price-relative (price change from the base period) and revenue-share (from the base period) format. In this form, the Laspeyres index can be written as the sum of base-period revenue shares of the items in the index times their corresponding price relatives. Statistical agency practice has introduced some approximations to the theoretical Laspeyres target due to a number of practical problems with producing the Laspeyres index exactly. For these and other pragmatic reasons, some agencies use alternatives depending on circumstances. See the IMF publication cited for a full explanation of the most commonly used approaches and trade-offs made for determining PPI.</cmns-av:explanatoryNote>
@@ -914,7 +915,7 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:label>productivity</rdfs:label>
-		<skos:definition>economic indicator representing a ratio of a volume measure of output to a volume measure of input use</skos:definition>
+		<skos:definition>economic indicator representing ratio of a volume measure of output to a volume measure of input use</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=2167</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/std/productivity-stats/2352458.pdf</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>The primary objectives of productivity measurement include: (a) tracing technology change, i.e., the currently known ways of converting resources into outputs desired by the economy, (b) identifying changes in efficiency, (c) understanding real cost savings, (d) benchmarking production processes, and (e) assessing standards of living. Productivity measures may also be single factor or multifactor.</cmns-av:explanatoryNote>
@@ -941,7 +942,7 @@ A household may be located in a housing unit or in a set of collective living qu
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>ultimate consumer</rdfs:label>
-		<skos:definition>a person that is the ultimate user of a good, product or service</skos:definition>
+		<skos:definition>person that is the ultimate user of a good, product or service</skos:definition>
 		<cmns-av:explanatoryNote>For the purposes of the CPI and related statistics, the definition of consumer is limited to humans. In general, a consumer could include a pet, as the consumer of pet food, for example, although the pet owner would likely be the purchaser and target of advertising.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>The consumer is not always the purchaser of the product. Consumers are considered to be the users of the final product. For example, purchasers of building products are interim users of these products while constructing the finished product, which then may be purchased by the consumer.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>consumer as defined by the Consumer Price Index (CPI)</cmns-av:synonym>
@@ -999,19 +1000,19 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;UnemployedPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;UnemployedPopulation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;UnemployedPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1027,13 +1028,13 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;ProducerPriceIndex"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;InputProducerPriceIndex"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;OutputProducerPriceIndex"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1046,7 +1047,7 @@ A household may be located in a housing unit or in a set of collective living qu
 	<owl:NamedIndividual rdf:about="&fibo-ind-ei-ei;Weekly">
 		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitRecurrenceInterval"/>
 		<rdfs:label>weekly</rdfs:label>
-		<skos:definition>an explicit recurrence interval of one week, or 7 days</skos:definition>
+		<skos:definition>explicit recurrence interval of one week, or 7 days</skos:definition>
 		<cmns-dt:hasDurationValue>P7D</cmns-dt:hasDurationValue>
 	</owl:NamedIndividual>
 	

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -21,6 +21,7 @@
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
@@ -58,6 +59,7 @@
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
@@ -89,6 +91,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
@@ -244,13 +247,13 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -296,7 +299,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:onClass rdf:resource="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -315,13 +318,13 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;FixedBasket"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -455,13 +458,13 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -570,7 +573,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EstablishmentPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -864,13 +867,13 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;FixedBasket"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -1000,13 +1003,13 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;UnemployedPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1028,13 +1031,13 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;ProducerPriceIndex"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;InputProducerPriceIndex"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;OutputProducerPriceIndex"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
@@ -42,6 +43,7 @@
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
@@ -105,6 +107,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
@@ -1015,7 +1018,7 @@ A household may be located in a housing unit or in a set of collective living qu
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-ind-ei-ei;hasBaselinePopulation">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;refersTo"/>
 		<rdfs:label>has baseline population</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;StatisticalUniverse"/>
 		<skos:definition>specifies the starting point statistical universe or population used for comparison or analysis</skos:definition>

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -126,7 +126,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230201/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230301/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20231201/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20240101/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate punning in the use of several indicators and normalize certain definitions to be ISO 704 compliant (GitHub-2038).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20240101/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified to eliminate punning in the use of several indicators, eliminate &apos;obsolete&apos; restrictions through refinement, and normalize certain definitions to be ISO 704 compliant (GitHub-2038 and GitHub-2028).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2014-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2014-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -247,19 +247,13 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasBaselinePopulation"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasComparisonPopulation"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -299,7 +293,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:onClass rdf:resource="&fibo-ind-ei-ei;GovernmentSpecifiedStatisticalArea"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -319,18 +313,12 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;FixedBasket"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasBaselinePopulation"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -458,19 +446,13 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasBaselinePopulation"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasComparisonPopulation"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -573,13 +555,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EstablishmentPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasBaselinePopulation"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EstablishmentPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -873,24 +849,7 @@ A household may be located in a housing unit or in a set of collective living qu
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;EnterprisePopulation">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;EstablishmentPopulation">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;FixedBasketPopulation">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasBaselinePopulation"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -1003,19 +962,13 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasBaselinePopulation"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;UnemployedPopulation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasComparisonPopulation"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;UnemployedPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1060,6 +1013,20 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether the calculation of the index includes energy and food prices or not</skos:definition>
 	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-ind-ei-ei;hasBaselinePopulation">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+		<rdfs:label>has baseline population</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;StatisticalUniverse"/>
+		<skos:definition>specifies the starting point statistical universe or population used for comparison or analysis</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-ind-ei-ei;hasComparisonPopulation">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+		<rdfs:label>has comparison population</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;StatisticalUniverse"/>
+		<skos:definition>specifies the subset of the baseline statistical universe or population used for comparison or analysis</skos:definition>
+	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-ind-ei-ei;hasDurationOfUnemployment">
 		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDuration"/>

--- a/IND/MarketIndices/BasketIndices.rdf
+++ b/IND/MarketIndices/BasketIndices.rdf
@@ -141,7 +141,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;WeightingFunction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:onProperty rdf:resource="&fibo-ind-mkt-bas;hasMarketCapitalization"/>
 				<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;MarketCapitalization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/IND/MarketIndices/BasketIndices.rdf
+++ b/IND/MarketIndices/BasketIndices.rdf
@@ -84,7 +84,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20231201/MarketIndices/BasketIndices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20240901/MarketIndices/BasketIndices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200901/MarketIndices/BasketIndices.rdf version of this ontology was revised to add the details needed to calculate market cap for a capitalization-based weighting function.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/MarketIndices/BasketIndices.rdf version of this ontology was revised to eliminate the restriction on reference index that it has an index value - the restriction should be on the quantity value such that the value refers to the indicator it represents.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210401/MarketIndices/BasketIndices.rdf version of this ontology was revised to loosen the restriction on a reference index to simply reference any weighted basket so that one could include commodity indices, for example.</skos:changeNote>
@@ -94,9 +94,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20220801/MarketIndices/BasketIndices.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230201/MarketIndices/BasketIndices.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230301/MarketIndices/BasketIndices.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20231201/MarketIndices/BasketIndices.rdf version of the ontology was modified to eliminate punning in the definition of market cap.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-ind-mkt-bas;BasketOfCreditRisks">


### PR DESCRIPTION
## Description

Eliminated the use of hasArgument to refer to certain inputs to various expressions which caused punning, added two properties and refined restrictions to eliminate the obsolete restrictions in the same ontology (GitHub-2028), and normalized language in definitions to eliminate indefinite articles, in compliance with ISO 704

Fixes: #2038


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).
