### PR TITLE
LOAN-168 - Revise the Loans ontologies as the basis for green loans

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -292,7 +292,7 @@
 
     <owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"/>
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
-	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"/>
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>

--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -26,7 +26,7 @@
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the very latest version of every FIBO ontology (released, provisional, and informative) based on the contents of GitHub, for use in particular while working on revisions. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-07-12T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-10-19T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
@@ -293,6 +293,7 @@
     <owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"/>
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
+	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"/>
 		
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"/>
 	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>

--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -236,6 +236,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
@@ -361,7 +362,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 	 
-	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20240701/AboutFIBODev/"/>
+	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20241001/AboutFIBODev/"/>
   </owl:Ontology>
   
 </rdf:RDF>

--- a/AboutFIBOProd-IncludingReferenceData.rdf
+++ b/AboutFIBOProd-IncludingReferenceData.rdf
@@ -26,7 +26,7 @@
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, including reference data but excluding examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. By reference data we mean ISO currency codes and USPS individuals in FND, juridictions and governments in BE, regulatory agencies and related financial services entities as well as business centers and MIC codes in FBC, FpML interest rates in IND, CFI codes in SEC (incomplete but planned for extension in subsequent releases), and so forth. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-09-06T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-10-26T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
@@ -299,6 +299,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
@@ -383,7 +384,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20240901/AboutFIBOProd-IncludingReferenceData/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20241001/AboutFIBOProd-IncludingReferenceData/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBOProd-TBoxOnly.rdf
+++ b/AboutFIBOProd-TBoxOnly.rdf
@@ -24,11 +24,11 @@
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, excluding reference data and examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-09-06T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-10-26T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
-		<cmns-av:usageNote>As of the Q3 2022 release of FIBO, there is one ontology, Bonds, in Securities, that brings in some reference individuals. The intent is to address this in a future release.</cmns-av:usageNote>
+		<cmns-av:usageNote>As of the Q3 2024 release of FIBO, there is one ontology, Bonds, in Securities, that brings in some reference individuals. The intent is to address this in a future release.</cmns-av:usageNote>
 		
 	<!-- 
 	///////////////////////////////////////////////////////////////////////////////////////
@@ -177,6 +177,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
@@ -249,7 +250,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20240901/AboutFIBOProd-TBoxOnly/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20241001/AboutFIBOProd-TBoxOnly/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -26,7 +26,7 @@
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-09-06T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-10-26T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>	
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
@@ -210,6 +210,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
@@ -296,7 +297,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20240901/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20241001/AboutFIBOProd/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/BP/SecuritiesIssuance/AgencyMBSIssuance.rdf
+++ b/BP/SecuritiesIssuance/AgencyMBSIssuance.rdf
@@ -89,7 +89,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;purchase"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">acquire mortgage</rdfs:label>
@@ -100,7 +100,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;addsToPool"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">add mortgage to pool</rdfs:label>
@@ -145,7 +145,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;isAssessmentOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">classify mortgage</rdfs:label>
@@ -193,7 +193,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">identify conforming mortgage</rdfs:label>
@@ -429,7 +429,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;addsToPool">
 		<rdfs:label xml:lang="en">adds to pool</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AddMortgageToPool"/>
-		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;allocatesIdentifier">
@@ -463,7 +463,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;isAssessmentOf">
 		<rdfs:label xml:lang="en">is assessment of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;ClassifyMortgage"/>
-		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;isDefiningOf">
@@ -487,7 +487,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;purchase">
 		<rdfs:label xml:lang="en">purchase</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AcquireMortgage"/>
-		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;purchases">

--- a/BP/SecuritiesIssuance/AgencyMBSIssuance.rdf
+++ b/BP/SecuritiesIssuance/AgencyMBSIssuance.rdf
@@ -16,7 +16,7 @@
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
+	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
 	<!ENTITY fibo-sec-dbt-mbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/">
 	<!ENTITY fibo-sec-dbt-pbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/">
@@ -44,7 +44,7 @@
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
+	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
 	xmlns:fibo-sec-dbt-mbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"
 	xmlns:fibo-sec-dbt-pbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"
@@ -71,7 +71,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>

--- a/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
+++ b/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
@@ -264,7 +264,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">identify conforming mortgage</rdfs:label>
@@ -485,7 +485,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;isPurchaseOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">purchase mortgage into pool</rdfs:label>
@@ -797,7 +797,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;isPurchaseOf">
 		<rdfs:label xml:lang="en">is purchase of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;PurchaseMortgageIntoPool"/>
-		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;maximumAmount">
@@ -828,7 +828,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;refersTo">
 		<rdfs:label xml:lang="en">refers to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;IdentifyConformingMortgage"/>
-		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+		<rdfs:range rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;requires">

--- a/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
+++ b/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
@@ -21,7 +21,7 @@
 	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
-	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
+	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
 	<!ENTITY fibo-sec-dbt-cdo "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/">
 	<!ENTITY fibo-sec-dbt-mbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/">
@@ -55,7 +55,7 @@
 	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
-	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
+	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
 	xmlns:fibo-sec-dbt-cdo="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"
 	xmlns:fibo-sec-dbt-mbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"
@@ -87,7 +87,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"/>

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -122,7 +122,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/DebtAndEquities/Debt.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/Debt.rdf version of this ontology was modified to incorporate certain general debt schedule terms that were previously in more specific ontologies (FBC-317).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240301/DebtAndEquities/Debt.rdf version of this ontology was modified to include a definition for accrued interest, needed for pricing, and correct certain process (methodology) issues in the class hierarchy (SEC-185).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240701/DebtAndEquities/Debt.rdf version of this ontology was modified to include a synonym of &apos;has dated date&apos; for &apos;has initial interest accrual date&apos; (FBC-322).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240701/DebtAndEquities/Debt.rdf version of this ontology was modified to include a synonym of &apos;has dated date&apos; for &apos;has initial interest accrual date&apos; (FBC-322), and to move the definition of promissory note to financial instruments (LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -443,12 +443,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit facility</rdfs:label>
@@ -1040,10 +1034,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PromissoryNote">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
-		<rdfs:label>promissory note</rdfs:label>
-		<skos:definition>negotiable instrument that is a written promise by one party to another that commits that party to pay a specified sum on demand or within a specified time frame under specified terms</skos:definition>
-		<cmns-av:explanatoryNote>Promissory notes are generally fully fungible.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;RateResetTimeOfDay">

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -202,20 +202,6 @@
 		<cmns-av:explanatoryNote>Payments are divided into equal amounts for the duration of the loan or debt instrument, making it the simplest repayment model. A greater amount of the payment is applied to interest at the beginning of the amortization schedule, while more money is applied to principal at the end.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-dae-dbt;AssetSpecificCollateralAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
-				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>asset-specific collateral agreement</rdfs:label>
-		<skos:definition>collateral agreement that grants a financial interest in some collateral to a party that is not an owner of that collateral, specifying terms, over and above those specified in the primary contract, under which the collateral must be made available to the lender</skos:definition>
-		<skos:example>Examples include deeds of trust and uniform commercial code (UCC) agreements.</skos:example>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Borrower">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Debtor"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
@@ -1073,6 +1059,27 @@
 		<rdfs:label xml:lang="en">revolving line of credit</rdfs:label>
 		<skos:definition xml:lang="en">credit facility that enables the borrower to withdraw funds, repay, and withdraw again</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">Revolving credit facilities are essentially lines of credit with variable interest rates.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;SecurityAgreement">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasEstimatedValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>security agreement</rdfs:label>
+		<skos:definition>collateral agreement that grants a financial interest in some collateral to a party that is not an owner of that collateral, specifying terms including relative duties and rights, over and above those specified in the primary contract, uregarding the disposition of the asset used as collateral</skos:definition>
+		<skos:example>Examples include deeds of trust and uniform commercial code (UCC) agreements.</skos:example>
+		<cmns-av:adaptedFrom>ISO 20022</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;SubFacility">

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -206,7 +206,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -1321,14 +1321,14 @@
 		<rdfs:label>is collateralization of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>relates some collateral to a credit agreement or debt instrument for which the property has been pledged as security for the debt</skos:definition>
+		<skos:definition>relates some collateral to an agreement pledging the asset as security</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;isCollateralizedBy">
 		<rdfs:label>is collateralized by</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
-		<skos:definition>relates a credit agreement or debt instrument to property pledged as security for the debt</skos:definition>
+		<skos:definition>relates an agreement to an asset pledged as security</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-dbt;isInterestOn">

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
@@ -41,6 +42,7 @@
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
@@ -101,6 +103,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
@@ -122,7 +125,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/DebtAndEquities/Debt.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/Debt.rdf version of this ontology was modified to incorporate certain general debt schedule terms that were previously in more specific ontologies (FBC-317).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240301/DebtAndEquities/Debt.rdf version of this ontology was modified to include a definition for accrued interest, needed for pricing, and correct certain process (methodology) issues in the class hierarchy (SEC-185).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240701/DebtAndEquities/Debt.rdf version of this ontology was modified to include a synonym of &apos;has dated date&apos; for &apos;has initial interest accrual date&apos; (FBC-322), and to move the definition of promissory note to financial instruments (LOAN-168).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240701/DebtAndEquities/Debt.rdf version of this ontology was modified to include a synonym of &apos;has dated date&apos; for &apos;has initial interest accrual date&apos; (FBC-322), and to move the definition of promissory note to financial instruments and clarify the definitions of collateral and collateral agreement(LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -197,6 +200,20 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>schedule of periodic payments (repayment installments) that specify changes in the balance of the debt over time</skos:definition>
 		<cmns-av:explanatoryNote>Payments are divided into equal amounts for the duration of the loan or debt instrument, making it the simplest repayment model. A greater amount of the payment is applied to interest at the beginning of the amortization schedule, while more money is applied to principal at the end.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;AssetSpecificCollateralAgreement">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>asset-specific collateral agreement</rdfs:label>
+		<skos:definition>collateral agreement that grants a financial interest in some collateral to a party that is not an owner of that collateral, specifying terms, over and above those specified in the primary contract, under which the collateral must be made available to the lender</skos:definition>
+		<skos:example>Examples include deeds of trust and uniform commercial code (UCC) agreements.</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Borrower">
@@ -294,28 +311,13 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizationOf"/>
-				<owl:onClass rdf:resource="&fibo-fnd-oac-own;TangibleAsset"/>
+				<owl:onClass rdf:resource="&fibo-fnd-oac-own;Asset"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>collateral</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<skos:definition>something pledged as security to ensure fulfillment of an obligation to another party, to lend money, extend credit, or provision securities</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-dbt;CollateralAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
-				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>collateral agreement</rdfs:label>
-		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>written contract that specifies terms, over and above those specified in a promissory note, loan, or other debt instrument, under which the collateral must be made available to the lender</skos:definition>
-		<skos:example>Examples include deeds of trust and uniform commercial code (UCC) agreements.</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;CollateralValueAsOfDate">

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -306,6 +306,11 @@
 		<skos:definition>something pledged as security to ensure fulfillment of an obligation to another party, to lend money, extend credit, or provision securities</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;CollateralAgreement">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;CollateralValueAsOfDate">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AppraisedValue"/>
 		<rdfs:subClassOf>
@@ -855,7 +860,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>managed interest rate</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>a variable interest rate charged by a financial institution for borrowing that is not prescribed as a margin over base rate but is set from time to time by the institution</skos:definition>
+		<skos:definition>variable interest rate charged by a financial institution for borrowing that is not prescribed as a margin over base rate but is set from time to time by the institution</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;MotorVehicleLease">

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -117,6 +117,10 @@
 		</rdfs:subClassOf>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PromissoryNote">
+		<owl:equivalentClass rdf:resource="&fibo-fbc-fi-fi;PromissoryNote"/>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;CashInstrument">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
 		<rdfs:label>cash instrument</rdfs:label>

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -102,18 +102,17 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/FinancialInstruments/FinancialInstruments.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FinancialInstruments/FinancialInstruments.rdf version of this ontology was modified to augment the definition of currency instrument with the notions of buying and selling currencies as well as the source(s) for anticipated rates (DER-143).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FinancialInstruments/FinancialInstruments.rdf version of this ontology was modified to refine the definition of issuer (FBC-284).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240801/FinancialInstruments/FinancialInstruments.rdf version of this ontology was modified to loosen the constraint on financial instrument with respect to having exactly 1 currency (DER-113).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240801/FinancialInstruments/FinancialInstruments.rdf version of this ontology was modified to loosen the constraint on financial instrument with respect to having exactly 1 currency (DER-113), and to move the definition of promissory note from debt to financial instruments (LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-fbc-dae-dbt;PromissoryNote">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DebtInstrument"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;CreditFacility">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;isNegotiable"/>
-				<owl:hasValue rdf:datatype="&xsd;boolean">true</owl:hasValue>
+				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;PromissoryNote"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>
@@ -401,6 +400,20 @@
 		<cmns-av:explanatoryNote>SEC Rule 434 defines structured securities as &apos;securities whose cash flow characteristics depend upon one or more indices or that have embedded forwards or options or securities where an investor&apos;s investment return and the issuer&apos;s payment obligations are contingent on, or highly sensitive to, changes in the value of underlying assets, indices, interest rates or cash flows&apos;.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>market-linked investment</cmns-av:synonym>
 		<cmns-av:synonym>structured product</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fi-fi;PromissoryNote">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DebtInstrument"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;isNegotiable"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>promissory note</rdfs:label>
+		<skos:definition>debt instrument that is a written promise by one party to another that commits that party to pay a specified sum on demand or within a specified time frame under specified terms</skos:definition>
+		<cmns-av:explanatoryNote>Promissory notes are generally fully fungible. They may or may not be negotiable.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;RedemptionProvision">

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -404,13 +404,6 @@
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;PromissoryNote">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;isNegotiable"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&xsd;boolean"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>promissory note</rdfs:label>
 		<skos:definition>debt instrument that is a written promise by one party to another that commits that party to pay a specified sum on demand or within a specified time frame under specified terms</skos:definition>
 		<cmns-av:explanatoryNote>Promissory notes are generally fully fungible. They may or may not be negotiable.</cmns-av:explanatoryNote>

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -201,7 +201,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isSubordinateContractTo"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isSubordinateTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -655,7 +655,7 @@
 		<rdfs:label>is primary contract for</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
 		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-agr-ctr;isSubordinateContractTo"/>
+		<owl:inverseOf rdf:resource="&fibo-fnd-agr-ctr;isSubordinateTo"/>
 		<skos:definition>indicates any subordinate agreement, such as a collateral agreement</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -665,12 +665,13 @@
 		<skos:definition>indicates a constraint, limitation or refinement on something</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;isSubordinateContractTo">
+	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;isSubordinateTo">
 		<rdfs:subPropertyOf rdf:resource="&cmns-doc;refersTo"/>
-		<rdfs:label>is subordinate contract to</rdfs:label>
+		<rdfs:label>is subordinate to</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
 		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
 		<skos:definition>indicates the primary contract referenced by a subordinate agreement, such as a collateral agreement</skos:definition>
+		<cmns-av:explanatoryNote>This property may also be used as the basis for linking agreements based on priority, such as linking a second or junior lien to the primary lien on some collateral</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;qualifies">

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -95,7 +95,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Agreements/Contracts.rdf version of the ontology was modified to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Agreements/Contracts.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Agreements/Contracts.rdf version of the ontology was modified to better integrate the parties to a contract with the latest patterns (FBC-284).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240501/Agreements/Contracts.rdf version of the ontology was modified to add an optional date of issuance to written contract, which may or may not be the same as the effective date (FBC-322).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240501/Agreements/Contracts.rdf version of the ontology was modified to add an optional date of issuance to written contract, which may or may not be the same as the effective date (FBC-322) and add a general notion of collateral agreement (LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -195,6 +195,20 @@
 		<rdfs:label xml:lang="en">breach of covenant</rdfs:label>
 		<skos:definition xml:lang="en">classifier of events representing breaking a promise specified in a contract to do or not to do something, without a legitimate excuse</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">In the case of a breach of a covenant or warranty, the contract remains binding and damages only are recoverable for the breach, whereas a breach of contract typically invalidates the entire contract.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-agr-ctr;CollateralAgreement">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasPrimaryContract"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>collateral agreement</rdfs:label>
+		<skos:definition>written contract related to another contract designed to provide clarity and additional protection for all parties involved, that is separate from the primary contract and that can be independently enforced</skos:definition>
+		<skos:example>Examples may be related to leases, to clarify responsibilities with respect to maintance and repair, to partnerships, clarifying how disputes should be resolved, loan agreements such as deeds of trust, covering the conditions under which the collateral would be forfeited, and uniform commercial code (UCC) agreements.</skos:example>
+		<cmns-av:explanatoryNote>In cases where there are discrepancies between the collateral agreement and primary contract, the primary contract, which may be a master agreement, for example, takes precedence.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ConditionPrecedent">
@@ -589,6 +603,13 @@
 		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;NonBindingTerm"/>
 		<skos:definition>refers to a term that is included in an agreement that is not considered legally binding</skos:definition>
 		<cmns-av:explanatoryNote>In other words, a breach of such terms in the future would not be considered to be a breach of the contract.</cmns-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasPrimaryContract">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;refersTo"/>
+		<rdfs:label>has primary contract</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+		<skos:definition>indicates the main contract referenced by a subordinate agreement, such as a collateral agreement</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasPrincipalParty">

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -201,7 +201,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasPrimaryContract"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isSubordinateContractTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -605,13 +605,6 @@
 		<cmns-av:explanatoryNote>In other words, a breach of such terms in the future would not be considered to be a breach of the contract.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasPrimaryContract">
-		<rdfs:subPropertyOf rdf:resource="&cmns-doc;refersTo"/>
-		<rdfs:label>has primary contract</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<skos:definition>indicates the main contract referenced by a subordinate agreement, such as a collateral agreement</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;hasPrincipalParty">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasActor"/>
@@ -657,10 +650,27 @@
 		<skos:definition>is attested by</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;isPrimaryContractFor">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isReferredToBy"/>
+		<rdfs:label>is primary contract for</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+		<owl:inverseOf rdf:resource="&fibo-fnd-agr-ctr;isSubordinateContractTo"/>
+		<skos:definition>indicates any subordinate agreement, such as a collateral agreement</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;isQualifiedBy">
 		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isCharacterizedBy"/>
 		<rdfs:label>is qualified by</rdfs:label>
 		<skos:definition>indicates a constraint, limitation or refinement on something</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;isSubordinateContractTo">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;refersTo"/>
+		<rdfs:label>is subordinate contract to</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+		<skos:definition>indicates the primary contract referenced by a subordinate agreement, such as a collateral agreement</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-agr-ctr;qualifies">

--- a/FND/AllFND.rdf
+++ b/FND/AllFND.rdf
@@ -35,6 +35,7 @@
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/">
 	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-plc-rp "https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
@@ -84,6 +85,7 @@
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
 	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-plc-rp="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
@@ -104,7 +106,7 @@
 The scope of the definitions provided in FND is limited to coverage of exactly those concepts needed by other FIBO domain areas. They may be useful for other domains, such as insurance, but are intentionally underspecified to avoid unintended consequences and thus do not provide exhaustive coverage for any concept contained herein. However, Foundations is designed for growth over time. The expectation is that as additional foundational knowledge is needed to define concepts in other FIBO domain areas, additional ontologies and/or concepts will be integrated into Foundations as required.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-20T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-10-24T18:00:00</dct:modified>
 		<dct:title>FIBO FND Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Foundations (FND) Domain</dct:title>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
@@ -140,6 +142,7 @@ The scope of the definitions provided in FND is limited to coverage of exactly t
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
@@ -148,13 +151,14 @@ The scope of the definitions provided in FND is limited to coverage of exactly t
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/AllFND/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241001/AllFND/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/AllFND.rdf version of this ontology was modified to incorporate the recently released assessments and ratings ontologies.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190601/AllFND.rdf version of this ontology was modified to eliminate the unused legitimate organizations ontology, thereby simplifying the overal organization hierarchy, eliminate duplication with LCC, and merge countries with locations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/AllFND.rdf version of this ontology was modified to merge goals with objectives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201101/AllFND.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary and to eliminate unnecessary imports statements.</skos:changeNote>
-		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/AllFND.rdf version of the ontology was modified to add an ontology for real property (LOAN-168).</skos:changeNote>
+		<cmns-av:copyright>Copyright (c) 2017-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2024 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:explanatoryNote>The &apos;all&apos; FND ontology is provided for convenience for FIBO users.  It imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND) domain, and can be loaded directly in tools such as Protege with the expectation that all of the accompanying content will be loaded.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -64,7 +64,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Places/Addresses/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Places/Addresses/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report. Differences from the 1.0 version include the addition of a hasAddress property and PhysicalAddress class as a parent of PostalAddress.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20160201/Places/Addresses.rdf version of this ontology was modified for the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20130801/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/. Primary differences include elimination of data properties in favor of a simple class model,the addition of virtual address, and the addition of addressing scheme.</skos:changeNote>
@@ -77,7 +77,6 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20211201/Places/Addresses.rdf version of this ontology was modified to address hygiene issues with respect to text formatting.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/Places/Addresses.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Places/Addresses.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Places/Addresses.rdf version of this ontology was modified to augment the definition of parcel to include an address (LOAN-168).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/Foundations/20130601/Organizations/Addresses.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
 	(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -882,15 +881,5 @@
 		<skos:definition>if true, indicates that an additional qualifier is needed to complete the delivery point description, such as an apartment number</skos:definition>
 		<cmns-av:explanatoryNote>Note that in some cases, such as for lobby or office, if there are multiple secondary units then a range may be needed to differentiate between them, even if the range is not always required.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
-	
-	<owl:Class rdf:about="&fibo-fnd-plc-loc;Parcel">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddress"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
 
 </rdf:RDF>

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -85,8 +85,8 @@
 	(5) to incorporate changes to the specification metadata to support documentation at the family, specification, module, and ontology level, similar to the abbreviations
 	(6) to move this ontology from Organizations to Places and eliminate unnecessary properties and related imports dependencies.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;Address">

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -64,7 +64,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Places/Addresses/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Places/Addresses/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report. Differences from the 1.0 version include the addition of a hasAddress property and PhysicalAddress class as a parent of PostalAddress.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20160201/Places/Addresses.rdf version of this ontology was modified for the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20130801/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/. Primary differences include elimination of data properties in favor of a simple class model,the addition of virtual address, and the addition of addressing scheme.</skos:changeNote>
@@ -77,6 +77,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20211201/Places/Addresses.rdf version of this ontology was modified to address hygiene issues with respect to text formatting.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/Places/Addresses.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Places/Addresses.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Places/Addresses.rdf version of this ontology was modified to augment the definition of parcel to include an address (LOAN-168).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/Foundations/20130601/Organizations/Addresses.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
 	(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -85,8 +86,8 @@
 	(5) to incorporate changes to the specification metadata to support documentation at the family, specification, module, and ontology level, similar to the abbreviations
 	(6) to move this ontology from Organizations to Places and eliminate unnecessary properties and related imports dependencies.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;Address">
@@ -881,5 +882,15 @@
 		<skos:definition>if true, indicates that an additional qualifier is needed to complete the delivery point description, such as an apartment number</skos:definition>
 		<cmns-av:explanatoryNote>Note that in some cases, such as for lobby or office, if there are multiple secondary units then a range may be needed to differentiate between them, even if the range is not always required.</cmns-av:explanatoryNote>
 	</owl:DatatypeProperty>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-loc;Parcel">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddress"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
 
 </rdf:RDF>

--- a/FND/Places/Locations.rdf
+++ b/FND/Places/Locations.rdf
@@ -37,7 +37,7 @@
 		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20180801/Places/Locations.rdf version of this ontology was modified eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20190901/Places/Locations.rdf version of this ontology was modified to revise definitions to improve them and make them ISO 704 compliant, and merge the concepts that were previously in the countries ontology into this one.</skos:changeNote>
 		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20200301/Places/Locations.rdf version of this ontology was modified to address hygiene issues with respect to text formatting.</skos:changeNote>
-		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20230101/Places/Locations.rdf version of this ontology was modified to move the definition of parcel to the new real property ontology (LOAN-168).</skos:changeNote>
+		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20230101/Places/Locations.rdf version of this ontology was modified to move definitions related to parcel and real estate to a new real property ontology (LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -100,10 +100,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;RealEstate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
-		<rdfs:label xml:lang="en">real estate</rdfs:label>
-		<skos:definition>tract or plot of land including any fixed structures on it, as well as the natural resources of the land including uncultivated flora and fauna, farmed crops and livestock, water, and any additional mineral deposits</skos:definition>
-		<cmns-av:explanatoryNote>Although media often refers to the &quot;real estate market&quot; from the perspective of residential living, real estate can be grouped into three broad categories based on its use, namely residential, commercial and industrial. Examples of real estate include undeveloped land, houses, condominiums, townhomes, office buildings, retail store buildings and factories.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-plc-loc;hasBusinessCenter">

--- a/FND/Places/Locations.rdf
+++ b/FND/Places/Locations.rdf
@@ -30,16 +30,17 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Places/Locations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Places/Locations/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20130801/Places/Locations.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://www.omg.org/spec/EDMC-FIBO/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Places/Locations.rdf version of this ontology was modified for the FIBO 2.0 RFC to integrate it with LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/Places/Locations.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20180801/Places/Locations.rdf version of this ontology was modified eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20190901/Places/Locations.rdf version of this ontology was modified to revise definitions to improve them and make them ISO 704 compliant, and merge the concepts that were previously in the countries ontology into this one.</skos:changeNote>
 		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20200301/Places/Locations.rdf version of this ontology was modified to address hygiene issues with respect to text formatting.</skos:changeNote>
+		<skos:changeNote>The https://www.omg.org/spec/EDMC-FIBO/FND/20230101/Places/Locations.rdf version of this ontology was modified to move the definition of parcel to the new real property ontology (LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;BusinessCenter">
@@ -83,10 +84,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;Parcel">
-		<rdfs:subClassOf rdf:resource="&lcc-cr;GeographicRegion"/>
-		<rdfs:label xml:lang="en">parcel</rdfs:label>
-		<skos:definition xml:lang="en">tract or plot of land</skos:definition>
-		<cmns-av:explanatoryNote>A parcel is a defined piece of real estate, usually resulting from the division of a large area of land.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-loc;PhysicalLocation">

--- a/FND/Places/MetadataFNDPlaces.rdf
+++ b/FND/Places/MetadataFNDPlaces.rdf
@@ -26,12 +26,12 @@
 		<dct:abstract>This is the metadata ontology used to describe the Foundations Places Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2022-06-14T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-20T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-10-24T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Places/MetadataFNDPlaces/"/>
-		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Places/MetadataFNDPlaces/"/>
+		<cmns-av:copyright>Copyright (c) 2017-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-mod;PlacesModule">
@@ -43,13 +43,14 @@
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO FND Places Module</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Foundations (FND) Places Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FND/Places/RealProperty.rdf
+++ b/FND/Places/RealProperty.rdf
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
+	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
+	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
+	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-plc-rp "https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
+	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
+	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
+	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-plc-rp="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/">
+		<rdfs:label xml:lang="en">Real Property Ontology</rdfs:label>
+		<dct:abstract>This ontology defines concepts including real and personal property from a legal perspective, as well as assessments of those assets, for reference for taxation, lending, and related purposes.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Places/RealProperty/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+		<cmns-av:copyright>Copyright (c) 2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024 Object Management Group, Inc.</cmns-av:copyright>
+	</owl:Ontology>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-loc;Parcel">
+		<owl:equivalentClass rdf:resource="&fibo-fnd-plc-rp;TractOfLand"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-loc;RealEstate">
+		<owl:equivalentClass rdf:resource="&fibo-fnd-plc-rp;RealEstate"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;PersonalProperty">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isEvaluatedBy"/>
+				<owl:onClass rdf:resource="&fibo-fnd-arr-asmt;Appraisal"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">personal property</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
+		<skos:definition xml:lang="en">movable items or possessions that are not fixed to land</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Personal property may include tangible assets, such as machinery, furniture, vehicles, artwork, and jewelry, regardless of whether such assets are owned by a person or organization, and intangible assets, including but not limited to intellectual property and financial instruments.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;PropertyInspection">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentActivity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:someValuesFrom rdf:resource="&cmns-pts;PartyRole"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>property inspection</rdfs:label>
+		<skos:definition>assessment activity that involves analyzing one or more aspects of a real property with respect to status or deficiency</skos:definition>
+		<cmns-av:explanatoryNote>The concept of a property inspection is independent and separate from conducting an appraisal. Examples are termite inspections, construction inspections, etc.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;RealEstate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
+		<rdfs:label xml:lang="en">real estate</rdfs:label>
+		<skos:definition xml:lang="en">real property, interests in mortgages on real property (including interests in mortgages on leaseholds of land or improvements thereon), and shares in other qualified real estate investment trusts</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/cfr/text/26/1.856-3</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">The term &apos;mortgages on real property&apos; includes deeds of trust on real property. Note that interpretation of the term &apos;real estate&apos; is context-dependent - this broader interpretation is used in tax law in the US and elsewhere.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">real estate asset</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;RealProperty">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;PhysicalAsset"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-rp;RealEstate"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isEvaluatedBy"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-rp;RealPropertyAppraisal"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">real property</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/r/real-property.asp"/>
+		<skos:definition xml:lang="en">physical asset defined as land together with any structures that are permanently attached to that land, such as houses, trees, fences and other improvements</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/cfr/text/10/600.101</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Real property may be classified according to its general use as residential, commercial, agricultural, industrial, or special purpose. This term is sometimes used synonymously with &apos;real estate&apos;, though not in all circumstances under US law.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Real property typically encompasses both the physical land and everything that lies above, below, or on its surface, including any fixed structures, natural resources, and rights or interests (e.g., mineral rights). There are cases, such as condominiums, in which the interior of the structure is owned by a party that may not own the land. There are also cases in which certain long-term leases have similar characteristics to ownership, but are time-bound.</cmns-av:explanatoryNote>
+		<cmns-av:synonym xml:lang="en">parcel</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;RealPropertyAppraisal">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;Appraisal"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-rp;PropertyInspection"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGeneratedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;Appraiser"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>real property appraisal</rdfs:label>
+		<skos:definition>value assessment that estimates the amount of money some real property is worth</skos:definition>
+		<cmns-av:explanatoryNote>The valuation uses one or more methodologies and is conducted by an appraiser or technology with a logical model that performs the same function.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;TractOfLand">
+		<rdfs:subClassOf rdf:resource="&lcc-cr;GeographicRegion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddress"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">tract of land</rdfs:label>
+		<skos:definition xml:lang="en">geographic region that is a specific area within a larger region on the surface of the earth</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Such a description typically includes a detailed, quantitative specification for that region specified using a prescribed coordinate and/or mapping system and/or a narrative description, such as &apos;metes and bounds&apos;, which provides a qualitative, but less precise, legal description of the location. The system(s) used to describe the tract are specified in local, regional, and national law.</cmns-av:explanatoryNote>
+	</owl:Class>
+
+</rdf:RDF>

--- a/FND/Places/RealProperty.rdf
+++ b/FND/Places/RealProperty.rdf
@@ -94,7 +94,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">personal property</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
-		<skos:definition xml:lang="en">movable items or possessions that are not fixed to land</skos:definition>
+		<skos:definition xml:lang="en">asset that includes movable items or possessions that are not fixed to land</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">Personal property may include tangible assets, such as machinery, furniture, vehicles, artwork, and jewelry, regardless of whether such assets are owned by a person or organization, and intangible assets, including but not limited to intellectual property and financial instruments.</cmns-av:explanatoryNote>
 	</owl:Class>
 	

--- a/FND/Places/RealProperty.rdf
+++ b/FND/Places/RealProperty.rdf
@@ -136,7 +136,7 @@
 	<owl:Class rdf:about="&fibo-fnd-plc-rp;RealEstate">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
 		<rdfs:label xml:lang="en">real estate</rdfs:label>
-		<skos:definition xml:lang="en">real property, interests in mortgages on real property (including interests in mortgages on leaseholds of land or improvements thereon), and shares in other qualified real estate investment trusts</skos:definition>
+		<skos:definition xml:lang="en">real property, interests in mortgages on real property (including interests in mortgages on leaseholds of land or improvements thereon), and shares in qualified real estate investment trusts</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/cfr/text/26/1.856-3</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote xml:lang="en">The term &apos;mortgages on real property&apos; includes deeds of trust on real property. Note that interpretation of the term &apos;real estate&apos; is context-dependent - this broader interpretation is used in tax law in the US and elsewhere.</cmns-av:explanatoryNote>
 		<cmns-av:synonym xml:lang="en">real estate asset</cmns-av:synonym>
@@ -191,23 +191,31 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cxtid;ContextualIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
+				<owl:onClass rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>real property identifier</rdfs:label>
-		<skos:definition>unique identifier given to unequivocally identify a specific real property in some jurisidiction</skos:definition>
+		<skos:definition>unique identifier given to identify a specific real property in some jurisidiction</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-rp;TractIdentifier">
 		<rdfs:subClassOf rdf:resource="&cmns-cxtid;ContextualIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
+				<owl:onClass rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
@@ -215,14 +223,8 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>tract identifier</rdfs:label>
-		<skos:definition>unique identifier given to unequivocally identify a tract in some jurisidiction</skos:definition>
+		<skos:definition>unique identifier given to identify a tract in some jurisidiction</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-rp;TractOfLand">
@@ -236,6 +238,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">tract of land</rdfs:label>
 		<skos:definition xml:lang="en">geographic region that is a specific area within a larger region on the surface of the earth</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">In some cases, such as in the case of unimproved land that may be owned by a government but without improvements, there may not be an address.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote xml:lang="en">Such a description typically includes a detailed, quantitative specification for that region specified using a prescribed coordinate and/or mapping system and/or a narrative description, such as &apos;metes and bounds&apos;, which provides a qualitative, but less precise, legal description of the location. The system(s) used to describe the tract are specified in local, regional, and national law.</cmns-av:explanatoryNote>
 	</owl:Class>
 

--- a/FND/Places/RealProperty.rdf
+++ b/FND/Places/RealProperty.rdf
@@ -2,12 +2,15 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-cxtid "https://www.omg.org/spec/Commons/ContextualIdentifiers/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
@@ -24,12 +27,15 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-cxtid="https://www.omg.org/spec/Commons/ContextualIdentifiers/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
@@ -50,6 +56,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
@@ -57,6 +64,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
@@ -160,6 +169,44 @@
 		<rdfs:label>real property appraisal</rdfs:label>
 		<skos:definition>value assessment that estimates the amount of money some real property is worth</skos:definition>
 		<cmns-av:explanatoryNote>The valuation uses one or more methodologies and is conducted by an appraiser or technology with a logical model that performs the same function.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;RealPropertyIdentifier">
+		<rdfs:subClassOf rdf:resource="&cmns-cxtid;ContextualIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>real property identifier</rdfs:label>
+		<skos:definition>unique identifier given to unequivocally identify a specific real property in some jurisidiction</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;TractIdentifier">
+		<rdfs:subClassOf rdf:resource="&cmns-cxtid;ContextualIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-rp;TractOfLand"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>tract identifier</rdfs:label>
+		<skos:definition>unique identifier given to unequivocally identify a tract in some jurisidiction</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-rp;TractOfLand">

--- a/FND/Places/RealProperty.rdf
+++ b/FND/Places/RealProperty.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-cxtid "https://www.omg.org/spec/Commons/ContextualIdentifiers/">
+	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -29,6 +30,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-cxtid="https://www.omg.org/spec/Commons/ContextualIdentifiers/"
+	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -66,6 +68,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
@@ -94,27 +97,40 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">personal property</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
-		<skos:definition xml:lang="en">asset that includes movable items or possessions that are not fixed to land</skos:definition>
+		<skos:definition xml:lang="en">asset that is a movable item or possession not fixed to land</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">Personal property may include tangible assets, such as machinery, furniture, vehicles, artwork, and jewelry, regardless of whether such assets are owned by a person or organization, and intangible assets, including but not limited to intellectual property and financial instruments.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-rp;PropertyInspection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentActivity"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentEvent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOutput"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-rp;PropertyInspectionReport"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:label>property inspection</rdfs:label>
+		<skos:definition>event that involves analyzing one or more aspects of a real property</skos:definition>
+		<cmns-av:explanatoryNote>The concept of a property inspection is separate from conducting an overarching appraisal. Examples are termite inspections, construction inspections, evaluation for completion of some milestone, improvement, correction, etc.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;PropertyInspectionReport">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentReport"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&cmns-pts;PartyRole"/>
+				<owl:onProperty rdf:resource="&cmns-doc;isAbout"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>property inspection</rdfs:label>
-		<skos:definition>assessment activity that involves analyzing one or more aspects of a real property with respect to status or deficiency</skos:definition>
-		<cmns-av:explanatoryNote>The concept of a property inspection is independent and separate from conducting an appraisal. Examples are termite inspections, construction inspections, etc.</cmns-av:explanatoryNote>
+		<rdfs:label>property inspection report</rdfs:label>
+		<skos:definition>report covering the findings of a property inspection</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-rp;RealEstate">
@@ -138,7 +154,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">real property</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.investopedia.com/terms/r/real-property.asp"/>
-		<skos:definition xml:lang="en">physical asset defined as land together with any structures that are permanently attached to that land, such as houses, trees, fences and other improvements</skos:definition>
+		<skos:definition xml:lang="en">physical asset defined as land together with any structures that are permanently attached to that land, such as houses, trees, fences and improvements</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/cfr/text/10/600.101</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote xml:lang="en">Real property may be classified according to its general use as residential, commercial, agricultural, industrial, or special purpose. This term is sometimes used synonymously with &apos;real estate&apos;, though not in all circumstances under US law.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote xml:lang="en">Real property typically encompasses both the physical land and everything that lies above, below, or on its surface, including any fixed structures, natural resources, and rights or interests (e.g., mineral rights). There are cases, such as condominiums, in which the interior of the structure is owned by a party that may not own the land. There are also cases in which certain long-term leases have similar characteristics to ownership, but are time-bound.</cmns-av:explanatoryNote>
@@ -150,7 +166,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-rp;PropertyInspection"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-rp;PropertyInspectionReport"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -162,7 +178,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGeneratedBy"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;Appraiser"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/ProductsAndServices/ProductsAndServices.rdf
+++ b/FND/ProductsAndServices/ProductsAndServices.rdf
@@ -14,6 +14,7 @@
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/">
 	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-plc-rp "https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -38,6 +39,7 @@
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
 	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-plc-rp="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -58,6 +60,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -66,7 +69,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240101/ProductsAndServices/ProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241001/ProductsAndServices/ProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20150801/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report to replace MoneyAmount with AmountOfMoney.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified for the FIBO 2.0 RFC to add NegotiableCommodity and Consumer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified to include classes to support automated inclusion of all ISO 4217 codes published as of 2018-06-04.</skos:changeNote>
@@ -83,6 +86,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/ProductsAndServices/ProductsAndServices.rdf version of the ontology was modified to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/ProductsAndServices/ProductsAndServices.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/ProductsAndServices/ProductsAndServices.rdf version of the ontology was modified to replace the definition of real estate with the new definition in the real property ontology (LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -204,7 +208,7 @@
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Good">
 		<rdfs:label>good</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
+		<owl:disjointWith rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
 		<skos:definition>physical, produced item over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money or real estate</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://data.oecd.org/trade/trade-in-goods.htm</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/ucc/9/9-102#goods</cmns-av:adaptedFrom>

--- a/FND/ProductsAndServices/ProductsAndServices.rdf
+++ b/FND/ProductsAndServices/ProductsAndServices.rdf
@@ -208,7 +208,7 @@
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Good">
 		<rdfs:label>good</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
+		<owl:disjointWith rdf:resource="&fibo-fnd-plc-rp;RealEstate"/>
 		<skos:definition>physical, produced item over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money or real estate</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://data.oecd.org/trade/trade-in-goods.htm</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/ucc/9/9-102#goods</cmns-av:adaptedFrom>

--- a/LOAN/AllLOAN.rdf
+++ b/LOAN/AllLOAN.rdf
@@ -11,7 +11,8 @@
 	<!ENTITY fibo-loan-mod "https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/">
 	<!ENTITY fibo-loan-reln-cnst "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/">
 	<!ENTITY fibo-loan-reln-hmda "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/">
-	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
+	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
+	<!ENTITY fibo-loan-reln-org "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/">
 	<!ENTITY fibo-loan-spc-cns "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/">
 	<!ENTITY fibo-loan-spc-crd "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/">
 	<!ENTITY fibo-loan-spc-mar "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MarineFinance/">
@@ -35,7 +36,8 @@
 	xmlns:fibo-loan-mod="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/"
 	xmlns:fibo-loan-reln-cnst="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"
 	xmlns:fibo-loan-reln-hmda="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"
-	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
+	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
+	xmlns:fibo-loan-reln-org="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"
 	xmlns:fibo-loan-spc-cns="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/ConsumerLoans/"
 	xmlns:fibo-loan-spc-crd="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/"
 	xmlns:fibo-loan-spc-mar="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MarineFinance/"
@@ -61,7 +63,7 @@
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-09-06T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-10-19T18:00:00</dct:modified>
 		<dct:title>Financial Industry Business Ontology (FIBO) Loans (LOAN) Domain</dct:title>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"/>
@@ -77,7 +79,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/"/>
 		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for LOAN is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Loans (LOAN) domains, excluding individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</cmns-av:explanatoryNote>

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -151,7 +151,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isPrimaryContractFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;CollateralAgreement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">collateralized loan</rdfs:label>
@@ -531,7 +531,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;SecurityAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CollateralAgreement"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasEstimatedValue"/>

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -100,7 +100,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20230301/LoansGeneral/Loans.rdf version of this ontology was modified to eliminate a subproperty relationship between the principal and notional amount, which may not be appropriate (DER-127) and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20231201/LoansGeneral/Loans.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20240101/LoansGeneral/Loans.rdf version of this ontology was modified to move certain terms athat are general debt schedule terms to the Debt ontology (FBC-317).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20240301/LoansGeneral/Loans.rdf version of this ontology was modified to correct the distinction between amortization schedule and loan payment schedule (LOAN-168).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20240301/LoansGeneral/Loans.rdf version of this ontology was modified to correct the distinction between amortization schedule and loan payment schedule and move security agreement to the debt ontology (LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -129,6 +129,21 @@
 				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;isInitiallyPayable"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-dbt;SecurityAgreement">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;LenderLienPosition"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;OwnershipInterest"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>
@@ -517,7 +532,7 @@
 				<owl:unionOf rdf:parseType="Collection">
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-						<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;SecurityAgreement"/>
+						<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;SecurityAgreement"/>
 					</owl:Restriction>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-col;comprises"/>
@@ -528,37 +543,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>secured loan</rdfs:label>
 		<skos:definition>loan in which the borrower pledges some asset via a security agreement as collateral for the loan, or that is secured via third-party guarantee</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-ln-ln;SecurityAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasEstimatedValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;LenderLienPosition"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;OwnershipInterest"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-ln-ln;Loan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>security agreement</rdfs:label>
-		<skos:definition>agreement between parties that contains information about their relative duties and rights regarding the disposition of a specified asset used as collateral</skos:definition>
-		<cmns-av:adaptedFrom>ISO 20022</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;Servicer">

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -94,12 +94,13 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20240301/LoansGeneral/Loans/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20241001/LoansGeneral/Loans/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20220601/LoansGeneral/Loans.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20230201/LoansGeneral/Loans.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20230301/LoansGeneral/Loans.rdf version of this ontology was modified to eliminate a subproperty relationship between the principal and notional amount, which may not be appropriate (DER-127) and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20231201/LoansGeneral/Loans.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20240101/LoansGeneral/Loans.rdf version of this ontology was modified to move certain terms athat are general debt schedule terms to the Debt ontology (FBC-317).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20240301/LoansGeneral/Loans.rdf version of this ontology was modified to correct the distinction between amortization schedule and loan payment schedule (LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -331,7 +332,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;LoanPaymentSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;AmortizationSchedule"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasAnticipatedNumberOfPayments"/>
@@ -345,7 +346,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>loan payment schedule</rdfs:label>
-		<skos:definition>regular payment schedule associated with a given loan-specific account</skos:definition>
+		<skos:definition>regular or explicit (ad hoc) payment schedule associated with a given loan-specific account</skos:definition>
+		<cmns-av:explanatoryNote>Loan payment schedules may or may not be amortization schedules, i.e., they may or may not include principal.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;LoanPrincipal">

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -150,7 +150,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isPrimaryContractFor"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;CollateralAgreement"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/LOAN/LoansSpecific/LoanProducts.rdf
+++ b/LOAN/LoansSpecific/LoanProducts.rdf
@@ -18,7 +18,8 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 	<!ENTITY fibo-loan-ln-reg "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/">
-	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
+	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
+	<!ENTITY fibo-loan-reln-org "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/">
 	<!ENTITY fibo-loan-spc-prod "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -45,7 +46,8 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:fibo-loan-ln-reg="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"
-	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
+	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
+	xmlns:fibo-loan-reln-org="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"
 	xmlns:fibo-loan-spc-prod="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -68,7 +70,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
@@ -77,7 +80,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/LoanProducts/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;Loan">
@@ -153,7 +156,7 @@
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&fibo-fnd-pas-pas;Product">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-loan-reln-mtg;ChargeCategory">
+							<rdf:Description rdf:about="&fibo-loan-reln-org;ChargeCategory">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -321,7 +324,7 @@
 		<skos:editorialNote>Future consideration: move this property to ProductsAndServices ontology (fibo-fnd-pas-pas).</skos:editorialNote>
 	</owl:ObjectProperty>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;MortgageLoanPurpose">
+	<owl:Class rdf:about="&fibo-loan-reln-org;MortgageLoanPurpose">
 		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-prod;LoanPurpose"/>
 	</owl:Class>
 

--- a/LOAN/LoansSpecific/LoanProducts.rdf
+++ b/LOAN/LoansSpecific/LoanProducts.rdf
@@ -274,7 +274,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isExemplifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/LOAN/RealEstateLoans/ConstructionLoans.rdf
+++ b/LOAN/RealEstateLoans/ConstructionLoans.rdf
@@ -8,6 +8,7 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-plc-rp "https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ev "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
@@ -27,6 +28,7 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-plc-rp="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ev="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
@@ -45,6 +47,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
@@ -53,10 +56,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-fnd-plc-loc;RealEstate">
+	<owl:Class rdf:about="&fibo-fnd-plc-rp;RealProperty">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>

--- a/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
+++ b/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
@@ -2,11 +2,15 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -25,11 +29,15 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -49,7 +57,9 @@
 		<rdfs:label>Home Mortgage Disclosure Act (HMDA) Covered Mortgages Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts specific to mortgages that are covered by the Home Mortgage Disclosure Act (HMDA) and related regulations. This includes the concept of a HMDA report as well as specializations of the core classes for pre-approval requests, covered loan contracts.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
@@ -60,7 +70,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -211,6 +223,27 @@
 		</rdfs:subClassOf>
 		<rdfs:label>race</rdfs:label>
 		<skos:definition>a category based on a person&apos;s physical characteristics, such as bone structure and skin, hair, or eye color</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-hmda;UniversalLoanIdentifier">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;FinancialInstrumentIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onClass rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>universal loan identifier</rdfs:label>
+		<skos:definition>unique identifier given to unequivocally identify a specific loan secured by real estate</skos:definition>
+		<cmns-av:explanatoryNote>In the US, the structure of this identifier is defined in the 2015 revision to the Home Mortgage Disclosure Act.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-reln-hmda;hasHMDA-DispositionDate">

--- a/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
+++ b/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
@@ -15,7 +15,7 @@
 	<!ENTITY fibo-loan-ln-app "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 	<!ENTITY fibo-loan-reln-hmda "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/">
-	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
+	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -38,7 +38,7 @@
 	xmlns:fibo-loan-ln-app="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:fibo-loan-reln-hmda="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"
-	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
+	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -57,7 +57,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>

--- a/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
+++ b/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
@@ -81,7 +81,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;HMDA-CoveredLoanContract">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>

--- a/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans.rdf
+++ b/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans.rdf
@@ -26,12 +26,12 @@
 		<dct:abstract>This module contains ontologies defining concepts that apply to loans related to land and anything permanently attached to it, whether natural or man-made, including but not limited to construction loans.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-03-31T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-10-19T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230301/RealEstateLoans/MetadataLOANRealEstateLoans/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20241001/RealEstateLoans/MetadataLOANRealEstateLoans/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mod;RealEstateLoansModule">
@@ -50,13 +50,14 @@
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
-		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"/>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO LOAN Real Estate Loans Module</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Loans (LOAN) Real Estate Loans Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/RealEstateLoans/MortgageOrigination.rdf
+++ b/LOAN/RealEstateLoans/MortgageOrigination.rdf
@@ -28,14 +28,15 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-app "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
-	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
+	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
+	<!ENTITY fibo-loan-reln-org "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
@@ -64,14 +65,15 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-app="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
-	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
+	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
+	xmlns:fibo-loan-reln-org="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/">
 		<rdfs:label xml:lang="en">Mortgage Loans Ontology</rdfs:label>
 		<dct:abstract>Loans that have collateral posted as security and where that collateral is real estate, and the real estate which makes up the collateral is purchased with the funds loaned. This ontology covers a range of mortgage concepts and parties, along with catewgories of mortgage loan purpose (remortgage, second home etc.).</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
@@ -92,8 +94,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
@@ -102,178 +104,130 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-fnd-plc-loc;RealEstate">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasEstimatedValue"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddress"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;RealPropertyAppraisal"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;hasNumberOfAffordableDwellingUnits"/>
-				<owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;hasNumberOfDwellingUnits"/>
-				<owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;DwellingCapacity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;AmortizationType">
+	<owl:Class rdf:about="&fibo-loan-reln-org;AmortizationType">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>amortization type</rdfs:label>
 		<skos:definition>classifier of amortization algorithms</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-adjustableRate">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AmortizationType-adjustableRate">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AmortizationType"/>
 		<rdfs:label>adjustable rate</rdfs:label>
 		<skos:definition>a loan that allows the lender to periodically adjust the interest rate in accordance with a specified index</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-fixedRate">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AmortizationType-fixedRate">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AmortizationType"/>
 		<rdfs:label>fixed rate</rdfs:label>
 		<skos:definition>a loan in which the interest rate and payments remain the same for the life of the loan</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-graduatedPayment">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AmortizationType-graduatedPayment">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AmortizationType"/>
 		<rdfs:label>graduated payment</rdfs:label>
 		<skos:definition>a flexible payment loan where the payments increase for a specified period of time and then level off</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Usually involves negative amortization.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-graduatedPaymentAdjustable">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AmortizationType-graduatedPaymentAdjustable">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AmortizationType"/>
 		<rdfs:label>graduated payment adjustable</rdfs:label>
 		<skos:definition>a loan for which there are periodic payments/rate changes with additional specified principal and interest changes as documented in the Security Instruments.</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-growingEquity">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AmortizationType-growingEquity">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AmortizationType"/>
 		<rdfs:label>growing equity</rdfs:label>
 		<skos:definition>A graduated payment loan in which increases in a borrowers loan payments are used to accelerate reduction of principal on the mortgage</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Due to increased payment, the borrower acquires equity more rapidly and retires the debt earlier.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-rateImprovement">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AmortizationType-rateImprovement">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AmortizationType"/>
 		<rdfs:label>rate improvement</rdfs:label>
 		<skos:definition>a type of flexible loan where the interest rate may decrease based on payment history.</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AmortizationType-step">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AmortizationType"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AmortizationType-step">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AmortizationType"/>
 		<rdfs:label>step</rdfs:label>
 		<skos:definition>a loan with fixed periodic payment/rate changes without subsidy or negative amortization.</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem">
+	<owl:Class rdf:about="&fibo-loan-reln-org;AutomatedUnderwritingSystem">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-aap-agt;AutomatedSystem"/>
 		<rdfs:label>automated underwriting system</rdfs:label>
 		<skos:definition>software system that collects the information necessary to approve a loan application and supports a mortgage lender&apos;s analysis of a new loan application</skos:definition>
 		<cmns-av:explanatoryNote>In the United States, automated underwriting systems review the applicant&apos;s credit history and ability to repay the loan, and determine whether the price the applicant is offering to pay is supported by the property value.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem-DesktopUnderwriter">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AutomatedUnderwritingSystem-DesktopUnderwriter">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AutomatedUnderwritingSystem"/>
 		<rdfs:label>Desktop Underwriter</rdfs:label>
 		<skos:definition>an automated underwriting software system produced by Fannie Mae</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem-FHAScorecard">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AutomatedUnderwritingSystem-FHAScorecard">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AutomatedUnderwritingSystem"/>
 		<rdfs:label>FHA Scorecard</rdfs:label>
 		<skos:definition>an automated underwriting software system produced by Federal Housing Administration (FHA)</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem-GuaranteedUnderwritingSystem">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AutomatedUnderwritingSystem-GuaranteedUnderwritingSystem">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AutomatedUnderwritingSystem"/>
 		<rdfs:label>Guaranteed Underwriting System</rdfs:label>
 		<skos:definition>an automated underwriting software system used by the USDA rural development loan program</skos:definition>
 		<cmns-av:synonym>GUS</cmns-av:synonym>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem-LoanProspector">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;AutomatedUnderwritingSystem"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;AutomatedUnderwritingSystem-LoanProspector">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;AutomatedUnderwritingSystem"/>
 		<rdfs:label>Loan Prospector</rdfs:label>
 		<skos:definition>an automated underwriting software system produced by Freddie Mac</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;CashOutStatus">
+	<owl:Class rdf:about="&fibo-loan-reln-org;CashOutStatus">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>cash-out status</rdfs:label>
 		<skos:definition>classifier indicating the extent to which funds are released to the borrower on a new loan origination that refinances an existing loan</skos:definition>
 		<cmns-av:explanatoryNote>This is subject to lender and/or investor policy(s).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;CashOutStatus-CashOut">
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;CashOutStatus-CashOut">
 		<rdf:type rdf:resource="&owl;Thing"/>
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;CashOutStatus"/>
+		<rdf:type rdf:resource="&fibo-loan-reln-org;CashOutStatus"/>
 		<rdfs:label>cashout</rdfs:label>
 		<skos:definition>the mortgage is refinanced for more than is owed and the borrower pockets the difference.</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;CashOutStatus-LimitedCashOut">
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;CashOutStatus-LimitedCashOut">
 		<rdf:type rdf:resource="&owl;Thing"/>
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;CashOutStatus"/>
+		<rdf:type rdf:resource="&fibo-loan-reln-org;CashOutStatus"/>
 		<rdfs:label>limited cashout</rdfs:label>
 		<skos:definition>a cashout mortgage where the amount is limited by the lenger. 80% loan to value ratio is a common limit.</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;CashOutStatus-NoCashOut">
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;CashOutStatus-NoCashOut">
 		<rdf:type rdf:resource="&owl;Thing"/>
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;CashOutStatus"/>
+		<rdf:type rdf:resource="&fibo-loan-reln-org;CashOutStatus"/>
 		<rdfs:label>no cashout</rdfs:label>
 		<skos:definition>The mortgage is refinanced for less than or equal to what is owed.</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;ChargeCategory">
+	<owl:Class rdf:about="&fibo-loan-reln-org;ChargeCategory">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>charge category</rdfs:label>
 		<skos:definition>Examples include closing costs, interest, taxes, and other service-related fees.</skos:definition>
@@ -281,207 +235,96 @@
 		<cmns-av:usageNote>Use with LineItem, (has ChargeCategory instance), (hasNumericalValue for number of units) and (hasCost for the amount of money)</cmns-av:usageNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ChargeCategory-appraisalFee">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ChargeCategory"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;ChargeCategory-appraisalFee">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;ChargeCategory"/>
 		<rdfs:label>appraisal fee</rdfs:label>
 		<skos:definition>a charge for an appraisal</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ChargeCategory-discountPoints">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ChargeCategory"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;ChargeCategory-discountPoints">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;ChargeCategory"/>
 		<rdfs:label>discount points</rdfs:label>
 		<skos:definition>a charge for lowering your interest rate</skos:definition>
 		<cmns-av:adaptedFrom>https://www.consumerfinance.gov/askcfpb/136/what-are-discount-points-and-lender-credits-and-how-do-they-work.html</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ChargeCategory-lenderCredits">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ChargeCategory"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;ChargeCategory-lenderCredits">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;ChargeCategory"/>
 		<rdfs:label>lender credits</rdfs:label>
 		<skos:definition>a credit whereby the lender reduces closing costs in exchange for a higher interest rate.</skos:definition>
 		<cmns-av:adaptedFrom>https://www.consumerfinance.gov/askcfpb/136/what-are-discount-points-and-lender-credits-and-how-do-they-work.html</cmns-av:adaptedFrom>
 		<cmns-av:usageNote>This needs to be treated as a negative charge.</cmns-av:usageNote>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ChargeCategory-originationFee">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ChargeCategory"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;ChargeCategory-originationFee">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;ChargeCategory"/>
 		<rdfs:label>origination fee</rdfs:label>
 		<skos:definition>a charge for an origination</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ChargeCategory-principal">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ChargeCategory"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;ChargeCategory-principal">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;ChargeCategory"/>
 		<rdfs:label>principal</rdfs:label>
 		<skos:definition>the principal of the loan that is owed</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;DwellingCapacity">
+	<owl:Class rdf:about="&fibo-loan-reln-org;DwellingCapacity">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>dwelling capacity</rdfs:label>
 		<skos:definition>classifier indicating how many dwellings some property has</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;DwellingCapacity-multiFamily">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;DwellingCapacity"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;DwellingCapacity-multiFamily">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;DwellingCapacity"/>
 		<rdfs:label>multi-family</rdfs:label>
 		<skos:definition>5 or more units</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;DwellingCapacity-singleFamily">
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;DwellingCapacity-singleFamily">
 		<rdf:type rdf:resource="&owl;Thing"/>
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;DwellingCapacity"/>
+		<rdf:type rdf:resource="&fibo-loan-reln-org;DwellingCapacity"/>
 		<rdfs:label>single family</rdfs:label>
 		<skos:definition>1-4 units</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;GovernmentSponsoredLoan">
+	<owl:Class rdf:about="&fibo-loan-reln-org;GovernmentSponsoredLoan">
 		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
 		<rdfs:label xml:lang="en">government-sponsored loan</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification">
+	<owl:Class rdf:about="&fibo-loan-reln-org;ManufacturedHomeLegalClassification">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>manufactured home legal classification</rdfs:label>
 		<skos:definition>category indicating whether the covered loan is secured by a manufactured home only or with land as well</skos:definition>
 		<cmns-av:adaptedFrom>2015 Revised HMDA regulation</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification-personalProperty">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;ManufacturedHomeLegalClassification-personalProperty">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;ManufacturedHomeLegalClassification"/>
 		<rdfs:label>personal property</rdfs:label>
 		<skos:definition>the covered loan is secured by a manufactured home but not land</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification-realProperty">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;ManufacturedHomeLegalClassification"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;ManufacturedHomeLegalClassification-realProperty">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;ManufacturedHomeLegalClassification"/>
 		<rdfs:label>real property</rdfs:label>
 		<skos:definition>the covered loan is secured by a manufactured home and land</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;Mortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-ln;ClosedEndCredit"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-ln;CollateralizedLoan"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;isServicedBy"/>
-				<owl:onClass rdf:resource="&fibo-loan-ln-ln;Servicer"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;assumes"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-gty;hasGuarantor"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;MortgageIndemnityGuarantor"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;UniversalLoanIdentifier"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;hasClosingDate"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;Date"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;hasOriginatingServiceProvider"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
-							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
-								<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;NMLSR-ID"/>
-							</owl:Restriction>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;hasOriginatorPerson"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-le-lp;LegallyCompetentNaturalPerson">
-							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
-								<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;NMLSR-ID"/>
-							</owl:Restriction>
-						</owl:intersectionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>mortgage</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:intersectionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-loan-ln-ln;Loan">
-					</rdf:Description>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-						<owl:someValuesFrom>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-loan-ln-ln;SecurityAgreement">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
-										<owl:someValuesFrom>
-											<owl:Class>
-												<owl:intersectionOf rdf:parseType="Collection">
-													<rdf:Description rdf:about="&fibo-fbc-dae-dbt;PhysicalCollateral">
-													</rdf:Description>
-													<owl:Restriction>
-														<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-														<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
-													</owl:Restriction>
-												</owl:intersectionOf>
-											</owl:Class>
-										</owl:someValuesFrom>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
-						</owl:someValuesFrom>
-					</owl:Restriction>
-				</owl:intersectionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition>a loan contract that is secured by real property</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition probably incomplete. Mortgage is not only securitized on the real estate but is used to fund the purchase of that real estate. Not sure of the best form of wording.</skos:editorialNote>
-		<cmns-av:adaptedFrom>the Cambridge Business English Dictionary</cmns-av:adaptedFrom>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;MortgageIndemnityGuarantee">
+	<owl:Class rdf:about="&fibo-loan-reln-org;MortgageIndemnityGuarantee">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-gty;InsuranceBackedGuaranty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-gty;isGuaranteedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;MortgageIndemnityGuarantor"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-org;MortgageIndemnityGuarantor"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isExemplifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;MortgageIndemnityInsurancePolicy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-org;MortgageIndemnityInsurancePolicy"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">mortgage indemnity guarantee</rdfs:label>
@@ -489,7 +332,7 @@
 		<skos:editorialNote xml:lang="en">See notes from SME Review and in MIG Provider. Applies to securitized pool, insures the lender. Additional note (IBM): there is a further application of this. When a lender takes a loan which is a where the value of the loan is greater than 80% of the value of the property, at that point it is required for the lender to also get a private mortgage insurance, so they are paying separately for the mortgage insurance so that if the borrower defaults above 80% then the mortgage insurance pays the loss. In the Loan Party Insurer (new &quot;Party&quot; type) you have Loan Party Insured Ratio (e.g. the 80% in the example above). These are different situations but the same principle. So this needs to be modeled for both. 30 June: Is this Lender or Borrower? since you have one lender and one borrower in a single loan, but multiple lenders in the case of packaging this up for a security - there are then multiple lenders and multiple borrowers. A similar kind of insurance exists in the one lender one borrower scenario i.e. the mortgage loan itself. There are two concepts here. the MIG thing was for bundling these. the MIG might apply across multiple contracts, but still be a fact about &quot;the&quot; contract? The notes about 80% above (IBM) are about the individual loan. ACTION: Tidy this up.</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;MortgageIndemnityGuarantor">
+	<owl:Class rdf:about="&fibo-loan-reln-org;MortgageIndemnityGuarantor">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-gty;Guarantor"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-gty;Insurer"/>
 		<rdfs:label xml:lang="en">mortgage indemnity guarantor</rdfs:label>
@@ -497,55 +340,55 @@
 		<cmns-av:explanatoryNote xml:lang="en">SME Review notes 16 Sept: Guaranty - mortgage insurance e.g. insure up to 80% exposure. When you get into indemnification, then for instance if the product doesn&apos;t meet the investor&apos;s requirement such that if it doesn&apos;t get paid then the lender steps in and takes the hit for the loan - this is usually a precondition for securitizing (issuing) the loan in a pool. If the loan is not going to be sold on the secondary market there would be no need to indemnify that loan so this term would not apply. Indemnification is insurance for the investor, while the lender is the one providing that indemnification.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;MortgageIndemnityInsurancePolicy">
+	<owl:Class rdf:about="&fibo-loan-reln-org;MortgageIndemnityInsurancePolicy">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-gty;InsurancePolicy"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidenceFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;MortgageIndemnityGuarantee"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-org;MortgageIndemnityGuarantee"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">mortgage indemnity insurance policy</rdfs:label>
 		<skos:definition xml:lang="en">insurance policy providing the mortgage indemnity guarantee</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;MortgageLoanPurpose">
+	<owl:Class rdf:about="&fibo-loan-reln-org;MortgageLoanPurpose">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>mortgage loan purpose</rdfs:label>
 		<skos:definition>the purpose for which mortgage loan proceeds will be used, such as real property purchase, dwelling construction, or loan refinancing</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;MortgageLoanPurpose-BusinessOrCommercial">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;MortgageLoanPurpose"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;MortgageLoanPurpose-BusinessOrCommercial">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;MortgageLoanPurpose"/>
 		<rdfs:label>business or commercial</rdfs:label>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;MortgageLoanPurpose-DwellingConstruction">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;MortgageLoanPurpose"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;MortgageLoanPurpose-DwellingConstruction">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;MortgageLoanPurpose"/>
 		<rdfs:label>dwelling construction</rdfs:label>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;MortgageLoanPurpose-HomeImprovement">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;MortgageLoanPurpose"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;MortgageLoanPurpose-HomeImprovement">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;MortgageLoanPurpose"/>
 		<rdfs:label>home improvement</rdfs:label>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;MortgageLoanPurpose-LoanRefinancing">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;MortgageLoanPurpose"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;MortgageLoanPurpose-LoanRefinancing">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;MortgageLoanPurpose"/>
 		<rdfs:label>loan refinancing</rdfs:label>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;MortgageLoanPurpose-MortgageModification">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;MortgageLoanPurpose"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;MortgageLoanPurpose-MortgageModification">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;MortgageLoanPurpose"/>
 		<rdfs:label>mortgage modification</rdfs:label>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;MortgageLoanPurpose-RealPropertyPurchase">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;MortgageLoanPurpose"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;MortgageLoanPurpose-RealPropertyPurchase">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;MortgageLoanPurpose"/>
 		<rdfs:label>real property purchase</rdfs:label>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;NMLSR-ID">
+	<owl:Class rdf:about="&fibo-loan-reln-org;NMLSR-ID">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LicenseIdentifier"/>
 		<rdfs:label>Nationwide Mortgage Licensing System and Registry Identifier</rdfs:label>
 		<skos:definition>the number permanently assigned by the Nationwide Mortgage Licensing System and Registry (NMLS) for each company, branch, and individual that maintains a single account on NMLS.</skos:definition>
@@ -553,146 +396,51 @@
 		<cmns-av:adaptedFrom>http://mortgage.nationwidelicensingsystem.org/about/Pages/NMLSID.aspx</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;PropertyInspection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&cmns-pts;PartyRole"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;isInspectionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>property inspection</rdfs:label>
-		<skos:definition>assessment activity that involves analyzing one or more aspects of a real property for independent assessment of status or deficiency</skos:definition>
-		<cmns-av:explanatoryNote>This is independent and separate from conducting an appraisal. Examples are termite inspections, construction inspections, etc.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;PropertyUsage">
+	<owl:Class rdf:about="&fibo-loan-reln-org;PropertyUsage">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>property usage</rdfs:label>
 		<skos:definition>a category indicating the manner in which the borrower intends to utilize the property</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;PropertyUsage-investment">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;PropertyUsage"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;PropertyUsage-investment">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;PropertyUsage"/>
 		<rdfs:label>investment</rdfs:label>
 		<skos:definition>a home owned for the purpose of generating income</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;PropertyUsage-primaryResidence">
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;PropertyUsage"/>
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;PropertyUsage-primaryResidence">
+		<rdf:type rdf:resource="&fibo-loan-reln-org;PropertyUsage"/>
 		<rdfs:label>primary residence</rdfs:label>
 		<skos:definition>residence that the owner physically occupies and uses as his or her principal residence</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-loan-reln-mtg;PropertyUsage-secondHome">
+	<owl:NamedIndividual rdf:about="&fibo-loan-reln-org;PropertyUsage-secondHome">
 		<rdf:type rdf:resource="&owl;Thing"/>
-		<rdf:type rdf:resource="&fibo-loan-reln-mtg;PropertyUsage"/>
+		<rdf:type rdf:resource="&fibo-loan-reln-org;PropertyUsage"/>
 		<rdfs:label>second home</rdfs:label>
 		<skos:definition>a property occupied by the owner for a portion of the year that is not the primary residence</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;RealPropertyAppraisal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;ValueAssessment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;PropertyInspection"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasAppraiser"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;Appraiser"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;hasAppraisedValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>real property appraisal</rdfs:label>
-		<skos:definition>value assessment that estimates the amount of money a real estate property is worth</skos:definition>
-		<skos:editorialNote>Ensure that the appraiser parties have NMLS Identifier and contact preferences, e.g. phone number and address. As needed, connect appraisers to an appraisal management company.</skos:editorialNote>
-		<skos:editorialNote>Future consideration: add information about variability analysis and maybe the algorithm used.</skos:editorialNote>
-		<cmns-av:explanatoryNote>The valuation uses one or more methodologies and is conducted by an appraiser or technology with a logical model that performs the same function.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;ReverseMortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;hasCreditLimit"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">reverse mortgage</rdfs:label>
-		<rdfs:label>reverse mortgage</rdfs:label>
-		<skos:definition>mortgage contract that pays out money to the borrower against a set principal limit that is based on the value of existing equity in the underlying collateral.</skos:definition>
-		<cmns-av:explanatoryNote>A reverse mortgage and an open end loan both have a credit limit.</cmns-av:explanatoryNote>
-		<cmns-av:explanatoryNote>The interest is added to the principal balance.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;UniversalLoanIdentifier">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;FinancialInstrumentIdentifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&fibo-loan-ln-ln;Loan"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>universal loan identifier</rdfs:label>
-		<skos:definition>a unique identifier given to unequivocally identify a specific mortgage loan.</skos:definition>
-		<cmns-av:explanatoryNote>In the US, the structure of this identifier is defined in the 2015 revision to the Home Mortgage Disclosure Act.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;assumes">
+	<owl:ObjectProperty rdf:about="&fibo-loan-reln-org;assumes">
 		<rdfs:label>assumes</rdfs:label>
 		<skos:definition>relates a new mortgage loan contract to a previous one made to a different borrower for the same property. The new contract is created via a legally binding process where the new borrower assumes the terms of the previous loan contract</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;hasAppraisedValue">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
-		<rdfs:label>has appraised value</rdfs:label>
-		<skos:definition>relates to a monetary amount that is the product of a valuation event</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;hasClosingDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasEffectiveDate"/>
-		<rdfs:label>has closing date</rdfs:label>
-		<skos:definition>relates, e.g. a loan contract to the date on which the contract is consummated, officially creating the obligations therein</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-reln-mtg;hasNumberOfAffordableDwellingUnits">
-		<rdfs:subPropertyOf rdf:resource="&fibo-loan-reln-mtg;hasNumberOfDwellingUnits"/>
+	<owl:DatatypeProperty rdf:about="&fibo-loan-reln-org;hasNumberOfAffordableDwellingUnits">
+		<rdfs:subPropertyOf rdf:resource="&fibo-loan-reln-org;hasNumberOfDwellingUnits"/>
 		<rdfs:label>has number of affordable dwelling units</rdfs:label>
 		<skos:definition>relates real estate to the number of dwelling units it contains that are income-restricted under Federal, State, or local affordable housing programs.</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-reln-mtg;hasNumberOfDwellingUnits">
+	<owl:DatatypeProperty rdf:about="&fibo-loan-reln-org;hasNumberOfDwellingUnits">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasCount"/>
 		<rdfs:label>has number of dwelling units</rdfs:label>
 		<skos:definition>relates real estate to the number of dwelling units it contains</skos:definition>
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;hasOriginatingServiceProvider">
+	<owl:ObjectProperty rdf:about="&fibo-loan-reln-org;hasOriginatingServiceProvider">
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasPartyRole"/>
 		<rdfs:label>has originating service provider</rdfs:label>
 		<rdfs:range>
@@ -715,27 +463,100 @@
 		<cmns-av:explanatoryNote>Typically this will be a bank, mortgage broker, investment bank, or other similar party.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;hasOriginatorPerson">
+	<owl:ObjectProperty rdf:about="&fibo-loan-reln-org;hasOriginatorPerson">
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasParty"/>
 		<rdfs:label>has originator person</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
 		<skos:definition>relates something, typically a loan, to a person that initially originates or creates it</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-reln-mtg;isARMConvertible">
-		<rdfs:label xml:lang="en">is ARM convertible</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-ln-ln;Loan"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">indicates whether or not the mortgage can be converted into an adjustable-rate mortgage (ARM)</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;isInspectionOf">
-		<rdfs:label>is inspection of</rdfs:label>
-		<skos:definition>relates an inspection to the thing being inspected</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;isLienOn">
+	<owl:ObjectProperty rdf:about="&fibo-loan-reln-org;isLienOn">
 		<rdfs:label>is lien on</rdfs:label>
 	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;Mortgage">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;isServicedBy"/>
+				<owl:onClass rdf:resource="&fibo-loan-ln-ln;Servicer"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-gty;hasGuarantor"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-org;MortgageIndemnityGuarantor"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-loan-reln-org;assumes"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-loan-reln-org;hasOriginatingServiceProvider"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+								<owl:someValuesFrom rdf:resource="&fibo-loan-reln-org;NMLSR-ID"/>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-loan-reln-org;hasOriginatorPerson"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-be-le-lp;LegallyCompetentNaturalPerson">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+								<owl:someValuesFrom rdf:resource="&fibo-loan-reln-org;NMLSR-ID"/>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;RealProperty">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-loan-reln-org;hasNumberOfAffordableDwellingUnits"/>
+				<owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-loan-reln-org;hasNumberOfDwellingUnits"/>
+				<owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-org;DwellingCapacity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-org;ManufacturedHomeLegalClassification"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
 
 </rdf:RDF>

--- a/LOAN/RealEstateLoans/MortgageOrigination.rdf
+++ b/LOAN/RealEstateLoans/MortgageOrigination.rdf
@@ -288,7 +288,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-org;GovernmentSponsoredLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 		<rdfs:label xml:lang="en">government-sponsored loan</rdfs:label>
 	</owl:Class>
 	
@@ -474,7 +474,7 @@
 		<rdfs:label>is lien on</rdfs:label>
 	</owl:ObjectProperty>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;Mortgage">
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;LoanSecuredByRealEstate">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;isServicedBy"/>
@@ -492,7 +492,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-loan-reln-org;assumes"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
-	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -23,13 +19,9 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
-	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -47,9 +39,7 @@
 		<rdfs:label xml:lang="en">Mortgages Ontology</rdfs:label>
 		<dct:abstract>This ontology covers high-level concepts related to loans secured by real property.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -57,9 +47,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
@@ -154,27 +142,6 @@
 		<rdfs:label>reverse mortgage loan</rdfs:label>
 		<skos:definition>loan secured by real estate that pays money to the borrower against a set principal limit based on the value of existing equity in the underlying collateral</skos:definition>
 		<cmns-av:explanatoryNote>The interest accrued is added to the principal balance.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;UniversalLoanIdentifier">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;FinancialInstrumentIdentifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>universal loan identifier</rdfs:label>
-		<skos:definition>unique identifier given to unequivocally identify a specific loan secured by real estate</skos:definition>
-		<cmns-av:explanatoryNote>In the US, the structure of this identifier is defined in the 2015 revision to the Home Mortgage Disclosure Act.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;hasInitialFundingDate">

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -10,6 +10,7 @@
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
+	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
@@ -36,6 +37,7 @@
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
+	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
@@ -60,6 +62,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
@@ -125,7 +128,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;RealProperty">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PhysicalAsset"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;PhysicalAsset"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-fpas;isEmbodiedIn"/>

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -9,6 +9,7 @@
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
+	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
@@ -34,6 +35,7 @@
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
+	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
@@ -57,6 +59,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
@@ -125,7 +128,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PhysicalAsset"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isEmbodiedIn"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-fpas;isEmbodiedIn"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-loc;Parcel"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -88,7 +88,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;AssetSpecificCollateralAgreement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;SecurityAgreement"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>loan secured by real estate</rdfs:label>
@@ -102,7 +102,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;Mortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;AssetSpecificCollateralAgreement"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;SecurityAgreement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -134,7 +134,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&fibo-loan-ln-ln;Loan"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -146,13 +146,13 @@
 	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;hasInitialFundingDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasEffectiveDate"/>
 		<rdfs:label>has initial funding date</rdfs:label>
-		<skos:definition>relates, e.g. a loan contract to the date on which the contract is consummated, officially creating the obligations therein</skos:definition>
+		<skos:definition>relates a mortgage to the date on which the contract is consummated, officially creating the obligations therein</skos:definition>
 		<cmns-av:synonym>has closing date</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-loan-reln-mtg;isARMConvertible">
 		<rdfs:label xml:lang="en">is ARM convertible</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-ln-ln;Loan"/>
+		<rdfs:domain rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">indicates whether or not the mortgage can be converted into an adjustable-rate mortgage (ARM)</skos:definition>
 	</owl:DatatypeProperty>

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -9,7 +9,6 @@
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
-	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -36,7 +35,6 @@
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
-	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -61,7 +59,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -112,14 +109,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentActivity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&cmns-pts;PartyRole"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;RealProperty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;isInspectionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;RealProperty"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:someValuesFrom rdf:resource="&cmns-pts;PartyRole"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>property inspection</rdfs:label>
@@ -131,7 +128,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;PhysicalAsset"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-fpas;isEmbodiedIn"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasRegion"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-loc;Parcel"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -159,7 +156,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasAppraiser"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGeneratedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;Appraiser"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -216,10 +213,5 @@
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">indicates whether or not the mortgage can be converted into an adjustable-rate mortgage (ARM)</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;isInspectionOf">
-		<rdfs:label>is inspection of</rdfs:label>
-		<skos:definition>relates an inspection to the thing being inspected</skos:definition>
-	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -15,6 +15,7 @@
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-plc-rp "https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
@@ -41,6 +42,7 @@
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-plc-rp="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
@@ -65,6 +67,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
@@ -91,7 +94,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;RealProperty"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -103,47 +106,6 @@
 		<rdfs:label>mortgage</rdfs:label>
 		<skos:definition>collateralized loan and closed-end credit agreement that is secured by the title of some real property, specifically a home, plot of land, or other asset</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">The borrower agrees to pay the lender over time, typically in a series of regular payments divided into principal and interest. The property then serves as collateral to secure the loan.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;RealProperty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;PhysicalAsset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasRegion"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-loc;Parcel"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isEvaluatedBy"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;RealPropertyAppraisal"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">real property</rdfs:label>
-		<skos:definition xml:lang="en">land together with any structures that are permanently attached to that land, such as houses, trees, fences and other improvements</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">Real property typically encompasses both the physical land and everything that lies above, below, or on its surface. There are cases, such as condominiums, in which the interior of the structure is owned by a party that may not own the land. There are also cases in which certain long-term leases have similar characteristics to ownership, but are time-bound.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;RealPropertyAppraisal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;Appraisal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;PropertyInspection"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGeneratedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;Appraiser"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>real property appraisal</rdfs:label>
-		<skos:definition>value assessment that estimates the amount of money some real property is worth</skos:definition>
-		<cmns-av:explanatoryNote>The valuation uses one or more methodologies and is conducted by an appraiser or technology with a logical model that performs the same function.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;ReverseMortgage">

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -2,21 +2,16 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
-	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
-	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
-	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
-	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
 	<!ENTITY fibo-fnd-plc-rp "https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
@@ -29,21 +24,16 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
-	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
-	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
-	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
-	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
 	xmlns:fibo-fnd-plc-rp="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
@@ -54,43 +44,47 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
-		<rdfs:label xml:lang="en">Mortgage Loans Ontology</rdfs:label>
-		<dct:abstract>Loans that have collateral posted as security and where that collateral is real estate, and the real estate which makes up the collateral is purchased with the funds loaned. This ontology covers a range of mortgage concepts and parties, along with catewgories of mortgage loan purpose (remortgage, second home etc.).</dct:abstract>
+		<rdfs:label xml:lang="en">Mortgages Ontology</rdfs:label>
+		<dct:abstract>This ontology covers high-level concepts related to loans secured by real property.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;Mortgage">
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;ClosedEndMortgageLoan">
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-ln;ClosedEndCredit"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
+		<rdfs:label>closed-end mortgage loan</rdfs:label>
+		<skos:definition>loan secured by real estate with no ability for the borrower to receive additional funds under the loan at a later date</skos:definition>
+		<cmns-av:adaptedFrom>MISMO Business Glossary, available at https://www.mismo.org/standards-resources/business-glossary/</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;ClosedEndReverseMortgage">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;ClosedEndMortgageLoan"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;ReverseMortgageLoan"/>
+		<rdfs:label>closed-end reverse mortgage</rdfs:label>
+		<dct:source>Instructions for the Preparation of Consolidated Reports of Condition and Income, FFIEC 031 and FFIEC 041, Updated March 2023, clause A-91</dct:source>
+		<skos:definition>reverse mortgage that provides a lump sum payment to the borrower at closing, with no ability for the borrower to receive additional funds under the mortgage at a later date</skos:definition>
+		<cmns-av:explanatoryNote>Normally, closed-end reverse mortgages are first liens.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;LoanSecuredByRealEstate">
 		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-ln;CollateralizedLoan"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;UniversalLoanIdentifier"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
@@ -103,23 +97,63 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;TransactionDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>mortgage</rdfs:label>
-		<skos:definition>collateralized loan and closed-end credit agreement that is secured by the title of some real property, specifically a home, plot of land, or other asset</skos:definition>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;AssetSpecificCollateralAgreement"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>loan secured by real estate</rdfs:label>
+		<dct:source>Consolidated Reports of Condition and Income for a Bank with Domestic and Foreign Offices—FFIEC 031; Board of Governors of the Federal Reserve System OMB Number 7100-0036, Federal Deposit Insurance Corporation OMB Number 3064-0052, Office of the Comptroller of the Currency OMB Number 1557-0081, dated 20240930</dct:source>
+		<dct:source>Instructions for the Preparation of Consolidated Reports of Condition and Income, FFIEC 031 and FFIEC 041, Updated March 2023, clause A-91</dct:source>
+		<skos:definition>loan that, at origination, is secured wholly or substantially by a lien or liens on real property for which the lien or liens are central to the extension of the credit - that is, the borrower would not have been extended credit in the same amount or on terms as favorable without the lien or liens on real property</skos:definition>
+		<skos:example xml:lang="en">Examples include (a) Construction, land development, and other land loans: (1) 1-4 family residential construction loans, and (2) Other construction loans and all land development and other land loans; (b) Secured by farmland (including farm residential and other improvements); (c) Secured by 1-4 family residential properties: (1) Revolving, open-end loans secured by 1-4 family residential properties and extended under lines of credit, and (2) Closed-end loans secured by 1-4 family residential properties including those secured by first liens and those secured by junior liens; (d) Secured by multifamily (5 or more) residential properties; and (e) Secured by nonfarm nonresidential properties: (1) Loans secured by owner-occupied nonfarm nonresidential, and (2) Loans secured by other nonfarm nonresidential properties.</skos:example>
+		<cmns-av:explanatoryNote xml:lang="en">In general parlance, loans secured by real estate are often called mortgages or mortgage loans. This usage conflates a number of related concepts, which would limit the usability of FIBO for financial institutions and regulators with respect to such loans. As described herein, many different kinds of loans can be secured by real estate, including various commercial, construction, agricultural, and consumer loans.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">In the US, to be considered wholly or substantially secured by a lien or liens on real property, the estimated value of the real estate collateral at origination (after deducting any more senior liens held by others) must be greater than 50 percent of the principal amount of the loan at origination.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote xml:lang="en">The borrower agrees to pay the lender over time, typically in a series of regular payments divided into principal and interest. The property then serves as collateral to secure the loan.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;ReverseMortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;Mortgage">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;AssetSpecificCollateralAgreement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-rp;RealProperty"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>mortgage</rdfs:label>
+		<skos:definition>grant of financial interest in real property to a party that is not an owner of that real property and is recorded by a registration authority</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">A mortgage prevents transfer of the ownership of the real property unless the financial interest is satisfied. Any loan can be collateralized by a mortgage, including, for example, a bail bond</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;OpenEndMortgageLoan">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-ln;OpenEndCredit"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
+		<rdfs:label>open-end mortgage loan</rdfs:label>
+		<skos:definition>loan secured by real estate with a provision that the outstanding loan amount may be increased upon mutual agreement of the lender and the borrower</skos:definition>
+		<cmns-av:adaptedFrom>MISMO Business Glossary, available at https://www.mismo.org/standards-resources/business-glossary/</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;OpenEndReverseMortgage">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;OpenEndMortgageLoan"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;ReverseMortgageLoan"/>
+		<rdfs:label>open-end reverse mortgage</rdfs:label>
+		<dct:source>Instructions for the Preparation of Consolidated Reports of Condition and Income, FFIEC 031 and FFIEC 041, Updated March 2023, clause A-91</dct:source>
+		<skos:definition>reverse mortgage structured like a home equity line of credit in that it provides the borrower with additional funds after closing (either as fixed monthly payments, under a line of credit, or both)</skos:definition>
+		<cmns-av:explanatoryNote>Normally, open-end reverse mortgages are first liens. These include combinations of both a lump sum payment to the borrower at closing and payments after the closing of the loan.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;ReverseMortgageLoan">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;hasCreditLimit"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">reverse mortgage</rdfs:label>
-		<rdfs:label>reverse mortgage</rdfs:label>
-		<skos:definition>mortgage that pays money to the borrower against a set principal limit that is based on the value of existing equity in the underlying collateral</skos:definition>
-		<cmns-av:explanatoryNote>A reverse mortgage and an open end loan both have a credit limit. The interest accrued is added to the principal balance.</cmns-av:explanatoryNote>
+		<rdfs:label>reverse mortgage loan</rdfs:label>
+		<skos:definition>loan secured by real estate that pays money to the borrower against a set principal limit based on the value of existing equity in the underlying collateral</skos:definition>
+		<cmns-av:explanatoryNote>The interest accrued is added to the principal balance.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;UniversalLoanIdentifier">
@@ -134,12 +168,12 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>universal loan identifier</rdfs:label>
-		<skos:definition>unique identifier given to unequivocally identify a specific mortgage loan</skos:definition>
+		<skos:definition>unique identifier given to unequivocally identify a specific loan secured by real estate</skos:definition>
 		<cmns-av:explanatoryNote>In the US, the structure of this identifier is defined in the 2015 revision to the Home Mortgage Disclosure Act.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -152,9 +186,9 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-loan-reln-mtg;isARMConvertible">
 		<rdfs:label xml:lang="en">is ARM convertible</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+		<rdfs:domain rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">indicates whether or not the mortgage can be converted into an adjustable-rate mortgage (ARM)</skos:definition>
+		<skos:definition xml:lang="en">indicates whether or not the loan can be converted into an adjustable-rate mortgage contract (ARM)</skos:definition>
 	</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -105,25 +105,6 @@
 		<cmns-av:explanatoryNote xml:lang="en">The borrower agrees to pay the lender over time, typically in a series of regular payments divided into principal and interest. The property then serves as collateral to secure the loan.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-loan-reln-mtg;PropertyInspection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;evaluates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;RealProperty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&cmns-pts;PartyRole"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>property inspection</rdfs:label>
-		<skos:definition>assessment activity that involves analyzing one or more aspects of a real property for independent assessment of status or deficiency</skos:definition>
-		<cmns-av:explanatoryNote>This is independent and separate from conducting an appraisal. Examples are termite inspections, construction inspections, etc.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-loan-reln-mtg;RealProperty">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;PhysicalAsset"/>
 		<rdfs:subClassOf>

--- a/LOAN/RealEstateLoans/Mortgages.rdf
+++ b/LOAN/RealEstateLoans/Mortgages.rdf
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
+	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
+	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
+	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
+	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
+	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
+	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
+		<rdfs:label xml:lang="en">Mortgage Loans Ontology</rdfs:label>
+		<dct:abstract>Loans that have collateral posted as security and where that collateral is real estate, and the real estate which makes up the collateral is purchased with the funds loaned. This ontology covers a range of mortgage concepts and parties, along with catewgories of mortgage loan purpose (remortgage, second home etc.).</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
+	</owl:Ontology>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;Mortgage">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-ln;ClosedEndCredit"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-ln-ln;CollateralizedLoan"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;UniversalLoanIdentifier"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;RealProperty"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;hasInitialFundingDate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;TransactionDate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>mortgage</rdfs:label>
+		<skos:definition>collateralized loan and closed-end credit agreement that is secured by the title of some real property, specifically a home, plot of land, or other asset</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">The borrower agrees to pay the lender over time, typically in a series of regular payments divided into principal and interest. The property then serves as collateral to secure the loan.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;PropertyInspection">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentActivity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:someValuesFrom rdf:resource="&cmns-pts;PartyRole"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-loan-reln-mtg;isInspectionOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;RealProperty"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>property inspection</rdfs:label>
+		<skos:definition>assessment activity that involves analyzing one or more aspects of a real property for independent assessment of status or deficiency</skos:definition>
+		<cmns-av:explanatoryNote>This is independent and separate from conducting an appraisal. Examples are termite inspections, construction inspections, etc.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;RealProperty">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PhysicalAsset"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isEmbodiedIn"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-loc;Parcel"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isEvaluatedBy"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;RealPropertyAppraisal"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">real property</rdfs:label>
+		<skos:definition xml:lang="en">land together with any structures that are permanently attached to that land, such as houses, trees, fences and other improvements</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Real property typically encompasses both the physical land and everything that lies above, below, or on its surface. There are cases, such as condominiums, in which the interior of the structure is owned by a party that may not own the land. There are also cases in which certain long-term leases have similar characteristics to ownership, but are time-bound.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;RealPropertyAppraisal">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;Appraisal"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+				<owl:onClass rdf:resource="&fibo-loan-reln-mtg;PropertyInspection"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasAppraiser"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;Appraiser"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>real property appraisal</rdfs:label>
+		<skos:definition>value assessment that estimates the amount of money some real property is worth</skos:definition>
+		<cmns-av:explanatoryNote>The valuation uses one or more methodologies and is conducted by an appraiser or technology with a logical model that performs the same function.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;ReverseMortgage">
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-loan-ln-ln;hasCreditLimit"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">reverse mortgage</rdfs:label>
+		<rdfs:label>reverse mortgage</rdfs:label>
+		<skos:definition>mortgage that pays money to the borrower against a set principal limit that is based on the value of existing equity in the underlying collateral</skos:definition>
+		<cmns-av:explanatoryNote>A reverse mortgage and an open end loan both have a credit limit. The interest accrued is added to the principal balance.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-reln-mtg;UniversalLoanIdentifier">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;FinancialInstrumentIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onClass rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
+				<owl:onClass rdf:resource="&fibo-loan-ln-ln;Loan"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>universal loan identifier</rdfs:label>
+		<skos:definition>unique identifier given to unequivocally identify a specific mortgage loan</skos:definition>
+		<cmns-av:explanatoryNote>In the US, the structure of this identifier is defined in the 2015 revision to the Home Mortgage Disclosure Act.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;hasInitialFundingDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasEffectiveDate"/>
+		<rdfs:label>has initial funding date</rdfs:label>
+		<skos:definition>relates, e.g. a loan contract to the date on which the contract is consummated, officially creating the obligations therein</skos:definition>
+		<cmns-av:synonym>has closing date</cmns-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-loan-reln-mtg;isARMConvertible">
+		<rdfs:label xml:lang="en">is ARM convertible</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-loan-ln-ln;Loan"/>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition xml:lang="en">indicates whether or not the mortgage can be converted into an adjustable-rate mortgage (ARM)</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-loan-reln-mtg;isInspectionOf">
+		<rdfs:label>is inspection of</rdfs:label>
+		<skos:definition>relates an inspection to the thing being inspected</skos:definition>
+	</owl:ObjectProperty>
+
+</rdf:RDF>

--- a/SEC/Debt/CollateralizedDebtObligations.rdf
+++ b/SEC/Debt/CollateralizedDebtObligations.rdf
@@ -8,7 +8,6 @@
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
-	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
@@ -42,7 +41,6 @@
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"
-	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
@@ -73,7 +71,6 @@
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -587,7 +584,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;MBSTrancheNote">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;PromissoryNote"/>
 		<rdfs:label xml:lang="en">m b s tranche note</rdfs:label>
 		<skos:definition xml:lang="en">An individual note of a tranche.</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">A Tranche is made up of e.g. $500m in notes and so on. These may be in different notes, with different denominations. Analytics that would apply to the Tranche would by implication apply to each slice of the tranche.</cmns-av:explanatoryNote>

--- a/SEC/Debt/DebtInstruments.rdf
+++ b/SEC/Debt/DebtInstruments.rdf
@@ -81,7 +81,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240301/Debt/DebtInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241001/Debt/DebtInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Debt/DebtInstruments.rdf version of this ontology was modified to reflect use of actualExpression as an annotation rather than datatype property, to deprecate maturity-related properties which have been moved to financial instruments more generally, and to simplify restrictions on tradable debt instrument.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to support integration of the bonds ontology.</skos:changeNote>
@@ -93,12 +93,20 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211001/Debt/DebtInstruments.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/DebtInstruments.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Debt/DebtInstruments.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to augment the ontology with details regarding schedules for interest rate calculations, payment calculations, rate resets and the like (FBC-317).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240301/Debt/DebtInstruments.rdf version of this ontology was modified to loosen the constraint that a debt instrument must have at least one redemption provision, making it optional (LOAN-168).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;DebtInstrument">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasRedemptionProvision"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;RedemptionProvision"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasCallFeature"/>
@@ -118,12 +126,6 @@
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasPutFeature"/>
 				<owl:onClass rdf:resource="&fibo-sec-dbt-dbti;PutFeature"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasRedemptionProvision"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;RedemptionProvision"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/SEC/Debt/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/MortgageBackedSecurities.rdf
@@ -20,7 +20,7 @@
 	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/">
+	<!ENTITY fibo-loan-reln-mtg "https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/">
 	<!ENTITY fibo-sec-dbt-abs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
 	<!ENTITY fibo-sec-dbt-mbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/">
@@ -55,7 +55,7 @@
 	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"
+	xmlns:fibo-loan-reln-mtg="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"
 	xmlns:fibo-sec-dbt-abs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
 	xmlns:fibo-sec-dbt-mbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"
@@ -88,7 +88,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>

--- a/SEC/Debt/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/MortgageBackedSecurities.rdf
@@ -8,7 +8,6 @@
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/">
-	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -43,7 +42,6 @@
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -76,7 +74,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -354,7 +351,7 @@ Consensus:Review.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-mbs;PassThroughMBSInstrumentNote">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;PromissoryNote"/>
 		<rdfs:label xml:lang="en">pass through m b s instrument note</rdfs:label>
 		<skos:definition xml:lang="en">An individual note of a pass through instrument.</skos:definition>
 	</owl:Class>
@@ -427,7 +424,7 @@ Consensus:Review.</skos:editorialNote>
 		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasPart"/>
 		<rdfs:label xml:lang="en">has note</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-mbs;MortgageBackedSecurity"/>
-		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
+		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;PromissoryNote"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mbs;isAlso">
@@ -439,7 +436,7 @@ Consensus:Review.</skos:editorialNote>
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mbs;isSliceOf">
 		<rdfs:subPropertyOf rdf:resource="&cmns-col;isPartOf"/>
 		<rdfs:label xml:lang="en">is slice of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;PromissoryNote"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;PromissoryNote"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-mbs;MortgageBackedSecurity"/>
 		<owl:inverseOf rdf:resource="&fibo-sec-dbt-mbs;hasNote"/>
 	</owl:ObjectProperty>

--- a/SEC/Debt/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/MortgageBackedSecurities.rdf
@@ -264,7 +264,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;Mortgage"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-reln-mtg;LoanSecuredByRealEstate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">mortgage pool</rdfs:label>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -239,7 +239,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/ConstructionLoans/" uri="./LOAN/RealEstateLoans/ConstructionLoans.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/" uri="./LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/" uri="./LOAN/RealEstateLoans/MetadataLOANRealEstateLoans.rdf"/>	
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageLoans/" uri="./LOAN/RealEstateLoans/MortgageLoans.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/" uri="./LOAN/RealEstateLoans/Mortgages.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/" uri="./MD/CIVTemporal/FundsTemporal.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/" uri="./MD/CIVTemporal/MetadataMDCIVTemporal.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/" uri="./MD/DebtTemporal/DebtAnalytics.rdf"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -183,6 +183,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/" uri="./FND/Places/Addresses.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/" uri="./FND/Places/Facilities.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/" uri="./FND/Places/Locations.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/" uri="./FND/Places/RealProperty.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/MetadataFNDPlaces/" uri="./FND/Places/MetadataFNDPlaces.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/" uri="./FND/Places/NorthAmerica/USPostalServiceAddresses.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/" uri="./FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -240,6 +240,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/" uri="./LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/" uri="./LOAN/RealEstateLoans/MetadataLOANRealEstateLoans.rdf"/>	
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/" uri="./LOAN/RealEstateLoans/Mortgages.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/" uri="./LOAN/RealEstateLoans/MortgageOrigination.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/" uri="./MD/CIVTemporal/FundsTemporal.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/" uri="./MD/CIVTemporal/MetadataMDCIVTemporal.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/" uri="./MD/DebtTemporal/DebtAnalytics.rdf"/>


### PR DESCRIPTION
## Description

1. Split the MortgageLoans ontology into two separate ontologies - one small-ish ontology describing mortgages, but limited to primary contract details, with a second ontology including the origination and servicing content that was previously in MortgageLoans. Resulting ontologies include Mortages and MortgageOrigination (which may be split again into origination and servicing components)
2. Move real property concepts to a separate ontology in Foundations and revise definitions to reflect what is in the law
3. Refined the definition of collateralized loan, including higher level concepts in the debt and contracts ontologies based on SME input
4. Revised the definition mortgage to distinguish between the notion of something secured by real property and the contract, leveraging regulatory language to be clear about the distinction, extended notions related to closed-end and open-end mortgage loans and reverse mortgage loans, again based on regulations and call report requirements
5. Moved the definition of universal loan identifier to the HMDA ontology, to which it is specific

Fixes: #2061 / LOAN-168


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


