### PR TITLE
LOAN-169a - Add Sustainability-linked loan and related concepts

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -328,15 +328,14 @@
      -->
 	 
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyntheticCDOs/"/>
-	
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/"/>

--- a/AboutFIBOProd-IncludingReferenceData.rdf
+++ b/AboutFIBOProd-IncludingReferenceData.rdf
@@ -359,6 +359,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>

--- a/AboutFIBOProd-TBoxOnly.rdf
+++ b/AboutFIBOProd-TBoxOnly.rdf
@@ -231,6 +231,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -271,6 +271,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -229,6 +229,7 @@
 		<rdfs:label>key performance indicator</rdfs:label>
 		<skos:definition>measurable target that indicates how an individual or business is performing in terms of meeting its goals</skos:definition>
 		<skos:example>Examples include profits, sales numbers, employee turnover and average annual expenses.</skos:example>
+		<cmns-av:abbreviation>KPI</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.forbes.com/advisor/business/what-is-a-kpi-definition-examples/</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.kpi.org/KPI-Basics/</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Although they are both designed to measure performance, KPIs and metrics have different characteristics and are used by businesses in different ways. Metrics are measures used to track progress and evaluate success, while KPIs are metrics tied to specific goals during a certain period of time. KPIs are designed to align with business goals and targets, while metrics evaluate the performance of particular processes.</cmns-av:explanatoryNote>

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -222,8 +222,16 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;QualifiedMeasure"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;NumericIndexValue"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasObservedValue"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;DatedStructuredCollection"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasTargetValue"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;DatedStructuredCollection"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>key performance indicator</rdfs:label>
@@ -288,7 +296,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;isValueOf"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;ScopedMeasure"/>
+				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;QualifiedMeasure"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -647,6 +655,13 @@
 		<rdfs:label>has subtrahend</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;Difference"/>
 		<skos:definition>specifies the quantity value that is subtracted from something</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasTargetValue">
+		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasArgument"/>
+		<rdfs:label>has target value</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatedStructuredCollection"/>
+		<skos:definition>specifies a collection of values that represent planned or projected goals or objectives for some something over time</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;hasUniverseSize">

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -89,7 +89,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230501/Utilities/Analytics.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231101/Utilities/Analytics.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Utilities/Analytics.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to move the concept of an anchor date to Financial Dates (FBC-317).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240201/Utilities/Analytics.rdf version of the ontology was modified to eliminate elements that have been deprecated for several quarters (FND-386).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240201/Utilities/Analytics.rdf version of the ontology was modified to eliminate elements that have been deprecated for several quarters (FND-386) and to add the concept of a key performance indicator (KPI) (LOAN-169).</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
@@ -216,6 +216,23 @@
 		<rdfs:label>geometric mean</rdfs:label>
 		<skos:definition>mean that indicates the central tendency or typical value of a set of numbers by using the product of their values (as opposed to the arithmetic mean which uses their sum)</skos:definition>
 		<cmns-av:explanatoryNote>The geometric mean is defined as the nth root of the product of n numbers. A geometric mean is often used when comparing different items - finding a single &apos;figure of merit&apos; for these items - when each item has multiple properties that have different numeric ranges. For example, the geometric mean can give a meaningful &apos;average&apos; to compare two companies which are each rated at 0 to 5 for their environmental sustainability, and are rated at 0 to 100 for their financial viability. If an arithmetic mean were used instead of a geometric mean, the financial viability is given more weight because its numeric range is larger - so a small percentage change in the financial rating (e.g. going from 80 to 90) makes a much larger difference in the arithmetic mean than a large percentage change in environmental sustainability (e.g. going from 2 to 5).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;KeyPerformanceIndicator">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;QualifiedMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;NumericIndexValue"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>key performance indicator</rdfs:label>
+		<skos:definition>measurable target that indicates how an individual or business is performing in terms of meeting its goals</skos:definition>
+		<skos:example>Examples include profits, sales numbers, employee turnover and average annual expenses.</skos:example>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.forbes.com/advisor/business/what-is-a-kpi-definition-examples/</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.kpi.org/KPI-Basics/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Although they are both designed to measure performance, KPIs and metrics have different characteristics and are used by businesses in different ways. Metrics are measures used to track progress and evaluate success, while KPIs are metrics tied to specific goals during a certain period of time. KPIs are designed to align with business goals and targets, while metrics evaluate the performance of particular processes.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Key Performance Indicators (KPIs) are the critical (key) quantifiable indicators of progress toward an intended result. KPIs provide a focus for strategic and operational improvement, create an analytical basis for decision making and help focus attention on what matters most. Managing with the use of KPIs includes setting targets (the desired level of performance) and tracking progress against those targets.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-utl-alx;Mean">

--- a/LOAN/AllLOAN.rdf
+++ b/LOAN/AllLOAN.rdf
@@ -56,10 +56,12 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/">
 		<rdfs:label>Loans (LOAN) Domain</rdfs:label>
 		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>FIÙTUR</dct:contributor>
 		<dct:contributor>Federated Knowledge LLC</dct:contributor>
 		<dct:contributor>Hypercube Ltd.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Semantic Arts, Inc.</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
@@ -88,6 +90,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/Mortgages/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/"/>
 		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2024 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for LOAN is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Loans (LOAN) domains, excluding individuals for governments and jurisdictions, financial services, regulatory organizations and related registries, and reference individuals, as well as the LCC region-specific ontologies.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/LOAN/AllLOAN.rdf
+++ b/LOAN/AllLOAN.rdf
@@ -56,7 +56,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/">
 		<rdfs:label>Loans (LOAN) Domain</rdfs:label>
 		<dct:contributor>Adaptive, Inc.</dct:contributor>
-		<dct:contributor>FIÙTUR</dct:contributor>
+		<dct:contributor>FIUTUR</dct:contributor>
 		<dct:contributor>Federated Knowledge LLC</dct:contributor>
 		<dct:contributor>Hypercube Ltd.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>

--- a/LOAN/LoansSpecific/GreenLoans.rdf
+++ b/LOAN/LoansSpecific/GreenLoans.rdf
@@ -17,7 +17,7 @@
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 	<!ENTITY fibo-loan-spc-com "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/">
 	<!ENTITY fibo-loan-spc-grn "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/">
-	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
+	<!ENTITY fibo-sec-dbt-dln "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -42,7 +42,7 @@
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:fibo-loan-spc-com="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"
 	xmlns:fibo-loan-spc-grn="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"
-	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
+	xmlns:fibo-sec-dbt-dln="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"

--- a/LOAN/LoansSpecific/GreenLoans.rdf
+++ b/LOAN/LoansSpecific/GreenLoans.rdf
@@ -72,7 +72,7 @@
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2024 FIÙTUR</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024 FIUTUR</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	

--- a/LOAN/LoansSpecific/GreenLoans.rdf
+++ b/LOAN/LoansSpecific/GreenLoans.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
@@ -27,6 +28,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
@@ -68,6 +70,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -138,7 +141,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;KeyPerformanceIndicator"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;SustainabilityKeyPerformanceIndicator"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">sustainability and business strategy</rdfs:label>
@@ -146,7 +149,6 @@
 		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainability-linked-loan-principles-sllp/</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote xml:lang="en">A SLL borrower should clearly communicate to its lender(s) its rationale for the selection of its KPI(s) (i.e. relevance, materiality, whether it is core to the borrower&apos;s overall business) and the motivation for the SPT(s) (i.e. ambition level, benchmarking approach and how the borrower intends to reach such SPTs). Borrowers are encouraged to position this information within the context of their overarching objectives, sustainability strategy, policy, sustainability commitments and/or processes relating to sustainability.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote xml:lang="en">SLLs aim to support a borrower&apos;s efforts in improving its sustainability profile over the term of the loan. They do so by aligning loan terms to the borrower&apos;s performance, which is measured using one or more sustainability KPIs that can be internal and/or external. The KPIs must be material to the borrower&apos;s core sustainability and business strategy, and address relevant ESG challenges of its industry sector.</cmns-av:explanatoryNote>
-		<cmns-av:explanatoryNote xml:lang="en">The KPIs must be: (a) relevant, core and material to the borrower&apos;s overall business, and of high strategic significance to the borrower&apos;s current and/or future operations; (b) measurable or quantifiable on a consistent methodological basis; and (c) able to be benchmarked (i.e. as much as possible using an external reference or definitions to facilitate the assessment of the SPT&apos;s level of ambition). A clear definition of the KPI(s) should be provided by the borrower and should include the applicable scope or parameters, as well as the calculation methodology, a definition of a baseline and be benchmarked against an industry standard and/or industry peers where feasible.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityBusinessObjective">
@@ -155,6 +157,21 @@
 		<skos:definition xml:lang="en">objective related to improving the sustainability profile of the business</skos:definition>
 		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainability-linked-loan-principles-sllp/</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote xml:lang="en">The borrower of an SLL should clearly communicate to its lenders its sustainability objective(s) and how such objectives align with its proposed sustainability performance targets (SPTs).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityKeyPerformanceIndicator">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;KeyPerformanceIndicator"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasTargetValue"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;SustainabilityPerformanceTarget"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">sustainability key performance indicator</rdfs:label>
+		<skos:definition xml:lang="en">measurable performance indicator that is sustainability specific</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainability-linked-loan-principles-sllp/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">A sustainability KPI must be: (a) relevant, core and material to the borrower&apos;s overall business, and of high strategic significance to the borrower&apos;s current and/or future operations; (b) measurable or quantifiable on a consistent methodological basis; and (c) able to be benchmarked (i.e. as much as possible using an external reference or definitions to facilitate the assessment of the SPT&apos;s level of ambition). A clear definition of the KPI(s) should be provided by the borrower and should include the applicable scope or parameters, as well as the calculation methodology, a definition of a baseline and be benchmarked against an industry standard and/or industry peers where feasible.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityLinkedLoan">
@@ -196,9 +213,15 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityPerformanceTarget">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;QualifiedMeasure"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;DatedStructuredCollection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;isCalculatedViaMethodology"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">sustainability performance target</rdfs:label>
-		<skos:definition xml:lang="en">quantitative measure used to calibrate the level of achievement a borrower makes with respect to a key performance indicator, including, but not limited to, the methodology used to calculate its value at any point over the lifetime of a loan</skos:definition>
+		<skos:definition xml:lang="en">collection of quantitative target values used to calibrate the level of achievement a borrower makes with respect to a key performance indicator, by date, including, but not limited to, the methodology used to calculate its value at any point over the lifetime of a loan</skos:definition>
 		<cmns-av:abbreviation xml:lang="en">SPT</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainability-linked-loan-principles-sllp/</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote xml:lang="en">A SLL borrower should clearly communicate to its lenders its rationale for the selection of its KPI(s) (i.e. relevance, materiality, whether it is core to the borrower’s overall business) and the motivation for the SPT(s) (i.e. ambition level, benchmarking approach and how the borrower intends to reach such SPTs). Borrowers are encouraged to position this information within the context of their overarching objectives, sustainability strategy, policy, sustainability commitments and/or processes relating to sustainability.</cmns-av:explanatoryNote>

--- a/LOAN/LoansSpecific/GreenLoans.rdf
+++ b/LOAN/LoansSpecific/GreenLoans.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
@@ -8,10 +9,13 @@
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
+	<!ENTITY fibo-loan-spc-com "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/">
 	<!ENTITY fibo-loan-spc-grn "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/">
 	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -22,6 +26,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
@@ -29,10 +34,13 @@
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
+	xmlns:fibo-loan-spc-com="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"
 	xmlns:fibo-loan-spc-grn="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"
 	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -50,12 +58,16 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -93,7 +105,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">green loan</rdfs:label>
-		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as a bonding lines, guarantee line or letter of credit) made available exclusively to finance, re-finance or guarantee, in whole or in part, new and/or existing eligible green projects and which are aligned to the four core components of the Green Loan Principles (GLP)</skos:definition>
+		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as bonding lines, a guarantee line or letter of credit) made available exclusively to finance, re-finance or guarantee, in whole or in part, new and/or existing eligible green projects and which are aligned to the four core components of the Green Loan Principles (GLP)</skos:definition>
 		<skos:example xml:lang="en">Example indicative categories of eligibility contained in the LMA&apos;s Green Loan Principles (GLP) include loans designed to facilitate renewable energy, energy efficiency, climate change adaptation and green buildings that meet regional, national or internationally recognised standards or certifications.</skos:example>
 		<cmns-av:adaptedFrom xml:lang="en">https://www.addleshawgoddard.com/en/insights/insights-briefings/2020/financial-services/green-loans-and-sustainability-linked-loans-what-is-the-difference/</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainable-lending-glossary-of-terms/</cmns-av:adaptedFrom>
@@ -107,6 +119,90 @@
 		<cmns-av:explanatoryNote>All designated Green Projects should provide clear environmental benefits, which will be assessed, and where feasible, quantified, measured and reported by the borrower, per requirements outlined in the LMA Green Loan Principles (GLP). Where funds are to be used, in whole or part, for refinancing, it is recommended that borrowers provide an estimate of the share of financing versus refinancing. Where appropriate, they should also clarify which investments or project portfolios may be refinanced, and, to the extent relevant, the expected look-back period for refinanced Green Projects. A green loan may take the form of one or more tranches of a loan facility. In such cases, the green tranche(s) must be clearly designated, with proceeds of the green tranche(s) credited to a separate account or tracked by the borrower in an appropriate manner. 
 		
 		The GLP explicitly recognise several broad categories of eligibility for Green Projects with the objective of addressing key areas of environmental concern such as climate change, natural resources depletion, loss of biodiversity, and air, water and soil pollution. This non-exhaustive list, set out in Appendix 1, is intended to capture the most usual types of projects supported, and expected to be supported, by the green loan market. However, it is recognised that definitions of green and green projects may vary depending on sector and geography</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityAndBusinessStrategy">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;BusinessStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidencedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;SustainabilityPerformanceTarget"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasObjective"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;SustainabilityBusinessObjective"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;KeyPerformanceIndicator"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">sustainability and business strategy</rdfs:label>
+		<skos:definition xml:lang="en">strategy for achieving specific business objectives related to sustainability (from an environmental and/or social and/or governance (ESG) perspective)</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainability-linked-loan-principles-sllp/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">A SLL borrower should clearly communicate to its lender(s) its rationale for the selection of its KPI(s) (i.e. relevance, materiality, whether it is core to the borrower&apos;s overall business) and the motivation for the SPT(s) (i.e. ambition level, benchmarking approach and how the borrower intends to reach such SPTs). Borrowers are encouraged to position this information within the context of their overarching objectives, sustainability strategy, policy, sustainability commitments and/or processes relating to sustainability.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">SLLs aim to support a borrower&apos;s efforts in improving its sustainability profile over the term of the loan. They do so by aligning loan terms to the borrower&apos;s performance, which is measured using one or more sustainability KPIs that can be internal and/or external. The KPIs must be material to the borrower&apos;s core sustainability and business strategy, and address relevant ESG challenges of its industry sector.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The KPIs must be: (a) relevant, core and material to the borrower&apos;s overall business, and of high strategic significance to the borrower&apos;s current and/or future operations; (b) measurable or quantifiable on a consistent methodological basis; and (c) able to be benchmarked (i.e. as much as possible using an external reference or definitions to facilitate the assessment of the SPT&apos;s level of ambition). A clear definition of the KPI(s) should be provided by the borrower and should include the applicable scope or parameters, as well as the calculation methodology, a definition of a baseline and be benchmarked against an industry standard and/or industry peers where feasible.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityBusinessObjective">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;BusinessObjective"/>
+		<rdfs:label xml:lang="en">sustainability business objective</rdfs:label>
+		<skos:definition xml:lang="en">objective related to improving the sustainability profile of the business</skos:definition>
+		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainability-linked-loan-principles-sllp/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">The borrower of an SLL should clearly communicate to its lenders its sustainability objective(s) and how such objectives align with its proposed sustainability performance targets (SPTs).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityLinkedLoan">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreementRepaidPeriodically"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-com;CommercialLoan"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasMilestoneProvision"/>
+				<owl:onClass rdf:resource="&fibo-fnd-agr-ctr;ContractMilestone"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
+				<owl:onClass rdf:resource="&fibo-fnd-agr-ctr;MilestoneSchedule"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;DisclosureProvision"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;SustainabilityAndBusinessStrategy"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">sustainability-linked loan</rdfs:label>
+		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as a bonding lines, guarantee line or letter of credit) for which the economic characteristics can vary depending on whether the borrower achieves ambitious, material and quantifiable predetermined sustainability performance objectives aligned with Sustainability-Linked Loan Principles (SSLP)</skos:definition>
+		<skos:example xml:lang="en">The use of proceeds in relation to a SLL is not a determinant in its categorisation and, in most instances, SLLs will be used for general corporate purposes. Instead, SLLs look to support a borrower in improving its sustainability performance.</skos:example>
+		<cmns-av:abbreviation xml:lang="en">SLL</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom xml:lang="en">https://www.addleshawgoddard.com/en/insights/insights-briefings/2020/financial-services/green-loans-and-sustainability-linked-loans-what-is-the-difference/</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainable-lending-glossary-of-terms/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">A borrower&apos;s sustainability performance is measured using sustainability performance targets (SPTs), which include key performance indicators, external ratings and/or equivalent metrics that measure improvements in the borrower&apos;s sustainability profile.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityPerformanceTarget">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;QualifiedMeasure"/>
+		<rdfs:label xml:lang="en">sustainability performance target</rdfs:label>
+		<skos:definition xml:lang="en">quantitative measure used to calibrate the level of achievement a borrower makes with respect to a key performance indicator, including, but not limited to, the methodology used to calculate its value at any point over the lifetime of a loan</skos:definition>
+		<cmns-av:abbreviation xml:lang="en">SPT</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainability-linked-loan-principles-sllp/</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">A SLL borrower should clearly communicate to its lenders its rationale for the selection of its KPI(s) (i.e. relevance, materiality, whether it is core to the borrower’s overall business) and the motivation for the SPT(s) (i.e. ambition level, benchmarking approach and how the borrower intends to reach such SPTs). Borrowers are encouraged to position this information within the context of their overarching objectives, sustainability strategy, policy, sustainability commitments and/or processes relating to sustainability.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The process for calibration of the SPT(s) per KPI is key to the structuring of SLLs, since it will be the expression of the level of ambition the borrower is ready to commit to. The SPTs must be set in good faith and remain relevant (so long as they apply) and ambitious throughout the life of the loan.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityStructuringAgent">

--- a/LOAN/LoansSpecific/GreenLoans.rdf
+++ b/LOAN/LoansSpecific/GreenLoans.rdf
@@ -13,7 +13,7 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 	<!ENTITY fibo-loan-spc-grn "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/">
-	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/">
+	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -34,7 +34,7 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:fibo-loan-spc-grn="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"
-	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/"
+	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -54,13 +54,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2024 FIÙTUR</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;GreenLoan">

--- a/SEC/AllSEC-Europe.rdf
+++ b/SEC/AllSEC-Europe.rdf
@@ -42,6 +42,7 @@
 		<dct:contributor>Mizuho</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Quarule</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
@@ -51,13 +52,13 @@
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:issued rdf:datatype="&xsd;dateTime">2024-07-12T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-07-12T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-11-15T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain, European Extension</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-Europe/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/EuropeanSecurities/EUSecuritiesRestrictions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240701/AllSEC-Europe/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/AllSEC-Europe/"/>
 		<cmns-av:copyright>Copyright (c) 2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2024 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for the European Extension of SEC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Indices and Indicators (IND) domains, including all of FND but excluding individuals for North American governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</cmns-av:explanatoryNote>

--- a/SEC/AllSEC-ExampleIndividuals.rdf
+++ b/SEC/AllSEC-ExampleIndividuals.rdf
@@ -44,6 +44,7 @@
 		<dct:contributor>Mizuho</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Quarule</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
@@ -53,7 +54,7 @@
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-07-12T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-11-15T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain with Example Individuals</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ExampleIndividuals/"/>
@@ -61,7 +62,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/SEC/AllSEC-NorthAmerica/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/AllSEC-ExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/AllSEC-ExampleIndividuals/"/>
 		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for SEC example individuals is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, including all individuals, with examples of how to encode information for a specific exchange-traded security.</cmns-av:explanatoryNote>

--- a/SEC/AllSEC-NorthAmerica.rdf
+++ b/SEC/AllSEC-NorthAmerica.rdf
@@ -42,6 +42,7 @@
 		<dct:contributor>Mizuho</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Quarule</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
@@ -51,13 +52,13 @@
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:issued rdf:datatype="&xsd;dateTime">2024-06-07T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-06-07T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-11-15T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain, North American Extension</dct:title>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-NorthAmerica/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/NorthAmericanSecurities/USSecuritiesRestrictions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240601/AllSEC-NorthAmerica/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/AllSEC-NorthAmerica/"/>
 		<cmns-av:copyright>Copyright (c) 2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2024 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for the North American Extension of SEC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), and Indices and Indicators (IND) domains, including all of FND but excluding individuals for European governments and jurisdictions, financial services and regulatory organizations and related registries, as well as the related LCC region-specific ontologies.</cmns-av:explanatoryNote>

--- a/SEC/AllSEC-ReferenceIndividuals.rdf
+++ b/SEC/AllSEC-ReferenceIndividuals.rdf
@@ -44,6 +44,7 @@
 		<dct:contributor>Mizuho</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Quarule</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
@@ -53,7 +54,7 @@
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-07-12T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-11-15T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain with Reference Individuals</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-ReferenceRates/"/>
@@ -61,7 +62,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-NorthAmerica/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240701/AllSEC-ReferenceIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/AllSEC-ReferenceIndividuals/"/>
 		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:explanatoryNote>The &apos;all&apos; ontology for SEC is provided for convenience for FIBO users. This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, including all individuals.</cmns-av:explanatoryNote>

--- a/SEC/AllSEC.rdf
+++ b/SEC/AllSEC.rdf
@@ -9,7 +9,7 @@
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
 	<!ENTITY fibo-sec-dbt-pbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/">
+	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 	<!ENTITY fibo-sec-dbt-tstd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/">
 	<!ENTITY fibo-sec-eq-dr "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
@@ -38,7 +38,7 @@
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
 	xmlns:fibo-sec-dbt-pbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/"
+	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
 	xmlns:fibo-sec-dbt-tstd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"
 	xmlns:fibo-sec-eq-dr="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
@@ -77,6 +77,7 @@
 		<dct:contributor>Mizuho</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Quarule</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
@@ -86,16 +87,16 @@
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-11-08T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-11-15T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>

--- a/SEC/AllSEC.rdf
+++ b/SEC/AllSEC.rdf
@@ -7,9 +7,9 @@
 	<!ENTITY fibo-sec-dbt-abs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
+	<!ENTITY fibo-sec-dbt-dln "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
 	<!ENTITY fibo-sec-dbt-pbs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 	<!ENTITY fibo-sec-dbt-tstd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/">
 	<!ENTITY fibo-sec-eq-dr "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
@@ -36,9 +36,9 @@
 	xmlns:fibo-sec-dbt-abs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
+	xmlns:fibo-sec-dbt-dln="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
 	xmlns:fibo-sec-dbt-pbs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
 	xmlns:fibo-sec-dbt-tstd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"
 	xmlns:fibo-sec-eq-dr="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"

--- a/SEC/Debt/DistributedLoans.rdf
+++ b/SEC/Debt/DistributedLoans.rdf
@@ -11,15 +11,16 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-loan-spc-com "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
-	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/">
+	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/"
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
@@ -31,15 +32,16 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-loan-spc-com="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
-	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/"
+	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/">
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 		<rdfs:label xml:lang="en">Syndicated Loans Ontology</rdfs:label>
 		<dct:abstract>This ontology defines contracts which give the holder some formal participation in some loan.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
@@ -49,13 +51,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2024 FIÙTUR</cmns-av:copyright>
 	</owl:Ontology>
@@ -118,15 +121,25 @@
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-sl;LoanParticipationNote">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditFacility"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-com;CommercialLoan"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;FixedIncomeSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-pts;hasActor"/>
+				<owl:onClass rdf:resource="&fibo-sec-dbt-sl;LeadArranger"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">loan participation note</rdfs:label>
-		<skos:definition xml:lang="en">fixed-income security that permits investors to buy portions of an outstanding loan or package of loans; LPN holders participate, on a pro rata basis, in collecting interest and principal payments. Banks or other financial institutions often enter into loan participation agreements with local businesses, and also offer loan participation notes as a type of short-term investment.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML has &quot;Syndicated Loan&quot;. Assume this is the same thing. Review session notes (pre-OTC SMER): [From: Investopedia: Loan Participation Note] Review: 1. Add terms e.g. contractual terms for participation 2. Are there other types of Participation Note which allow for participation in other forms of Asset / Collateral? 3. Can these be traded or not? Definition suggests a bilateral contract. 14 July: The note is documentation. That is, this is evidence for the security. An underwriting document (?) is similar. Someone promises to issue the notes for you. This is similar to how debt securities begin life - the underwriter sets the limits on what you will pay fo rthe ssecurity, and of course the amount. Two step orocess of creating the security and then selling it. See Bond / Debt Issuance diagrams and models. (see diagram notes etc. here) Note = tradeability. Indicates that someone has made a commitment at large. Loan Participation Note is either the other end of the loan, or a way of participating in the loan facility. If the latter, it would be a way of documenting the loan facility in a way that you can freely trade it. The alternative (non LPN) would be different. Circles - trading groups - members of the circle. Have to tell the other members of the circle what&apos;s going on, and get their permission from the members of that circle before you can assign those rights to someone else. This would mark out the OTC variant of these things. Then: risk participany, who has no original participation, but (later) agrees to take all of your risk off you. So now we have something with a secondary market and something without. Which is which, and what are they called? Which is the one described in FpML (presumably OTC). Generally, if you document your commitment to lend money, then other members of the syndicate also have a risk in that you might not stump up your obligations. This has implicatiojns for being able to make this a security. This differs from a bond, where there is no intervening credit facility, you just buyt the thing that way you have become the lender. So there remain some doubts about how a participation note works. There is an element of credit embedded against the purchaser of any such note that gave someone membership ofa syndicate. There are also two sets of words in play: - Syndicated Loan - Loan Participation Note. So one of these probably gives you membership of the syndicate, and the other just gives you participation in the loan. It is less likely that there is a secondary market in the note that gives you participationm in a syndicate (because of the credit risk) but in theory at least, it is possible to create an instrument for this. We just don&apos;t know if it exists.</skos:editorialNote>
+		<skos:definition xml:lang="en">credit facility and fixed-income security that may be distributed across a group of lenders</skos:definition>
 		<cmns-av:abbreviation xml:lang="en">LPN</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote xml:lang="en">The main difference between a loan participation and a loan syndication is that in a loan participation, one lender sells ownership interests in a loan to other lenders, while in a loan syndication, the lenders work together to originate and lend on the loan.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">With an LPN, a lead bank underwrites and issues the loan. This lending institution then recruits other banks to participate and share the risks and profits on a pro rata basis. The lead lender keeps a partial interest in the loan and is responsible for servicing it.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-sl;SyndicatedLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreementRepaidPeriodically"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditFacility"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-com;CommercialLoan"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-pts;hasActor"/>

--- a/SEC/Debt/DistributedLoans.rdf
+++ b/SEC/Debt/DistributedLoans.rdf
@@ -13,7 +13,7 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-spc-com "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
-	<!ENTITY fibo-sec-dbt-sl "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
+	<!ENTITY fibo-sec-dbt-dln "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -34,7 +34,7 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-spc-com="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
-	xmlns:fibo-sec-dbt-sl="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
+	xmlns:fibo-sec-dbt-dln="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -42,7 +42,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
-		<rdfs:label xml:lang="en">Syndicated Loans Ontology</rdfs:label>
+		<rdfs:label xml:lang="en">Distributed Loans Ontology</rdfs:label>
 		<dct:abstract>This ontology defines contracts which give the holder some formal participation in some loan.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
@@ -64,34 +64,34 @@
 		<cmns-av:copyright>Copyright (c) 2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-sl;AdministrativeAgent">
+	<owl:Class rdf:about="&fibo-sec-dbt-dln;AdministrativeAgent">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;SyndicateMember"/>
 		<rdfs:label xml:lang="en">administrative agent</rdfs:label>
 		<skos:definition xml:lang="en">role of a financial institution (often one of the primary lenders in the syndicate) designated to act as an intermediary between the borrowers and the syndicate lenders</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">An administrative agent is designated by the syndicate and granted the authority to disburse funds, collect payments, monitor compliance and act as the communications intermediary with the borrower on behalf of the syndicate. This coordination role is crucial to ensuring that lenders&apos; rights and oblications are properly coordinated and to streamline operations. Their authority and the scope of what they can do is explicitly stated in the loan agreement, and does not allow unilateral decision making with respect to the terms of the loan.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-sl;Bookrunner">
+	<owl:Class rdf:about="&fibo-sec-dbt-dln;Bookrunner">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label xml:lang="en">bookrunner</rdfs:label>
 		<skos:definition xml:lang="en">financial institution (typically a commercial or investment bank) responsible for coordinating the arrangement, structuring, and marketing of the loan to potential lenders</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">A &apos;bookrunner&apos; is primarily responsible for managing the distribution and sale of a security during a new issuance, while a &apos;lead arranger&apos; is the primary bank that structures and leads a syndicated loan, often assigning portions of the loan to other banks to participate in the deal; essentially, the bookrunner focuses on selling the security to investors, while the lead arranger focuses on structuring the loan itself and coordinating the syndicate of lenders involved.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-sl;DocumentationAgent">
+	<owl:Class rdf:about="&fibo-sec-dbt-dln;DocumentationAgent">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;SyndicateMember"/>
 		<rdfs:label xml:lang="en">documentation agent</rdfs:label>
 		<skos:definition xml:lang="en">financial institution designated to oversee the drafting, negotiation, and finalization of the loan documentation</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-sl;FinanceSyndicate">
+	<owl:Class rdf:about="&fibo-sec-dbt-dln;FinanceSyndicate">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;Syndicate"/>
 		<rdfs:label xml:lang="en">finance syndicate</rdfs:label>
 		<skos:definition xml:lang="en">group of financial institutions or lenders that collectively agree to provide funding for a large loan to a single borrower</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">Syndicates are formed to enable the provision of substantial financing amounts that would be challenging or risky for any one lender to offer alone. The syndicate structure allows lenders to share the loan amount, spreading both the funding and associated risks among multiple participants.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-sl;FinanceSyndicateMember">
+	<owl:Class rdf:about="&fibo-sec-dbt-dln;FinanceSyndicateMember">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;SyndicateMember"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:subClassOf>
@@ -100,7 +100,7 @@
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
-						<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-sl;FinanceSyndicate"/>
+						<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-dln;FinanceSyndicate"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
 			</owl:Restriction>
@@ -110,7 +110,7 @@
 		<cmns-av:explanatoryNote xml:lang="en">Syndicate members may include a variety of financial institutions, such as commercial banks, investment banks, institutional investors - insurance companies, pension funds, and hedge funds, and specialty finance firms, focused on specific industries or credit profiles, which may join syndicates for specialized or higher-risk loans.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-sl;LeadArranger">
+	<owl:Class rdf:about="&fibo-sec-dbt-dln;LeadArranger">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label xml:lang="en">lead arranger</rdfs:label>
 		<skos:definition xml:lang="en">financial institution that spearheads the loan structuring and syndication process on behalf of the borrower</skos:definition>
@@ -120,14 +120,14 @@
 		<cmns-av:synonym xml:lang="en">lead manager</cmns-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-sl;LoanParticipationNote">
+	<owl:Class rdf:about="&fibo-sec-dbt-dln;LoanParticipationNote">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditFacility"/>
 		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-com;CommercialLoan"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;FixedIncomeSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-pts;hasActor"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-sl;LeadArranger"/>
+				<owl:onClass rdf:resource="&fibo-sec-dbt-dln;LeadArranger"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -138,7 +138,7 @@
 		<cmns-av:explanatoryNote xml:lang="en">With an LPN, a lead bank underwrites and issues the loan. This lending institution then recruits other banks to participate and share the risks and profits on a pro rata basis. The lead lender keeps a partial interest in the loan and is responsible for servicing it.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-sl;SyndicatedLoan">
+	<owl:Class rdf:about="&fibo-sec-dbt-dln;SyndicatedLoan">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditFacility"/>
 		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-com;CommercialLoan"/>
 		<rdfs:subClassOf>
@@ -147,17 +147,17 @@
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-dbt-sl;LeadArranger">
+							<rdf:Description rdf:about="&fibo-sec-dbt-dln;LeadArranger">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-sl;Bookrunner">
+							<rdf:Description rdf:about="&fibo-sec-dbt-dln;Bookrunner">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-sl;AdministrativeAgent">
+							<rdf:Description rdf:about="&fibo-sec-dbt-dln;AdministrativeAgent">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-sl;DocumentationAgent">
+							<rdf:Description rdf:about="&fibo-sec-dbt-dln;DocumentationAgent">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-sl;SyndicationAgent">
+							<rdf:Description rdf:about="&fibo-sec-dbt-dln;SyndicationAgent">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-sl;FinanceSyndicateMember">
+							<rdf:Description rdf:about="&fibo-sec-dbt-dln;FinanceSyndicateMember">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -169,7 +169,7 @@
 		<cmns-av:explanatoryNote xml:lang="en">A syndicated loan enables pooling of funds from multiple financial institutions, typically under the leadership of one or more arranging banks. These kinds of credit agreements are often used by large corporations, private equity investors and government entities for significant capital needs such as acquisitions, project financing, or to meet operational requirements.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-sl;SyndicationAgent">
+	<owl:Class rdf:about="&fibo-sec-dbt-dln;SyndicationAgent">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label xml:lang="en">syndication agent</rdfs:label>
 		<skos:definition xml:lang="en">financial institution (typically a commercial or investment bank) designated to help structure, arrange, and manage the loan syndication process</skos:definition>

--- a/SEC/Debt/DistributedLoans.rdf
+++ b/SEC/Debt/DistributedLoans.rdf
@@ -60,7 +60,8 @@
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2024 FIÙTUR</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024 FIUTUR</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-sl;AdministrativeAgent">

--- a/SEC/Debt/MetadataSECDebt.rdf
+++ b/SEC/Debt/MetadataSECDebt.rdf
@@ -26,12 +26,12 @@
 		<dct:abstract>The SEC Debt Module covers content specific to debt instruments, including but not limited to bonds and asset-backed securities. This ontology provides metadata about the Debt module and its contents.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-11-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Debt/MetadataSECDebt/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/Debt/MetadataSECDebt/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-mod;DebtModule">
@@ -54,6 +54,7 @@
 		<dct:contributor>Mizuho</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Quarule</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
@@ -65,18 +66,18 @@
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/"/>
-		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyntheticCDOs/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO SEC Debt Module</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Securities and Equities (SEC) Debt Module</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/Equities/DepositaryReceipts.rdf
+++ b/SEC/Equities/DepositaryReceipts.rdf
@@ -73,7 +73,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Equities/DepositaryReceipts.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/DepositaryReceipts.rdf version of this ontology was modified to add the concept of a Chinese depositary receipt.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/DepositaryReceipts.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/2023020120230301/Equities/DepositaryReceipts.rdf version of this ontology was modified to address a deprecated term that was replaced with a new term over 6 months ago (FND-386).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/2023020120230301/Equities/DepositaryReceipts.rdf version of this ontology was modified to address a deprecated term that was replaced with a new term over 6 months ago (FND-386) and eliminate punning issues (LOAN-169).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
@@ -279,7 +279,7 @@ the one where the original securities were issued, such as in a local market. De
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-rst;hasRestriction"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-usrst;RegulationS"/>
+				<owl:hasValue rdf:resource="&fibo-sec-sec-usrst;RegulationS"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">offshore depositary receipt</rdfs:label>
@@ -313,7 +313,7 @@ jurisdictions other than the one where the original debt instruments were issued
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-rst;hasRestriction"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-usrst;Rule144A"/>
+				<owl:hasValue rdf:resource="&fibo-sec-sec-usrst;Rule144A"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">privately placed depositary receipt</rdfs:label>

--- a/SEC/MetadataSEC.rdf
+++ b/SEC/MetadataSEC.rdf
@@ -34,14 +34,14 @@
 		<dct:abstract>The Securities (SEC) Domain covers many of the concepts that are common to a wide variety of securities as well as those specific to equities and various debt instruments, including but not limited to bonds and a wide range of asset-backed securities. This ontology provides metadata about the Securities Domain and its contents.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2024-11-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/MetadataSECEquities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/MetadataSECFunds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/MetadataSECSecurities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/MetadataSEC/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/MetadataSEC/"/>
 		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
@@ -66,6 +66,7 @@
 		<dct:contributor>Mizuho</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
+		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Quarule</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
@@ -82,8 +83,8 @@
 		<dct:title>FIBO SEC Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Securities (SEC) Domain</dct:title>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -258,7 +258,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/" uri="./SEC/AllSEC-ReferenceIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/" uri="./SEC/Debt/AssetBackedSecurities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/" uri="./SEC/Debt/CollateralizedDebtObligations.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyndicatedLoans/" uri="./SEC/Debt/SyndicatedLoans.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/" uri="./SEC/Debt/DistributedLoans.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/" uri="./SEC/Debt/MortgageBackedSecurities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/PoolBackedSecurities/" uri="./SEC/Debt/PoolBackedSecurities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/SyntheticCDOs/" uri="./SEC/Debt/SyntheticCDOs.rdf"/>


### PR DESCRIPTION
## Description

1. Revised the definition of loan participation note per discussion in the DER FCT
2. Renamed SyndicatedLoans to DistributedLoans per discussion in the SEC FCT telecon and released it, including all related metadata
3. Added the concept of a key performance indicator to the analytics ontology in FND
4. Added concepts related to sustainability-linked loans to the green loans ontology
5. Refined definitions of KPI and sustainability performance target to link the two as series of dated values (observations as well as targets)

Fixes: #2072 / LOAN-169a


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


