### PR TITLE
fix scaffolding.ttl with terminating dot after last @prefix

### DIFF
--- a/etc/vocabulary/scaffolding.ttl
+++ b/etc/vocabulary/scaffolding.ttl
@@ -1,7 +1,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix fibo-skos: <https://spec.edmcouncil.org/fibo/vocabulary/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 
 


### PR DESCRIPTION


## Description

fix scaffolding.ttl with terminating dot after last @prefix

Fixes: #2092

## Checklist:

> Note: I have not spent much time looking at the overall project, but this change appears reasonably small and tested the file `scaffolding.ttl` in my private project with python rdflib. Please let me know if I must understand the overall project and only then complete the checklist before re-submitting the patch.

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


