### PR TITLE
GitHub-2054 - Eliminate extra space in annotations on the US Securities Restrictions ontology

### DIFF
--- a/SEC/Securities/NorthAmericanSecurities/USSecuritiesRestrictions.rdf
+++ b/SEC/Securities/NorthAmericanSecurities/USSecuritiesRestrictions.rdf
@@ -54,7 +54,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240601/Securities/NorthAmericanSecurities/USSecuritiesRestrictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240901/Securities/NorthAmericanSecurities/USSecuritiesRestrictions/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240601/Securities/NorthAmericanSecurities/USSecuritiesRestrictions/.rdf version of this ontology was revised to eliminate typos in a few annotations.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -138,7 +139,7 @@
 		<skos:definition>securities regulation that is part of Regulation SHO that is a circuit breaker limiting short sales to prevent them from causing a security&apos;s price to drop further after a significant decline</skos:definition>
 		<cmns-av:adaptedFrom>https://www.sec.gov/divisions/marketreg/rule201faq.htm</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>On February 26, 2010, the Commission adopted Rule 201 of Regulation SHO. Rule 201 restricts the price at which short sales may be effected when a stock has experienced significant downward price pressure. Rule 201 became effective on May 10, 2010. (Securities Exchange Act Release No. 61595 (Feb. 26, 2010), 75 FR 11232 (Mar. 10, 2010) (&apos;Rule 201 Adopting Release&apos;)). Compliance with the new rule is required as of February 28, 2011. (Securities Exchange Act Release No. 63247 (Nov. 4, 2010), 75 FR 68702 (Nov. 9, 2010)).</cmns-av:explanatoryNote>
-		<cmns-av:explanatoryNote>The Securities and Exchange Commission (SEC) short sale alternative uptick rule (Rule 201) requires the establishment of a short sale-related circuit breaker in the event a security&apos;s price decreases by ten percent or more from the previous day&apos;s closing price. Once activated, the short sale restriction will remain in effect for the remainder of the day as well as the following day. Values are A - &apos;Flag in Effect/Activated&apos;, C - &apos;Flag Continued&apos; and N - &apos;Flag Not in Effect&apos;.  If not given the default is &apos;N - Flag Not in Effect&apos;. When a stock is triggered, traders can only execute short sales of the stock above the National Best Bid (NBB) price.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The Securities and Exchange Commission (SEC) short sale alternative uptick rule (Rule 201) requires the establishment of a short sale-related circuit breaker in the event a security&apos;s price decreases by ten percent or more from the previous day&apos;s closing price. Once activated, the short sale restriction will remain in effect for the remainder of the day as well as the following day. Values are A - &apos;Flag in Effect/Activated&apos;, C - &apos;Flag Continued&apos; and N - &apos;Flag Not in Effect&apos;. If not given the default is &apos;N - Flag Not in Effect&apos;. When a stock is triggered, traders can only execute short sales of the stock above the National Best Bid (NBB) price.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>alternative uptick rule</cmns-av:synonym>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
@@ -146,7 +147,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-usrst;TEFRACRule">
 		<rdf:type rdf:resource="&fibo-sec-sec-rst;SecuritiesRegulation"/>
 		<rdfs:label>TEFRA C rule</rdfs:label>
-		<skos:definition>securities regulation that is a U.S. Treasury Regulation  section 1.163-5(c)(2)(i)(C), or any successor regulation, established under the Tax Equity and Fiscal Responsibility Act of 1982 (TEFRA), that relates to the classification of debt obligations as either &apos;bearer&apos; or &apos;registered&apos; for U.S. tax purposes and ensures that an issue of bearer debt satisfied &apos;reasonable arrangement&apos; requirements</skos:definition>
+		<skos:definition>securities regulation that is a U.S. Treasury Regulation section 1.163-5(c)(2)(i)(C), or any successor regulation, established under the Tax Equity and Fiscal Responsibility Act of 1982 (TEFRA), that relates to the classification of debt obligations as either &apos;bearer&apos; or &apos;registered&apos; for U.S. tax purposes and ensures that an issue of bearer debt satisfied &apos;reasonable arrangement&apos; requirements</skos:definition>
 		<cmns-av:adaptedFrom>https://www.lawinsider.com/dictionary/tefra-c-rules</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>TEFRA C is used only if all parties are comfortable that there is no intention to place any of the securities in the U.S. and that it is unlikely that there will be any interest in the U.S. in such securities.</cmns-av:explanatoryNote>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
@@ -155,7 +156,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-usrst;TEFRADRule">
 		<rdf:type rdf:resource="&fibo-sec-sec-rst;SecuritiesRegulation"/>
 		<rdfs:label>TEFRA D rule</rdfs:label>
-		<skos:definition>securities regulation that is a U.S. Treasury Regulation section 1.163-5(c)(2)(i)(D), or any successor regulation, established under the Tax Equity and Fiscal Responsibility Act of 1982 (TEFRA), that  relates to the classification of debt obligations as either &apos;bearer&apos; or &apos;registered&apos; for U.S. tax purposes,  applies to most straightforward issues of bearer debt in the Euromarkets, and ensures that an issue of bearer debt satisfied &apos;reasonable arrangement&apos; requirements</skos:definition>
+		<skos:definition>securities regulation that is a U.S. Treasury Regulation section 1.163-5(c)(2)(i)(D), or any successor regulation, established under the Tax Equity and Fiscal Responsibility Act of 1982 (TEFRA), that relates to the classification of debt obligations as either &apos;bearer&apos; or &apos;registered&apos; for U.S. tax purposes, applies to most straightforward issues of bearer debt in the Euromarkets, and ensures that an issue of bearer debt satisfied &apos;reasonable arrangement&apos; requirements</skos:definition>
 		<cmns-av:adaptedFrom>https://www.lexisnexis.co.uk/legal/guidance/us-regulation-of-debt-capital-markets-one-minute-guide</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>TEFRA D provides for a restricted period of 40 days from the closing date of the issue and requires that certification of non-U.S. beneficial ownership be obtained before definitive securities can be issued or interest paid to security holders.</cmns-av:explanatoryNote>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>


### PR DESCRIPTION
## Description

Eliminated double spaces in annotations in the US securities restrictions ontology, which occurred in the original text copied to add background details.

Fixes: #2054 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


