### PR TITLE
LOAN-169b - Add concepts related to transition loans, including supporting green projects

### DIFF
--- a/FND/GoalsAndObjectives/Objectives.rdf
+++ b/FND/GoalsAndObjectives/Objectives.rdf
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -13,8 +16,11 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -27,10 +33,13 @@
 		<rdfs:label>Objectives Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts including goal, objective, program, and strategy. Objectives are defined as being distinct from goals, in that they constitute time limited and measurable targets which some entity may seek to attain in pursuit of its goals.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/GoalsAndObjectives/Objectives/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241101/GoalsAndObjectives/Objectives/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/GoalsAndObjectives/Objectives.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
 	(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -46,6 +55,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to add the property &apos;has strategy&apos; for use in linking to pricing, quotation, distribution, delivery, and other strategies or methods.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20221001/GoalsAndObjectives/Objectives.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary and eliminate unnecessary references to LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to add the concept of a project and related attributes (LOAN-169b).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -110,6 +120,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-gao-obj;Program">
+		<rdfs:subClassOf rdf:resource="&cmns-pts;Situation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasGoal"/>
@@ -124,10 +135,58 @@
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
+				<owl:onClass rdf:resource="&fibo-fnd-gao-obj;Project"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">program</rdfs:label>
 		<rdfs:label xml:lang="en-GB">programme</rdfs:label>
-		<skos:definition>coordinated set of activities designed to obtain benefits not available from managing them individually</skos:definition>
+		<skos:definition>state of affairs and coordinated set of activities designed to obtain benefits not available from managing them individually</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.prince2.com/usa/blog/project-vs-programme</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-gao-obj;Project">
+		<rdfs:subClassOf rdf:resource="&cmns-pts;Situation"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasInput"/>
+				<owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;hasOutput"/>
+				<owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasGoal"/>
+				<owl:onClass rdf:resource="&fibo-fnd-gao-obj;Goal"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasObjective"/>
+				<owl:onClass rdf:resource="&fibo-fnd-gao-obj;Objective"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-fnd-gao-obj;Program"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>project</rdfs:label>
+		<skos:definition>state of affairs and unique and temporary organization, designed to deliver a tangible output</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.prince2.com/usa/blog/project-vs-programme</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">A project has a fixed - generally fairly short - timeframe, and a project manager is responsible for delivering the output on time and on budget.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-gao-obj;SalesStrategy">

--- a/LOAN/LoansSpecific/GreenLoans.rdf
+++ b/LOAN/LoansSpecific/GreenLoans.rdf
@@ -280,5 +280,115 @@
 		<skos:definition xml:lang="en">financial institution appointed to help design, implement, and monitor the sustainability aspects of a syndicated green loan</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">This role is typically present in sustainability-linked loans (SLLs) or green loans, which tie the loan&apos;s terms to the borrower&apos;s environmental, social, and governance (ESG) performance. The sustainability structuring agent&apos;s role is crucial in ensuring that the loan&apos;s sustainability metrics align with both the borrower&apos;s goals and the expectations of the participating lenders.</cmns-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;TransitionLoan">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreementRepaidPeriodically"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-spc-com;CommercialLoan"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasMilestoneProvision"/>
+				<owl:onClass rdf:resource="&fibo-fnd-agr-ctr;ContractMilestone"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
+				<owl:onClass rdf:resource="&fibo-fnd-agr-ctr;MilestoneSchedule"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;DisclosureProvision"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;TransitionUseOfProceedsProvision"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;TransitionStrategy"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">transition loan</rdfs:label>
+		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as a bonding lines, guarantee line or letter of credit) designed to help businesses and organizations shift from carbon-intensive or environmentally harmful practices to more sustainable and environmentally friendly operations</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Transition loans are part of the broader sustainable finance market and are specifically tailored for companies in industries that are not inherently green but are committed to adopting practices that align with a low-carbon or sustainable economy.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Transition loans are structured to assist companies in reducing greenhouse gas (GHG) emissions, improving energy efficiency, adopting renewable energy sources, or meeting other sustainability targets aligned with climate transition goals. They support initiatives such as retrofitting fossil fuel-based systems, decarbonizing supply chains, or adopting cleaner production methods. Transition loans align with emerging Climate Transition Finance principles (developed by groups like the International Capital Market Association, ICMA). Borrowers are expected to demonstrate that the loan aligns with long-term, science-based climate goals, such as those outlined in the Paris Agreement (e.g., limiting global warming to well below 2°C).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;TransitionProject">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Project"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;MilestoneSchedule"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTextualName"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;TransitionUseOfProceedsProvision"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasDescription"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>transition project</rdfs:label>
+		<skos:definition>project can support broad, sector-specific efforts to reduce environmental impact</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Borrowers must demonstrate a credible transition plan, which include: (a) Clear sustainability performance targets (SPTs), (b) Alignment with recognized climate goals and frameworks (e.g., the Science Based Targets initiative, SBTi), and (c) ransparency in reporting progress and outcomes. Third-party verification or certification of the transition plan and its alignment with best practices is often required.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Green loans focus on funding projects with direct and measurable environmental benefits (e.g., solar farms, green buildings). Transition loans are for broader initiatives aimed at improving sustainability in traditionally carbon-intensive sectors.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Sustainability-Linked Loans (SLLs): Transition loans share similarities with SLLs, as both tie terms (such as interest rates) to achieving predefined sustainability goals. However, transition loans are specifically framed within the context of long-term decarbonization or sustainability transitions.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;TransitionStrategy">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;BusinessStrategy"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidencedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;SustainabilityPerformanceTarget"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasObjective"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;SustainabilityBusinessObjective"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;SustainabilityKeyPerformanceIndicator"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">transition strategy</rdfs:label>
+		<skos:definition xml:lang="en">strategy for achieving specific business objectives related to sustainability in the context of long-term decarbonization or sustainability transitions</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;TransitionUseOfProceedsProvision">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;UseOfProceedsProvision"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;governs"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;TransitionProject"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>transition use of proceeds provision</rdfs:label>
+		<skos:definition>use of proceeds provision specifying that funds obtained through financing, such as through a credit agreement, offering, warrant, or other instrument are intended to be used to fund specific projects, investments, or operational changes that support a company&apos;s transition toward sustainability</skos:definition>
+	</owl:Class>
 
 </rdf:RDF>

--- a/LOAN/LoansSpecific/GreenLoans.rdf
+++ b/LOAN/LoansSpecific/GreenLoans.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
@@ -29,6 +30,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
@@ -71,6 +73,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -114,8 +117,51 @@
 		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainable-lending-glossary-of-terms/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;GreenProject">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Project"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;MilestoneSchedule"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTextualName"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;GreenProjectUseOfProceedsProvision"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasDescription"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>green project</rdfs:label>
+		<skos:definition>project that contributes to environmental sustainability by addressing climate change, conserving natural resources, reducing pollution, or promoting ecological balance</skos:definition>
+		<skos:example xml:lang="en">Examples include: renewable energy projects (e.g., solar, wind, hydroelectric power), green buildings certified by recognized standards (e.g., LEED, BREEAM), sustainable water and wastewater management systems, pollution reduction technologies and systems, sustainable forestry and agriculture initiatives, circular economy projects, such as recycling or waste-to-energy facilities, low-carbon transportation infrastructure (e.g., electric vehicle charging stations, public transit projects), and the like.</skos:example>
+		<cmns-av:adaptedFrom>Loan Market Association (LMA) Green Loan Principles, available at https://www.icmagroup.org/assets/documents/Regulatory/Green-Bonds/LMA_Green_Loan_Principles_Booklet-220318.pdf.</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom xml:lang="en">https://www.lma.eu.com/application/files/8916/9755/2443/Green_Loan_Principles_23_February_2023.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.prince2.com/usa/blog/project-vs-programme</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote xml:lang="en">Green projects must align with established green finance principles, such as the Green Loan Principles (GLP) issued by the Loan Market Association (LMA), or other recognized sustainability frameworks.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">The borrower must demonstrate that the project meets predefined eligibility criteria for green financing. These criteria are usually aligned with the taxonomy or standards set forth by the Green Loan Principles, the EU Taxonomy for Sustainable Activities, or other regional or international guidelines.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">To qualify as a green project within a green loan: (a) the project must meet use-of-proceeds requirements, meaning that funds must be exclusively allocated to activities that qualify as green, (b) the borrower must establish clear processes for evaluating and selecting eligible projects, (c) there must be transparency in how funds are managed and allocated, often verified through audits or certifications, and (d) the borrower must report regularly on the environmental impact of the project, typically through measurable metrics (e.g., tons of CO₂ avoided, energy saved).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;GreenProjectUseOfProceedsProvision">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;UseOfProceedsProvision"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;governs"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;GreenProject"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>green project use of proceeds provision</rdfs:label>
 		<dct:source>Loan Market Association (LMA) Green Loan Principles, available at https://www.icmagroup.org/assets/documents/Regulatory/Green-Bonds/LMA_Green_Loan_Principles_Booklet-220318.pdf.</dct:source>
 		<skos:definition>use of proceeds provision specifying that funds obtained through financing, such as through a credit agreement, offering, warrant, or other instrument are intended to be used for Green Projects (including other related and supporting expenditures, including research and development)</skos:definition>

--- a/LOAN/LoansSpecific/GreenLoans.rdf
+++ b/LOAN/LoansSpecific/GreenLoans.rdf
@@ -2,8 +2,11 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
+	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
@@ -13,6 +16,7 @@
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
+	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -29,8 +33,11 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
+	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
@@ -40,6 +47,7 @@
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
+	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -63,6 +71,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
@@ -72,8 +81,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/GreenLoans/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -111,14 +123,28 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">green loan</rdfs:label>
-		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as bonding lines, a guarantee line or letter of credit) made available exclusively to finance, re-finance or guarantee, in whole or in part, new and/or existing eligible green projects and which are aligned to the four core components of the Green Loan Principles (GLP)</skos:definition>
-		<skos:example xml:lang="en">Example indicative categories of eligibility contained in the LMA&apos;s Green Loan Principles (GLP) include loans designed to facilitate renewable energy, energy efficiency, climate change adaptation and green buildings that meet regional, national or internationally recognised standards or certifications.</skos:example>
+		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as a bonding line, guarantee line or letter of credit) made available exclusively to finance, re-finance or guarantee, in whole or in part, new and/or existing eligible green projects that are aligned to the four core components of the Green Loan Principles (GLP)</skos:definition>
+		<skos:example xml:lang="en">Example categories of eligibility contained in the LMA&apos;s Green Loan Principles (GLP) include loans designed to facilitate renewable energy, energy efficiency, climate change adaptation and green buildings that meet regional, national or internationally recognised standards or certifications.</skos:example>
 		<cmns-av:adaptedFrom xml:lang="en">https://www.addleshawgoddard.com/en/insights/insights-briefings/2020/financial-services/green-loans-and-sustainability-linked-loans-what-is-the-difference/</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainable-lending-glossary-of-terms/</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;GreenProject">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Project"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-fac;Facility"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-fac;Site"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
@@ -170,6 +196,36 @@
 		The GLP explicitly recognise several broad categories of eligibility for Green Projects with the objective of addressing key areas of environmental concern such as climate change, natural resources depletion, loss of biodiversity, and air, water and soil pollution. This non-exhaustive list, set out in Appendix 1, is intended to capture the most usual types of projects supported, and expected to be supported, by the green loan market. However, it is recognised that definitions of green and green projects may vary depending on sector and geography</cmns-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;ObservedIndicatorValue">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;DatedCollectionConstituent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
+				<owl:someValuesFrom rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">observed indicator value</rdfs:label>
+		<skos:definition xml:lang="en">observation (measurement) of a key performance indicator measured at specific date and time</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;ObservedIndicatorValueStructure">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;DatedStructuredCollection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;ObservedIndicatorValue"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasDatePeriod"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;CalculationPeriod"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">observed indicator value structure</rdfs:label>
+		<skos:definition xml:lang="en">collection of observations for some key performance indicator measured over a specified window of time</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityAndBusinessStrategy">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;BusinessStrategy"/>
 		<rdfs:subClassOf>
@@ -193,7 +249,7 @@
 		<rdfs:label xml:lang="en">sustainability and business strategy</rdfs:label>
 		<skos:definition xml:lang="en">strategy for achieving specific business objectives related to sustainability (from an environmental and/or social and/or governance (ESG) perspective)</skos:definition>
 		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainability-linked-loan-principles-sllp/</cmns-av:adaptedFrom>
-		<cmns-av:explanatoryNote xml:lang="en">A SLL borrower should clearly communicate to its lender(s) its rationale for the selection of its KPI(s) (i.e. relevance, materiality, whether it is core to the borrower&apos;s overall business) and the motivation for the SPT(s) (i.e. ambition level, benchmarking approach and how the borrower intends to reach such SPTs). Borrowers are encouraged to position this information within the context of their overarching objectives, sustainability strategy, policy, sustainability commitments and/or processes relating to sustainability.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">An SLL borrower should clearly communicate to its lender(s) its rationale for the selection of its KPI(s) (i.e. relevance, materiality, whether it is core to the borrower&apos;s overall business) and the motivation for the SPT(s) (i.e. ambition level, benchmarking approach and how the borrower intends to reach such SPTs). Borrowers are encouraged to position this information within the context of their overarching objectives, sustainability strategy, policy, sustainability commitments and/or processes relating to sustainability.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote xml:lang="en">SLLs aim to support a borrower&apos;s efforts in improving its sustainability profile over the term of the loan. They do so by aligning loan terms to the borrower&apos;s performance, which is measured using one or more sustainability KPIs that can be internal and/or external. The KPIs must be material to the borrower&apos;s core sustainability and business strategy, and address relevant ESG challenges of its industry sector.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -207,6 +263,13 @@
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;SustainabilityKeyPerformanceIndicator">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;KeyPerformanceIndicator"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasObservedValue"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;ObservedIndicatorValueStructure"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasTargetValue"/>
@@ -250,7 +313,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">sustainability-linked loan</rdfs:label>
-		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as a bonding lines, guarantee line or letter of credit) for which the economic characteristics can vary depending on whether the borrower achieves ambitious, material and quantifiable predetermined sustainability performance objectives aligned with Sustainability-Linked Loan Principles (SSLP)</skos:definition>
+		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as a bonding line, guarantee line or letter of credit) for which the economic characteristics can vary depending on whether the borrower achieves ambitious, material and quantifiable predetermined sustainability performance objectives aligned with Sustainability-Linked Loan Principles (SSLP)</skos:definition>
 		<skos:example xml:lang="en">The use of proceeds in relation to a SLL is not a determinant in its categorisation and, in most instances, SLLs will be used for general corporate purposes. Instead, SLLs look to support a borrower in improving its sustainability performance.</skos:example>
 		<cmns-av:abbreviation xml:lang="en">SLL</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom xml:lang="en">https://www.addleshawgoddard.com/en/insights/insights-briefings/2020/financial-services/green-loans-and-sustainability-linked-loans-what-is-the-difference/</cmns-av:adaptedFrom>
@@ -266,11 +329,23 @@
 				<owl:someValuesFrom rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;TargetIndicatorValue"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasDatePeriod"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;CalculationPeriod"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">sustainability performance target</rdfs:label>
 		<skos:definition xml:lang="en">collection of quantitative target values used to calibrate the level of achievement a borrower makes with respect to a key performance indicator, by date, including, but not limited to, the methodology used to calculate its value at any point over the lifetime of a loan</skos:definition>
 		<cmns-av:abbreviation xml:lang="en">SPT</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom xml:lang="en">https://www.lsta.org/content/sustainability-linked-loan-principles-sllp/</cmns-av:adaptedFrom>
-		<cmns-av:explanatoryNote xml:lang="en">A SLL borrower should clearly communicate to its lenders its rationale for the selection of its KPI(s) (i.e. relevance, materiality, whether it is core to the borrower’s overall business) and the motivation for the SPT(s) (i.e. ambition level, benchmarking approach and how the borrower intends to reach such SPTs). Borrowers are encouraged to position this information within the context of their overarching objectives, sustainability strategy, policy, sustainability commitments and/or processes relating to sustainability.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">An SLL borrower should clearly communicate to its lenders its rationale for the selection of its KPI(s) (i.e. relevance, materiality, whether it is core to the borrower’s overall business) and the motivation for the SPT(s) (i.e. ambition level, benchmarking approach and how the borrower intends to reach such SPTs). Borrowers are encouraged to position this information within the context of their overarching objectives, sustainability strategy, policy, sustainability commitments and/or processes relating to sustainability.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote xml:lang="en">The process for calibration of the SPT(s) per KPI is key to the structuring of SLLs, since it will be the expression of the level of ambition the borrower is ready to commit to. The SPTs must be set in good faith and remain relevant (so long as they apply) and ambitious throughout the life of the loan.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -279,6 +354,18 @@
 		<rdfs:label xml:lang="en">sustainability structuring agent</rdfs:label>
 		<skos:definition xml:lang="en">financial institution appointed to help design, implement, and monitor the sustainability aspects of a syndicated green loan</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">This role is typically present in sustainability-linked loans (SLLs) or green loans, which tie the loan&apos;s terms to the borrower&apos;s environmental, social, and governance (ESG) performance. The sustainability structuring agent&apos;s role is crucial in ensuring that the loan&apos;s sustainability metrics align with both the borrower&apos;s goals and the expectations of the participating lenders.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-loan-spc-grn;TargetIndicatorValue">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;DatedCollectionConstituent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
+				<owl:someValuesFrom rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">target indicator value</rdfs:label>
+		<skos:definition xml:lang="en">target value for a key performance indicator as of a specific date and time</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;TransitionLoan">
@@ -317,9 +404,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">transition loan</rdfs:label>
-		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as a bonding lines, guarantee line or letter of credit) designed to help businesses and organizations shift from carbon-intensive or environmentally harmful practices to more sustainable and environmentally friendly operations</skos:definition>
+		<skos:definition xml:lang="en">credit agreement and/or contingent facility (such as a bonding line, guarantee line or letter of credit) designed to help a business or organization shift from carbon-intensive or environmentally harmful practices to more sustainable and environmentally friendly operations</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">Transition loans are part of the broader sustainable finance market and are specifically tailored for companies in industries that are not inherently green but are committed to adopting practices that align with a low-carbon or sustainable economy.</cmns-av:explanatoryNote>
-		<cmns-av:explanatoryNote xml:lang="en">Transition loans are structured to assist companies in reducing greenhouse gas (GHG) emissions, improving energy efficiency, adopting renewable energy sources, or meeting other sustainability targets aligned with climate transition goals. They support initiatives such as retrofitting fossil fuel-based systems, decarbonizing supply chains, or adopting cleaner production methods. Transition loans align with emerging Climate Transition Finance principles (developed by groups like the International Capital Market Association, ICMA). Borrowers are expected to demonstrate that the loan aligns with long-term, science-based climate goals, such as those outlined in the Paris Agreement (e.g., limiting global warming to well below 2°C).</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">Transition loans are structured to assist companies in reducing greenhouse gas (GHG) emissions, improving energy efficiency, adopting renewable energy sources, or meeting other sustainability targets aligned with climate transition goals. They support initiatives such as retrofitting fossil fuel-based systems, decarbonizing supply chains, or adopting cleaner production methods. Transition loans align with emerging Climate Transition Finance principles (developed by groups such as the International Capital Market Association, ICMA). Borrowers are expected to demonstrate that the loan aligns with long-term, science-based climate goals, such as those outlined in the Paris Agreement (e.g., limiting global warming to well below 2°C).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;TransitionProject">
@@ -338,8 +425,20 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-fac;Site"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-grn;TransitionUseOfProceedsProvision"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-fac;Facility"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -349,8 +448,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>transition project</rdfs:label>
-		<skos:definition>project can support broad, sector-specific efforts to reduce environmental impact</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">Borrowers must demonstrate a credible transition plan, which include: (a) Clear sustainability performance targets (SPTs), (b) Alignment with recognized climate goals and frameworks (e.g., the Science Based Targets initiative, SBTi), and (c) ransparency in reporting progress and outcomes. Third-party verification or certification of the transition plan and its alignment with best practices is often required.</cmns-av:explanatoryNote>
+		<skos:definition>project that supports broad, sector-specific efforts to reduce environmental impact</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Borrowers must demonstrate a credible transition plan, which include: (a) clear sustainability performance targets (SPTs), (b) alignment with recognized climate goals and frameworks (e.g., the Science Based Targets initiative, SBTi), and (c) transparency in reporting progress and outcomes. Third-party verification or certification of the transition plan and its alignment with best practices is often required.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote xml:lang="en">Green loans focus on funding projects with direct and measurable environmental benefits (e.g., solar farms, green buildings). Transition loans are for broader initiatives aimed at improving sustainability in traditionally carbon-intensive sectors.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote xml:lang="en">Sustainability-Linked Loans (SLLs): Transition loans share similarities with SLLs, as both tie terms (such as interest rates) to achieving predefined sustainability goals. However, transition loans are specifically framed within the context of long-term decarbonization or sustainability transitions.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -377,6 +476,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">transition strategy</rdfs:label>
 		<skos:definition xml:lang="en">strategy for achieving specific business objectives related to sustainability in the context of long-term decarbonization or sustainability transitions</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Note that although there are similarities with sustainability business strategies, they are not the same. KPIs and SPTs may, however, be defined similarly for a given project.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-grn;TransitionUseOfProceedsProvision">


### PR DESCRIPTION
## Description

1. Added the general concept of a project to the objectives ontology
2. Add the concept of a green project and link it to the green project use of proceeds concept
3. Add definitions for transition loans, strategies and projects
4. Add the notion of target and observed values as part of SPTs and to support KPI calculations


Fixes: #2074 / LOAN-169


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


