### PR TITLE
FND-389a - Integrate the ontologies added to Commons 1.2 (Organizations, phase 2)

### DIFF
--- a/BE/Corporations/Corporations.rdf
+++ b/BE/Corporations/Corporations.rdf
@@ -13,7 +13,6 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -36,7 +35,6 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -64,7 +62,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -132,7 +129,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:onClass rdf:resource="&cmns-org;FormalOrganization"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/BE/Corporations/Corporations.rdf
+++ b/BE/Corporations/Corporations.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
@@ -13,7 +14,6 @@
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -27,6 +27,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
@@ -36,7 +37,6 @@
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -48,7 +48,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 		<rdfs:label>Corporations Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for companies incorporated by the issuance of shares. Terms defined in this ontology are those which are applicable to all such entities. Many of these concepts form the basis of the relationships of ownership and control which obtain between entities of this type.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
@@ -56,14 +65,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/Corporations/Corporations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/Corporations/Corporations/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/Corporations/Corporations.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/Corporations/Corporations.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180901/Corporations/Corporations.rdf version of this ontology was modified per the FIBO 2.0 RFC to generalize certain unions where they were no longer required.</skos:changeNote>
@@ -76,9 +85,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20211201/Corporations/Corporations.rdf version of this ontology was modified to address text formatting hygiene issues and eliminate a dead link.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220801/Corporations/Corporations.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary and revise definitions to be ISO 704 compliant as needed.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/Corporations/Corporations.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/Corporations/Corporations.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-corp-corp;BoardAgreement">
@@ -111,7 +121,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-corp-corp;RegistrationIdentifier">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
@@ -139,7 +149,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-corp-corp;RegistrationIdentifierScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentificationScheme"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentificationScheme"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>

--- a/BE/FunctionalEntities/FunctionalEntities.rdf
+++ b/BE/FunctionalEntities/FunctionalEntities.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -14,7 +15,6 @@
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -31,6 +31,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -39,7 +40,6 @@
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -52,7 +52,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 		<rdfs:label>Functional Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for entities defined by their function, such as the relationship to the various forms which one or another functionally-defined entity may take. It also includes a number of basic types of entity defined by function, such as business and non-profit. The concepts in this ontology are intended to be extensible in other ontologies which may be dedicated to specific kinds of functionally-defined business entity or organization.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
@@ -66,9 +75,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20241101/FunctionalEntities/FunctionalEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/FunctionalEntities/FunctionalEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20150201/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.1 RTF report. Changes include deprecation of the SoleProprietorship class and making it equivalent to the class with the same name in the Sole Proprietorships ontology. This version also introduces a new FunctionalEntity class, as the parent of FunctionalBusinessEntity in this ontology and as the parent of Government in the GovernmentEntities ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160801/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified by the FIBO 2.0 revision to address missing labels and definitions on the deprecated sole proprietorship class to match those in the equivalent class.</skos:changeNote>
@@ -84,9 +94,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/FunctionalEntities/FunctionalEntities.rdf version of this ontology was augmented to include general definitions for syndicate and syndicate member (LOAN-169).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20241101/FunctionalEntities/FunctionalEntities.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;Association">
@@ -225,7 +236,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;Syndicate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;Organization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;Organization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
@@ -239,7 +250,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;SyndicateMember">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
@@ -264,7 +275,11 @@
 		<skos:definition>provides a text description of the sector to which the code applies</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:Class rdf:about="&fibo-fnd-org-org;OrganizationIdentifier">
+	<owl:Class rdf:about="&fibo-fnd-pas-pas;ServiceProvider">
+		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalEntity"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-org;OrganizationIdentifier">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
@@ -281,10 +296,6 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pas-pas;ServiceProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalEntity"/>
 	</owl:Class>
 
 </rdf:RDF>

--- a/BE/FunctionalEntities/FunctionalEntities.rdf
+++ b/BE/FunctionalEntities/FunctionalEntities.rdf
@@ -12,9 +12,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -36,9 +34,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -51,9 +47,9 @@
 		<rdfs:label>Functional Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for entities defined by their function, such as the relationship to the various forms which one or another functionally-defined entity may take. It also includes a number of basic types of entity defined by function, such as business and non-profit. The concepts in this ontology are intended to be extensible in other ontologies which may be dedicated to specific kinds of functionally-defined business entity or organization.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -61,9 +57,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -272,10 +266,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>provides a text description of the sector to which the code applies</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:Class rdf:about="&fibo-fnd-pas-pas;ServiceProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalEntity"/>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&cmns-org;OrganizationIdentifier">
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -293,6 +283,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-org;ServiceProvider">
+		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalEntity"/>
 	</owl:Class>
 
 </rdf:RDF>

--- a/BE/FunctionalEntities/FunctionalEntities.rdf
+++ b/BE/FunctionalEntities/FunctionalEntities.rdf
@@ -14,7 +14,6 @@
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -39,7 +38,6 @@
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -65,7 +63,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -133,7 +130,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:onClass rdf:resource="&cmns-org;FormalOrganization"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/BE/GovernmentEntities/GovernmentEntities.rdf
+++ b/BE/GovernmentEntities/GovernmentEntities.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
@@ -13,7 +14,6 @@
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -26,6 +26,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
@@ -36,7 +37,6 @@
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -65,12 +65,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/GovernmentEntities/GovernmentEntities/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was added to Business Entities, per the issue resolutions identified in the FIBO BE 1.1 RTF report.</skos:changeNote>
@@ -242,7 +242,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;GovernmentBody">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;FormalOrganization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasObjective"/>

--- a/BE/GovernmentEntities/GovernmentEntities.rdf
+++ b/BE/GovernmentEntities/GovernmentEntities.rdf
@@ -303,7 +303,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;Instrumentality">
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;GovernmentBody"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isMandatedBy"/>
@@ -388,7 +388,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;Polity">
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;GovernmentBody"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalPerson"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-ge-ge;hasSovereigntyOver"/>

--- a/BE/GovernmentEntities/GovernmentEntities.rdf
+++ b/BE/GovernmentEntities/GovernmentEntities.rdf
@@ -49,9 +49,9 @@
 		<rdfs:label>Government Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for representing polities and government entities and their relations.</dct:abstract>
 		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
-		Copyright (c) 2016-2025 Object Management Group, Inc.
+Copyright (c) 2016-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -210,7 +210,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;GovernmentBody"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:onClass rdf:resource="&fibo-be-ge-ge;GovernmentAppointee"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -229,7 +229,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:onClass>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDesignatedBy"/>
+						<owl:onProperty rdf:resource="&cmns-org;isDesignatedBy"/>
 						<owl:onClass rdf:resource="&fibo-be-ge-ge;GovernmentBody"/>
 						<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 					</owl:Restriction>
@@ -259,7 +259,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;GovernmentBody"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:onClass rdf:resource="&fibo-be-ge-ge;GovernmentMinister"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/BE/LegalEntities/CorporateBodies.rdf
+++ b/BE/LegalEntities/CorporateBodies.rdf
@@ -137,7 +137,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-cor;Constitution"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:cardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/BE/LegalEntities/CorporateBodies.rdf
+++ b/BE/LegalEntities/CorporateBodies.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
@@ -19,6 +20,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
@@ -57,6 +59,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/LegalEntities/CorporateBodies/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160201/LegalEntities/CorporateBodies.rdf version of this ontology was modified per the FIBO 2.0 RFC to address issues including elimination of missing labels and comments, integration with LCC, and replacing min 1 QCRs with someValuesFrom.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20180801/LegalEntities/CorporateBodies.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies.</skos:changeNote>
@@ -89,7 +92,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-cb;Corporation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-le-cb;isConstitutedBy"/>

--- a/BE/LegalEntities/CorporateBodies.rdf
+++ b/BE/LegalEntities/CorporateBodies.rdf
@@ -38,18 +38,26 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 		<rdfs:label>Corporate Bodies Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the basic mechanisms that establish legal personhood for judicial or artificial persons, specifically those that are corporate bodies, including bodies incorporated by equity, by guarantee, and by agreement.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230101/LegalEntities/CorporateBodies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/LegalEntities/CorporateBodies/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160201/LegalEntities/CorporateBodies.rdf version of this ontology was modified per the FIBO 2.0 RFC to address issues including elimination of missing labels and comments, integration with LCC, and replacing min 1 QCRs with someValuesFrom.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20180801/LegalEntities/CorporateBodies.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/LegalEntities/CorporateBodies.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
@@ -59,9 +67,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/LegalEntities/CorporateBodies.rdf version of this ontology was modified to eliminate unnecessary references, including those that have incorrect datatypes, and remove a reference that doesn&apos;t resolve.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210301/LegalEntities/CorporateBodies.rdf version of this ontology was modified to revise a dead link.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220801/LegalEntities/CorporateBodies.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/LegalEntities/CorporateBodies.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-le-cb;BenefitCorporation">

--- a/BE/LegalEntities/FormalBusinessOrganizations.rdf
+++ b/BE/LegalEntities/FormalBusinessOrganizations.rdf
@@ -13,7 +13,6 @@
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -38,7 +37,6 @@
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -68,7 +66,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -137,7 +134,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-fbo;NotForProfitOrganization">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;FormalOrganization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasObjective"/>

--- a/BE/LegalEntities/FormalBusinessOrganizations.rdf
+++ b/BE/LegalEntities/FormalBusinessOrganizations.rdf
@@ -112,7 +112,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-fbo;JointVenture">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:label>joint venture</rdfs:label>
 		<skos:definition>legal entity that is formed between parties that pool their resources for the purpose of accomplishing a specific task but otherwise retain their distinct identities</skos:definition>
 		<cmns-av:explanatoryNote>In a joint venture, each of the participants is responsible for profits, losses, and costs associated with it. However, the venture is its own entity, separate from the participants&apos; other business interests.</cmns-av:explanatoryNote>
@@ -176,7 +176,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-le-fbo;hasEquity">
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasExpression"/>
 		<rdfs:label>has equity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-aeq;OwnersEquity"/>
 		<skos:definition>indicates owners&apos; equity associated with the entity</skos:definition>
 	</owl:ObjectProperty>
@@ -205,7 +205,20 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>identifies an address that is officially recorded with some government authority and at which legal papers may be served</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:Class rdf:about="&fibo-be-le-lp;LegalEntity">
+	<owl:Class rdf:about="&fibo-fnd-pty-pty;TaxIdentifier">
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&cmns-org;OrganizationIdentifier">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-aap-ppl;NationalIdentificationNumber">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-org;LegalEntity">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
@@ -219,19 +232,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:onClass rdf:resource="&fibo-fnd-arr-cls;IndustrySectorClassifier"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pty-pty;TaxIdentifier">
-		<rdfs:subClassOf>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&cmns-org;OrganizationIdentifier">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-aap-ppl;NationalIdentificationNumber">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
 		</rdfs:subClassOf>
 	</owl:Class>
 

--- a/BE/LegalEntities/FormalBusinessOrganizations.rdf
+++ b/BE/LegalEntities/FormalBusinessOrganizations.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -11,10 +12,8 @@
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
-	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -28,6 +27,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -37,10 +37,8 @@
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
-	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -54,7 +52,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 		<rdfs:label>Formal Business Organizations Ontology</rdfs:label>
 		<dct:abstract>This ontology defines formal business organizations and related concepts. The ontology covers parts of organizations, membership, classification, address relations and other properties which are applicable to formal business organizations generally. The concept of a formal business organization forms the basis for articulation of types of organization, both incorporated and non-incorporated, in other FIBO-BE ontologies.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
@@ -62,16 +69,16 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/LegalEntities/FormalBusinessOrganizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/LegalEntities/FormalBusinessOrganizations/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was modified per the FIBO 2.0 RFC to address minor bug fixes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy.</skos:changeNote>
@@ -89,19 +96,20 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/LegalEntities/FormalBusinessOrganizations.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-le-fbo;Branch">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationalSubUnit"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationalSubUnit"/>
 		<rdfs:label>branch</rdfs:label>
 		<skos:definition>part of a larger organization that might not be co-located with it</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-fbo;Division">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationalSubUnit"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationalSubUnit"/>
 		<rdfs:label>division</rdfs:label>
 		<skos:definition>part of an organization, such as a line of business, that may have separate accounting and reporting requirements</skos:definition>
 	</owl:Class>
@@ -157,8 +165,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-fbo;ValueAddedTaxIdentificationNumber">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;TaxIdentifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentifier"/>
 		<rdfs:label>value-added tax identification number</rdfs:label>
 		<skos:definition>tax identifier that identifies a taxable person (business) or non-taxable legal entity for a consumption tax that is assessed incrementally, levied on the price of a product or service at each stage of production, distribution, and sale to the end consumer</skos:definition>
 		<cmns-av:abbreviation>VATIN</cmns-av:abbreviation>
@@ -187,7 +195,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-be-le-fbo;hasOperatingAddress">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-plc-adr;hasAddress"/>
 		<rdfs:label>has operating address</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;Organization"/>
+		<rdfs:domain rdf:resource="&cmns-org;Organization"/>
 		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
 		<skos:definition>indicates an address at which an organization carries out operations</skos:definition>
 	</owl:ObjectProperty>
@@ -221,7 +229,7 @@
 		<rdfs:subClassOf>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-org-org;OrganizationIdentifier">
+					<rdf:Description rdf:about="&cmns-org;OrganizationIdentifier">
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-fnd-aap-ppl;NationalIdentificationNumber">
 					</rdf:Description>

--- a/BE/LegalEntities/LEIEntities.rdf
+++ b/BE/LegalEntities/LEIEntities.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
@@ -16,7 +17,6 @@
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -34,6 +34,7 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
@@ -43,7 +44,6 @@
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -70,7 +70,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -81,6 +80,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
@@ -277,7 +277,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lei;LegalEntityIdentifier">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
@@ -298,7 +298,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lei;LegalEntityIdentifierScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentificationScheme"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentificationScheme"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
@@ -505,7 +505,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fnd-org-org;OrganizationName">
+	<owl:Class rdf:about="&cmns-org;OrganizationName">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-le-lei;hasTransliteratedName"/>

--- a/BE/LegalEntities/LEIEntities.rdf
+++ b/BE/LegalEntities/LEIEntities.rdf
@@ -14,7 +14,6 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
@@ -41,7 +40,6 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
@@ -57,9 +55,9 @@
 		<rdfs:label>Legal Entity Identifier (LEI) Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts around contractually capable business entities. The terms defined here are those which are relevant to the Legal Entity Identifier (LEI) work. The term known as legal entity in that work is identified as a formal organization which is recognized in some jurisdiction as being capable of incurring some liability, whether or not is a legal person as understood by the legal community. This is labeled as contractually capable entity, to avoid confusion with the accepted legal term for Legal Entity. Such entities are recognized as requiring an LEI, but the identifier itself is allocated to the formal organization which is recognized as being contractually capable.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -67,7 +65,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
@@ -124,7 +121,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:onClass rdf:resource="&cmns-org;LegalEntity"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -173,7 +170,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -264,7 +261,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-be-le-lei;LEIRegisteredEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalPerson"/>
 		<rdfs:label>LEI registered entity</rdfs:label>
 		<owl:equivalentClass>
 			<owl:Restriction>
@@ -281,7 +278,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:onClass rdf:resource="&cmns-org;LegalPerson"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -388,7 +385,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lei;hasLegalAddress">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-le-fbo;hasRegisteredAddress"/>
 		<rdfs:label>has legal address</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
 		<skos:definition>indicates the legal address for the entity, in the jurisdiction in which the entity is established, used for registration purposes with respect to obtaining an LEI</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
@@ -397,7 +394,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lei;hasLegalForm">
 		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has legal form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-le-lei;EntityLegalForm"/>
 		<skos:definition>indicates the nature of the entity as defined from a legal or regulatory perspective in a given jurisdiction</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
@@ -433,7 +430,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lei;isConsolidatedBy">
 		<rdfs:label>is consolidated by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:range rdf:resource="&cmns-org;LegalEntity"/>
 		<skos:definition>indicates the entity considered the &apos;end node&apos; or consolidating entity (parent) from an ISO 17442 perspective</skos:definition>
 		<cmns-av:adaptedFrom>GLEIF Level 2 Relationship Record (RR) Common Data Format (CDF), see https://www.gleif.org/en/about-lei/common-data-file-format/relationship-record-cdf-format#</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
@@ -441,7 +438,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lei;isConsolidationOf">
 		<rdfs:subPropertyOf rdf:resource="&cmns-col;comprises"/>
 		<rdfs:label>is consolidation of</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:range rdf:resource="&cmns-org;LegalEntity"/>
 		<skos:definition>indicates the entity considered the &apos;start node&apos; or consolidated entity from an ISO 17442 perspective</skos:definition>
 		<cmns-av:adaptedFrom>GLEIF Level 2 Relationship Record (RR) Common Data Format (CDF), see https://www.gleif.org/en/about-lei/common-data-file-format/relationship-record-cdf-format#</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
@@ -449,7 +446,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lei;isDirectlyConsolidatedBy">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-le-lei;isConsolidatedBy"/>
 		<rdfs:label>is directly consolidated by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:range rdf:resource="&cmns-org;LegalEntity"/>
 		<skos:definition>indicates that the entity considered the &apos;end node&apos; or consolidating entity (parent) fully consolidates the accounting of the &apos;start node&apos; (child) per the accounting rules specified, and is the closest consolidating entity to that child in any applicable ownership hierarchy</skos:definition>
 		<cmns-av:adaptedFrom>GLEIF Level 2 Relationship Record (RR) Common Data Format (CDF), see https://www.gleif.org/en/about-lei/common-data-file-format/relationship-record-cdf-format#</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
@@ -457,7 +454,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lei;isInternationalBranchOf">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-le-lei;isConsolidatedBy"/>
 		<rdfs:label>is an international branch of</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:range rdf:resource="&cmns-org;LegalEntity"/>
 		<skos:definition>indicates that the entity considered the &apos;start node&apos; or consolidated entity (child) is an international subsidiary of the &apos;end node&apos; (parent) in the jurisdiction of the child</skos:definition>
 		<cmns-av:adaptedFrom>GLEIF Level 2 Relationship Record (RR) Common Data Format (CDF), see https://www.gleif.org/en/about-lei/common-data-file-format/relationship-record-cdf-format#</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
@@ -472,12 +469,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lei;isUltimatelyConsolidatedBy">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-le-lei;isConsolidatedBy"/>
 		<rdfs:label>is ultimately consolidated by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:range rdf:resource="&cmns-org;LegalEntity"/>
 		<skos:definition>indicates that the entity considered the &apos;end node&apos; or consolidating entity (parent) fully consolidates the accounting of the &apos;start node&apos; (child) per the accounting rules specified, and is the most distant consolidating entity to that child in any applicable ownership hierarchy</skos:definition>
 		<cmns-av:adaptedFrom>GLEIF Level 2 Relationship Record (RR) Common Data Format (CDF), see https://www.gleif.org/en/about-lei/common-data-file-format/relationship-record-cdf-format#</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
-	<owl:Class rdf:about="&fibo-be-le-lp;LegalEntity">
+	<owl:Class rdf:about="&cmns-org;LegalEntity">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-le-lei;hasLegalForm"/>
@@ -495,7 +492,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-be-le-lp;LegalPerson">
+	<owl:Class rdf:about="&cmns-org;LegalPerson">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>

--- a/BE/LegalEntities/LegalPersons.rdf
+++ b/BE/LegalEntities/LegalPersons.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -26,6 +27,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -48,7 +50,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 		<rdfs:label>Legal Persons Ontology</rdfs:label>
 		<dct:abstract>This ontology defines legal personhood concepts. A legal person as defined here is any natural person or organization which is capable of accruing liability on its own part.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -61,9 +72,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/LegalEntities/LegalPersons/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/LegalEntities/LegalPersons/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/LegalEntities/LegalPersons.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/LegalEntities/LegalPersons.rdf version of this ontology was modified per the FIBO 2.0 RFC to normalize restrictions on business license.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/LegalEntities/LegalPersons.rdf version of this ontology was modified to rationalize natural person and legally capable person in a new concept, namely legally competent natural person, simplify / merge the legal person and formal organization class hierarchies, and correct certain definitions, including power of attorney.</skos:changeNote>
@@ -82,13 +94,14 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/LegalEntities/LegalPersons.rdf version of the ontology was modified to move the property, &apos;is conferred on&apos; from Relations to the Legal Capacity ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/LegalEntities/LegalPersons.rdf version of the ontology was modified to add a French label to special purpose vehicle.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230401/LegalEntities/LegalPersons.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/LegalEntities/LegalPersons.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;BusinessEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;FormalOrganization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasObjective"/>
@@ -137,7 +150,7 @@
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;LegalEntity">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;FormalOrganization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-le-lp;isOrganizedIn"/>

--- a/BE/LegalEntities/LegalPersons.rdf
+++ b/BE/LegalEntities/LegalPersons.rdf
@@ -51,9 +51,9 @@
 		<rdfs:label>Legal Persons Ontology</rdfs:label>
 		<dct:abstract>This ontology defines legal personhood concepts. A legal person as defined here is any natural person or organization which is capable of accruing liability on its own part.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -141,7 +141,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;CharteredLegalPerson">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:label>chartered legal person</rdfs:label>
 		<skos:definition>a legal person created by a royal charter or decree</skos:definition>
 		<skos:example>Anything with &apos;Royal Institute&apos; in the name. Also universities are generally set up by royal charter in a monarchy or principality, (often pre-dating any Privy Council i.e. directly be the monarch in the case of older universities). The Bank of England and the British Broadcasting Council (BBC) are also incorporated through Royal Charter.</skos:example>
@@ -149,50 +149,18 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;LegalEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-		<rdfs:subClassOf rdf:resource="&cmns-org;FormalOrganization"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-le-lp;isOrganizedIn"/>
-				<owl:onClass rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>legal entity</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-be-le-lp;LegallyCompetentNaturalPerson"/>
-		<skos:definition>legal person that is a partnership, corporation, or other organization having the capacity to negotiate contracts, assume financial obligations, and pay off debts, organized under the laws of some jurisdiction</skos:definition>
-		<skos:example>Examples of eligible legal entities include, without limitation:
-- all financial intermediaries;
-- banks and finance companies;
-- all entities that issue equity, debt or other securities for other capital structures;
-- all entities listed on an exchange;
-- all entities that trade stock or debt, investment vehicles, including mutual funds, pension funds and alternative investment vehicles constituted as corporate entities or collective investment agreements (including umbrella funds as well as funds under an umbrella structure, hedge funds, private equity funds, etc.);
-- all entities under the purview of a financial regulator and their affiliates, subsidiaries and holding companies;
-- counterparties to financial transactions.</skos:example>
-		<skos:scopeNote>The term &apos;legal entities&apos; includes, but is not limited to, unique parties that are legally or financially responsible for the performance of financial transactions or have the legal right in their jurisdiction to enter independently into legal contracts, regardless of whether they are incorporated or constituted in some other way (e.g. trust, partnership, contractual). It excludes natural persons, but includes governmental organizations and supranationals.</skos:scopeNote>
-		<cmns-av:adaptedFrom>ISO 17442, Financial services - Legal Entity Identifier (LEI), first edition, 2012-06-01, section 3.1</cmns-av:adaptedFrom>
-		<cmns-av:synonym>artificial person</cmns-av:synonym>
-		<cmns-av:synonym>juridical entity</cmns-av:synonym>
-		<cmns-av:synonym>juridical person</cmns-av:synonym>
-		<cmns-av:synonym>juristic person</cmns-av:synonym>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;LegalEntity"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;LegalPerson">
-		<rdfs:subClassOf rdf:resource="&cmns-pts;Party"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-le-lp;isRecognizedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">legal person</rdfs:label>
-		<skos:definition>autonomous agent that is recognized as having rights and obligations under the law, including but not limited to the right to sue and be sued, enter into contracts, own property, and incur financial and other obligations</skos:definition>
-		<cmns-av:explanatoryNote>To have legal personality means to be capable of having legal rights and duties within a certain legal system, such as to enter into contracts, sue, and be sued. Legal personality is a prerequisite to legal capacity, the ability of any legal person to amend (enter into, transfer, etc.) rights and obligations.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;LegalPerson"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;LegallyCompetentNaturalPerson">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalPerson"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-aap-ppl;Person"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalPerson"/>
 		<rdfs:label>legally competent natural person</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fnd-aap-ppl;IncapacitatedAdult"/>
 		<skos:definition>person who is considered competent, under the circumstances, to enter into a contract, conduct business, or participate in other activities that generally require the mental ability to understand problems and make decisions on his or her own behalf</skos:definition>
@@ -251,7 +219,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;SpecialPurposeVehicle">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:label xml:lang="fr-FR">fonds commun de placement</rdfs:label>
 		<rdfs:label xml:lang="en-US">special purpose vehicle</rdfs:label>
 		<skos:definition xml:lang="en">legal entity created to fulfill narrow, specific, and frequently temporary objectives</skos:definition>
@@ -262,13 +230,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;StatutoryBody">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:label>statutory body</rdfs:label>
 		<skos:definition>legal entity established by a government to consider evidence and make judgements in some field of activity</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;VariableInterestEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:label xml:lang="en">variable interest entity</rdfs:label>
 		<skos:definition xml:lang="en">legal entity whose shareholders are entitled to a percentage of a named company&apos;s profits via a private contract</skos:definition>
 		<cmns-av:abbreviation xml:lang="en">VIE</cmns-av:abbreviation>
@@ -279,7 +247,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lp;isOrganizedIn">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-le-lp;isRecognizedIn"/>
 		<rdfs:label>is organized in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<skos:definition>indicates the jurisdiction whose laws a legal entity is organized under</skos:definition>
 	</owl:ObjectProperty>
@@ -289,7 +257,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:domain>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-be-le-lp;LegalPerson">
+					<rdf:Description rdf:about="&cmns-org;LegalPerson">
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-fnd-agr-agr;Agreement">
 					</rdf:Description>
@@ -304,7 +272,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:onClass rdf:resource="&cmns-org;LegalPerson"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -314,17 +282,44 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-fm;employs">
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalPerson"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-fm;isEmployedBy">
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+		<rdfs:range rdf:resource="&cmns-org;LegalPerson"/>
 	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&cmns-org;LegalEntity">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-le-lp;isOrganizedIn"/>
+				<owl:onClass rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<skos:example>Examples of eligible legal entities include, without limitation:
+- all financial intermediaries;
+- banks and finance companies;
+- all entities that issue equity, debt or other securities for other capital structures;
+- all entities listed on an exchange;
+- all entities that trade stock or debt, investment vehicles, including mutual funds, pension funds and alternative investment vehicles constituted as corporate entities or collective investment agreements (including umbrella funds as well as funds under an umbrella structure, hedge funds, private equity funds, etc.);
+- all entities under the purview of a financial regulator and their affiliates, subsidiaries and holding companies;
+- counterparties to financial transactions.</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-org;LegalPerson">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-le-lp;isRecognizedIn"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
 
 </rdf:RDF>

--- a/BE/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf
+++ b/BE/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf
@@ -3,13 +3,13 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-ge-usj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
 	<!ENTITY fibo-be-le-usee "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/NorthAmericanEntities/USExampleEntities/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
@@ -23,13 +23,13 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-ge-usj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
 	xmlns:fibo-be-le-usee="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/NorthAmericanEntities/USExampleEntities/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
@@ -42,28 +42,38 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/NorthAmericanEntities/USExampleEntities/">
 		<rdfs:label>US Example Entities</rdfs:label>
 		<dct:abstract>This ontology includes example entities that are companies in the US that issue stock and that are represented in the Dow Jones Industrial Average (DJIA), to demonstrate how to begin to model those entities in FIBO.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2020-2025 EDM Council, Inc.
+		Copyright (c) 2020-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20230301/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200701/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to update the LEI format to use the form published by the GLEIF at data.world.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to make incorporation and registration dates explicit dates and to replace references to the legacy LCC UnitedStates country representation with UnitedStatesOfAmerica.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210301/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to update a dead link.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220801/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-2572IBTT8CCZW6AU4141-LEI">
@@ -121,8 +131,8 @@
 		<skos:definition>publicly held company and for profit corporation legal entity for Alphabet Inc., a Delaware stock corporation</skos:definition>
 		<fibo-be-corp-corp:hasDateOfIncorporation rdf:resource="&fibo-be-le-usee;AlphabetIncIncorporationDate"/>
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>Alphabet Inc.</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;AlphabetIncBusinessEntityIdentifier">
@@ -147,8 +157,8 @@
 		<skos:definition>publicly held company and for profit corporation legal entity for Apple Inc., a California stock corporation</skos:definition>
 		<fibo-be-corp-corp:hasDateOfIncorporation rdf:resource="&fibo-be-le-usee;AppleIncIncorporationDate"/>
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>Apple Inc.</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;AppleIncBusinessEntityIdentifier">
@@ -174,8 +184,8 @@
 		<skos:definition>publicly held company and for profit corporation legal entity for International Business Machines Corporation, a New York domestic business corporation</skos:definition>
 		<fibo-be-corp-corp:hasDateOfIncorporation rdf:resource="&fibo-be-le-usee;InternationalBusinessMachinesCorporationIncorporationDate"/>
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfNewYorkJurisdiction"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>International Business Machines Corporation</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;InternationalBusinessMachinesCorporationBusinessEntityIdentifier">
@@ -200,8 +210,8 @@
 		<skos:definition>publicly held company and for profit corporation legal entity for The Coca-Cola Company, a Delaware corporation</skos:definition>
 		<fibo-be-corp-corp:hasDateOfIncorporation rdf:resource="&fibo-be-le-usee;TheCoca-ColaCompanyIncorporationDate"/>
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>The Coca-Cola Company</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheCoca-ColaCompanyBusinessEntityIdentifier">
@@ -234,8 +244,8 @@
 		<skos:definition>publicly held company and for profit corporation legal entity for The Home Depot, Inc., a Delaware corporation</skos:definition>
 		<fibo-be-corp-corp:hasDateOfIncorporation rdf:resource="&fibo-be-le-usee;TheHomeDepotIncorporationDate"/>
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>The Home Depot, Inc.</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheHomeDepotIncorporationDate">
@@ -252,8 +262,8 @@
 		<skos:definition>publicly held company and for profit corporation legal entity for The Proctor &amp; Gamble Company, an Ohio corporation</skos:definition>
 		<fibo-be-corp-corp:hasDateOfIncorporation rdf:resource="&fibo-be-le-usee;TheProctorAndGambleCompanyIncorporationDate"/>
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfOhioJurisdiction"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>The Proctor &amp; Gamble Company</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheProctorAndGambleCompanyBusinessEntityIdentifier">

--- a/BE/OwnershipAndControl/ControlParties.rdf
+++ b/BE/OwnershipAndControl/ControlParties.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -11,7 +12,6 @@
 	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/">
 	<!ENTITY fibo-fnd-oac-ctl "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -22,6 +22,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -32,7 +33,6 @@
 	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"
 	xmlns:fibo-fnd-oac-ctl="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -44,20 +44,29 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/">
 		<rdfs:label>Control Parties Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts relating to types of controlling parties. The concepts defined here are party in role concepts, which define the nature of some entity such as an organization or a legal person, in some role such as that of owning a controlling interest in the entity or of controlling that entity. These roles are defined in terms of the types of control enjoyed by the party, for example de facto or de jure control. An important feature of this ontology is the distinction between the holding of a controlling interest (such as voting shares), and the de facto existence of control of one body by another as asserted in company filings or as a conclusion drawn from computational analysis of controlling interests.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/ControlParties/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/OwnershipAndControl/ControlParties/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/ControlParties.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/ControlParties.rdf version of this ontology was modified per the FIBO 2.0 RFC to add missing labels and definitions, eliminate references to BusinessFacingTypes, etc.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/ControlParties.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to correct reasoning anomalies.</skos:changeNote>
@@ -67,9 +76,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/OwnershipAndControl/ControlParties.rdf version of the ontology was modified to correct the label on hasControllingOrganizationMember and reflect the move of OrganizationMember from Parties to Organizations in FND, and to incorporate the latest insights into how control relations should integrate with the control situation.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210401/OwnershipAndControl/ControlParties.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/OwnershipAndControl/ControlParties.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/ControlParties.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cpty;ContractualControl">
@@ -270,7 +280,7 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;hasControllingParty"/>
 		<rdfs:label>has controlling organization member</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:range rdf:resource="&cmns-org;OrganizationMember"/>
 		<owl:inverseOf rdf:resource="&fibo-be-oac-cpty;isControllingMemberOf"/>
 		<skos:definition>relates a controlled party to a controlling member of the organization</skos:definition>
 	</owl:ObjectProperty>
@@ -302,7 +312,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;isControllingMemberOf">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isPartyControlling"/>
 		<rdfs:label>is controlling member of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:domain rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
 		<skos:definition>identifies a controlled organization over which the member has some measure of control</skos:definition>
 	</owl:ObjectProperty>

--- a/BE/OwnershipAndControl/ControlParties.rdf
+++ b/BE/OwnershipAndControl/ControlParties.rdf
@@ -5,7 +5,6 @@
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -26,7 +25,6 @@
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -54,7 +52,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
@@ -157,7 +154,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-oac-ctl;isControllingPartyOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>entity controlling party</rdfs:label>
@@ -288,7 +285,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;hasMajorityControllingParty">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isControlledPartyOf"/>
 		<rdfs:label>has majority controlling party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cpty;MajorityControllingParty"/>
 		<skos:definition>indicates a party that owns a controlling stake (over 50 percent) in the entity</skos:definition>
 	</owl:ObjectProperty>

--- a/BE/OwnershipAndControl/CorporateControl.rdf
+++ b/BE/OwnershipAndControl/CorporateControl.rdf
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-cctl "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/">
 	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
 	<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/">
@@ -20,11 +20,11 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-cctl="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"
 	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
 	xmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"
@@ -40,18 +40,27 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/">
 		<rdfs:label>Corporate Control Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts relating to corporation-specific control. These concepts are based on the general types of control (both de facto control and controlling interests), as defined in the ControlParties ontology, and are the specific examples of these concepts as they apply to companies incorporated by the issuance of shares.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/CorporateControl/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/OwnershipAndControl/CorporateControl/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified per the FIBO 2.0 RFC to add missing definitions and labels, eliminate references to BusinessFacingTypes, replace min 1 QCRs with someValuesFrom, address other hygiene issues, and limit the burden of certain restrictions, such as those on stock corporation, for typical applications.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to correct reasoning anomalies.</skos:changeNote>
@@ -62,9 +71,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210401/OwnershipAndControl/CorporateControl.rdf version of the ontology was modified to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220801/OwnershipAndControl/CorporateControl.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/OwnershipAndControl/CorporateControl.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/CorporateControl.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;Affiliate">
@@ -113,7 +123,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:allValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>controlled affiliate</rdfs:label>
@@ -184,7 +194,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasAffiliate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isControlledPartyOf"/>
 		<rdfs:label>has affiliate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cctl;Affiliate"/>
 		<skos:definition>has a party which directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with the company</skos:definition>
 	</owl:ObjectProperty>
@@ -218,7 +228,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasSubsidiary">
 		<rdfs:label>has subsidiary</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cctl;Subsidiary"/>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
 			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
@@ -266,7 +276,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;isWhollyOwnedBy">
 		<rdfs:label>is wholly owned by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestParty"/>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
 			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -385,7 +385,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 								<owl:unionOf rdf:parseType="Collection">
 									<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
 									</rdf:Description>
-									<rdf:Description rdf:about="&fibo-fnd-org-fm;FormalOrganization">
+									<rdf:Description rdf:about="&cmns-org;FormalOrganization">
 									</rdf:Description>
 								</owl:unionOf>
 							</owl:Class>
@@ -637,7 +637,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasResponsibleParty">
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasPartyRole"/>
 		<rdfs:label>has responsible party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdfs:domain rdf:resource="&cmns-org;FormalOrganization"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;ResponsibleParty"/>
 		<skos:definition>identifies a party that has some assignment, commitment or obligation with respect to the formal organization</skos:definition>
 	</owl:ObjectProperty>

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -17,7 +18,6 @@
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-oac-ctl "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -29,6 +29,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -44,7 +45,6 @@
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-oac-ctl="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -56,7 +56,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
 		<rdfs:label>Executives Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts relating to executives and their formal capacities. The concepts defined in this ontology cover types of corporate officers, board members and the like, along with the capacities in terms of which those party roles are defined, and the kinds of entity (principally natural persons) that are able to perform in those roles.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
@@ -67,15 +76,15 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/Executives/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/OwnershipAndControl/Executives/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/Executives.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160801/OwnershipAndControl/Executives.rdf version of this ontology was modified per the FIBO 2.0 RFC to fix reasoning issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/Executives.rdf version of this ontology was modified to clarify the definition of responsible party.</skos:changeNote>
@@ -92,9 +101,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220801/OwnershipAndControl/Executives.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/OwnershipAndControl/Executives.rdf version of the ontology was modified to move the property, &apos;is conferred on&apos; from Relations to the Legal Capacity ontology, and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/OwnershipAndControl/Executives.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/Executives.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cpty;DeFactoControllingInterestParty">
@@ -262,7 +272,7 @@
 	<owl:Class rdf:about="&fibo-be-oac-exec;BoardMember">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;ResponsibleParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
@@ -429,7 +439,7 @@
 	<owl:Class rdf:about="&fibo-be-oac-exec;CorporateOfficer">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;Executive"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;Signatory"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:label>corporate officer</rdfs:label>
 		<skos:definition>high-level management executive of a corporation or other organization, hired by the board of directors or the business owner(s), charged with certain operational responsibilities, and who has the authority to act on behalf of the organization, including the authority to enter into contracts on behalf of the organization</skos:definition>
 		<skos:example>Corporate officers may include a Chief Executive Officer (CEO), Chief Financial Officer (CFO), president, vice president(s), and in some cases a Chief Operating Officer (COO), Chief Compliance Officer (CCO), or other executive responsible for a critical function in the organization.</skos:example>
@@ -480,7 +490,7 @@
 	
 	<owl:Class rdf:about="&fibo-be-oac-exec;PrincipalParty">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;Signatory"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:label>principal party</rdfs:label>
 		<skos:definition>controlling party that is responsible for the management of daily business operations of an organization</skos:definition>
 	</owl:Class>

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -186,7 +186,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:onClass rdf:resource="&cmns-org;LegalPerson"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -383,7 +383,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 						<owl:someValuesFrom>
 							<owl:Class>
 								<owl:unionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
+									<rdf:Description rdf:about="&cmns-org;LegalEntity">
 									</rdf:Description>
 									<rdf:Description rdf:about="&cmns-org;FormalOrganization">
 									</rdf:Description>
@@ -473,7 +473,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:allValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>legally delegated authority</rdfs:label>

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -57,9 +57,9 @@
 		<rdfs:label>Executives Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts relating to executives and their formal capacities. The concepts defined in this ontology cover types of corporate officers, board members and the like, along with the capacities in terms of which those party roles are defined, and the kinds of entity (principally natural persons) that are able to perform in those roles.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -379,7 +379,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+						<owl:onProperty rdf:resource="&cmns-org;manages"/>
 						<owl:someValuesFrom>
 							<owl:Class>
 								<owl:unionOf rdf:parseType="Collection">
@@ -556,7 +556,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;delegatesControlTo">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-exec;authorizes"/>
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;designates"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;designates"/>
 		<rdfs:label>delegates control to</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
 		<skos:definition>indicates a party to which this legal person has delegated some authority or control</skos:definition>
@@ -564,7 +564,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;designatesSignatory">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-exec;authorizes"/>
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;designates"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;designates"/>
 		<rdfs:label>designates signatory</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;Signatory"/>
 		<skos:definition>authorizes to sign agreements, access accounts and/or perform other similar tasks</skos:definition>

--- a/BE/OwnershipAndControl/OwnershipParties.rdf
+++ b/BE/OwnershipAndControl/OwnershipParties.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
@@ -25,6 +26,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
@@ -46,7 +48,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 		<rdfs:label>Ownership Parties Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts relating to types of organization owning parties. The concepts defined here are party in role concepts, which define the nature of some entity such as an organization or a legal person, in some role such as that of owning equity in the entity. These roles are defined in terms of the ownership enjoyed by the party, with distinctions between constitutional ownership i.e. ownership defined in terms of stockholder equity, and investment ownership more generally.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
@@ -59,8 +70,9 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/OwnershipParties/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/OwnershipAndControl/OwnershipParties/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified per the FIBO 2.0 RFC to address missing labels and comments, and revise terminology related to shareholders&apos; equity due to requirements for SEC/Equities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to support GLEIF LEI Level 2 ownership relationships.</skos:changeNote>
@@ -76,10 +88,11 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1 and clean up a few definitions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20231201/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to replace additional concepts from FIBO FND with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/OwnershipParties.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to add a parent class of contract party to the definition of investory (SEC-113).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-le-lei;RelationshipRecord">
@@ -184,7 +197,7 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-be-le-lp;BusinessEntity">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
+							<rdf:Description rdf:about="&cmns-org;LegalEntity">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -194,7 +207,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-oac-opty;hasOwningEntity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>entity ownership</rdfs:label>
@@ -267,7 +280,7 @@
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-be-le-lp;BusinessEntity">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
+					<rdf:Description rdf:about="&cmns-org;LegalEntity">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -302,7 +315,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-opty;hasInvestmentOwnership">
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;playsActiveRoleIn"/>
 		<rdfs:label>has investment ownership</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalPerson"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-opty;EntityOwnership"/>
 		<owl:inverseOf rdf:resource="&fibo-be-oac-opty;hasOwningEntity"/>
 		<skos:definition>relates a legal person to the context in which it owns a formal organization</skos:definition>
@@ -319,7 +332,7 @@
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-be-le-lp;BusinessEntity">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
+					<rdf:Description rdf:about="&cmns-org;LegalEntity">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -331,7 +344,7 @@
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasActiveParty"/>
 		<rdfs:label>has owning entity</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-opty;EntityOwnership"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+		<rdfs:range rdf:resource="&cmns-org;LegalPerson"/>
 		<skos:definition>indicates a party that owns a formal organization</skos:definition>
 	</owl:ObjectProperty>
 

--- a/BE/Partnerships/Partnerships.rdf
+++ b/BE/Partnerships/Partnerships.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -12,7 +13,6 @@
 	<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -24,6 +24,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -34,7 +35,6 @@
 	xmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -46,21 +46,30 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/Partnerships/Partnerships/">
 		<rdfs:label>Partnerships Ontology</rdfs:label>
 		<dct:abstract>This ontology defines partnerships and related concepts. The concepts distinguish general from limited partners, as well as the types of equity that they hold. Included are abstract definitions of partnership types based on whether they have general, limited or both kinds of partners. Both legally incorporated and non incorporated forms of partnerships are covered.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/Partnerships/Partnerships/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/Partnerships/Partnerships/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/Partnerships/Partnerships.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/Partnerships/Partnerships.rdf version of this ontology was modified per the FIBO 2.0 RFC to reference shareholders&apos; equity vs. stockholders&apos; equity and correct a number of restrictions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/Partnerships/Partnerships.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies.</skos:changeNote>
@@ -74,9 +83,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220801/Partnerships/Partnerships.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/Partnerships/Partnerships.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/Partnerships/Partnerships.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/Partnerships/Partnerships.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-ptr-ptr;GeneralPartner">
@@ -179,7 +189,7 @@
 	
 	<owl:Class rdf:about="&fibo-be-ptr-ptr;Partner">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;ConstitutionalOwner"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>

--- a/BE/Partnerships/Partnerships.rdf
+++ b/BE/Partnerships/Partnerships.rdf
@@ -193,7 +193,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:onClass rdf:resource="&cmns-org;LegalPerson"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -225,7 +225,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-be-ptr-ptr;Partnership">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;BusinessEntity"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasObjective"/>

--- a/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
+++ b/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -10,7 +11,6 @@
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-be-plc-plc "https://spec.edmcouncil.org/fibo/ontology/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -21,6 +21,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -29,7 +30,6 @@
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-be-plc-plc="https://spec.edmcouncil.org/fibo/ontology/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -40,17 +40,26 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/">
 		<rdfs:label>Private Limited Companies Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for representing private limited companies -- i.e., companies that have characteristics of corporations and of partnerships but are neither.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/PrivateLimitedCompanies/PrivateLimitedCompanies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/PrivateLimitedCompanies/PrivateLimitedCompanies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies, and add limited liability company, limited liability company taxed as a corporation, managing member, and private limited company.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20201201/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified to eliminate a smart quote in an explanatory note on manager-managed limited liability company, and to reflect the move of OrganizationMember from Parties to Organizations in FND</skos:changeNote>
@@ -58,9 +67,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20211201/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230201/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-plc-plc;LimitedLiabilityCompany">
@@ -97,7 +107,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;DeJureControllingInterestParty"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;EntityControllingParty"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;EntityOwner"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-oac-cpty;isControllingMemberOf"/>

--- a/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
+++ b/BE/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
@@ -177,7 +177,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-be-plc-plc;PrivateCompanyWithLimitedLiability">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;BusinessEntity"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:label>private company with limited liability</rdfs:label>
 		<skos:definition>hybrid business entity having characteristics of both a corporation and a partnership or sole proprietorship (depending on how many owners there are)</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://en.wikipedia.org/wiki/Limited_liability_company#Overview</cmns-av:adaptedFrom>

--- a/BE/SoleProprietorships/SoleProprietorships.rdf
+++ b/BE/SoleProprietorships/SoleProprietorships.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -17,6 +18,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/SoleProprietorships/SoleProprietorships/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -34,15 +36,25 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/SoleProprietorships/SoleProprietorships/">
 		<rdfs:label>Sole Proprietorships Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for representing sole proprietorships -- i.e., organizations that are owned by an individual that is responsible for the liabilities of the organization.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+Copyright (c) 2016-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/OwnershipAndControl/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/SoleProprietorships/SoleProprietorships/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/SoleProprietorships/SoleProprietorships/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/SoleProprietorships/SoleProprietorships.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/SoleProprietorships/SoleProprietorships.rdf version of this ontology was modified to use natural person rather than legally capable person.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20181101/SoleProprietorships/SoleProprietorships.rdf version of this ontology was modified to eliminate a redundant subclass relationship, enhance ownership relations, and revise definitions to be ISO 704 compliant.</skos:changeNote>
@@ -50,9 +62,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210301/SoleProprietorships/SoleProprietorships.rdf version of this ontology was modified to make sole proprietorship a subclass of legal person.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20220101/SoleProprietorships/SoleProprietorships.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/SoleProprietorships/SoleProprietorships.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/SoleProprietorships/SoleProprietorships.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-sps-sps;SoleProprietor">
@@ -90,7 +103,7 @@
 	
 	<owl:Class rdf:about="&fibo-be-sps-sps;SoleProprietorship">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;BusinessEntity"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalPerson"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-oac-oac;isOwnedAndControlledBy"/>

--- a/BE/Trusts/Trusts.rdf
+++ b/BE/Trusts/Trusts.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -10,7 +11,6 @@
 	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
 	<!ENTITY fibo-be-tr-tr "https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/">
 	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -22,6 +22,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -30,7 +31,6 @@
 	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
 	xmlns:fibo-be-tr-tr="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/"
 	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -42,19 +42,28 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/">
 		<rdfs:label>Trusts Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental common terms for trusts. Trusts are entities set up in terms of the applicable local statutes goerning trusts, and have as a minimum three specific, defined parties, known in many jurisdictions as trustor (sometimes sponsor), trustee and beneficiary. The terms in this ontology may be extended as necessary to represent specific types of trust, for example in the funds arena.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20240101/Trusts/Trusts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/Trusts/Trusts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/Trusts/Trusts.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20150201/Trusts/Trusts.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/Trusts/Trusts.rdf version of this ontology was modified to simplify / merge the legal person and formal organization class hierarchies.</skos:changeNote>
@@ -65,9 +74,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210401/Trusts/Trusts.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/Trusts/Trusts.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/Trusts/Trusts.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/Trusts/Trusts.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;IrrevocableTrust">
@@ -194,7 +204,7 @@
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;Trustee">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
@@ -235,7 +245,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;Trustor">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>

--- a/BE/Trusts/Trusts.rdf
+++ b/BE/Trusts/Trusts.rdf
@@ -110,7 +110,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-be-tr-tr;Trust">
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;BusinessEntity"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>

--- a/BE/Trusts/Trusts.rdf
+++ b/BE/Trusts/Trusts.rdf
@@ -43,9 +43,9 @@
 		<rdfs:label>Trusts Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental common terms for trusts. Trusts are entities set up in terms of the applicable local statutes goerning trusts, and have as a minimum three specific, defined parties, known in many jurisdictions as trustor (sometimes sponsor), trustee and beneficiary. The terms in this ontology may be extended as necessary to represent specific types of trust, for example in the funds arena.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -192,7 +192,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+						<owl:onProperty rdf:resource="&cmns-org;manages"/>
 						<owl:allValuesFrom rdf:resource="&fibo-be-tr-tr;Trust"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
@@ -210,7 +210,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+						<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
 						<owl:allValuesFrom rdf:resource="&fibo-be-tr-tr;Trust"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
@@ -221,7 +221,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
+						<owl:onProperty rdf:resource="&cmns-org;manages"/>
 						<owl:allValuesFrom rdf:resource="&fibo-be-tr-tr;Trust"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>

--- a/BP/SecuritiesIssuance/EquitiesIPOIssuance.rdf
+++ b/BP/SecuritiesIssuance/EquitiesIPOIssuance.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -16,7 +17,6 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -30,6 +30,7 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -42,7 +43,6 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -54,7 +54,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/EquitiesIPOIssuance/">
 		<rdfs:label xml:lang="en">Equities IPO Issuance Ontology</rdfs:label>
 		<dct:abstract>Issuance process for equity instruments that are issued via an Initial Public Offering (IPO).</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/IssuanceDocuments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/IssuanceProcess/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -63,18 +72,18 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/EquitiesIPOIssuance/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-bp-iss-ipo;AgreeBasisForAllocation">
@@ -111,7 +120,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-ipo;InitialPublicOfferingProcessStep"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;designates"/>
+				<owl:onProperty rdf:resource="&cmns-org;designates"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -141,7 +150,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-ipo;InitialPublicOfferingProcessStep"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -167,7 +176,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-ipo;InitialPublicOfferingProcessStep"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -261,7 +270,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-ipo;InitialPublicOfferingProcessStep"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/CAE/CorporateEvents/CorporateActions.rdf
+++ b/CAE/CorporateEvents/CorporateActions.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
@@ -27,6 +28,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
@@ -44,8 +46,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 		<rdfs:label xml:lang="en">Corporate Actions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides a high level overview of actions including corporate, market, and regulatory actions, ranging from business oriented events such as address and name changes, to those that are more specific to securities.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+		Copyright (c) 2016-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
@@ -57,12 +67,14 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20230301/CorporateEvents/CorporateActions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20250301/CorporateEvents/CorporateActions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20220301/CorporateEvents/CorporateActions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20230201/CorporateEvents/CorporateActions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20230301/CorporateEvents/CorporateActions.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;Action">
@@ -79,7 +91,7 @@
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
+							<rdf:Description rdf:about="&cmns-org;LegalEntity">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-fbc-fi-fi;Security">
 							</rdf:Description>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -38,6 +39,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -70,7 +72,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
 		<rdfs:label xml:lang="en">Credit Default Swaps Ontology</rdfs:label>
 		<dct:abstract>Credit default swaps are financial instruments that allow the transfer of credit risk among market participants, potentially facilitating greater efficiency in the pricing and distribution/offset of credit risk. They are bilateral contracts in which one party (the protection seller) agrees to provide payment(s) to the other party (the protection buyer) should a credit event occur against the underlying. The underlier for a CDS may be a specified debt (the reference obligation), a specific debt issuer (reference entity), in which case the credit events involving the entity is what triggers the payment, a basket of reference entities and/or reference obligations, or a credit index (reference index). This ontology defines the concept of a basic credit default swap as well as more specific kinds of CDS and specifies related details.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
@@ -95,17 +106,19 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20240101/CreditDerivatives/CreditDefaultSwaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20250301/CreditDerivatives/CreditDefaultSwaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20221201/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/CreditDerivatives/CreditDefaultSwaps.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230301/CreditDerivatives/CreditDefaultSwaps.rdf version of this ontology was modified to add the concept of a credit default swap index.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231001/CreditDerivatives/CreditDefaultSwaps.rdf version of this ontology was modified to move the nominal for auction market from CDS to the pricing ontology (its IRI was that of the instrument pricing ontology but it was mistakenly in the CDS ontology) and simplify the definition (DER-140).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231101/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to eliminate a subproperty relationship between the contract price and notional amount, which may not be appropriate (DER-127), and to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to replace additional concepts from FIBO FND with their counterparts in the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20240101/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;AssetBackedCreditDefaultSwap">
@@ -206,14 +219,14 @@
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Notice"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
+				<owl:onProperty rdf:resource="&cmns-doc;isAbout"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;TriggeringEvent"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit event notice</rdfs:label>

--- a/DER/DerivativesContracts/DerivativesBasics.rdf
+++ b/DER/DerivativesContracts/DerivativesBasics.rdf
@@ -7,10 +7,10 @@
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
@@ -47,10 +47,10 @@
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
@@ -92,7 +92,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 See https://opensource.org/licenses/MIT.</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
@@ -121,9 +120,10 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20250201/DerivativesContracts/DerivativesBasics/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20250301/DerivativesContracts/DerivativesBasics/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and eliminate a redundant subclass declaration in observable value.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200401/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to loosen the domain of the hasUnderlier property, which could be either an instrument or leg, refine the definition of Underlier and hasUnderlier based on recent work on swaps, add the definition of a contract for difference (CFD), simplify the contract party hierarchy where the subclasses of contract party do not add semantics, add the concepts of underlying asset valuation and calculation agent, which are needed for various derivatives (moved from forwards) and eliminate the language related to transactions as well as the distinction between an OTC contract and exchange-traded contract / listed security, given how blurry the lines are today, across derivatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20201201/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to eliminate hasThirdParty as a superproperty of hasCalculationAgent, which led to unintended reasoning consequences, added concepts and properties specific to settlement and valuation required for futures, forwards, and options, and moved general properties from forwards and swaps up to derivatives basics.</skos:changeNote>
@@ -137,6 +137,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231101/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to extend the definition of has notional amount, covering the variations allowed by the ISO CFI standard (DER-127) and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to eliminate a redundant restriction on derivative instrument (GitHub-2028).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20240901/DerivativesContracts/DerivativesBasics.rdf version of this ontology was modified to support details of ISO 4914, Financial services - Unique Product Identifier (UPI), (DER-146), and refine definitions related to underliers (DER-112).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20250201/DerivativesContracts/DerivativesBasics.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -363,7 +364,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdf:type rdf:resource="&fibo-fbc-fct-ra;Registry"/>
 		<rdfs:label>unique product identifier reference data library</rdfs:label>
 		<skos:definition>set of data comprised of reference data elements with specific values that together describe the product</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-der-drc-bsc;UniqueProductIdentifierServiceProvider"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-der-drc-bsc;UniqueProductIdentifierServiceProvider"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-der-drc-bsc;UniqueProductIdentifierRegistryEntry">
@@ -449,7 +450,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-bsc;hasCalculationAgent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isProvidedBy"/>
 		<rdfs:label xml:lang="en">has calculation agent</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-der-drc-bsc;CalculationAgent"/>
 		<skos:definition>indicates the party that is responsible for determining the value of a derivative</skos:definition>

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-ma "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/">
@@ -14,7 +15,6 @@
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -26,6 +26,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-ma="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/"
@@ -37,7 +38,6 @@
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -48,7 +48,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/">
 		<rdfs:label xml:lang="en">Derivatives Master Agreements Ontology</rdfs:label>
 		<dct:abstract>Terms that make up the OTC Derivatives Master agreement as defined in the ISDA literature. This is an experimental ontology and needs considerable re-work if it is to be considered for release.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -59,16 +68,16 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;CreditEventDefinition">
@@ -94,7 +103,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/DebtAndEquities/CreditEvents.rdf
+++ b/FBC/DebtAndEquities/CreditEvents.rdf
@@ -3,8 +3,8 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -22,8 +22,8 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -41,8 +41,16 @@
 		<rdfs:label xml:lang="en">Credit Events Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a range of credit events, that is events in which some payment or payments are not made. These include credit events relating to a specific debt obligation and events relating to the business entity as a whole. 
 		Note: the events defined herein are primarily business rather than consumer oriented, and are specified fairly generally. Many credit events are jurisdiction-specific, such as Chapter 11 restructuring and Chapter 7 bankruptcy in the United States. This ontology is designed to facilitate jurisdiction and instrument-specific extensions as needed.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -52,16 +60,18 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/CreditEvents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/DebtAndEquities/CreditEvents/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to move a restriction involving breach of covenant from credit event, since not all credit events involve breaches, to default event, and loosen the constraint since a breach depends on the contract.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220401/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to augment the definition of obligation-specific event with an optional default threshold to better support credit default swaps.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221001/DebtAndEquities/CreditEvents.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/DebtAndEquities/CreditEvents.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/DebtAndEquities/CreditEvents.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/CreditEvents.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2020-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;Bankruptcy">
@@ -110,7 +120,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">entity-specific credit event</rdfs:label>

--- a/FBC/DebtAndEquities/CreditRatings.rdf
+++ b/FBC/DebtAndEquities/CreditRatings.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
@@ -18,7 +19,6 @@
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
 	<!ENTITY fibo-fnd-arr-rt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -36,6 +36,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
@@ -47,7 +48,6 @@
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
 	xmlns:fibo-fnd-arr-rt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -77,7 +77,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -88,6 +87,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
@@ -451,7 +451,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-arr-rt;rates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;FormalOrganization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">organization credit rating</rdfs:label>

--- a/FBC/DebtAndEquities/CreditRatings.rdf
+++ b/FBC/DebtAndEquities/CreditRatings.rdf
@@ -196,7 +196,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crt;CreditRatingScale"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -239,7 +239,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-rt;RatingScale"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crt;CreditRatingAgency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -879,7 +879,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;VariableInterestRate"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -9,11 +9,11 @@
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
@@ -47,11 +47,11 @@
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
@@ -88,7 +88,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 See https://opensource.org/licenses/MIT.</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -114,6 +113,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
@@ -286,7 +286,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>borrowing capacity</rdfs:label>
@@ -474,7 +474,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:allValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -620,7 +620,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:allValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/FBC/DebtAndEquities/Guaranty.rdf
+++ b/FBC/DebtAndEquities/Guaranty.rdf
@@ -3,11 +3,11 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-dae-gty "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
@@ -30,11 +30,11 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-dae-gty="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"
@@ -56,9 +56,17 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
 		<rdfs:label>Guaranty Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts related to contractual guaranty.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+		Copyright (c) 2016-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -73,9 +81,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/Guaranty/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/DebtAndEquities/Guaranty/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Guaranty/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181001/DebtAndEquities/Guaranty/ version of this ontology revised to add financial asset as a parent of letter of credit.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181001/DebtAndEquities/Guaranty/ version of this ontology revised to incorporate refinement of the concept of a guaranty as needed for debt securities and loans.</skos:changeNote>
@@ -86,9 +95,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/Guaranty.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/DebtAndEquities/Guaranty.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/DebtAndEquities/Guaranty.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/Guaranty.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-gty;CollateralizedGuaranty">
@@ -127,7 +137,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:allValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -5,12 +5,12 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -34,12 +34,12 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -71,7 +71,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -88,10 +87,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250201/FinancialInstruments/FinancialInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FinancialInstruments/FinancialInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified for the FIBO 2.0 RFC, including minor bug fixes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified as a part of organizational hierarchy simplification, to add maturity-related properties, and to add exempt security.</skos:changeNote>
@@ -117,6 +117,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240801/FinancialInstruments/FinancialInstruments.rdf version of this ontology was modified to loosen the constraint on financial instrument with respect to having exactly 1 currency (DER-113), and to move the definition of promissory note from debt to financial instruments (LOAN-168).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20241001/FinancialInstruments/FinancialInstruments.rdf version of this ontology was modified to add a restriction related to initial exchange date.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20241201/FinancialInstruments/FinancialInstruments.rdf version of this ontology was modified to unify and simplify the notion of an underlier across FIBO (DER-112).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250201/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -524,7 +525,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fi-fi;hasPrincipalExecutiveOfficeAddress">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-le-fbo;hasRegisteredAddress"/>
 		<rdfs:label>has principal executive office address</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+		<rdfs:domain rdf:resource="&cmns-org;LegalPerson"/>
 		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
 		<skos:definition>relates an organization, specifically the issuer of a financial instrument, to its principal executive address, as required for issuance of that instrument</skos:definition>
 		<cmns-av:explanatoryNote>Note that in most cases, the principal executive office address is also the headquarters address for a company.</cmns-av:explanatoryNote>

--- a/FBC/FunctionalEntities/BusinessRegistries.rdf
+++ b/FBC/FunctionalEntities/BusinessRegistries.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
@@ -19,7 +20,6 @@
 	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -37,6 +37,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
@@ -49,7 +50,6 @@
 	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -81,7 +81,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -92,6 +91,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/BusinessRegistries/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.1 RTF report.</skos:changeNote>
@@ -532,7 +532,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;FormalOrganization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>North American Industry Classification System code</rdfs:label>
@@ -632,7 +632,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;FormalOrganization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>standard industrial classification code</rdfs:label>
@@ -812,7 +812,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;RegistryIdentifier"/>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fnd-org-fm;FormalOrganization">
+	<owl:Class rdf:about="&cmns-org;FormalOrganization">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>

--- a/FBC/FunctionalEntities/BusinessRegistries.rdf
+++ b/FBC/FunctionalEntities/BusinessRegistries.rdf
@@ -13,7 +13,6 @@
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-fct-breg "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
@@ -43,7 +42,6 @@
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-fct-breg="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
@@ -75,7 +73,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
@@ -122,58 +119,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-be-le-lei;LegalEntityIdentifier">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;RegistryIdentifier"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-le-lp;LegalEntity">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-breg;hasEntityExpirationReason"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-breg;hasEntityStatus"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;EntityStatus"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-breg;hasEntityExpirationDate"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&cmns-dt;CombinedDateTime"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dt;precedes"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;NorthAmericanIndustryClassificationSystemCode"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;StandardIndustrialClassificationCode"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-le-fbo;hasHeadquartersAddress"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;ActiveStatus">
@@ -824,6 +769,58 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;StandardIndustrialClassificationCode"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-org;LegalEntity">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-breg;hasEntityExpirationReason"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-breg;hasEntityStatus"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;EntityStatus"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-breg;hasEntityExpirationDate"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&cmns-dt;CombinedDateTime"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;NorthAmericanIndustryClassificationSystemCode"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;StandardIndustrialClassificationCode"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-le-fbo;hasHeadquartersAddress"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;precedes"/>
+				<owl:onClass rdf:resource="&cmns-org;LegalEntity"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/FunctionalEntities/BusinessRegistries.rdf
+++ b/FBC/FunctionalEntities/BusinessRegistries.rdf
@@ -167,7 +167,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-breg;BusinessRegistry"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -188,7 +188,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-breg;BusinessRegistrationAuthority"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FBC/FunctionalEntities/BusinessRegistries.rdf
+++ b/FBC/FunctionalEntities/BusinessRegistries.rdf
@@ -20,7 +20,6 @@
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -51,7 +50,6 @@
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -84,7 +82,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>

--- a/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-eufse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -14,10 +14,10 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-eufse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -28,19 +28,29 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/">
 		<rdfs:label>European Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with additional kinds of entities that that provide services in Europe, across national boundaries, such as European market data providers, organizations that provide exchanges in multiple countries, organizations that support the European Union, and so forth.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2017-2025 EDM Council, Inc.
+Copyright (c) 2017-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf version of this ontology was revised to adjust the name of the CreditInstitutionOrInvestmentFirm classification to eliminate the &apos;or&apos; in the name to address hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20210801/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2017-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2017-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eufse;CRDCreditInstitution">
@@ -86,7 +96,7 @@
 					<rdf:Description rdf:about="&fibo-fbc-fct-fse;InvestmentCompany">
 					</rdf:Description>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+						<owl:onProperty rdf:resource="&cmns-org;provides"/>
 						<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;InvestmentService"/>
 					</owl:Restriction>
 				</owl:unionOf>
@@ -119,7 +129,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-eufse;CreditInstitutionInvestmentFirm"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;PaymentService"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
@@ -20,7 +20,6 @@
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
@@ -51,7 +50,6 @@
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
@@ -85,7 +83,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -188,11 +185,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>European Central Bank</rdfs:label>
 		<skos:definition>European Central Bank, whose main aim is to maintain price stability, i.e. to safeguard the value of the euro</skos:definition>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-eurga;EuropeanCentralBankHeadquartersAndLegalAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ecb.europa.eu/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>European Central Bank</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:abbreviation>ECB</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.ecb.europa.eu/ecb/orga/escb/ecb-mission/html/index.en.html</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>The European Central Bank is responsible for the prudential supervision of credit institutions located in the euro area and participating non-euro area Member States, within the Single Supervisory Mechanism, which also comprises the national competent authorities. It thereby contributes to the safety and soundness of the banking system and the stability of the financial system within the EU and each participating Member State.</cmns-av:explanatoryNote>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ecb.europa.eu/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eurga;EuropeanCentralBankHeadquartersAndLegalAddress">

--- a/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
@@ -35,6 +36,7 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
@@ -63,9 +65,9 @@
 		<rdfs:label>European Regulatory Agencies Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary regulatory agencies ontology in FBC with additional agencies and registries that regulate and provide services in Europe, across national boundaries, such as agencies that support the European Union.</dct:abstract>
 		<dct:license>Copyright (c) 2017-2025 EDM Council, Inc.
-		Copyright (c) 2017-2025 Object Management Group, Inc.
+Copyright (c) 2017-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -91,6 +93,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"/>
@@ -122,8 +125,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-ra;Registry"/>
 		<rdfs:label>Credit Institution Register</rdfs:label>
 		<skos:definition>registry of credit institutions to which authorisation has been granted to operate within the European Union and European Economic Area countries (EEA), a repository of financial data and institution characteristics for covered institutions collected by the the European Banking Authority (EBA)</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-eurga;EuropeanBankingAuthorityRegulator"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/risk-analysis-and-data/credit-institutions-register</cmns-av:adaptedFrom>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-eurga;EuropeanBankingAuthorityRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-eurga;CreditInstitutionRegisterEntry">
@@ -165,8 +168,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-rga;RegulatoryAgency"/>
 		<rdfs:label>European Banking Authority (EBA) Regulator</rdfs:label>
 		<skos:definition>European Banking Authority (EBA) regulator and registration authority</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-eurga;CreditInstitutionRegister"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.eba.europa.eu/about-us/missions-and-tasks</cmns-av:adaptedFrom>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-eurga;CreditInstitutionRegister"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-eurga;EuropeanBankingAuthority"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
@@ -63,9 +63,9 @@
 		<rdfs:label>European Financial Services Entities Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with individuals representing additional kinds of entities that provide services internationally, such as international market data providers, organizations that provide exchanges in multiple countries, etc.</dct:abstract>
 		<dct:license>Copyright (c) 2017-2025 EDM Council, Inc.
-		Copyright (c) 2017-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2017-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -217,8 +217,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Business Entity Data (BED) B.V.</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.gmeiutility.org/"/>
 		<skos:definition>individual representing Business Entity Data (BED) B.V.</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
 		<cmns-av:explanatoryNote>wholly-owned subsidiary of DTCC that owns and operates the Global Market Entity Identifier Utility (GMEI) legal entity identifier (LEI) solution in the federated Global LEI system (GLEIS)</cmns-av:explanatoryNote>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-eufseind;BusinessEntityData-NL"/>
 	</owl:NamedIndividual>
 	
@@ -396,7 +396,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.wm-leiportal.org/?lang=en"/>
 		<skos:definition>subdivision of Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann that operates the WM Datenservice, Europe&apos;s largest registry for the Legal Entity Identifier (LEI)</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-eufseind;WMDatenserviceEntityIdentifierRegistry"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-eufseind;WMDatenserviceEntityIdentifierRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-eufseind;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmannGmbHAndCoKG-DE"/>
 	</owl:NamedIndividual>
 	
@@ -427,7 +427,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>London Stock Exchange as local operating unit</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.londonstockexchange.com/home/homepage.htm"/>
 		<skos:definition>London Stock Exchange functional entity that is an LEI Local Operating Unit (LOU) registrar</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangeUnaVistaRegistry"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangeUnaVistaRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangePlc"/>
 	</owl:NamedIndividual>
 	
@@ -494,7 +494,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Lux CSD</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.luxcsd.com/luxcsd-en/"/>
 		<skos:definition>Lux CSD functional entity that is an LEI Local Operating Unit (LOU) registrar</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDLEIRegistry"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDLEIRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDSA"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
@@ -18,7 +19,6 @@
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fct-usfsind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -34,6 +34,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
@@ -48,7 +49,6 @@
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fct-usfsind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -60,8 +60,8 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/">
-		<rdfs:label>International Financial Services Entities Ontology</rdfs:label>
-		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with additional kinds of entities that provide services internationally, such as international market data providers, organizations that provide exchanges in multiple countries, etc.</dct:abstract>
+		<rdfs:label>European Financial Services Entities Individuals Ontology</rdfs:label>
+		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with individuals representing additional kinds of entities that provide services internationally, such as international market data providers, organizations that provide exchanges in multiple countries, etc.</dct:abstract>
 		<dct:license>Copyright (c) 2017-2025 EDM Council, Inc.
 		Copyright (c) 2017-2025 Object Management Group, Inc.
 		
@@ -90,9 +90,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250101/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20230101/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
@@ -626,7 +627,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;SwedishBankersAssociation">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<rdfs:label>Swedish Bankers&apos; Association</rdfs:label>
 		<skos:definition>association that represents banks and financial institutions established in Sweden that contributes to a sound and efficient regulatory framework that facilitates for banks to help create economic wealth for customers and society</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swedishbankers.se/en-us/about/about-us/about-us/</cmns-av:adaptedFrom>

--- a/FBC/FunctionalEntities/FinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/FinancialServicesEntities.rdf
@@ -179,7 +179,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialProduct"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -192,7 +192,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -392,7 +392,7 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;ClearingService"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -501,7 +501,7 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;DataProcessingServicer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -571,7 +571,7 @@ CCPs benefit both parties in a transaction because they bear most of the credit 
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/FunctionalEntities/FinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/FinancialServicesEntities.rdf
@@ -29,7 +29,6 @@
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-oac-ctl "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -71,7 +70,6 @@
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-oac-ctl="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -112,7 +110,6 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
@@ -243,7 +240,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:onClass rdf:resource="&cmns-org;FormalOrganization"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/FunctionalEntities/FinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/FinancialServicesEntities.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -29,7 +30,6 @@
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-oac-ctl "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -49,6 +49,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -71,7 +72,6 @@
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-oac-ctl="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -113,7 +113,6 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
@@ -126,10 +125,11 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250201/FunctionalEntities/FinancialServicesEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/FinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified per the FIBO 2.0 RFC, including, but not limited to, the addition of trade settlement concepts and generalizing the concept of a credit union.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified to refine the concept of a credit union and generalize the definition of an underwriter.</skos:changeNote>
@@ -148,6 +148,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to augment the representation of institutions based on their definitions in the law, to clarify and extend definitions related to non-bank financial institutions,and to add multilingual labels.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230401/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to correct a labelling issue.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250201/FunctionalEntities/FinancialServicesEntities.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -215,13 +216,13 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BusinessIdentifierCode">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cxtid;StructuredIdentifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-org;OrganizationPartIdentifier"/>
+				<owl:onClass rdf:resource="&cmns-org;OrganizationSubUnitIdentifier"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -263,7 +264,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<skos:definition>international identifier for financial and non-financial institutions used to facilitate automated processing of information for financial services</skos:definition>
 		<cmns-av:abbreviation>BIC</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom>ISO 9362:2014 Banking -- Banking telecommunication messages -- Business identifier code (BIC)</cmns-av:adaptedFrom>
-		<cmns-av:explanatoryNote>The BIC is used for addressing messages, routing business transactions and identifying business parties. Note that the use of OrganizationPartIdentifier in FIBO corresponds to the Branch Code in the SWIFT scheme.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The BIC is used for addressing messages, routing business transactions and identifying business parties. Note that the use of OrganizationSubUnitIdentifier in FIBO corresponds to the Branch Code in the SWIFT scheme.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>SWIFT ID</cmns-av:synonym>
 		<cmns-av:synonym>SWIFT code</cmns-av:synonym>
 		<cmns-av:synonym>SWIFT-BIC</cmns-av:synonym>
@@ -272,8 +273,8 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BusinessIdentifierCodeScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentificationScheme"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentificationScheme"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
@@ -287,8 +288,8 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;BusinessPartyPrefix">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;isIncludedIn"/>

--- a/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf
+++ b/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
@@ -35,6 +36,7 @@
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
@@ -63,9 +65,9 @@
 		<rdfs:label>International Registries and Authorities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the Business Registries ontology to define commonly referenced international registration authorities and related registry details, where the multi-national responsibilities for registering and/or managing various identifiers needed in banking applications occur, such as SWIFT. These individuals and in some cases, such as registry entries, are managed independently to reduce the import footprint for applications that do not require them, in other words, to support modularity needs of FIBO users.</dct:abstract>
 		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
-		Copyright (c) 2015-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2015-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -90,6 +92,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/InternationalRegistriesAndAuthorities/"/>
@@ -217,11 +220,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:label>Business Identifier Code registration authority</rdfs:label>
 		<skos:definition>registration authority and financial service provider, appointed by the International Standards Organization (ISO), that is the official registration authority (RA) for ISO 9362, Banking - Banking telecommunication messages - Business identifier code (BIC)</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistry"/>
 		<cmns-av:abbreviation>BIC RA</cmns-av:abbreviation>
 		<cmns-av:abbreviation>BIC registration authority</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic</cmns-av:adaptedFrom>
 		<cmns-av:synonym>BIC code registrar</cmns-av:synonym>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunication"/>
 	</owl:NamedIndividual>
 	
@@ -229,9 +232,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;BusinessRegistry"/>
 		<rdfs:label>business identifier code registry</rdfs:label>
 		<skos:definition>registry for registering and maintaining information about bank and other business identifier codes that conform to ISO 9362</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistrationAuthority"/>
 		<cmns-av:abbreviation>BIC registry</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/bic</cmns-av:adaptedFrom>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistrationAuthority"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;GLEIFLegalEntityIdentifierRegistryEntry">
@@ -279,8 +282,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:label>IBAN registration authority</rdfs:label>
 		<skos:definition>ISO 13616:2007, International Bank Account Number (IBAN) Registration Authority (RA) and financial service provider, appointed by the International Standards Organization (ISO), that is the official registration authority (RA) for ISO 13616:2007, Financial services - International bank account number (IBAN)</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistry"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.swift.com/standards/data-standards/iban</cmns-av:adaptedFrom>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-ireg;BusinessIdentifierCodeRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunication"/>
 	</owl:NamedIndividual>
 	
@@ -288,7 +291,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-ra;RegistrationAuthority"/>
 		<rdfs:label>Legal Entity Identifier registration authority</rdfs:label>
 		<skos:definition>registration authority appointed by the International Standards Organization (ISO) that is the official registration authority (RA) for ISO 17442, Financial services - Legal entity identifier (LEI)</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-ireg;GlobalLEIIndex"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-ireg;GlobalLEIIndex"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-ireg;GlobalLegalEntityIdentifierFoundation"/>
 	</owl:NamedIndividual>
 	
@@ -297,11 +300,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:label>MIC registration authority</rdfs:label>
 		<skos:definition>ISO 10383, Market Identifier Code (MIC) Registration Authority (RA) and financial service provider, appointed by the International Standards Organization (ISO), that is the official registration authority (RA) for ISO 10383, Codes for exchanges and market identification (MIC)</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-ireg;MarketIdentifierCodeRegistry"/>
 		<cmns-av:abbreviation>MIC RA</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.anna-web.org/standards/mic-iso-10383/</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/10383/iso-10383-market-identifier-codes</cmns-av:adaptedFrom>
 		<cmns-av:synonym>ISO 10383 Registration Authority</cmns-av:synonym>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-ireg;MarketIdentifierCodeRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunication"/>
 	</owl:NamedIndividual>
 	
@@ -309,9 +312,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-ra;Registry"/>
 		<rdfs:label>market identifier code registry</rdfs:label>
 		<skos:definition>registry for registering and maintaining information for market identifier codes that conform to ISO 10383</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-ireg;MICRegistrationAuthority"/>
 		<cmns-av:abbreviation>MIC registry</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso20022.org/10383/iso-10383-market-identifier-codes</cmns-av:adaptedFrom>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-ireg;MICRegistrationAuthority"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-ireg;MarketIdentifierCodeRegistryEntry">

--- a/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf
+++ b/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf
@@ -20,7 +20,6 @@
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
@@ -51,7 +50,6 @@
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
@@ -84,7 +82,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -142,11 +139,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>international financial organization that serves central banks in their pursuit of monetary and financial stability, helping to foster international cooperation in those areas and acting as a bank for central banks</skos:definition>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-ireg;BankForInternationalSettlementsAddress"/>
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-ireg;BankForInternationalSettlementsAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bis.org/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="de">Bank für Internationalen Zahlungsausgleich</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:abbreviation>BIS</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom>Office of Financial Research (OFR) Annual Report, 2012, Glossary</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Established in 1930, the BIS is owned by 63 central banks, representing countries from around the world that together account for about 95 percent of world GDP. Its head office is in Basel, Switzerland and it has two representative offices: in Hong Kong SAR and in Mexico City, as well as Innovation Hub Centres around the world.</cmns-av:explanatoryNote>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bis.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;BankForInternationalSettlementsAddress">
@@ -262,9 +259,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>Global Legal Entity Identifier Foundation (GLEIF) legal entity, tasked to support the implementation and use of the Legal Entity Identifier (LEI)</skos:definition>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-ireg;GlobalLegalEntityIdentifierFoundationAddress"/>
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-ireg;GlobalLegalEntityIdentifierFoundationAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>Global Legal Entity Identifier Foundation</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:abbreviation>GLEIF</cmns-av:abbreviation>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;GlobalLegalEntityIdentifierFoundationAddress">
@@ -376,9 +373,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>Society for Worldwide Interbank Financial Telecommunication (SWIFT) legal entity, which is a global member-owned cooperative and the world&apos;s leading provider of secure financial messaging services</skos:definition>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunicationAddress"/>
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunicationAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.swift.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>Society for Worldwide Interbank Financial Telecommunication SCRL/CVBA</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:abbreviation>SWIFT</cmns-av:abbreviation>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.swift.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunicationAddress">

--- a/FBC/FunctionalEntities/Markets.rdf
+++ b/FBC/FunctionalEntities/Markets.rdf
@@ -10,7 +10,6 @@
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-fct-breg "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
@@ -40,7 +39,6 @@
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-fct-breg="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
@@ -63,9 +61,9 @@
 		<rdfs:label>Markets Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for markets, exchanges, regulated markets, and multilateral trading facilities.</dct:abstract>
 		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
-		Copyright (c) 2015-2025 Object Management Group, Inc.
+Copyright (c) 2015-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -73,7 +71,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>

--- a/FBC/FunctionalEntities/Markets.rdf
+++ b/FBC/FunctionalEntities/Markets.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -18,7 +19,6 @@
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -36,6 +36,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -48,7 +49,6 @@
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -81,7 +81,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -92,6 +91,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/Markets/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/Markets/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 RTF report.</skos:changeNote>
@@ -371,7 +371,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;ExchangeParticipant">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;RegisteredAgent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;isRegisteredBy"/>

--- a/FBC/FunctionalEntities/Markets.rdf
+++ b/FBC/FunctionalEntities/Markets.rdf
@@ -325,7 +325,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -771,7 +771,7 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-mkt;AlternativeTradingSystem"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:allValuesFrom rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -842,7 +842,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -927,7 +927,7 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/FBC/FunctionalEntities/Markets.rdf
+++ b/FBC/FunctionalEntities/Markets.rdf
@@ -19,7 +19,6 @@
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/">
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -48,7 +47,6 @@
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -79,7 +77,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -224,7 +224,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/you-need-a-business-number-a-program-account.html"/>
 		<skos:definition>Canada Revenue Agency service for the registration of business entities</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;BusinessNumberRegistry">
@@ -233,8 +233,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>Canada Revenue Agency business number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CanadaRevenueAgency">
@@ -282,8 +282,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Canadian business and tax registrar</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and registration authority role of the Canada Revenue Agency</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumberRegistry"/>
-		<fibo-fnd-rel-rel:provides rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumberRegistrationService"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumberRegistry"/>
+		<cmns-org:provides rdf:resource="&fibo-fbc-fct-cajrga;BusinessNumberRegistrationService"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgency"/>
 	</owl:NamedIndividual>
 	
@@ -330,7 +330,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html"/>
 		<skos:definition>Canada Revenue Agency service for the registration of corporation income tax accounts</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CorporationIncomeTaxNumberRegistry">
@@ -339,8 +339,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>Canada Revenue Agency corporation income tax number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;GoodsServicesTaxHarmonizedSalesTaxNumberRegistry">
@@ -350,9 +350,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/e-services/e-services-businesses/confirming-a-gst-hst-account-number/terms-conditions-use.html"/>
 		<skos:definition>registry that records and tracks individual GST/HST numbers for the Canada Revenue Agency</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 		<cmns-av:abbreviation>GST/HST number registry</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Limited public access.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;GoodsServicesTaxHarmonizedSalesTaxRegistrationIdentifierScheme">
@@ -401,7 +401,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html"/>
 		<skos:definition>Canada Revenue Agency service for the registration of GST/HST accounts</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;ImportExportProgramNumber">
@@ -447,7 +447,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/register.html"/>
 		<skos:definition>Canada Revenue Agency service for the registration of import export program number accounts</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;ImportExportProgramNumberRegistry">
@@ -456,8 +456,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>Canada Revenue Agency import export program number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;InformationReturnsIdentifierScheme">
@@ -503,7 +503,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/register.html"/>
 		<skos:definition>Canada Revenue Agency service for the registration of an information return program number accounts</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;InformationReturnsProgramNumberRegistry">
@@ -512,8 +512,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>Canada Revenue Agency information return program number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;PayrollDeductionsProgramIdentifierRegistrationService">
@@ -523,7 +523,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/How-open-payroll-account.html"/>
 		<skos:definition>Canada Revenue Agency service for the registration of payroll deductions program number accounts</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;PayrollDeductionsProgramIdentifierScheme">
@@ -568,8 +568,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>Canada Revenue Agency payroll deduction program registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 		<cmns-av:explanatoryNote>No public access.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;RegisteredCharityProgramNumber">
@@ -615,7 +615,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/registering-your-business/register.html"/>
 		<skos:definition>Canada Revenue Agency service for the registration of a registered charity program number accounts</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;RegisteredCharityProgramNumberRegistry">
@@ -625,8 +625,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://apps.cra-arc.gc.ca/ebci/hacc/srch/pub/dsplyBscSrch?request_locale=en"/>
 		<skos:definition>Canada Revenue Agency registered charity program number registry</skos:definition>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 		<cmns-av:explanatoryNote>Full public access.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-cajrga;CanadianBusinessTaxRegistrar"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
@@ -23,7 +24,6 @@
 	<!ENTITY fibo-fbc-fct-usfsind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
@@ -45,6 +45,7 @@
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
@@ -62,7 +63,6 @@
 	xmlns:fibo-fbc-fct-usfsind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
@@ -104,7 +104,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
@@ -116,6 +115,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
@@ -188,8 +188,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-cajrga;BusinessNumber">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;TaxIdentifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -26,7 +26,6 @@
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -65,7 +64,6 @@
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -81,9 +79,9 @@
 		<rdfs:label>Canadian Regulatory Agencies Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary regulatory agencies ontology in FBC with additional regulators that are specific to the United States and augments certain U.S. financial services entities based on who regulates them.</dct:abstract>
 		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
-		Copyright (c) 2016-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2016-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -106,7 +104,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -153,7 +150,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>central bank of Canada</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-cajrga;BankOfCanadaHeadOfficeAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bankofcanada.ca/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="en">Bank of Canada</fibo-fnd-rel-rel:hasLegalName>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="fr">Banque du Canada</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bankofcanada.ca/wp-content/uploads/2010/11/regulation_canadian_financial.pdf</cmns-av:adaptedFrom>
@@ -161,6 +157,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
  
  The Bank provides liquidity to the financial system, gives policy advice to the federal government on the design and development of the system, oversees major clearing and settlement systems, and provides banking services to these systems and their participants.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bankofcanada.ca/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;BankOfCanadaHeadOfficeAddress">
@@ -245,12 +242,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>taxation authority of the Government of Canada</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgencyHeadOfficeAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="fr">Agence du revenu du Canada</fibo-fnd-rel-rel:hasLegalName>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="en">Canada Revenue Agency</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>This agency administers tax laws for the Canadian government and for several of the provinces and territories of Canada.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CanadaRevenueAgencyHeadOfficeAddress">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -38,7 +38,6 @@
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
@@ -88,7 +87,6 @@
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
@@ -103,9 +101,9 @@
 		<rdfs:label>US Example Individuals</rdfs:label>
 		<dct:abstract>This ontology includes example individuals for US national banks, state chartered banks, and other institutions, as well as details related to some of the larger corporations that issue stock and are represented in the Dow Jones Industrial Average and S&amp;P 500.</dct:abstract>
 		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
-		Copyright (c) 2015-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2015-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -139,7 +137,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -282,7 +279,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;AlphabetIncCorporateAddress"/>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>Alphabet</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://abc.xyz/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://abc.xyz/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;AlphabetIncBusinessEntityIdentifier">
@@ -298,7 +295,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-usind;AppleIncCorporateAddress"/>
 		<fibo-fbc-fct-breg:hasPriorLegalName>Apple Computer, Inc.</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>Apple</fibo-fbc-fct-breg:hasTradingOrOperationalName>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.apple.com/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.apple.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;AppleIncBusinessEntityIdentifier">
@@ -314,7 +311,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-usind;InternationalBusinessMachinesCorporationAddress"/>
 		<fibo-fbc-fct-breg:hasPriorLegalName>COMPUTING-TABULATING-RECORDING-CO.</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>IBM</fibo-fbc-fct-breg:hasTradingOrOperationalName>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.ibm.com/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.ibm.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;InternationalBusinessMachinesCorporationBusinessEntityIdentifier">
@@ -329,7 +326,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;TheCoca-ColaCompanyCorporateAddress"/>
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-usind;TheCoca-ColaCompanyCorporateAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.coca-colacompany.com/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.coca-colacompany.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheCoca-ColaCompanyBusinessEntityIdentifier">
@@ -352,12 +349,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;TheHomeDepotIncCorporateAddress"/>
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-usind;TheHomeDepotIncCorporateAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.homedepot.com/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.homedepot.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheProctorAndGambleCompany-US-OH">
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyCorporateAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://us.pg.com/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://us.pg.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-le-usee;TheProctorAndGambleCompanyBusinessEntityIdentifier">
@@ -557,8 +554,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;BankOfNewYorkMellonCorporationAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bnymellon.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>The Bank of New York Mellon Corporation</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bnymellon.com/</cmns-org:hasWebsite>
 		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
@@ -982,8 +979,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;FMRLLCHeadquartersAddress"/>
 		<fibo-fbc-fct-breg:hasPriorLegalName>Fidelity Management and Research Company</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.fidelity.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>FMR LLC</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.fidelity.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;FMRLLCBusinessEntityIdentifier">
@@ -1103,8 +1100,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCoHeadquartersAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.jpmorganchase.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>JPMorgan Chase &amp; Co.</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.jpmorganchase.com/</cmns-org:hasWebsite>
 		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
@@ -1207,8 +1204,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-oac-cctl:hasDomesticUltimateParent rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCo"/>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>JPMorgan Chase Bank, N.A.</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.chase.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>JPMorgan Chase Bank, National Association</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.chase.com/</cmns-org:hasWebsite>
 		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
@@ -1337,8 +1334,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;PinnacleBankHeadquartersAddress"/>
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-usind;PinnacleBankLegalAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://pinnacle.bank/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>Pinnacle Bank</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://pinnacle.bank/</cmns-org:hasWebsite>
 		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
@@ -1566,8 +1563,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfMassachusettsJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;StateStreetCorporationHeadquartersAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.statestreet.com/home.html</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>State Street Corporation</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.statestreet.com/home.html</cmns-org:hasWebsite>
 		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
@@ -35,7 +36,6 @@
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
@@ -57,6 +57,7 @@
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
@@ -85,7 +86,6 @@
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
@@ -138,7 +138,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
@@ -151,6 +150,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
@@ -436,8 +436,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>BNY Mellon</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>BNY Mellon Wealth Management</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>BNY Mellon, N.A.</fibo-fbc-fct-breg:hasTradingOrOperationalName>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>BNY Mellon, National Association</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;BNYMellonNationalAssociationAddress">
@@ -557,9 +557,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;BankOfNewYorkMellonCorporationAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bnymellon.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>The Bank of New York Mellon Corporation</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;BankOfNewYorkMellonCorporationAddress">
@@ -639,8 +639,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-oac-opty:hasDirectOwningEntity rdf:resource="&fibo-fbc-fct-usind;CitigroupInc-US-DE"/>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>Citibank, N.A.</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>Citi Cards South Dakota Acceptance Corp.</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CitiCardsSouthDakotaAcceptanceCorpBusinessEntityIdentifier">
@@ -714,8 +714,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-breg:hasPriorLegalName>First National City Bank</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-fct-breg:hasPriorLegalName>First National City Bank of New York</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>Citibank, N.A.</fibo-fbc-fct-breg:hasTradingOrOperationalName>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>Citibank, National Association</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CitibankNABusinessEntityIdentifier">
@@ -839,8 +839,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;CitigroupIncHeadquartersAddress"/>
 		<fibo-be-oac-cctl:hasSubsidiary rdf:resource="&fibo-fbc-fct-usind;CitibankNA"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>Citicorp LLC</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CiticorpLLCBusinessEntityIdentifier">
@@ -913,8 +913,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-breg:hasPriorLegalName>The Travelers Inc.</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-fct-breg:hasPriorLegalName>Travelers Group Inc.</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>Citigroup Inc.</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;CitigroupIncBusinessEntityIdentifier">
@@ -1103,9 +1103,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCoHeadquartersAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.jpmorganchase.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>JPMorgan Chase &amp; Co.</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseAndCoBusinessEntityIdentifier">
@@ -1207,9 +1207,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-oac-cctl:hasDomesticUltimateParent rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCo"/>
 		<fibo-fbc-fct-breg:hasTradingOrOperationalName>JPMorgan Chase Bank, N.A.</fibo-fbc-fct-breg:hasTradingOrOperationalName>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.chase.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>JPMorgan Chase Bank, National Association</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationAddress">
@@ -1337,9 +1337,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;PinnacleBankHeadquartersAddress"/>
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-usind;PinnacleBankLegalAddress"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://pinnacle.bank/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>Pinnacle Bank</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;PinnacleBankBusinessEntityIdentifier">
@@ -1448,8 +1448,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-breg:hasPriorLegalName>Second Bank - State Street Trust Company</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-fct-breg:hasPriorLegalName>State Street Trust Company</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>State Street Bank And Trust Company</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyBusinessEntityIdentifier">
@@ -1566,9 +1566,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfMassachusettsJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usind;StateStreetCorporationHeadquartersAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.statestreet.com/home.html</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>State Street Corporation</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;StateStreetCorporationBusinessEntityIdentifier">
@@ -1772,8 +1772,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-oac-cctl:hasSubsidiary rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociation"/>
 		<fibo-fbc-fct-breg:hasPriorLegalName>WFC Holdings Corporation</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>WFC Holdings, LLC</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WFCHoldingsLLCBusinessEntityIdentifier">
@@ -1847,8 +1847,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-breg:hasPriorLegalName>Northwest Bancorporation</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-fct-breg:hasPriorLegalName>Norwest Corporation</fibo-fbc-fct-breg:hasPriorLegalName>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>Wells Fargo &amp; Company</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WellsFargoAndCompanyBusinessEntityIdentifier">
@@ -1922,8 +1922,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-lei:hasLegalAddress rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationLegalAddress"/>
 		<fibo-be-le-lp:isOrganizedIn rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<fibo-be-oac-cctl:hasDomesticUltimateParent rdf:resource="&fibo-fbc-fct-usind;WellsFargoAndCompany"/>
-		<fibo-fnd-org-fm:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fnd-rel-rel:hasLegalName>Wells Fargo Bank, National Association</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:isDomiciledIn rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationBusinessIdentifierCode">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-usj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/">
@@ -16,7 +17,6 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-oac-ctl "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -31,6 +31,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-usj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"
@@ -44,7 +45,6 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-oac-ctl="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -76,7 +76,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
@@ -85,6 +84,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities/"/>
@@ -127,7 +127,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
+						<owl:onProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 						<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
@@ -256,7 +256,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;OfficeOfAForeignBank"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
+				<owl:onProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 				<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -287,7 +287,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;BranchOfADepositoryInstitution"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
+				<owl:onProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 				<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -317,7 +317,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 					<owl:Class>
 						<owl:intersectionOf rdf:parseType="Collection">
 							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
+								<owl:onProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 								<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 							</owl:Restriction>
 							<owl:Restriction>
@@ -377,7 +377,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;Branch"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
+				<owl:onProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 				<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -520,7 +520,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
+						<owl:onProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 						<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
@@ -558,7 +558,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-usfse;ForeignBranchOfUSBank"/>
 		<owl:disjointWith>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
+				<owl:onProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 				<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 			</owl:Restriction>
 		</owl:disjointWith>
@@ -605,7 +605,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:disjointWith rdf:resource="&fibo-fbc-fct-usfse;DomesticBranchOfDomesticBank"/>
 		<owl:disjointWith>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
+				<owl:onProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 				<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 			</owl:Restriction>
 		</owl:disjointWith>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf
@@ -9,7 +9,6 @@
 	<!ENTITY fibo-be-ge-usj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-cctl "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
@@ -18,7 +17,6 @@
 	<!ENTITY fibo-fnd-oac-ctl "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -37,7 +35,6 @@
 	xmlns:fibo-be-ge-usj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-cctl="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
@@ -46,7 +43,6 @@
 	xmlns:fibo-fnd-oac-ctl="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -59,9 +55,9 @@
 		<rdfs:label>US Financial Services Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary financial services entities ontology in FBC with additional kinds of entities that are specific to the United States.</dct:abstract>
 		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
-		Copyright (c) 2015-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2015-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -71,7 +67,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
@@ -79,7 +74,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Control/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
@@ -569,7 +563,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usfse;ForeignBranchOfForeignBank"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
@@ -13,7 +14,6 @@
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-cctl "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/">
 	<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
@@ -48,6 +48,7 @@
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
@@ -56,7 +57,6 @@
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-cctl="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"
 	xmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
@@ -89,9 +89,9 @@
 		<rdfs:label>American Financial Services Entities - Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the financial services entities ontology in FBC with individual American entities that provide broad based services required by other FIBO domains, such as market data providers, instrument identifier issuers, organizations that provide exchanges in multiple countries, and so forth.</dct:abstract>
 		<dct:license>Copyright (c) 2017-2025 EDM Council, Inc.
-		Copyright (c) 2017-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2017-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -104,7 +104,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
@@ -129,6 +128,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
@@ -289,7 +289,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Bloomberg Finance L.P. as local operating unit</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>Bloomberg Finance L.P. functional entity that is a legal entity identifier (LEI) local operating unit (LOU) registrar</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usfsind;BloombergLEIRegistry"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usfsind;BloombergLEIRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergFinanceLP-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -588,9 +588,9 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>ICE Benchmark Administration</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>ICE Benchmark Administration Limited (IBA) was established in July 2013 following an announcement by the Hogg Tendering Advisory Committee, an independent committee set up by the UK government to select the new administrator for the London Interbank Offered Rate (LIBOR).</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchange"/>
 		<fibo-fnd-utl-av:definitionOrigin rdf:resource="https://www.theice.com/iba.jhtml"/>
 		<cmns-av:abbreviation>IBA</cmns-av:abbreviation>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchange"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;IntercontinentalExchange">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
@@ -42,6 +43,7 @@
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
@@ -77,9 +79,9 @@
 		<rdfs:label>US Markets and Exchanges Individuals</rdfs:label>
 		<dct:abstract>This ontology includes extended individuals (examples that are more complete) for a sampling of markets operating in the US corresponding to the ISO 10383 Codes for exchanges and market identification (MIC).</dct:abstract>
 		<dct:license>Copyright (c) 2018-2025 EDM Council, Inc.
-		Copyright (c) 2018-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2018-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -111,6 +113,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
@@ -124,6 +127,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20221201/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2018-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -178,7 +182,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.cboe.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>Chicago Board Options Exchange</fibo-fnd-rel-rel:hasFormalName>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;ChicagoBoardOptionsExchangeAsServiceProvider"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;ChicagoBoardOptionsExchangeAsServiceProvider"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;ChicagoBoardOptionsExchangeAsServiceProvider">
@@ -222,8 +226,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/markets/american-options</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>NYSE American Options</fibo-fnd-rel-rel:hasFormalName>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEAmericanOptionsAsServiceProvider"/>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEAmericanOptionsAsServiceProvider"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;NYSEAmericanOptionsAsServiceProvider">
@@ -273,8 +277,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>NYSE Arca</fibo-fnd-rel-rel:hasFormalName>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEArcaAsServiceProvider"/>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEArcaAsServiceProvider"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;NYSEArcaAsServiceProvider">
@@ -378,8 +382,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>NYSE Dark</fibo-fnd-rel-rel:hasFormalName>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchange"/>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchange"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;NYSEGroup">
@@ -465,8 +469,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>New York Stock Exchange</fibo-fnd-rel-rel:hasFormalName>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchangeAsServiceProvider"/>
 		<cmns-av:explanatoryNote>The New York Stock Exchange is a leading global cash equity exchange. It is the leading equity exchange for initial public offerings, or IPOs, globally, and enables companies seeking to raise capital to become publicly listed through the IPO process upon meeting exchange listing standards. In addition to common stocks, preferred stocks and warrants, the NYSE lists structured products, such as capital securities and mandatory convertible securities. In addition, NYSE operates NYSE Bonds, an electronic trading platform with transparent pricing for debt securities, including corporate bonds.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchangeAsServiceProvider"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usmkt;NewYorkStockExchangeAsServiceProvider">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
@@ -26,7 +26,6 @@
 	<!ENTITY fibo-fbc-fct-usmkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
@@ -64,7 +63,6 @@
 	xmlns:fibo-fbc-fct-usmkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
@@ -105,7 +103,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -180,8 +177,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:hasFacilityAcronym>CBOE</fibo-fbc-fct-mkt:hasFacilityAcronym>
 		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.cboe.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>Chicago Board Options Exchange</fibo-fnd-rel-rel:hasFormalName>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.cboe.com/</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;ChicagoBoardOptionsExchangeAsServiceProvider"/>
 	</owl:NamedIndividual>
 	
@@ -224,9 +221,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:hasFacilityAcronym>NYSE</fibo-fbc-fct-mkt:hasFacilityAcronym>
 		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/markets/american-options</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>NYSE American Options</fibo-fnd-rel-rel:hasFormalName>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/markets/american-options</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEAmericanOptionsAsServiceProvider"/>
 	</owl:NamedIndividual>
 	
@@ -275,9 +272,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:hasFacilityAcronym>NYSE</fibo-fbc-fct-mkt:hasFacilityAcronym>
 		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>NYSE Arca</fibo-fnd-rel-rel:hasFormalName>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEArcaAsServiceProvider"/>
 	</owl:NamedIndividual>
 	
@@ -310,7 +307,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:label>NYSE Arca Holdings</rdfs:label>
 		<skos:definition>NYSE Group holding company and financial service provider that operates three listings exchanges, NYSE, NYSE American and NYSE Arca, each of which has a unique market model designed for corporate and ETF issuers, as well as NYSE National, which is a trading venue but not a listings market</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</cmns-org:hasWebsite>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEArcaHoldingsInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -380,9 +377,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:hasFacilityAcronym>NYSEDARK</fibo-fbc-fct-mkt:hasFacilityAcronym>
 		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>NYSE Dark</fibo-fnd-rel-rel:hasFormalName>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchange"/>
 	</owl:NamedIndividual>
 	
@@ -391,7 +388,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:label>NYSE Group</rdfs:label>
 		<skos:definition>NYSE Group functional entity that operates three listings exchanges, NYSE, NYSE American and NYSE Arca, each of which has a unique market model designed for corporate and ETF issuers, as well as NYSE National, which is a trading venue but not a listings market</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</cmns-org:hasWebsite>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEGroupInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -427,7 +424,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 		<rdfs:label>NYSE Holdings</rdfs:label>
 		<skos:definition>NYSE Holdings functional entity that through its subsidiaries, operates stock exchanges, including the New York Stock Exchange (NYSE), NYSE Arca, Inc., and NYSE MKT LLC in the United States; and European based exchanges comprising Euronext N.V. - the London, Paris, Amsterdam, Brussels, and Lisbon stock exchanges, as well as the NYSE Liffe derivatives markets in London, Paris, Amsterdam, Brussels, and Lisbon</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</cmns-org:hasWebsite>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usmkt;NYSEHoldingsLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -467,9 +464,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-mkt:hasFacilityAcronym>NYSE</fibo-fbc-fct-mkt:hasFacilityAcronym>
 		<fibo-fbc-fct-mkt:operatesInCountry rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<fibo-fbc-fct-mkt:operatesInMunicipality rdf:resource="&fibo-fbc-fct-bci;New_York"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasFormalName>New York Stock Exchange</fibo-fnd-rel-rel:hasFormalName>
 		<cmns-av:explanatoryNote>The New York Stock Exchange is a leading global cash equity exchange. It is the leading equity exchange for initial public offerings, or IPOs, globally, and enables companies seeking to raise capital to become publicly listed through the IPO process upon meeting exchange listing standards. In addition to common stocks, preferred stocks and warrants, the NYSE lists structured products, such as capital securities and mandatory convertible securities. In addition, NYSE operates NYSE Bonds, an electronic trading platform with transparent pricing for debt securities, including corporate bonds.</cmns-av:explanatoryNote>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.nyse.com/</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchangeAsServiceProvider"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -29,7 +29,6 @@
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -71,7 +70,6 @@
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -115,7 +113,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -267,8 +264,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usjrga;AccuityIncHeadquartersAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://accuity.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>Accuity Inc.</fibo-fnd-rel-rel:hasLegalName>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://accuity.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;AccuityIncBusinessEntityIdentifier">
@@ -303,9 +300,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usjrga;ABAHeadquartersAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.aba.com/Pages/default.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>American Bankers Association</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:abbreviation>ABA</cmns-av:abbreviation>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.aba.com/Pages/default.aspx</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;AmericanBankersAssociationRTNRegistrar">
@@ -367,8 +364,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="http://www.sos.ca.gov/business-programs/business-entities/"/>
 		<skos:definition>registry of business entities for businesses that have registered with the State of California Business Programs Division</skos:definition>
 		<fibo-fbc-fct-breg:hasRegistryName>California Business Entities (BE)</fibo-fbc-fct-breg:hasRegistryName>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://businesssearch.sos.ca.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://businesssearch.sos.ca.gov/</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrar"/>
 	</owl:NamedIndividual>
 	
@@ -378,8 +375,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>California Business Programs Division</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of California, Secretary of State, Business Programs Division</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sos.ca.gov/business-programs/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sos.ca.gov/business-programs/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrar">
@@ -417,9 +414,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of California&apos;s Department of Business Oversight</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://dbo.ca.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:explanatoryNote>The Department of Business Oversight (DBO) protects consumers and oversees financial service providers and products. The DBO supervises the operations of state-licensed financial institutions, including banks, credit unions and money transmitters. Additionally, the DBO licenses and regulates a variety of financial service providers, including securities brokers and dealers, investment advisers, payday lenders and other consumer finance lenders.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://dbo.ca.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaRegistrationAuthorityCode">
@@ -449,9 +446,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Commodity Futures Trading Commission (CFTC), an independent Federal agency whose mission is to foster open, transparent, competitive, and financially sound markets, to avoid systemic risk, and to protect the market users and their funds, consumers, and the public from fraud, manipulation, and abusive practices related to derivatives and other products that are subject to the Commodity Exchange Act</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.cftc.gov/index.htm</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>CFTC</cmns-av:abbreviation>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.cftc.gov/index.htm</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;ConsumerFinanceRegulator">
@@ -470,9 +467,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Consumer Financial Protection Bureau (CFPB), an independent Federal agency that helps consumer finance markets work by making rules more effective, by consistently and fairly enforcing those rules, and by empowering consumers to take more control over their economic lives</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.consumerfinance.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>CFPB</cmns-av:abbreviation>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.consumerfinance.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CorporationServiceCompany">
@@ -493,9 +490,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompanyAddress"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.cscglobal.com/cscglobal/home/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>Corporation Service Company</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:abbreviation>CSC</cmns-av:abbreviation>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.cscglobal.com/cscglobal/home/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CorporationServiceCompanyAddress">
@@ -539,9 +536,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>The Corporation Trust Company (CT Corporation) legal entity, which provides registered agent and incorporation services</skos:definition>
 		<fibo-be-le-cb:isIncorporatedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompanyHeadquartersAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://ct.wolterskluwer.com/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:hasLegalName>CT Corporation</fibo-fnd-rel-rel:hasLegalName>
 		<cmns-av:abbreviation>CT</cmns-av:abbreviation>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://ct.wolterskluwer.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CorporationTrustCompanyBusinessEntityIdentifier">
@@ -574,8 +571,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Delaware business entities registry</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of Delaware, Division of Corporations, registry of business entities</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://icis.corp.delaware.gov/Ecorp/EntitySearch/NameSearch.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://icis.corp.delaware.gov/Ecorp/EntitySearch/NameSearch.aspx</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator"/>
 	</owl:NamedIndividual>
 	
@@ -614,8 +611,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Delaware Division of Corporations</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of Delaware&apos;s Division of Corporations</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://corp.delaware.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfDelawareGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://corp.delaware.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;DelawareRegistrationAuthorityCode">
@@ -739,10 +736,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Farm Credit Administration (FCA), an independent Federal agency that regulates and examines the banks, associations, and related entities of the Farm Credit System (FCS), including the Federal Agricultural Mortgage Corporation (Farmer Mac)</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://fca.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FCA</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The FCS is the largest agricultural lender in the United States. It is a nationwide network of lending institutions that are owned by their borrowers. It serves all 50 States and Puerto Rico.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://fca.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FarmCreditRegulator">
@@ -764,9 +761,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Deposit Insurance Corporation (FDIC), which preserves and promotes public confidence in the U.S. financial system by insuring deposits in banks and thrift institutions for at least $250,000; by identifying, monitoring and addressing risks to the deposit insurance funds; and by limiting the effect on the economy and the financial system when a bank or thrift institution fails.</skos:definition>
 		<fibo-be-ge-ge:isInstrumentOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.fdic.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FDIC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>An independent agency of the federal government, the FDIC was created in 1933 in response to the thousands of bank failures that occurred in the 1920s and early 1930s. Since the start of FDIC insurance on January 1, 1934, no depositor has lost a single cent of insured funds as a result of a failure.</cmns-av:explanatoryNote>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.fdic.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalDepositInsurerAndRegulator">
@@ -788,7 +785,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>FFIEC, a formal interagency body empowered to prescribe uniform principles, standards, and report forms for the federal examination of financial institutions by the Board of Governors of the Federal Reserve System (FRB), the Federal Deposit Insurance Corporation (FDIC), the National Credit Union Administration (NCUA), the Office of the Comptroller of the Currency (OCC), and the Consumer Financial Protection Bureau (CFPB), and to make recommendations to promote uniformity in the supervision of financial institutions</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FFIEC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The Federal Financial Institutions Examination Council (FFIEC) was established on March 10, 1979, pursuant to title X of the Financial Institutions Regulatory and Interest Rate Control Act of 1978 (FIRA), Public Law 95-630. In 1989, title XI of the Financial Institutions Reform, Recovery and Enforcement Act of 1989 (FIRREA) established The Appraisal Subcommittee (ASC) within the Examination Council.</cmns-av:explanatoryNote>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;ConsumerFinancialProtectionBureau"/>
@@ -797,6 +793,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;NationalCreditUnionAdministration"/>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalFinancialInstitutionsExaminationRegulator">
@@ -843,10 +840,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Housing Finance Agency (FHFA), responsible for strengthening and securing the United States secondary mortgage markets by providing effective supervision, sound research, reliable data, and relevant policies</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.fhfa.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FHFA</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The FHFA is an independent regulatory agency responsible for the oversight of vital components of the secondary mortgage markets - the housing government sponsored enterprises of Fannie Mae, Freddie Mac and the Federal Home Loan Bank System. Combined these entities provide more than $5.5 trillion in funding for the U.S. mortgage markets and financial institutions. Additionally, FHFA is the conservator of Fannie Mae and Freddie Mac.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.fhfa.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalHousingFinanceRegulator">
@@ -865,7 +862,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Atlanta, whose jurisdiction is the Sixth District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSixthDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.frbatlanta.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.frbatlanta.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfBoston">
@@ -874,7 +871,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Boston, whose jurisdiction is the First District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFirstDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.bostonfed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.bostonfed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfChicago">
@@ -883,7 +880,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Chicago, whose jurisdiction is the Seventh District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSeventhDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.chicagofed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.chicagofed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfCleveland">
@@ -892,7 +889,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Cleveland, whose jurisdiction is the Fourth District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFourthDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.clevelandfed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.clevelandfed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfDallas">
@@ -901,7 +898,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Dallas, whose jurisdiction is the Eleventh District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEleventhDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.dallasfed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.dallasfed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfKansasCity">
@@ -910,7 +907,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Kansas City, whose jurisdiction is the Tenth District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTenthDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.kansascityfed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.kansascityfed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfMinneapolis">
@@ -919,7 +916,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Minneapolis, whose jurisdiction is the Ninth District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveNinthDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.minneapolisfed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.minneapolisfed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfNewYork">
@@ -928,7 +925,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of New York, whose jurisdiction is the Second District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSecondDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.newyorkfed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.newyorkfed.org/</cmns-org:hasWebsite>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveBankOfNewYork-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -939,7 +936,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>legal entity and instrumentality that is Federal Reserve Bank of New York</skos:definition>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveBankOfNewYorkAddress"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.newyorkfed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.newyorkfed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfNewYorkAddress">
@@ -960,7 +957,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Philadelphia, whose jurisdiction is the Third District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveThirdDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.philadelphiafed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.philadelphiafed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfRichmond">
@@ -969,7 +966,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Richmond, whose jurisdiction is the Fifth District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFifthDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.richmondfed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.richmondfed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfSanFrancisco">
@@ -978,7 +975,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of San Francisco, whose jurisdiction is the Twelfth District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTwelfthDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.frbsf.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.frbsf.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfStLouis">
@@ -987,7 +984,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of St. Louis, whose jurisdiction is the Eighth District of the Federal Reserve</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEighthDistrict"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.stlouisfed.org/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.stlouisfed.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBoard">
@@ -996,7 +993,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Board</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Board (FRB)</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.federalreserve.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FRB</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The members of the Board of Governors are nominated by the President of the United States and confirmed by the U.S. Senate. By law, the appointments must yield a &apos;fair representation of the financial, agricultural, industrial, and commercial interests and geographical divisions of the country,&apos; and no two Governors may come from the same Federal Reserve District.
 
@@ -1007,6 +1003,7 @@ Once appointed, Governors may not be removed from office for their policy views.
 In addition to serving as members of the Board, the Chairman and Vice Chairman of the Board serve terms of four years, and they may be reappointed to those roles and serve until their terms as Governors expire. The Chairman serves as public spokesperson and representative of the Board and manager of the Board&apos;s staff. The Chairman also presides at Board meetings. Affirming the apolitical nature of the Board, recent Presidents of both major political parties have selected the same person as Board Chairman.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>Federal Reserve Board of Governors</cmns-av:synonym>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSystem"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.federalreserve.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FederalReserveDistrict">
@@ -1279,12 +1276,12 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>central banking system of the U.S., comprised of the Federal Reserve Board, the 12 Federal Reserve Banks, the Federal Open Market Committee, and the national and state member banks</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.federalreserve.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FRS</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The Federal Reserve, the central bank of the United States, provides the nation with a safe, flexible, and stable monetary and financial system.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>Fed</cmns-av:synonym>
 		<cmns-av:synonym>Federal Reserve</cmns-av:synonym>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.federalreserve.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSystemAsMemberBearingOrganization">
@@ -1458,9 +1455,9 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Financial Industry Regulatory Authority</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>largest non-governmental regulator of securities firms in the United States, namely, the Financial Industry Regulatory Authority (FINRA)</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.finra.org/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FINRA</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.finra.org/about/what-we-do</cmns-av:adaptedFrom>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.finra.org/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FinancialStabilityOversightCouncil">
@@ -1470,7 +1467,6 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Financial Stability Oversight Council (FSOC), which provides comprehensive monitoring of the stability of our nation&apos;s financial system, as established under the Dodd-Frank Wall Street Reform and Consumer Protection Act</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.treasury.gov/initiatives/fsoc/Pages/home.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>FSOC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The Council is charged with identifying risks to the financial stability of the United States; promoting market discipline; and responding to emerging risks to the stability of the United States&apos; financial system. The Council consists of 10 voting members and 5 nonvoting members and brings together the expertise of federal financial regulators, state regulators, and an independent insurance expert appointed by the President.</cmns-av:explanatoryNote>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;CommodityFuturesTradingCommission"/>
@@ -1482,6 +1478,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeCommission"/>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.treasury.gov/initiatives/fsoc/Pages/home.aspx</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;IssuerIdentificationNumber">
@@ -1556,8 +1553,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>registry of business entities for businesses that have registered with the Commonwealth of Massachusetts Secretary of State</skos:definition>
 		<fibo-fbc-fct-breg:hasRegistryName>Massachusetts Corporation Registry</fibo-fbc-fct-breg:hasRegistryName>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://corp.sec.state.ma.us/corpweb/CorpSearch/CorpSearch.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfMassachusettsJurisdiction"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://corp.sec.state.ma.us/corpweb/CorpSearch/CorpSearch.aspx</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrar"/>
 	</owl:NamedIndividual>
 	
@@ -1567,8 +1564,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Massachusetts Corporations Division</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Commonwealth of Massachusetts, Secretary of State, Corporations Division</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sec.state.ma.us/cor/coridx.htm</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfMassachusettsGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sec.state.ma.us/cor/coridx.htm</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;MassachusettsRegistrationAuthorityCode">
@@ -1625,10 +1622,10 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>National Credit Union Administration (NCUA), the independent federal agency that regulates, charters and supervises federal credit unions</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ncua.gov/Pages/default.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>NCUA</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>An independent agency of the federal government, the NCUA operates and manages the National Credit Union Share Insurance Fund (NCUSIF), insuring the deposits of more than 98 million account holders in all federal credit unions and the overwhelming majority of state-chartered credit unions.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ncua.gov/Pages/default.aspx</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NationalCreditUnionInsurerAndRegulator">
@@ -1649,8 +1646,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.ffiec.gov/nicpubweb/content/DataDownload/NPW%20Data%20Dictionary.pdf/"/>
 		<skos:definition>National Information Center (NIC) repository, a repository of financial data and institution characteristics collected by the Federal Reserve System</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/nicweb/NicHome.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:explanatoryNote>The National Information Center (NIC)repository provides comprehensive information on banks and other institutions for which the Federal Reserve has a supervisory, regulatory, or research interest including both domestic and foreign banking organizations operating in the U.S.</cmns-av:explanatoryNote>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/nicweb/NicHome.aspx</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveRegulatoryAgencyAndCentralBank"/>
 	</owl:NamedIndividual>
 	
@@ -1659,8 +1656,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>New York State (NYS) business entities registry</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>New York State (NYS) Department of State, Division of Corporations, State Records and Uniform Commercial Code (UCC) registry of business entities</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://appext20.dos.ny.gov/corp_public/corpsearch.entity_search_entry</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfNewYorkJurisdiction"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://appext20.dos.ny.gov/corp_public/corpsearch.entity_search_entry</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;NewYorkCorporationsRegulator"/>
 	</owl:NamedIndividual>
 	
@@ -1699,8 +1696,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>New York State (NYS) Department of State Division of Corporations</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>New York State (NYS) Department of State&apos;s Division of Corporations</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.dos.ny.gov/corps/index.html</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfNewYorkGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.dos.ny.gov/corps/index.html</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NewYorkRegistrationAuthorityCode">
@@ -1735,10 +1732,10 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>OCC, which charters, regulates, and supervises all national banks and federal savings associations as well as federal branches and agencies of foreign banks. The OCC is an independent bureau of the U.S. Department of the Treasury.</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>OCC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The mission of the OCC is to ensure that national banks and federal savings associations operate in a safe and sound manner, provide fair access to financial services, treat customers fairly, and comply with applicable laws and regulations.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OfficeOfThriftSupervision">
@@ -1748,9 +1745,9 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>OTS, which is a part of the OCC, responsible for chartering, regulating, and supervising all federal savings associations</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>OTS</cmns-av:abbreviation>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal">
@@ -1759,8 +1756,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>registry of business entities for businesses that have registered with the Ohio Secretary of State</skos:definition>
 		<fibo-fbc-fct-breg:hasRegistryName>Ohio Business Filing Portal</fibo-fbc-fct-breg:hasRegistryName>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.sos.state.oh.us/businesses/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfOhioJurisdiction"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.sos.state.oh.us/businesses/</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrar"/>
 	</owl:NamedIndividual>
 	
@@ -1799,8 +1796,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Ohio Business Services Division</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Ohio Secretary of State, Business Services Division</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.sos.state.oh.us/businesses/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfOhioGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.sos.state.oh.us/businesses/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OhioRegistrationAuthorityCode">
@@ -1915,13 +1912,13 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>independent commission established by the Securities Act of 1933 and Securities Exchange Act of 1934 whose mission is to protect investors, maintain fair, orderly, and efficient markets, and facilitate capital formation</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sec.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:abbreviation>SEC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The SEC oversees the key participants in the securities world, including securities exchanges, securities brokers and dealers, investment advisors, and mutual funds. Here the SEC is concerned primarily with promoting the disclosure of important market-related information, maintaining fair dealing, and protecting against fraud.
  Crucial to the SEC&apos;s effectiveness in each of these areas is its enforcement authority. Each year the SEC brings hundreds of civil enforcement actions against individuals and companies for violation of the securities laws. Typical infractions include insider trading, accounting fraud, and providing false or misleading information about securities and the companies that issue them.
  One of the major sources of information on which the SEC relies to bring enforcement action is investors themselves - another reason that educated and careful investors are so critical to the functioning of efficient markets. To help support investor education, the SEC offers the public a wealth of educational information on this Internet website, which also includes the EDGAR database of disclosure documents that public companies are required to file with the Commission.
  Though it is the primary overseer and regulator of the U.S. securities markets, the SEC works closely with many other institutions, including Congress, other federal departments and agencies, the self-regulatory organizations (e.g. the stock exchanges), state securities regulators, and various private sector organizations. In particular, the Chairman of the SEC, together with the Chairman of the Federal Reserve, the Secretary of the Treasury, and the Chairman of the Commodity Futures Trading Commission, serves as a member of the President&apos;s Working Group on Financial Markets.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sec.gov/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator">
@@ -1940,8 +1937,8 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:label>South Dakota business entities registry</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of South Dakota registry of business information</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://sosenterprise.sd.gov/businessservices/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfSouthDakotaJurisdiction"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://sosenterprise.sd.gov/businessservices/</cmns-org:hasWebsite>
 		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsRegulator"/>
 	</owl:NamedIndividual>
 	
@@ -1968,8 +1965,8 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:label>South Dakota, Secretary of State Corporations Division</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of South Dakota&apos;s Corporations Division</skos:definition>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://sosenterprise.sd.gov/businessservices/</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfSouthDakotaGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://sosenterprise.sd.gov/businessservices/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsRegulator">
@@ -2102,10 +2099,10 @@ A TIN must be on a withholding certificate if the beneficial owner is claiming a
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>U.S. Department of the Treasury, the executive agency responsible for promoting economic prosperity and ensuring the financial security of the United States</skos:definition>
 		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.treasury.gov/Pages/default.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<cmns-av:explanatoryNote>The Department is responsible for a wide range of activities such as advising the President on economic and financial issues, encouraging sustainable economic growth, and fostering improved governance in financial institutions. The Department of the Treasury operates and maintains systems that are critical to the nation&apos;s financial infrastructure, such as the production of coin and currency, the disbursement of payments to the American public, revenue collection, and the borrowing of funds necessary to run the federal government. The Department works with other federal agencies, foreign governments, and international financial institutions to encourage global economic growth, raise standards of living, and to the extent possible, predict and prevent economic and financial crises. The Treasury Department also performs a critical and far-reaching role in enhancing national security by implementing economic sanctions against foreign threats to the U.S., identifying and targeting the financial support networks of national security threats, and improving the safeguards of our financial systems.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>Treasury Department</cmns-av:synonym>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.treasury.gov/Pages/default.aspx</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;UniformBankPerformanceReportRepository">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -28,7 +28,6 @@
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
@@ -72,7 +71,6 @@
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
@@ -118,7 +116,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
@@ -1345,7 +1342,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 					<owl:Class>
 						<owl:intersectionOf rdf:parseType="Collection">
 							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
+								<owl:onProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 								<owl:hasValue rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 							</owl:Restriction>
 							<owl:Restriction>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -15,7 +15,6 @@
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
 	<!ENTITY fibo-fbc-fct-bci "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/">
 	<!ENTITY fibo-fbc-fct-breg "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/">
@@ -58,7 +57,6 @@
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
 	xmlns:fibo-fbc-fct-bci="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"
 	xmlns:fibo-fbc-fct-breg="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"
@@ -89,9 +87,9 @@
 		<rdfs:label>US Regulatory Agencies Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the primary regulatory agencies ontology in FBC with additional regulators that are specific to the United States and augments certain U.S. financial services entities based on who regulates them.</dct:abstract>
 		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
-		Copyright (c) 2015-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2015-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -104,7 +102,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"/>
@@ -201,7 +198,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>ABA IIN Registry</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>American Bankers Association (ABA) Issuer Identification Number (IIN) registry, a repository of institution characteristics for those that have assigned IINs, managed by the ABA</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;AmericanBankersAssociationRegistrationAuthority"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;AmericanBankersAssociationRegistrationAuthority"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;ABAIINRegistryEntry">
@@ -234,7 +231,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>ABA RTN Registry</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>American Bankers Association (ABA) Routing Transit Number (RTN) registry, a repository of institution characteristics for those that have assigned RTNs, managed by the ABA&apos;s designated registration authority (RA)</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;AmericanBankersAssociationRTNRegistrar"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;AmericanBankersAssociationRTNRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;ABARTNRegistryEntry">
@@ -317,8 +314,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>American Bankers Association RTN Registrar</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>American Bankers Association (ABA) Routing Transit Number (RTN) Registrar, which is a delegated capability currently provided by Accuity</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;ABARTNRegistry"/>
 		<cmns-av:abbreviation>ABA RTN Registrar</cmns-av:abbreviation>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;ABARTNRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;AccuityInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -328,8 +325,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>American Bankers Association Registration Authority</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>American Bankers Association (ABA) Registration Authority (RA), which is a function of the ABA for registration of issuer identification numbers in the US</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;ABAIINRegistry"/>
 		<cmns-av:abbreviation>ABA RA</cmns-av:abbreviation>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;ABAIINRegistry"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;AmericanBankersAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -349,8 +346,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>CFTC Industry Filings Repository</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>CFTC Industry Filings repository, a repository of organizational characteristics and financial data for Designated Contract Markets (DCM), Swap Execution Facilities (SEF), Derivatives Clearing Organizations (DCO), Swap Data Repositories (SDR), and Lists of Foreign Boards of Trade (FBOT) Registered with the Commission</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;CommoditiesFuturesAndDerivativesRegulator"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.cftc.gov/IndustryOversight/IndustryFilings/index.htm</cmns-av:adaptedFrom>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;CommoditiesFuturesAndDerivativesRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaBankingRegulator">
@@ -372,7 +369,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<fibo-fbc-fct-breg:hasRegistryName>California Business Entities (BE)</fibo-fbc-fct-breg:hasRegistryName>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://businesssearch.sos.ca.gov/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrar"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaBusinessProgramsDivision">
@@ -391,8 +388,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>California business registrar</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and registration authority role of the State of California&apos;s Business Programs Division</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:provides rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrationService"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessEntitiesRegistry"/>
+		<cmns-org:provides rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrationService"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessProgramsDivision"/>
 	</owl:NamedIndividual>
 	
@@ -410,7 +407,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="http://www.sos.ca.gov/business-programs/business-entities/service-options"/>
 		<skos:definition>State of California, Secretary of State, service for the registration of business entities</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaDepartmentOfBusinessOversight">
@@ -441,7 +438,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>commodities, futures and derivatives regulator</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and registration authority role of the Commodity Futures Trading Commission (CFTC)</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;CFTCIndustryFilingsRepository"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;CFTCIndustryFilingsRepository"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;CommodityFuturesTradingCommission"/>
 	</owl:NamedIndividual>
 	
@@ -579,7 +576,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>State of Delaware, Division of Corporations, registry of business entities</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://icis.corp.delaware.gov/Ecorp/EntitySearch/NameSearch.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme">
@@ -596,7 +593,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="http://corp.delaware.gov/"/>
 		<skos:definition>State of Delaware, Division of Corporations, service for the registration of business entities</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator">
@@ -606,8 +603,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="http://corp.delaware.gov/aboutagency.shtml"/>
 		<skos:definition>regulatory agency and registration authority role of the State of Delaware&apos;s Division of Corporations</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:provides rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationService"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
+		<cmns-org:provides rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationService"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareDivisionOfCorporations"/>
 	</owl:NamedIndividual>
 	
@@ -636,9 +633,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>EDGAR Repository</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>EDGAR repository, a repository of financial information about securities and their issuers, including but not limited to corporate quarterly and annual filings, collected by the SEC</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.sec.gov/edgar/aboutedgar.htm</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>EDGAR, the Electronic Data Gathering, Analysis, and Retrieval system, performs automated collection, validation, indexing, acceptance, and forwarding of submissions by companies and others who are required by law to file forms with the U.S. Securities and Exchange Commission (SEC). Its primary purpose is to increase the efficiency and fairness of the securities market for the benefit of investors, corporations, and the economy by accelerating the receipt, acceptance, dissemination, and analysis of time-sensitive corporate information filed with the agency.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;EmployerIdentificationNumber">
@@ -705,8 +702,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>FDIC Institution Directory</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Deposit Insurance Corporation&apos;s (FDIC) institution directory, a repository of financial data and institution characteristics for covered institutions collected by the FDIC</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalDepositInsurerAndRegulator"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www7.fdic.gov/idasp/index.asp</cmns-av:adaptedFrom>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalDepositInsurerAndRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FDICRegistryEntry">
@@ -780,7 +777,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.fdic.gov/"/>
 		<skos:definition>regulatory agency and registration authority role of the Federal Deposit Insurance Corporation (FDIC)</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;FDICInstitutionDirectory"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;FDICInstitutionDirectory"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalDepositInsuranceCorporation"/>
 	</owl:NamedIndividual>
 	
@@ -808,8 +805,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>federal financial institutions examination regulator</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and registration authority role of the Federal Financial Institutions Examination Council (FFIEC)</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;UniformBankPerformanceReportRepository"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/about.htm</cmns-av:adaptedFrom>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;UniformBankPerformanceReportRepository"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalFinancialInstitutionsExaminationCouncil"/>
 	</owl:NamedIndividual>
 	
@@ -1201,7 +1198,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="http://www.federalreserve.gov/"/>
 		<skos:definition>regulatory agency and registration authority role of the Federal Reserve System</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSystem"/>
 	</owl:NamedIndividual>
 	
@@ -1531,8 +1528,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="http://www.sec.state.ma.us/cor/coridx.htm"/>
 		<skos:definition>regulatory agency and registration authority role of the Commonwealth of Massachusetts&apos;s Corporations Division</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsCorporationRegistry"/>
-		<fibo-fnd-rel-rel:provides rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrationService"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsCorporationRegistry"/>
+		<cmns-org:provides rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrationService"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsCorporationsDivision"/>
 	</owl:NamedIndividual>
 	
@@ -1550,7 +1547,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:seeAlso rdf:resource="http://www.sec.state.ma.us/cor/corservices.htm"/>
 		<skos:definition>Commonwealth of Massachusetts, Secretary of State, Corporations Division, service for the registration of business entities</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;MassachusettsCorporationRegistry">
@@ -1561,7 +1558,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fbc-fct-breg:hasRegistryName>Massachusetts Corporation Registry</fibo-fbc-fct-breg:hasRegistryName>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://corp.sec.state.ma.us/corpweb/CorpSearch/CorpSearch.aspx</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfMassachusettsJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrar"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;MassachusettsCorporationsDivision">
@@ -1653,8 +1650,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:seeAlso rdf:resource="https://www.ffiec.gov/nicpubweb/content/DataDownload/NPW%20Data%20Dictionary.pdf/"/>
 		<skos:definition>National Information Center (NIC) repository, a repository of financial data and institution characteristics collected by the Federal Reserve System</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/nicweb/NicHome.aspx</fibo-fnd-plc-vrt:hasWebsite>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveRegulatoryAgencyAndCentralBank"/>
 		<cmns-av:explanatoryNote>The National Information Center (NIC)repository provides comprehensive information on banks and other institutions for which the Federal Reserve has a supervisory, regulatory, or research interest including both domestic and foreign banking organizations operating in the U.S.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveRegulatoryAgencyAndCentralBank"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry">
@@ -1664,7 +1661,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<skos:definition>New York State (NYS) Department of State, Division of Corporations, State Records and Uniform Commercial Code (UCC) registry of business entities</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://appext20.dos.ny.gov/corp_public/corpsearch.entity_search_entry</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfNewYorkJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;NewYorkCorporationsRegulator"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;NewYorkCorporationsRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NewYorkBusinessRegistrationIdentifierScheme">
@@ -1681,7 +1678,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:seeAlso rdf:resource="https://www.dos.ny.gov/about/corps-licensing.html"/>
 		<skos:definition>New York State (NYS) Department of State, Division of Corporations service for the registration of business entities</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-usjrga;NewYorkCorporationsRegulator"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;NewYorkCorporationsRegulator"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;NewYorkCorporationsRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NewYorkCorporationsRegulator">
@@ -1691,8 +1688,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.dos.ny.gov/corps/index.html"/>
 		<skos:definition>regulatory agency and registration authority role of the State of New York&apos;s Division of Corporations</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:provides rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessRegistrationService"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
+		<cmns-org:provides rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessRegistrationService"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;NewYorkDivisionOfCorporations"/>
 	</owl:NamedIndividual>
 	
@@ -1764,7 +1761,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<fibo-fbc-fct-breg:hasRegistryName>Ohio Business Filing Portal</fibo-fbc-fct-breg:hasRegistryName>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://www.sos.state.oh.us/businesses/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfOhioJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrar"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OhioBusinessRegistrar">
@@ -1774,8 +1771,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.sos.state.oh.us/businesses/"/>
 		<skos:definition>regulatory agency and registration authority role of the Ohio Secretary of State, Business Services Division</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal"/>
-		<fibo-fnd-rel-rel:provides rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrationService"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal"/>
+		<cmns-org:provides rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrationService"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessServicesDivision"/>
 	</owl:NamedIndividual>
 	
@@ -1793,7 +1790,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:seeAlso rdf:resource="https://www.sos.state.oh.us/businesses/"/>
 		<skos:definition>Ohio Secretary of State, Business Services Division service for the registration of business entities</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrar"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrar"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrar"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OhioBusinessServicesDivision">
@@ -1933,8 +1930,8 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:label>securities and exchange regulator</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>regulatory agency and registration authority role of the Securities and Exchange Commission (SEC)</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;EDGARRepository"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.sec.gov/about/whatwedo.shtml</cmns-av:adaptedFrom>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;EDGARRepository"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeCommission"/>
 	</owl:NamedIndividual>
 	
@@ -1945,7 +1942,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<skos:definition>State of South Dakota registry of business information</skos:definition>
 		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://sosenterprise.sd.gov/businessservices/</fibo-fnd-plc-vrt:hasWebsite>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfSouthDakotaJurisdiction"/>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsRegulator"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SouthDakotaBusinessRegistrationIdentifierScheme">
@@ -1962,7 +1959,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:seeAlso rdf:resource="https://sosenterprise.sd.gov/businessservices/"/>
 		<skos:definition>State of South Dakota, Secretary of State, Corporations Division service for the registration of business entities</skos:definition>
 		<fibo-fnd-pas-pas:isProvisionedBy rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsRegulator"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsRegulator"/>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsDivision">
@@ -1982,8 +1979,8 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://sosenterprise.sd.gov/businessservices/"/>
 		<skos:definition>regulatory agency and registration authority role of the State of South Dakota&apos;s Secretary of State, Corporations Division</skos:definition>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessInformationRegistry"/>
-		<fibo-fnd-rel-rel:provides rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessRegistrationService"/>
+		<cmns-org:manages rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessInformationRegistry"/>
+		<cmns-org:provides rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessRegistrationService"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaCorporationsDivision"/>
 	</owl:NamedIndividual>
 	
@@ -2116,8 +2113,8 @@ A TIN must be on a withholding certificate if the beneficial owner is claiming a
 		<rdfs:label>Uniform Bank Performance Report (UBPR) Repository</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Financial Institutions Examination Council (FFIEC)&apos;s Uniform Bank Performance Report (UBPR) Repository, a repository of institution characteristics and analytical tool created for bank supervisory, examination, and management purposes</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalFinancialInstitutionsExaminationRegulator"/>
 		<cmns-av:explanatoryNote>In a concise format, it shows the impact of management decisions and economic conditions on a bank&apos;s performance and balance-sheet composition. The performance and composition data contained in the report can be used as an aid in evaluating the adequacy of earnings, liquidity, capital, asset and liability management, and growth management. Bankers and examiners alike can use this report to further their understanding of a bank&apos;s financial condition, and through such understanding, perform their duties more effectively.</cmns-av:explanatoryNote>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalFinancialInstitutionsExaminationRegulator"/>
 	</owl:NamedIndividual>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-usjrga;hasPrimaryFederalRegulator">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
@@ -28,7 +29,6 @@
 	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
@@ -50,6 +50,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
@@ -72,7 +73,6 @@
 	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
@@ -119,7 +119,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
@@ -132,6 +131,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
@@ -646,7 +646,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;EmployerIdentificationNumber">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-usjrga;TaxpayerIdentificationNumber"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationIdentifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
@@ -1294,7 +1294,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSystemAsMemberBearingOrganization">
-		<rdf:type rdf:resource="&fibo-fnd-org-org;MemberBearingOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;MemberBearingOrganization"/>
 		<rdfs:label>Federal Reserve System as member bearing organization</rdfs:label>
 		<skos:definition>central banking system as an organization that has members that are people or other organizations</skos:definition>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSystem"/>
@@ -1302,7 +1302,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSystemMember">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
@@ -1320,10 +1320,10 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSystemMembership">
-		<rdf:type rdf:resource="&fibo-fnd-org-org;Membership"/>
+		<rdf:type rdf:resource="&cmns-org;Membership"/>
 		<rdfs:label>Federal Reserve System membership</rdfs:label>
 		<skos:definition>membership situation, in which the Federal Reserve System has at least one member for some period of time</skos:definition>
-		<fibo-fnd-org-org:hasMembership rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSystemAsMemberBearingOrganization"/>
+		<cmns-org:hasMembership rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSystemAsMemberBearingOrganization"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSystemNonMemberInstitution">

--- a/FBC/FunctionalEntities/RegistrationAuthorities.rdf
+++ b/FBC/FunctionalEntities/RegistrationAuthorities.rdf
@@ -12,7 +12,6 @@
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -34,7 +33,6 @@
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -58,7 +56,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -123,7 +120,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-ra;RegistrationAuthority">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;ServiceProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;registers"/>
@@ -181,7 +178,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-ra;RegistrationService">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Service"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;Service"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>

--- a/FBC/FunctionalEntities/RegistrationAuthorities.rdf
+++ b/FBC/FunctionalEntities/RegistrationAuthorities.rdf
@@ -12,7 +12,6 @@
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -33,7 +32,6 @@
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -56,7 +54,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
@@ -101,7 +98,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 								<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-ra;RegistrationCapacity"/>
 							</owl:Restriction>
 							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDesignatedBy"/>
+								<owl:onProperty rdf:resource="&cmns-org;isDesignatedBy"/>
 								<owl:someValuesFrom>
 									<owl:Restriction>
 										<owl:onProperty rdf:resource="&cmns-rlcmp;playsRole"/>
@@ -129,14 +126,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-ra;RegistrationService"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-ra;Registry"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -181,7 +178,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-org;Service"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -209,7 +206,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">

--- a/FBC/FunctionalEntities/RegistrationAuthorities.rdf
+++ b/FBC/FunctionalEntities/RegistrationAuthorities.rdf
@@ -5,10 +5,10 @@
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
@@ -27,10 +27,10 @@
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
@@ -46,8 +46,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 		<rdfs:label>Registration Authorities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts for representation of registration authorities, registrars, registration-specific identifiers and related identification schemes, and registration authorities specific to ISO and the financial industry. Examples of financial industry registration authorities in the US include the Federal Deposit Insurance Corporation (FDIC) and the Securities Exchange Commission (SEC).</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+Copyright (c) 2015-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
@@ -57,9 +65,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/RegistrationAuthorities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/RegistrationAuthorities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified as a part of organizational hierarchy simplification, to loosen the definition of registrar, and to leverage the composite date value datatype.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190201/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, make Registry a subclass of Record and StructuredCollection, make RegistryEntry a child of CollectionConstituent and correct a misspelled annotation.</skos:changeNote>
@@ -70,9 +79,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/RegistrationAuthorities.rdf version of the ontology was modified to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/FunctionalEntities/RegistrationAuthorities.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/RegistrationAuthorities.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-ra;Registrar">
@@ -137,7 +147,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:onClass rdf:resource="&cmns-org;LegalEntity"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/FunctionalEntities/RegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/RegulatoryAgencies.rdf
@@ -18,7 +18,6 @@
 	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -47,7 +46,6 @@
 	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -61,9 +59,9 @@
 		<rdfs:label>Regulatory Agencies Ontology</rdfs:label>
 		<dct:abstract>This ontology defines general purpose concepts for representation of regulatory agencies, also known as regulatory authorities or regulators. Examples of financial industry regulatory agencies in the US include the Securities Exchange Commission, FINRA, and the FDIC, among others. The SEC and FINRA are both registration authorities and regulatory agencies. The FDIC is a regulatory agency and an insurer, and may be a registration authority for certain state-chartered banks in the US without bank holding companies.</dct:abstract>
 		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
-		Copyright (c) 2015-2025 Object Management Group, Inc.
+Copyright (c) 2015-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -81,7 +79,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -187,7 +184,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-rga;RegulatoryAgency">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;ServiceProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;issues"/>
@@ -258,7 +255,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-rga;RegulatoryService">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Service"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;Service"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>

--- a/FBC/FunctionalEntities/RegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/RegulatoryAgencies.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
@@ -17,7 +18,6 @@
 	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -33,6 +33,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
@@ -46,7 +47,6 @@
 	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -60,7 +60,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
 		<rdfs:label>Regulatory Agencies Ontology</rdfs:label>
 		<dct:abstract>This ontology defines general purpose concepts for representation of regulatory agencies, also known as regulatory authorities or regulators. Examples of financial industry regulatory agencies in the US include the Securities Exchange Commission, FINRA, and the FDIC, among others. The SEC and FINRA are both registration authorities and regulatory agencies. The FDIC is a regulatory agency and an insurer, and may be a registration authority for certain state-chartered banks in the US without bank holding companies.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+		Copyright (c) 2015-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
@@ -71,7 +80,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -80,8 +88,9 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/RegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/RegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified per the FIBO 2.0 RFC, including deprecation of the hasJurisdiction property that was duplicated in BE via the BE 1.1 RTF.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified as a part of organizational hierarchy simplification.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to eliminate deprecated elements and duplication of concepts with LCC, and remove a redundant superclass declaration on GovernmentIssuedLicense.</skos:changeNote>
@@ -91,9 +100,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211001/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/RegulatoryAgencies.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-rga;Examiner">
@@ -188,7 +198,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:onClass rdf:resource="&cmns-org;FormalOrganization"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/FunctionalEntities/RegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/RegulatoryAgencies.rdf
@@ -207,7 +207,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-rga;RegulatoryService"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -258,7 +258,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-org;Service"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-rga;RegulatoryAgency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -283,7 +283,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;TaxIdentificationScheme"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -166,13 +166,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;Bank">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;CommercialLendingService"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;DemandDepositAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -181,7 +181,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;DepositoryInstitution">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;DepositAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -231,7 +231,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;AccountProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -483,7 +483,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;InvestmentAccount"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -571,7 +571,19 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;ServiceAgreement"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;AccountIdentifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:intersectionOf rdf:parseType="Collection">
@@ -582,18 +594,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;ServiceAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;AccountIdentifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>customer account</rdfs:label>
@@ -636,7 +636,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;InvestmentOrDepositAccount"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -779,7 +779,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;InvestmentOrDepositAccount"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -846,7 +846,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;ResponsibleParty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;Account"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -978,7 +978,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;AccountProvider"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -10,6 +10,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -50,6 +51,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -82,7 +84,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 		<rdfs:label>Clients and Accounts Ontology</rdfs:label>
 		<dct:abstract>This ontology provides basic concepts such as account, account holder, account provider, relationship manager that are commonly used by financial services providers to describe customers and to determine counterparty identities.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+Copyright (c) 2015-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
@@ -111,10 +122,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20241101/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/ProductsAndServices/ClientsAndAccounts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised per the FIBO 2.0 RFC with respect to the definitions for accounts and account identifiers, such as BBAN and IBAN identifiers, including but not limited to bank accounts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to support the addition of maturity-related properties to financial instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181101/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
@@ -135,9 +147,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230401/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to eliminate deprecated elements that were deprecated more than six months ago (FND-386).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20241101/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;CreditAgreement">
@@ -316,7 +329,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;ServiceProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -440,7 +440,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Dealer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;ServiceProvider"/>
 		<rdfs:subClassOf>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
@@ -510,7 +510,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;FinancialService">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Service"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;Service"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
@@ -523,7 +523,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;ServiceProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
@@ -898,7 +898,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;ThirdPartyAgent">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;LegalAgent"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;Licensee"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;ServiceProvider"/>
 		<rdfs:label>third-party agent</rdfs:label>
 		<skos:definition>any service provider that is licensed to perform a legally binding function and has been legally empowered to act on behalf of another party</skos:definition>
 		<cmns-av:adaptedFrom>17 CFR 45.1, Definitions - see the definition of agent</cmns-av:adaptedFrom>
@@ -961,7 +961,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&fibo-fnd-pas-pas;Good">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-pas-pas;Service">
+							<rdf:Description rdf:about="&cmns-org;Service">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-fnd-agr-ctr;Contract">
 							</rdf:Description>
@@ -1157,7 +1157,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-fpas;Trader">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;ServiceProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-fpas;facilitates"/>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -488,7 +488,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Product"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -513,7 +513,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf rdf:resource="&cmns-org;Service"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -533,7 +533,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
@@ -45,6 +46,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
@@ -113,6 +115,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
@@ -138,7 +141,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231201/ProductsAndServices/FinancialProductsAndServices.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/ProductsAndServices/FinancialProductsAndServices.rdf version of the ontology was modified to add the concept of a contract lifecycle, as distinct from a product or trade lifecycle (FBC-317).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240201/ProductsAndServices/FinancialProductsAndServices.rdf version of the ontology was modified to eliminate a redundant restriction (GitHub-2028).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240901/ProductsAndServices/FinancialProductsAndServices.rdf version of the ontology was modified to reconcile shareholding with equity position (BE-254).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240901/ProductsAndServices/FinancialProductsAndServices.rdf version of the ontology was modified to reconcile shareholding with equity position (BE-254), and to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389)..</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -524,7 +527,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:onClass rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:onClass rdf:resource="&cmns-org;LegalEntity"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1188,7 +1191,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-fpas;hasGeneratingEntity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>unique transaction identifier</rdfs:label>
@@ -1240,7 +1243,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-fpas;hasGeneratingEntity">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;generates"/>
 		<rdfs:label>has generating entity</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:range rdf:resource="&cmns-org;LegalEntity"/>
 		<skos:definition>specifies a legal entity that generates something</skos:definition>
 	</owl:ObjectProperty>
 	

--- a/FND/Accounting/AccountingEquity.rdf
+++ b/FND/Accounting/AccountingEquity.rdf
@@ -3,12 +3,12 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -21,12 +21,12 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -38,17 +38,26 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 		<rdfs:label>Accounting Equity Ontology</rdfs:label>
 		<dct:abstract>This ontology defines equity-related concepts for use in defining other FIBO ontology elements. These are based on basic accounting principles as they relate to equity, debt, assets and liabilities of a firm. Equity forms the basis for ownership of certain forms of corporate body.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Accounting/AccountingEquity/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Accounting/AccountingEquity/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Accounting/AccountingEquity.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
    (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -68,9 +77,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Accounting/AccountingEquity.rdf version of this ontology was modified to add a definition for EBITDA.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Accounting/AccountingEquity.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230601/Accounting/AccountingEquity.rdf version of this ontology was modified to correct the definition of EBITDA and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Accounting/AccountingEquity.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-aeq;CapitalSurplus">
@@ -84,7 +94,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:onClass rdf:resource="&cmns-org;FormalOrganization"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -121,7 +131,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:onClass rdf:resource="&cmns-org;FormalOrganization"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Arrangements/Assessments.rdf
+++ b/FND/Arrangements/Assessments.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -28,6 +29,7 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -70,6 +72,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Arrangements/Assessments/"/>
@@ -128,7 +131,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;Appraisal"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -146,7 +149,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&cmns-pts;AgentRole"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -184,7 +187,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&cmns-pts;AgentRole"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -346,7 +349,7 @@ Overall, value in business is about creating and capturing benefits that meet th
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-asmt;hasAppraiser">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isProvidedBy"/>
 		<rdfs:label>has appraiser</rdfs:label>
 		<skos:definition>relates an assessment or report to an agent that conducts the assessment</skos:definition>
 	</owl:ObjectProperty>

--- a/FND/Arrangements/Ratings.rdf
+++ b/FND/Arrangements/Ratings.rdf
@@ -49,9 +49,9 @@
 		<rdfs:label>Ratings Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation of ratings and rating schemes, particularly for ratings describing aspects of business performance, credit worthiness, and investment quality at a high level.</dct:abstract>
 		<dct:license>Copyright (c) 2019-2025 EDM Council, Inc.
-		Copyright (c) 2019-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2019-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -180,7 +180,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-asmt;AssessmentActivity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-rt;RatingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -212,7 +212,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-rt;RatingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -275,7 +275,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:onClass rdf:resource="&fibo-fnd-arr-rt;RatingScalePublisher"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -294,7 +294,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-pts;PartyRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-rt;RatingScale"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Arrangements/Ratings.rdf
+++ b/FND/Arrangements/Ratings.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -13,7 +14,6 @@
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
 	<!ENTITY fibo-fnd-arr-rt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -28,6 +28,7 @@
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -36,7 +37,6 @@
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
 	xmlns:fibo-fnd-arr-rt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -48,12 +48,20 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/">
 		<rdfs:label>Ratings Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation of ratings and rating schemes, particularly for ratings describing aspects of business performance, credit worthiness, and investment quality at a high level.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2019-2025 EDM Council, Inc.
+		Copyright (c) 2019-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -61,9 +69,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Arrangements/Ratings/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Arrangements/Ratings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190601/Arrangements/Ratings.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Arrangements/Ratings.rdf version of this ontology was revised to add properties indicating the &apos;best&apos; and &apos;worst&apos; scores on a given scale.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Ratings.rdf version of this ontology was revised to eliminate duplication with LCC.</skos:changeNote>
@@ -74,9 +83,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Arrangements/Ratings.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Arrangements/Ratings.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Arrangements/Ratings.rdf version of the ontology was modified to replace an additional property with its equivalent in the Commons Ontology Library (Commons) v1.1 (FBC-322).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Arrangements/Ratings.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2019-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2019-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2019-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2019-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-rt;QualitativeRatingScore">
@@ -159,7 +169,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;FormalOrganization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>rating agency</rdfs:label>

--- a/FND/Arrangements/Reporting.rdf
+++ b/FND/Arrangements/Reporting.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
@@ -20,6 +21,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
@@ -36,7 +38,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
 		<rdfs:label>Reporting Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the notion of a Report and related party concepts.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2018-2025 EDM Council, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -44,8 +55,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Arrangements/Reporting/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Arrangements/Reporting/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20241001/Arrangements/Reporting.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Arrangements/Reporting.rdf version of this ontology was modified to incorporate evaluates and isEvaluatedBy.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Reporting.rdf version of this ontology was modified to eliminate references to deprecated elements and to external dictionary sites that no longer resolve, and to integrate concepts related to making a request for something.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210301/Arrangements/Reporting.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
@@ -54,8 +67,8 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Arrangements/Reporting.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Arrangements/Reporting.rdf version of the ontology was modified to replace an additional property with its counterpart from the Commons Ontology Library (Commons) v1.1 (FBC-322).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-rep;Report">
@@ -103,7 +116,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-rep;ReportingParty"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -116,7 +129,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-pts;PartyRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-rep;Report"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -243,7 +256,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-rep;isSubmittedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isProvidedBy"/>
 		<rdfs:label>is submitted by</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-arr-rep;Submitter"/>
 		<owl:inverseOf rdf:resource="&fibo-fnd-arr-rep;submits"/>
@@ -271,7 +284,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-rep;submits">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;provides"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;provides"/>
 		<rdfs:label>submits</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-arr-rep;Submitter"/>
 		<skos:definition>presents something (a proposal, application, report, or other document) for consideration or review</skos:definition>

--- a/FND/Law/LegalCore.rdf
+++ b/FND/Law/LegalCore.rdf
@@ -2,9 +2,9 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -16,9 +16,9 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -30,13 +30,22 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/">
 		<rdfs:label>Legal Core Ontology</rdfs:label>
 		<dct:abstract>This ontology defines high-level legal concepts for use in other FIBO ontology elements. These concepts include law and constitution, both of which are framed at a more abstract level than national or state laws and constitutions, so that law forms the basis both for statutes and for company by-laws, and constitution forms the basis both for national or state constitutions and for instruments which are constitutive of incorporated legal entities. This ontology also defines some of the variants of these such as governmental constitutions and ordinances. Court of Law is also defined here.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Law/LegalCore/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Law/LegalCore/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20130801/Law/LegalCore.rdf version of the ontology was was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://www.omg.org/spec/EDMC-FIBO/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Law/LegalCore.rdf version of the ontology was was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Law/LegalCore.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
@@ -51,9 +60,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210101/Law/LegalCore.rdf version of the ontology was revised to address hygiene issues with respect to text formatting.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/Law/LegalCore.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Law/LegalCore.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Law/LegalCore.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2022 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2022 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-cor;Constitution">
@@ -70,7 +80,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-cor;CourtOfLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;FormalOrganization"/>
 		<rdfs:label>court of law</rdfs:label>
 		<skos:definition>person or body of persons having judicial authority to hear and resolve disputes on the basis of statutes or the common law</skos:definition>
 		<cmns-av:explanatoryNote>A court of law is a formal forum of justice that may have authority over civil, criminal, ecclesiastical, or military cases.</cmns-av:explanatoryNote>

--- a/FND/Organizations/FormalOrganizations.rdf
+++ b/FND/Organizations/FormalOrganizations.rdf
@@ -3,12 +3,13 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/">
+	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -21,12 +22,13 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"
+	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -37,7 +39,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 		<rdfs:label>Formal Organizations Ontology</rdfs:label>
-		<dct:abstract>This ontology defines the high level concept of a formal organization, which is purposefully underspecified to facilitate mapping to other organization ontologies, such as the W3C organization ontology, or others defined for specific business and financial services standards. It also defines general concepts related to employment by a formal organization.</dct:abstract>
+		<dct:abstract>This ontology extends the Commons concept of a formal organization, which is purposefully underspecified to facilitate mapping to other organization ontologies, such as the W3C organization ontology, or others defined for specific business and financial services standards. It also defines general concepts related to employment by a formal organization.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
 		Copyright (c) 2013-2025 Object Management Group, Inc.
 		
@@ -49,12 +51,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Organizations/FormalOrganizations/"/>
@@ -80,7 +83,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-fm;Employee">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isEmployedIn"/>
@@ -105,7 +108,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-fm;Employer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;MemberBearingOrganization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;MemberBearingOrganization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;hasEmployee"/>
@@ -123,7 +126,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-fm;Employment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;Membership"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;Membership"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;hasEmployedParty"/>
@@ -143,7 +146,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-fm;FormalOrganization">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;Organization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;Organization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
@@ -170,7 +173,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-fm;InformalOrganization">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;Organization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;Organization"/>
 		<rdfs:label>informal organization</rdfs:label>
 		<skos:definition>organization that is not formally constituted in some way</skos:definition>
 	</owl:Class>
@@ -183,7 +186,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-fm;hasEmployedParty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-org-org;hasOrganizationMember"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;hasOrganizationMember"/>
 		<rdfs:label>has employed party</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-org-fm;Employment"/>
 		<rdfs:range rdf:resource="&fibo-fnd-org-fm;Employee"/>
@@ -201,7 +204,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-fm;hasEmployingParty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-org-org;hasMembership"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;hasMembership"/>
 		<rdfs:label>has employing party</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-org-fm;Employment"/>
 		<rdfs:range rdf:resource="&fibo-fnd-org-fm;Employer"/>
@@ -216,7 +219,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:unionOf rdf:parseType="Collection">
 					<rdf:Description rdf:about="&fibo-fnd-org-fm;FormalOrganization">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-org-org;OrganizationalSubUnit">
+					<rdf:Description rdf:about="&cmns-org;OrganizationalSubUnit">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -234,7 +237,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-fm;isEmployedIn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-org-org;isOrganizationMember"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isOrganizationMember"/>
 		<rdfs:label>is employed in</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-org-fm;Employee"/>
 		<rdfs:range rdf:resource="&fibo-fnd-org-fm;Employment"/>
@@ -250,11 +253,21 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-fm;isEmployingParty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-org-org;isMembershipPartyIn"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isMembershipPartyIn"/>
 		<rdfs:label>is employing party</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-org-fm;Employer"/>
 		<rdfs:range rdf:resource="&fibo-fnd-org-fm;Employment"/>
 		<skos:definition>relates a party in the role of employer to the context of employment</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&cmns-org;Organization">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasGoal"/>
+				<owl:onClass rdf:resource="&fibo-fnd-gao-obj;Goal"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
 
 </rdf:RDF>

--- a/FND/Organizations/FormalOrganizations.rdf
+++ b/FND/Organizations/FormalOrganizations.rdf
@@ -146,18 +146,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-fm;FormalOrganization">
-		<rdfs:subClassOf rdf:resource="&cmns-org;Organization"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-org-fm;isDomiciledIn"/>
-				<owl:someValuesFrom rdf:resource="&cmns-loc;GeopoliticalEntity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>formal organization</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-org-fm;InformalOrganization"/>
-		<skos:definition>organization that is recognized in some legal jurisdiction, with associated rights and responsibilities</skos:definition>
-		<skos:example>Examples include a corporation, charity, government or church.</skos:example>
-		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/vocab-org/#class-formalorganization</cmns-av:adaptedFrom>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;FormalOrganization"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-fm;Group">
@@ -173,9 +163,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-fm;InformalOrganization">
-		<rdfs:subClassOf rdf:resource="&cmns-org;Organization"/>
-		<rdfs:label>informal organization</rdfs:label>
-		<skos:definition>organization that is not formally constituted in some way</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;FormalOrganization"/>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-fm;employs">
@@ -213,20 +202,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-fm;isDomiciledIn">
-		<rdfs:label>is domiciled in</rdfs:label>
-		<rdfs:domain>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-org-fm;FormalOrganization">
-					</rdf:Description>
-					<rdf:Description rdf:about="&cmns-org;OrganizationalSubUnit">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:domain>
-		<rdfs:range rdf:resource="&cmns-loc;GeopoliticalEntity"/>
-		<skos:definition>indicates the principal place where an entity conducts business, such as where its headquarters is located</skos:definition>
-		<cmns-av:explanatoryNote>Corporate domicile refers to a place where a company&apos;s affairs are discharged. It is also typically the legal home of a corporation because the place is considered by law as the center of corporate affairs. In cases where a business has incorporated in one location for convenience, such as for taxation, legal, or regulatory purposes, but operates primarily in one or more other locations, domicile in FIBO refers to the operational location(s) rather than legal location. Many companies in the US have incorporated in the State of Delaware, for example, but do not have operational facilities in Delaware (or only have small offices there).</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;isDomiciledIn"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-fm;isEmployedBy">

--- a/FND/Organizations/Organizations.rdf
+++ b/FND/Organizations/Organizations.rdf
@@ -1,18 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
-	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
-	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
-	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
-	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
-	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
-	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
-	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -22,18 +13,9 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
-	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
-	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
-	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
-	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
-	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
-	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
-	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -44,7 +26,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 		<rdfs:label>Organizations Ontology</rdfs:label>
 		<dct:abstract>This ontology defines high-level concepts for organizations and related terms, which is purposefully underspecified to facilitate mapping to specific organization ontologies, such as the W3C organization ontology, organization from a BMM or BPMN perspective, organization from a records management (RMS) perspective, and so forth.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
@@ -55,10 +46,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Organizations/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Organizations/Organizations/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20160201/Organizations/Organizations.rdf version of this ontology was modified per the FIBO 2.0 RFC, to revise the definition of Organization per ISO 6523.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Organizations/Organizations.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
@@ -77,227 +69,85 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20221201/Organizations/Organizations.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Organizations/Organizations.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Organizations/Organizations.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Organizations/Organizations.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389). Note that this ontology, which only contains deprecated elements as of this modification, will be eliminated from FIBO at a future date.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-org;MemberBearingOrganization">
-		<rdfs:subClassOf rdf:resource="&cmns-pts;PartyRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
-						<owl:someValuesFrom rdf:resource="&cmns-pts;Party"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>member-bearing organization</rdfs:label>
-		<skos:definition>role of a group or organization that has members that are people or other organizations</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;MemberBearingOrganization"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-org;Membership">
-		<rdfs:subClassOf rdf:resource="&cmns-pts;Situation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-org-org;hasMembership"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-org;MemberBearingOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-org-org;hasOrganizationMember"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">membership</rdfs:label>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-org/#class-membership"/>
-		<skos:definition>situation, corresponding to an n-ary relation, in which some group or organization has at least one member (person or organization) for some period of time</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;Membership"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-org;Organization">
-		<rdfs:subClassOf rdf:resource="&cmns-pts;Party"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;hasPart"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-org-org;Organization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
-				<owl:allValuesFrom rdf:resource="&cmns-pts;Party"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasGoal"/>
-				<owl:onClass rdf:resource="&fibo-fnd-gao-obj;Goal"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;hasName"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-org;OrganizationName"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">organization</rdfs:label>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-org/#org:Organization"/>
-		<skos:definition>collection of one or more people, or groups of people formed together into a community or other social, commercial or political structure to act, or that is designated to act, towards some purpose, such as to meet a need or pursue collective goals on a continuing basis</skos:definition>
-		<skos:example>This may be a business entity, government, international organization, not-for-profit, academic institution, or other unincorporated and/or informal social organization.</skos:example>
-		<cmns-av:adaptedFrom>https://www.iso.org/obp/ui/#iso:std:iso-iec:6523:-1:ed-1:v1:en</cmns-av:adaptedFrom>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;Organization"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-org;OrganizationIdentificationScheme">
-		<rdfs:subClassOf rdf:resource="&cmns-id;IdentificationScheme"/>
-		<rdfs:label>organization identification scheme</rdfs:label>
-		<skos:definition>identification scheme dedicated to the unique identification of organizations</skos:definition>
-		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/obp/ui/#iso:std:iso-iec:6523:-1:ed-1:v1:en</cmns-av:adaptedFrom>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;OrganizationIdentificationScheme"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-org;OrganizationIdentifier">
-		<rdfs:subClassOf rdf:resource="&cmns-id;Identifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-org;Organization"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-org;OrganizationIdentificationScheme"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>organization identifier</rdfs:label>
-		<skos:definition>identifier assigned to an organization within an organization identification scheme, and unique within that scheme</skos:definition>
-		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/obp/ui/#iso:std:iso-iec:6523:-1:ed-1:v1:en</cmns-av:adaptedFrom>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;OrganizationIdentifier"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-org;OrganizationMember">
-		<rdfs:subClassOf rdf:resource="&cmns-pts;PartyRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
-						<owl:allValuesFrom rdf:resource="&fibo-fnd-org-org;Organization"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>organization member</rdfs:label>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-org/#org:Role"/>
-		<skos:definition>party (person or organization) that has a membership role with respect to some organization</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;OrganizationMember"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-org;OrganizationName">
-		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;ContextualName"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;isNameOf"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-org;Organization"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>organization name</rdfs:label>
-		<skos:definition>designation by which some organization is known in some context</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;OrganizationName"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-org;OrganizationPartIdentifier">
-		<rdfs:subClassOf rdf:resource="&cmns-id;Identifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&fibo-fnd-org-org;OrganizationalSubUnit"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>organization part identifier</rdfs:label>
-		<skos:definition>identifier allocated to a particular organizational sub-unit</skos:definition>
-		<cmns-av:abbreviation>OPI</cmns-av:abbreviation>
-		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/obp/ui/#iso:std:iso-iec:6523:-1:ed-1:v1:en</cmns-av:adaptedFrom>
-		<cmns-av:synonym>organization sub-unit identifier</cmns-av:synonym>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;OrganizationSubUnitIdentifier"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-org;OrganizationalSubUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;Organization"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-org-org;Organization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>organizational sub-unit</rdfs:label>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-org/#org:OrganizationalUnit"/>
-		<skos:definition>any department, service, and other entity within a larger organization that only has full recognition within the context of that organization, but requires identification for some purpose</skos:definition>
-		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/obp/ui/#iso:std:iso-iec:6523:-1:ed-1:v1:en</cmns-av:adaptedFrom>
-		<cmns-av:explanatoryNote>In other words, it is not a legal entity in its own right.</cmns-av:explanatoryNote>
-		<cmns-av:synonym>organization part</cmns-av:synonym>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;OrganizationalSubUnit"/>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-org;hasMembership">
-		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasActor"/>
-		<rdfs:label>has membership role</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;Membership"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-org;MemberBearingOrganization"/>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-org/#org:organization"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-org-org;isMembershipPartyIn"/>
-		<skos:definition>identifies the organization acting in the role of having members in an organizational membership situation</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;hasMembership"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-org;hasOrganizationMember">
-		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasUndergoer"/>
-		<rdfs:label>has organization member</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;Membership"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-org/#org:member"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-org-org;isOrganizationMember"/>
-		<skos:definition>indicates the party that is the member in an organizational membership situation</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;hasOrganizationMember"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-org;hasSubUnit">
-		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasPart"/>
-		<rdfs:label>has sub-unit</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;Organization"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-org;OrganizationalSubUnit"/>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-org/#org:hasSubOrganization"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-org-org;isSubUnitOf"/>
-		<skos:definition>relates an organization to a part of that organization</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;hasSubUnit"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-org;isMembershipPartyIn">
-		<rdfs:subPropertyOf rdf:resource="&cmns-pts;actsIn"/>
-		<rdfs:label>is membership party in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;MemberBearingOrganization"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-org;Membership"/>
-		<skos:definition>indicates the context of membership in which the party plays the role of having members</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;isMembershipPartyIn"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-org;isOrganizationMember">
-		<rdfs:subPropertyOf rdf:resource="&cmns-pts;undergoes"/>
-		<rdfs:label>is organization member</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-org;Membership"/>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-org/#org:role"/>
-		<skos:definition>indicates the context of membership in which some party is an organization member</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;isOrganizationMember"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-org-org;isSubUnitOf">
-		<rdfs:subPropertyOf rdf:resource="&cmns-col;isPartOf"/>
-		<rdfs:label>is sub-unit of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;OrganizationalSubUnit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-org;Organization"/>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-org/#org:subOrganizationOf"/>
-		<skos:definition>relates a part of an organization to the larger entity</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;isSubUnitOf"/>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/FND/Places/Facilities.rdf
+++ b/FND/Places/Facilities.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
@@ -18,6 +19,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
@@ -49,6 +51,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Places/Facilities/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Places/Facilities.rdf version of this ontology was modified for the FIBO 2.0 RFC to integrate it with LCC.</skos:changeNote>
@@ -69,16 +72,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-fac;Capability">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-fac;Facility"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>capability</rdfs:label>
-		<skos:definition>ability to perform a particular type of work that may involve people with particular skills and knowledge, intellectual property, defined practices, operating facilities, tools and equipment</skos:definition>
-		<cmns-av:adaptedFrom>Value Delivery Modeling Language Specification, http://www.omg.org/spec/VDML/</cmns-av:adaptedFrom>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;Capability"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-fac;Facility">
@@ -98,8 +93,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-fac;Capability"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;Capability"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>facility</rdfs:label>
@@ -151,5 +146,15 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:inverseOf rdf:resource="&fibo-fnd-plc-fac;isSituatedAt"/>
 		<skos:definition>indicates the place, setting, or context in which something is placed</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&cmns-org;Capability">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;involves"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-fac;Facility"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
 
 </rdf:RDF>

--- a/FND/Places/RealProperty.rdf
+++ b/FND/Places/RealProperty.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY cmns-cxtid "https://www.omg.org/spec/Commons/ContextualIdentifiers/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
@@ -31,6 +32,7 @@
 	xmlns:cmns-cxtid="https://www.omg.org/spec/Commons/ContextualIdentifiers/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
@@ -53,9 +55,9 @@
 		<rdfs:label xml:lang="en">Real Property Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts including real and personal property from a legal perspective, as well as assessments of those assets, for reference for taxation, lending, and related purposes.</dct:abstract>
 		<dct:license>Copyright (c) 2024-2025 EDM Council, Inc.
-		Copyright (c) 2024-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2024-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -78,6 +80,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Places/RealProperty/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Places/RealProperty.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
@@ -186,7 +189,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;Appraiser"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Places/VirtualPlaces.rdf
+++ b/FND/Places/VirtualPlaces.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
@@ -17,6 +18,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
@@ -31,9 +33,9 @@
 		<rdfs:label>Virtual Places Ontology</rdfs:label>
 		<dct:abstract>This ontology provides scaffolding for use in describing virtual location-oriented concepts.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -41,11 +43,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Places/VirtualPlaces/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Places/VirtualPlaces.rdf version of this ontology was modified for the FIBO 2.0 RFC to integrate it with LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Places/VirtualPlaces.rdf version of this ontology was modified to eliminate duplication of concepts in LCC and email address and telephone number.</skos:changeNote>
@@ -117,19 +119,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-plc-vrt;hasURL">
-		<rdfs:label>has URL</rdfs:label>
-		<rdfs:range rdf:resource="&xsd;anyURI"/>
-		<skos:definition>links something to a web resource that specifies its location on a computer network and a method for retrieving it</skos:definition>
-		<cmns-av:synonym>has uniform resource locator</cmns-av:synonym>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;hasURL"/>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-plc-vrt;hasWebsite">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-plc-vrt;hasURL"/>
-		<rdfs:label>has website</rdfs:label>
-		<rdfs:range rdf:resource="&xsd;anyURI"/>
-		<rdfs:seeAlso rdf:resource="https://www.w3.org/standards/webdesign/"/>
-		<skos:definition>links something to a page or set of related web pages located under a single domain name, typically produced by a single person or organization</skos:definition>
-		<cmns-av:explanatoryNote>Web Design and Applications involve the standards for building and Rendering Web pages, including HTML, CSS, SVG, device APIs, and other technologies for Web Applications (&apos;WebApps&apos;). HTML (the Hypertext Markup Language) and CSS (Cascading Style Sheets) are two of the core technologies for building Web pages. HTML provides the structure of the page, CSS the (visual and aural) layout, for a variety of devices and services.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;hasWebsite"/>
 	</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/FND/ProductsAndServices/ProductsAndServices.rdf
+++ b/FND/ProductsAndServices/ProductsAndServices.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -28,6 +29,7 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -73,6 +75,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/ProductsAndServices/ProductsAndServices/"/>
@@ -343,7 +346,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-fac;Capability"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;Capability"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>service</rdfs:label>

--- a/FND/ProductsAndServices/ProductsAndServices.rdf
+++ b/FND/ProductsAndServices/ProductsAndServices.rdf
@@ -430,7 +430,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;isProvisionedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isProvidedBy"/>
 		<rdfs:label>is provisioned by</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-org;ServiceProvider"/>
 		<owl:inverseOf rdf:resource="&fibo-fnd-pas-pas;provisions"/>
@@ -438,7 +438,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;isSuppliedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isProvidedBy"/>
 		<rdfs:label>is supplied by</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-pas-pas;Product"/>
 		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;Supplier"/>
@@ -447,7 +447,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;provisions">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;provides"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;provides"/>
 		<rdfs:label>provisions</rdfs:label>
 		<rdfs:domain rdf:resource="&cmns-org;ServiceProvider"/>
 		<skos:definition>customizes, provides, or outfits something required for use in delivering a service</skos:definition>
@@ -470,7 +470,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;supplies">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;provides"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;provides"/>
 		<rdfs:label>supplies</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-pas-pas;Supplier"/>
 		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;Product"/>

--- a/FND/ProductsAndServices/ProductsAndServices.rdf
+++ b/FND/ProductsAndServices/ProductsAndServices.rdf
@@ -53,9 +53,9 @@
 		<rdfs:label>Products and Services Ontology</rdfs:label>
 		<dct:abstract>This ontology defines fundamental concepts for buyers, sellers, clients, customers, products, goods and services for use in other FIBO ontologies.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -261,7 +261,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-fnd-law-lcap;ContractualRight">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-pas-pas;Service">
+					<rdf:Description rdf:about="&cmns-org;Service">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -330,29 +330,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Service">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;isProvisionedBy"/>
-				<owl:onClass rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-				<owl:someValuesFrom rdf:resource="&cmns-org;Capability"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>service</rdfs:label>
-		<skos:definition>intangible activity performed by some party for the benefit of another party</skos:definition>
-		<skos:example>Services include intangible products, such as accounting, banking, cleaning, consultancy, education, insurance, expertise, medical treatment, or transportation services.</skos:example>
-		<cmns-av:explanatoryNote>Sometimes services are difficult to identify because they are closely associated with a good; such as the combination of a diagnosis with the administration of a medicine. No transfer of possession or ownership takes place when services are sold, and they (1) cannot be stored or transported, (2) are instantly perishable, and (3) come into existence at the time they are bought and consumed.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;Service"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;ServiceAgreement">
@@ -361,14 +340,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
-				<owl:onClass rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+				<owl:onClass rdf:resource="&cmns-org;ServiceProvider"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;governs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Service"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;Service"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>service agreement</rdfs:label>
@@ -377,29 +356,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;ServiceProvider">
-		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Role"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;provisions"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-fac;Facility"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;provisions"/>
-				<owl:onClass rdf:resource="&fibo-fnd-pas-pas;Service"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Service"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>service provider</rdfs:label>
-		<skos:definition>party that provides and typically provisions professional services, such as consulting, financial, legal, real estate, education, communications, storage, or processing services, to other parties, typically defined in a service agreement</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&cmns-org;ServiceProvider"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;Supplier">
@@ -474,7 +432,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;isProvisionedBy">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
 		<rdfs:label>is provisioned by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:range rdf:resource="&cmns-org;ServiceProvider"/>
 		<owl:inverseOf rdf:resource="&fibo-fnd-pas-pas;provisions"/>
 		<skos:definition>identifies the service provider that provisions the service or facility</skos:definition>
 	</owl:ObjectProperty>
@@ -491,7 +449,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-pas;provisions">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;provides"/>
 		<rdfs:label>provisions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:domain rdf:resource="&cmns-org;ServiceProvider"/>
 		<skos:definition>customizes, provides, or outfits something required for use in delivering a service</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -518,5 +476,32 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;Product"/>
 		<skos:definition>links a party in the role of outfitter, provisioner, distributor, etc. to something that they provide</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&cmns-org;Service">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;isProvisionedBy"/>
+				<owl:onClass rdf:resource="&cmns-org;ServiceProvider"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-org;ServiceProvider">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;provisions"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-fac;Facility"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-pas;provisions"/>
+				<owl:onClass rdf:resource="&cmns-org;Service"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
 
 </rdf:RDF>

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -20,6 +21,7 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -35,9 +37,9 @@
 		<rdfs:label>Relations Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a set of general purpose relations for use in other FIBO ontology elements. These include a number of properties required for reuse across the foundations and business entities models.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -49,6 +51,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Relations/Relations/"/>
@@ -110,9 +113,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;designates">
-		<rdfs:label>designates</rdfs:label>
-		<skos:definition>appoints someone officially</skos:definition>
-		<cmns-av:explanatoryNote>This property is intended to cover assigning a job or role to someone, selecting or designating someone to fill an office or a position, and fixing or setting by authority or by mutual agreement.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;designates"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;embodies">
@@ -219,9 +221,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isDesignatedBy">
-		<rdfs:label>is designated by</rdfs:label>
-		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;designates"/>
-		<skos:definition>indicates the party that has assigned or appointed someone to an office or position</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;isDesignatedBy"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isEvaluatedBy">
@@ -256,15 +257,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isIssuedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isProvidedBy"/>
 		<rdfs:label>is issued by</rdfs:label>
 		<skos:definition>indicates a functional entity or party responsible for circulating, distributing, or publishing something</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isManagedBy">
-		<rdfs:label>is managed by</rdfs:label>
-		<skos:definition>relates something to another thing that has some role in directing its affairs</skos:definition>
-		<cmns-av:explanatoryNote>The target or range of this property should be read as always being some kind of &apos;relative thing&apos;, that is a thing defined in some context. Generally this will be a &apos;party in role&apos;. This property is not intended to be used to relate a thing to some independent thing which it is managed by, only to something in the role of being that which manages it.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;isManagedBy"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isMandatedBy">
@@ -280,23 +280,20 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isProvidedBy">
-		<rdfs:label>is provided by</rdfs:label>
-		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;provides"/>
-		<skos:definition>is made available by</skos:definition>
-		<cmns-av:explanatoryNote>The target or range of this property should be read as always being some kind of &apos;relative thing&apos;, that is a thing defined in some context. Generally this will be a &apos;party in role&apos;. This property is not intended to be used to relate a thing to some independent thing which it is provided by, only to something in the role of being that which provides it.</cmns-av:explanatoryNote>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;isProvidedBy"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;issues">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;provides"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;provides"/>
 		<rdfs:label>issues</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
 		<skos:definition>officially makes something available</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;manages">
-		<rdfs:label>manages</rdfs:label>
-		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
-		<skos:definition>relates a party to something that it directs in some way</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;manages"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;mandates">
@@ -312,8 +309,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;provides">
-		<rdfs:label>provides</rdfs:label>
-		<skos:definition>makes something available</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-org;provides"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;wasFormerlyKnownAs">

--- a/FND/TransactionsExt/REATransactions.rdf
+++ b/FND/TransactionsExt/REATransactions.rdf
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -23,10 +23,10 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -46,8 +46,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/">
 		<rdfs:label xml:lang="en">REA Transactions Ontology</rdfs:label>
 		<dct:abstract>This is the core REA-derived ontology for transactions. A transaction is defined as an exchange of commitments between parties. Other aspects of REA such as claims and transaction events (commitment lifecycles) are given in separate ontologies in this module.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -58,11 +66,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-txn-rea;ContractualEconomicAgreement">
@@ -98,7 +107,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">contractual transaction party</rdfs:label>

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -8,12 +8,12 @@
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -31,12 +31,12 @@
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -49,9 +49,9 @@
 		<rdfs:label>Analytics Ontology</rdfs:label>
 		<dct:abstract>This ontology provides mathematical abstractions for use in other ontologies, including for example the basic components of formulae, parameters and values.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -61,7 +61,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
@@ -71,6 +70,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241101/Utilities/Analytics/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20140501/Utilities/Analytics.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/.</skos:changeNote>
@@ -494,12 +494,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Program"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalUniverse"/>
 			</owl:Restriction>
@@ -508,6 +502,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-loc;hasCoverageArea"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalArea"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>statistical program</rdfs:label>

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -518,7 +518,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>enterprise</rdfs:label>

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
@@ -24,7 +25,6 @@
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -46,6 +46,7 @@
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
@@ -63,7 +64,6 @@
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -103,7 +103,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -117,6 +116,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
@@ -901,7 +901,7 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;FormalOrganization"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>statistical information publisher</rdfs:label>

--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -483,7 +483,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:unionOf rdf:parseType="Collection">
 					<rdf:Description rdf:about="&fibo-fnd-pas-pas;Producer">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-pas-pas;ServiceProvider">
+					<rdf:Description rdf:about="&cmns-org;ServiceProvider">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -508,7 +508,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&fibo-fnd-pas-pas;Good">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-pas-pas;Service">
+							<rdf:Description rdf:about="&cmns-org;Service">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -616,7 +616,7 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 				<owl:unionOf rdf:parseType="Collection">
 					<rdf:Description rdf:about="&fibo-fnd-pas-pas;Good">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-pas-pas;Service">
+					<rdf:Description rdf:about="&cmns-org;Service">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -641,7 +641,7 @@ Excluded are directors of incorporated enterprises and members of shareholders c
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&fibo-fnd-pas-pas;Good">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-pas-pas;Service">
+							<rdf:Description rdf:about="&cmns-org;Service">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>

--- a/IND/Indicators/Indicators.rdf
+++ b/IND/Indicators/Indicators.rdf
@@ -8,7 +8,6 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -28,7 +27,6 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -42,7 +40,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
 		<rdfs:label>Indicators Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the concepts common to all market rates, indices and indicators; that is concepts descriptive of the numeric parameters themselves. These are modeled independently of the values they may take over time.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
@@ -54,7 +61,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20231201/Indicators/Indicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20250301/Indicators/Indicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/Indicators/Indicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/Indicators/Indicators.rdf version of this ontology was modified per the FIBO 2.0 RFC, namely, to integrate concepts recently added to the FND domain including Rate, ExchangeRate, InterestRate and StructuredCollection and revise definitions of TermStructure and Volatility to better support concepts such as yield curves and analysis of market rates generally.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/Indicators/Indicators.rdf version of this ontology was modified to integrate the composite date value and reflect migration of statistical measures to Analytics.</skos:changeNote>
@@ -68,9 +75,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20221001/Indicators/Indicators.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230201/Indicators/Indicators.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230301/Indicators/Indicators.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20231201/Indicators/Indicators.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-ind-ind-ind;DailyAverageMarketRate">

--- a/IND/InterestRates/CommonInterestRates.rdf
+++ b/IND/InterestRates/CommonInterestRates.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-usfsind "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/">
 	<!ENTITY fibo-fbc-fct-usjrga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/">
@@ -18,6 +19,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-usfsind="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"
 	xmlns:fibo-fbc-fct-usjrga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"
@@ -36,7 +38,18 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/">
 		<rdfs:label>Common Interest Rates Ontology</rdfs:label>
 		<dct:abstract>This ontology provides reference data for commonly referenced interest rates, specifically those that are referenced in the ISDA FpML codes for floating interest rates. The rates included herein are generated directly from the FpML published reference data.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+Copyright (c) 2015-2025 Object Management Group, Inc.
+Copyright (c) 2015-2025 Thematix Partners LLC
+Copyright (c) 2023-2025 Federated Knowledge, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"/>
@@ -45,7 +58,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20240601/InterestRates/CommonInterestRates/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20250301/InterestRates/CommonInterestRates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190101/InterestRates/InterestRates.rdf version of this ontology was revised extensively to restructure the way in which interest rate benchmarks are modeled and eliminate references to the merged interest rate publishers ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20190101/InterestRates/InterestRates.rdf version of this ontology was revised to reflect the latest FpML rates.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210301/InterestRates/InterestRates.rdf version of this ontology was revised to reflect the latest FpML rates, which include a number of changes, including deprecating some rates and replacing them with others.</skos:changeNote>
@@ -53,12 +67,13 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230201/InterestRates/InterestRates.rdf version of this ontology was modified to normalize the prefix for the EU individuals ontology and update the reference interest rates as of 10 March 2023.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230601/InterestRates/InterestRates.rdf version of this ontology was modified to normalize the prefix for the EU individuals ontology and update the reference interest rates as of 26 April 2024.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20240601/InterestRates/InterestRates.rdf version of this ontology was modified to update the reference interest rates as of Q4 2024.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20241201/InterestRates/InterestRates.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.fpml.org/coding-scheme/floating-rate-index-3-10.xml</cmns-av:adaptedFrom>
-		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2024 Object Management Group, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2024 Thematix Partners LLC</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2023-2024 Federated Knowledge, LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2023-2025 Federated Knowledge, LLC</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AED-EIBOR">
@@ -137,10 +152,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-LIBOR-BBA-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-LIBOR-BBA-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<cmns-av:abbreviation>AUD-LIBOR-BBA-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-LIBOR-Reference_Banks">
@@ -163,11 +178,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>AUD-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Semi-Annual_Swap_Rate-BGCANTOR-Reference_Banks">
@@ -191,10 +206,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;AUD-Swap_Rate-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>AUD-Swap Rate-Reuters</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<cmns-av:abbreviation>AUD-Swap Rate-Reuters</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;BRL-CDI">
@@ -224,10 +239,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-BA-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-BA-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 		<cmns-av:abbreviation>CAD-BA-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-CDOR">
@@ -289,19 +304,19 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-BBA-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-BBA-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 		<cmns-av:abbreviation>CAD-LIBOR-BBA-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-BBA-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-LIBOR-BBA-SwapMarker</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 		<cmns-av:abbreviation>CAD-LIBOR-BBA-SwapMarker</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-LIBOR-Reference_Banks">
@@ -339,19 +354,19 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-Reuters</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 		<cmns-av:abbreviation>CAD-TBILL-Reuters</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CAD-TBILL-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CAD-TBILL-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 		<cmns-av:abbreviation>CAD-TBILL-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-CME_vs_LCH-ICAP">
@@ -366,11 +381,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>CHF-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-EUREX_vs_LCH-ICAP">
@@ -385,21 +400,21 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-3M_LIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>CHF-3M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBORSWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBORSWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>CHF-6M LIBORSWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBOR_SWAP-CME_vs_LCH-ICAP">
@@ -423,11 +438,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>CHF-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CHF-Annual_Swap_Rate">
@@ -678,11 +693,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CNY-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>CNY-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CNY-Semi-Annual_Swap_Rate-Reference_Banks">
@@ -715,11 +730,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>CZK-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>CZK-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;CZK-Annual_Swap_Rate-Reference_Banks">
@@ -841,11 +856,11 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>EUR-3M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-3M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP">
@@ -862,11 +877,11 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>EUR-3M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-CME_vs_LCH-ICAP">
@@ -883,11 +898,11 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>EUR-6M EURIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-6M_EURIBOR_SWAP-EUREX_vs_LCH-ICAP">
@@ -904,11 +919,11 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>EUR-6M EURIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00">
@@ -923,21 +938,21 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-ICAP">
@@ -952,21 +967,21 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-SwapMarker</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00-SwapMarker</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-10_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-10:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>EUR-Annual Swap Rate-10:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00">
@@ -981,11 +996,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>EUR-Annual Swap Rate-11:00-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00-ICAP">
@@ -1000,11 +1015,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-11_00-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-11:00-SwapMarker</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>EUR-Annual Swap Rate-11:00-SwapMarker</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-3_Month">
@@ -1019,21 +1034,21 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-3_Month-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-3 Month-SwapMarker</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>EUR-Annual Swap Rate-3 Month-SwapMarker</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-Annual Swap Rate-4:15-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>EUR-Annual Swap Rate-4:15-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-Annual_Swap_Rate-Reference_Banks">
@@ -1075,10 +1090,10 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-10:00-BGCANTOR</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<cmns-av:abbreviation>EUR-EONIA-OIS-10:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-10_00-ICAP">
@@ -1094,10 +1109,10 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-10:00-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<cmns-av:abbreviation>EUR-EONIA-OIS-10:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS-11_00-ICAP">
@@ -1113,10 +1128,10 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EONIA-OIS-4:15-TRADITION</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<cmns-av:abbreviation>EUR-EONIA-OIS-4:15-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EONIA-OIS_Compound">
@@ -1159,10 +1174,10 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR-Act/365-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<cmns-av:abbreviation>EUR-EURIBOR-Act/365-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR-Reference_Banks">
@@ -1178,10 +1193,10 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-EURIBOR-Telerate</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-ind-ir-mdp;EuropeanMoneyMarketsInstituteBenchmarkPublisher"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<cmns-av:abbreviation>EUR-EURIBOR-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-EURIBOR_ICE_Swap_Rate-11_00">
@@ -1405,10 +1420,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC5-CNO-SwapMarker">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>EUR-TEC5-CNO-SwapMarker</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<cmns-av:abbreviation>EUR-TEC5-CNO-SwapMarker</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;SwapMarker"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;EUR-TEC5-Reference_Banks">
@@ -1484,11 +1499,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>GBP-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP">
@@ -1503,11 +1518,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-6M_LIBOR_SWAP-EUREX_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>GBP-6M LIBOR SWAP-EUREX vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-LIBOR">
@@ -1577,19 +1592,19 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA-OIS-11:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<cmns-av:abbreviation>GBP-SONIA-OIS-11:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-SONIA-OIS-4:15-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<cmns-av:abbreviation>GBP-SONIA-OIS-4:15-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-SONIA-OIS_Compound">
@@ -1719,21 +1734,21 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi_Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi Annual Swap Rate-11:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>GBP-Semi Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-Semi_Annual_Swap_Rate-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GBP-Semi Annual Swap Rate-4:15-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>GBP-Semi Annual Swap Rate-4:15-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GBP-UK_Base_Rate">
@@ -1771,10 +1786,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIBOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIBOR-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<cmns-av:abbreviation>GRD-ATHIBOR-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIMID-Reference_Banks">
@@ -1788,10 +1803,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;GRD-ATHIMID-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>GRD-ATHIMID-Reuters</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<cmns-av:abbreviation>GRD-ATHIMID-Reuters</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR">
@@ -1806,11 +1821,11 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-HIBOR-HIBOR-Bloomberg</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<cmns-av:abbreviation>HKD-HIBOR-HIBOR-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-HIBOR-HIBOR-Bloomberg&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-HIBOR-HIBOR_">
@@ -1875,36 +1890,36 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-11:00-BGCANTOR&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-11:00-TRADITION</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>HKD-Quarterly-Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-11:00-TRADITION&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-4_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Deprecated usage: &quot;HKD-Quarterly-Annual Swap Rate-4:00-BGCANTOR&quot; code has been deprecated in supplement 79 to the 2006 ISDA definitions (Removal of certain Hong Kong Rate Options.). The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;HKD-Quarterly-Annual_Swap_Rate-Reference_Banks">
@@ -1986,10 +2001,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-IDMA-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-IDMA-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<cmns-av:abbreviation>IDR-IDMA-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-IDRFIX">
@@ -2027,10 +2042,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SBI-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SBI-Reuters</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<cmns-av:abbreviation>IDR-SBI-Reuters</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SOR-Reference_Banks">
@@ -2045,30 +2060,30 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SOR-Reuters</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<cmns-av:abbreviation>IDR-SOR-Reuters</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Deprecated usage: &quot;IDR-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-SOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-SOR-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<cmns-av:abbreviation>IDR-SOR-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>IDR-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>IDR-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;IDR-Semi-Annual_Swap_Rate-Reference_Banks">
@@ -2212,11 +2227,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Semi-Annual_Swap_Rate-11_30-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>INR-Semi-Annual Swap Rate-11:30-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>INR-Semi-Annual Swap Rate-11:30-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;INR-Semi-Annual_Swap_Rate-Reference_Banks">
@@ -2256,21 +2271,21 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-Annual Swap Rate-11:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>JPY-Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Annual_Swap_Rate-3_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-Annual Swap Rate-3:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>JPY-Annual Swap Rate-3:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-BBSF-Bloomberg-10_00">
@@ -2388,19 +2403,19 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-OIS-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-OIS-11:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 		<cmns-av:abbreviation>JPY-OIS-11:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-OIS-3_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>JPY-OIS-3:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 		<cmns-av:abbreviation>JPY-OIS-3:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;JPY-Quoting_Banks-LIBOR">
@@ -2759,11 +2774,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-Quarterly_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>MYR-Quarterly Swap Rate-11:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>MYR-Quarterly Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;MYR-Quarterly_Swap_Rate-TRADITION-Reference_Banks">
@@ -2846,10 +2861,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BBR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-BBR-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 		<cmns-av:abbreviation>NZD-BBR-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-BKBM_Bid">
@@ -2895,11 +2910,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>NZD-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>NZD-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;NZD-Semi-Annual_Swap_Rate-BGCANTOR-Reference_Banks">
@@ -2956,11 +2971,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>PHP-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>PHP-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;PHP-Semi-Annual_Swap_Rate-Reference_Banks">
@@ -3071,11 +3086,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RON-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>RON-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RON-Annual_Swap_Rate-Reference_Banks">
@@ -3106,31 +3121,31 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>RUB-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-12_45-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-12:45-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>RUB-Annual Swap Rate-12:45-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-4_15-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>RUB-Annual Swap Rate-4:15-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>RUB-Annual Swap Rate-4:15-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;RUB-Annual_Swap_Rate-Reference_Banks">
@@ -3332,10 +3347,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SIBOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SIBOR-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<cmns-av:abbreviation>SGD-SIBOR-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SONAR-OIS-COMPOUND">
@@ -3369,10 +3384,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-SOR-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<cmns-av:abbreviation>SGD-SOR-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-SOR-VWAP-Reference_Banks">
@@ -3420,21 +3435,21 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-11.00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-11.00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-11.00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SGD-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>SGD-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SGD-Semi-Annual_Swap_Rate-11_00-Tullett_Prebon">
@@ -3502,10 +3517,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>SKK-BRIBOR-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<cmns-av:abbreviation>SKK-BRIBOR-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;SKK-BRIBOR-NBSK07">
@@ -3538,32 +3553,32 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-SOR-Reuters</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 		<cmns-av:abbreviation>THB-SOR-Reuters</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Deprecated usage: &quot;THB-SOR-Reuters&quot; code has been deprecated in supplement 35 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-SOR-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-SOR-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 		<cmns-av:abbreviation>THB-SOR-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>THB-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>THB-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Deprecated usage: the code has been deprecated in supplement 38 to the 2006 ISDA definitions. The code is kept in FpML for backward compatibility purposes.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;THB-Semi-Annual_Swap_Rate-Reference_Banks">
@@ -3612,11 +3627,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-Annual_Swap_Rate-11_15-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY-Annual Swap Rate-11:15-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>TRY-Annual Swap Rate-11:15-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY-Annual_Swap_Rate-Reference_Banks">
@@ -3672,21 +3687,21 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TRY_Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TRY Annual Swap Rate-11:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>TRY Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Quarterly-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>TWD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>TWD-Quarterly-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;TWD-Quarterly-Annual_Swap_Rate-Reference_Banks">
@@ -3766,11 +3781,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-3M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>USD-3M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-6M_LIBOR_SWAP-CME_vs_LCH-ICAP">
@@ -3785,11 +3800,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-6M_LIBOR_SWAP-CME_vs_LCH-ICAP-Bloomberg">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>USD-6M LIBOR SWAP-CME vs LCH-ICAP-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-AMERIBOR">
@@ -3843,31 +3858,31 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>USD-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Annual Swap Rate-11:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>USD-Annual Swap Rate-11:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Annual_Swap_Rate-4_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-Annual Swap Rate-4:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;TwelveMonths"/>
 		<cmns-av:abbreviation>USD-Annual Swap Rate-4:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-BA-H.15">
@@ -3939,19 +3954,19 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Reuters">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Reuters</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<cmns-av:abbreviation>USD-CMS-Reuters</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMS-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-CMS-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<cmns-av:abbreviation>USD-CMS-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-CMT">
@@ -3973,10 +3988,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-COF11-Telerate">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-COF11-Telerate</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<cmns-av:abbreviation>USD-COF11-Telerate</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReuters"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-COFI">
@@ -4127,10 +4142,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<cmns-av:abbreviation>USD-OIS-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-LON-ICAP">
@@ -4152,19 +4167,19 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-11_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-11:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<cmns-av:abbreviation>USD-OIS-11:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-3_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-3:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<cmns-av:abbreviation>USD-OIS-3:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-3_00-NY-ICAP">
@@ -4178,10 +4193,10 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-OIS-4_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-OIS-4:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<cmns-av:abbreviation>USD-OIS-4:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-Overnight_Bank_Funding_Rate">
@@ -4375,10 +4390,10 @@
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>USD-TBILL-H.15-Bloomberg</rdfs:label>
 		<fibo-fnd-rel-rel:isProducedBy rdf:resource="&fibo-fbc-fct-usjrga;BoardOfGovernorsOfTheFederalReserveSystem"/>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<cmns-av:abbreviation>USD-TBILL-H.15-Bloomberg</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;USD-TBILL_Auction_High_Rate">
@@ -4480,11 +4495,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;VND-Semi-Annual_Swap_Rate-11_00-BGCANTOR">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>VND-Semi-Annual Swap Rate-11:00-BGCANTOR</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Dong"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
 		<cmns-av:abbreviation>VND-Semi-Annual Swap Rate-11:00-BGCANTOR</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;FenicsMarketData"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;VND-Semi-Annual_Swap_Rate-Reference_Banks">
@@ -4547,21 +4562,21 @@
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Quarterly_Swap_Rate-1_00-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-Quarterly Swap Rate-1:00-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>ZAR-Quarterly Swap Rate-1:00-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Quarterly_Swap_Rate-5_30-TRADITION">
 		<rdf:type rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:label>ZAR-Quarterly Swap Rate-5:30-TRADITION</rdfs:label>
-		<fibo-fnd-rel-rel:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 		<fibo-ind-ir-ir:hasReferenceCurrency rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 		<fibo-ind-ir-ir:hasTenor rdf:resource="&fibo-ind-ir-ir;ThreeMonths"/>
 		<cmns-av:abbreviation>ZAR-Quarterly Swap Rate-5:30-TRADITION</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>Per 2006 ISDA Definitions or Annex to the 2000 ISDA Definitions, Section 7.1 Rate Options, as amended and supplemented through the date on which parties enter into the relevant transaction.</cmns-av:explanatoryNote>
+		<cmns-org:isProvidedBy rdf:resource="&fibo-ind-ir-mdp;Tradition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-ir-cm;ZAR-Quarterly_Swap_Rate-TRADITION-Reference_Banks">

--- a/IND/InterestRates/InterestRates.rdf
+++ b/IND/InterestRates/InterestRates.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -26,6 +27,7 @@
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -46,7 +48,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/">
 		<rdfs:label>Interest Rates Ontology</rdfs:label>
 		<dct:abstract>This ontology provides the basic types of interest rate which are recognized in the financial markets, and the relationships between these where applicable. These include bank base rates, inter-bank offer rates, overnight rates of interest and the US Federal Funds rate which is widely used as a rate of reference. It also includes the concept of a market rate spread between two interest rates.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2014-2025 EDM Council, Inc.
+Copyright (c) 2014-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
@@ -59,8 +70,9 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20231101/InterestRates/InterestRates/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20250301/InterestRates/InterestRates/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/InterestRates/InterestRates.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/InterestRates/InterestRates.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 2 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/InterestRates/InterestRates.rdf version of this ontology was modified per the FIBO 2.0 RFC, including adding support for reference rates from FpML.</skos:changeNote>
@@ -71,10 +83,11 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230201/InterestRates/InterestRates.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230301/InterestRates/InterestRates.rdf version of this ontology was modified to correct a restriction on specific provider interest rate benchmark.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230501/InterestRates/InterestRates.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20231101/InterestRates/InterestRates.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20231101/InterestRates/InterestRates.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;FloatingInterestRate">
@@ -175,7 +188,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityKind"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:onClass rdf:resource="&fibo-be-fct-pub;MarketDataProvider"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -338,7 +351,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ir-ir;InterestRateBenchmark"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:onClass rdf:resource="&fibo-be-fct-pub;MarketDataProvider"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/IND/MarketIndices/EquityIndexExampleIndividuals.rdf
+++ b/IND/MarketIndices/EquityIndexExampleIndividuals.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -18,7 +19,6 @@
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -38,6 +38,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -53,7 +54,6 @@
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -72,7 +72,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/EquityIndexExampleIndividuals/">
 		<rdfs:label>Equity Index Example Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology provides examples of how to represent common equity indices as identified in the IND-EFT-DEV use case.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2020-2025 EDM Council, Inc.
+Copyright (c) 2020-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
@@ -85,7 +94,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -97,18 +105,20 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20241101/MarketIndices/EquityIndexExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20250301/MarketIndices/EquityIndexExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20210901/MarketIndices/EquityIndexExampleIndividuals.rdf version of this ontology was modified to reflect the move of market data provider from interest rates in IND to publishers in BE.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20221001/MarketIndices/EquityIndexExampleIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230201/MarketIndices/EquityIndexExampleIndividuals.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230301/MarketIndices/EquityIndexExampleIndividuals.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20240101/MarketIndices/EquityIndexExampleIndividuals.rdf version of this ontology was modified to eliminate implicit punning and revise properties that are now deprecated (moved to Commons).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20240901/MarketIndices/EquityIndexExampleIndividuals.rdf version of this ontology was modified to revise a remaining property that moved to Commons.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20241101/MarketIndices/EquityIndexExampleIndividuals.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2020-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2020-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-mkt-eqind;DowJonesIndustrialAverage">
@@ -245,7 +255,7 @@
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-usfsind;SPGlobalHeadquartersAddress"/>
 		<fibo-be-oac-cctl:hasDomesticUltimateParent rdf:resource="&fibo-fbc-fct-usfsind;SPGlobal"/>
 		<fibo-fbc-pas-fpas:hasLegalAgent rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany"/>
-		<fibo-fnd-plc-vrt:hasWebsite rdf:datatype="&xsd;anyURI">https://us.spindices.com/</fibo-fnd-plc-vrt:hasWebsite>
+		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://us.spindices.com/</cmns-org:hasWebsite>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-mkt-eqind;StandardAndPoors500CompositeIndex">

--- a/LOAN/LoansGeneral/LoanEvents.rdf
+++ b/LOAN/LoansGeneral/LoanEvents.rdf
@@ -2,8 +2,8 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
@@ -25,8 +25,8 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
@@ -48,8 +48,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/">
 		<rdfs:label xml:lang="en">LoanEvents</rdfs:label>
 		<dct:abstract>This ontology defines a wide range of events relating to loans. These include legal proceedings, prepayments, and so forth.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+Copyright (c) 2016-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
@@ -64,10 +72,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanEvents/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ev;CollateralValuation">
@@ -118,7 +127,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-loan-ln-ev;isAgainst"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalPerson"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">legal proceeding</rdfs:label>
@@ -185,7 +194,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-loan-ln-ev;isAgainst">
 		<rdfs:label xml:lang="en">is against</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-loan-ln-ev;LegalProceeding"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+		<rdfs:range rdf:resource="&cmns-org;LegalPerson"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-loan-ln-ev;isDeferred">

--- a/LOAN/LoansGeneral/LoanEvents.rdf
+++ b/LOAN/LoansGeneral/LoanEvents.rdf
@@ -89,7 +89,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-asmt;Appraiser"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/LOAN/LoansGeneral/Loans.rdf
+++ b/LOAN/LoansGeneral/Loans.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -39,6 +40,7 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -101,6 +103,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20250301/LoansGeneral/Loans/"/>
@@ -413,7 +416,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">

--- a/LOAN/LoansGeneral/LoansRegulatory.rdf
+++ b/LOAN/LoansGeneral/LoansRegulatory.rdf
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-app "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/">
@@ -20,12 +20,12 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-app="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"
@@ -40,20 +40,29 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/">
 		<rdfs:label xml:lang="en">LoansRegulatory</rdfs:label>
 		<dct:abstract>This ontology contains concepts relating to regulatory requirements around loans, including disclosure rights and a small number of regulation-specific concepts. These include definitions of rights conferred on borrowers under consumer protection law, rights to equal treatment and the like.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoanApplications/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/LoansRegulatory/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;BorrowerDataProtectionRequirement">
@@ -107,7 +116,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-reg;ConsumerCreditReferenceAgency">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;FormalOrganization"/>
 		<rdfs:label xml:lang="en">consumer credit reference agency</rdfs:label>
 		<skos:definition xml:lang="en">Applicable regulations: vary by jurisdiciton. for example, only being allowed ot divulge actual judgements against a party, but not things that are not substantiated by judgements. For example, slow payments which are not covered by some judgement against the party. There will be different regulatory requirments about: 1. What the CR Agency can hold 2. Who they can divulge it to 3. What information they must provide the borrower at his/her request Some of the third thing there is covered in the EU the Data Protection Directive and local acts that implement this.</skos:definition>
 	</owl:Class>

--- a/LOAN/LoansSpecific/CardAccounts.rdf
+++ b/LOAN/LoansSpecific/CardAccounts.rdf
@@ -9,6 +9,7 @@
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -20,7 +21,6 @@
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -42,6 +42,7 @@
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -53,7 +54,6 @@
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -85,7 +85,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -99,9 +98,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20241001/LoansSpecific/CardAccounts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20250301/LoansSpecific/CardAccounts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20230601/LoansSpecific/CardAccounts.rdf version of this ontology was modified to add a distinction between consumer and commercial credit card agreements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20230701/LoansSpecific/CardAccounts.rdf version of this ontology was modified to make consumer credit card agreement a subclass of unsecured consumer loan.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20230901/LoansSpecific/CardAccounts.rdf version of the ontology was modified to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
@@ -335,7 +335,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-						<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+						<owl:someValuesFrom rdf:resource="&cmns-org;FormalOrganization"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
 			</owl:Restriction>

--- a/LOAN/LoansSpecific/CommercialLoans.rdf
+++ b/LOAN/LoansSpecific/CommercialLoans.rdf
@@ -2,9 +2,9 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -19,9 +19,9 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -36,19 +36,29 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/">
 		<rdfs:label xml:lang="en">Commercial Loans Ontology</rdfs:label>
 		<dct:abstract>Commercial loans are loans where the loan purpose is some commercial purpose. Note that these are distinguished by the loan purpose not by the borrower type - borrowers may be corporate or personal, though in the majority of cases they would also be corporate loans that is loans with a corporate borrower.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+		Copyright (c) 2016-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20250301/LoansSpecific/CommercialLoans/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20240101/LoansSpecific/CommercialLoans.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-spc-com;CommercialLoan">
@@ -73,7 +83,7 @@
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-						<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+						<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
 			</owl:Restriction>

--- a/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
+++ b/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
@@ -208,7 +208,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 						<owl:someValuesFrom>
 							<owl:Class>
 								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-be-le-lp;LegalPerson">
+									<rdf:Description rdf:about="&cmns-org;LegalPerson">
 									</rdf:Description>
 									<rdf:Description rdf:about="&cmns-org;FormalOrganization">
 									</rdf:Description>

--- a/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
+++ b/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
@@ -12,7 +13,6 @@
 	<!ENTITY fibo-fbc-fct-rga "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-arr-rep "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -32,6 +32,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
@@ -39,7 +40,6 @@
 	xmlns:fibo-fbc-fct-rga="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-arr-rep="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -56,13 +56,21 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/">
 		<rdfs:label>Home Mortgage Disclosure Act (HMDA) Covered Mortgages Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts specific to mortgages that are covered by the Home Mortgage Disclosure Act (HMDA) and related regulations. This includes the concept of a HMDA report as well as specializations of the core classes for pre-approval requests, covered loan contracts.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -73,11 +81,12 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/HomeMortgageDisclosureActCoveredMortgages/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-loan-reln-hmda;ConstructionType">
@@ -201,7 +210,7 @@
 								<owl:intersectionOf rdf:parseType="Collection">
 									<rdf:Description rdf:about="&fibo-be-le-lp;LegalPerson">
 									</rdf:Description>
-									<rdf:Description rdf:about="&fibo-fnd-org-fm;FormalOrganization">
+									<rdf:Description rdf:about="&cmns-org;FormalOrganization">
 									</rdf:Description>
 								</owl:intersectionOf>
 							</owl:Class>

--- a/MD/DebtTemporal/DebtAnalytics.rdf
+++ b/MD/DebtTemporal/DebtAnalytics.rdf
@@ -6,13 +6,13 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
@@ -36,13 +36,13 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
@@ -62,12 +62,20 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/">
 		<rdfs:label xml:lang="en">Debt Analytics Ontology</rdfs:label>
 		<dct:abstract>This ontology covers an extensive range of analytical measures for debt instruments and pools of debt instruments. These cover the well-known concepts of convexity, duration and life, as well as weighted average loan ages and maturities, prepayments speeds etc. for debt pools. Most of the widely referenced variants of these are included, for example modified duration. Some yield related concepts (e.g. for equivalent yield) are also included. Debt pricing and yields are intimately related, and this ontology sets out the basic concepts of debt price, including different ways in which debt and bod prices are described and calculated, as well as a range of different kinds of yield (simple yield, Wall Street Yield, Japanese Yield and so on). The pricing terms are supported by a range of trading and exchange related concepts that are used to differentiate different kinds of debt price, for example last, high and low exchange prices.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
@@ -83,10 +91,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;BondEquivalentYield">
@@ -206,7 +215,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtSecuritiesMarketMaker">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;ServiceProvider"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;determinesMarketPriceForDebt"/>

--- a/SEC/Debt/Bonds.rdf
+++ b/SEC/Debt/Bonds.rdf
@@ -4,12 +4,12 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-tr-tr "https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-dae-gty "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
@@ -48,12 +48,12 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-tr-tr="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-dae-gty="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"
@@ -90,11 +90,19 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
 		<rdfs:label>Bonds Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the basic concept of a bond and a number of bond variants including convertible and callable bonds. Medium term notes (MTNs) and debentures are also defined.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+		Copyright (c) 2018-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"/>
@@ -126,9 +134,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241001/Debt/Bonds/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Debt/Bonds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/Debt/Bonds.rdf version of this ontology was revised to reflect the refactored definition of a listing and improve the definition of corporate bond.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and eliminate a redundant superclass from RegularCouponSchedule.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate a duplicate &apos;isBasedOn&apos; property and replace it with the property of the same name in the debt ontology, to revise the inheritance hierarchy for bond conversion terms to reflect changes in the representation of redemption more generally, to reflect the move of redemption provision from debt to financial instruments, and eliminate circular and ambiguous definitions.</skos:changeNote>
@@ -143,9 +152,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20231201/Debt/Bonds.rdf version of the ontology was modified to replace concepts from additional FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240101/Debt/Bonds.rdf version of this ontology was modified to add an optional restriction on bond for &apos;has series&apos; (FBC-322).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240101/Debt/Bonds.rdf version of this ontology was modified to move details regarding step schedules to the debt instruments ontology for broader use and deprecate the use of a &apos;coupon&apos; schedule in favor of interest payment schedule, which is the more modern terminology, aligning with other uses of the related terms in FIBO (FBC-317).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20241001/Debt/Bonds.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;AmortizingBond">
@@ -395,7 +405,7 @@
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-						<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+						<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
 			</owl:Restriction>

--- a/SEC/Debt/CollateralizedDebtObligations.rdf
+++ b/SEC/Debt/CollateralizedDebtObligations.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -13,7 +14,6 @@
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/">
 	<!ENTITY fibo-sec-dbt-abs "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/">
@@ -37,6 +37,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -46,7 +47,6 @@
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"
 	xmlns:fibo-sec-dbt-abs="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"
@@ -68,7 +68,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/">
 		<rdfs:label xml:lang="en">Collateralized Debt Obligations Ontology</rdfs:label>
 		<dct:abstract>Collateralized debt obligations are tranched debt instruments based on pools of debt instruments, and those pools may have different management styles and objectives. Generally includes an equity tranche. This ontology also covers CDO squared.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+Copyright (c) 2015-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -79,7 +88,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/Loans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/AssetBackedSecurities/"/>
@@ -95,11 +103,12 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/CollateralizedDebtObligations/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;ABSCDODeal">
@@ -256,12 +265,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;DebtOffering"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-cdo;CDOPortfolioManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-cdo;CDOPortfolio"/>
 			</owl:Restriction>
@@ -296,6 +299,12 @@
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-cdo;CollateralizedDebtObligation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-cdo;CDOPortfolioManager"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">c d o deal</rdfs:label>
 		<skos:definition xml:lang="en">An Issue of a set of CDO tranches as part of an offering to the market.</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">Multiple tranches of securities are issued by the CDO issue (usually referred to simply as the CDO), offering investors various maturity and credit risk characteristics. Note that it is in the sense of CDO as an issue that one might say that a CDO &quot;has tranches&quot;. The CDO as an individual instrument (labelled CDO in this model) does not have tranches but is itself a member of one or another tranche.</cmns-av:explanatoryNote>
@@ -323,14 +332,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-cdo;CDOPortfolioManager"/>
+				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-cdo;MBSInstrumentSlice"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-cdo;MBSInstrumentSlice"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-cdo;CDOPortfolioManager"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">c d o portfolio</rdfs:label>
@@ -341,7 +350,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-pts;PartyRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-cdo;CDOPortfolio"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Debt/DistributedLoans.rdf
+++ b/SEC/Debt/DistributedLoans.rdf
@@ -9,7 +9,6 @@
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-spc-com "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
@@ -30,7 +29,6 @@
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-spc-com="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
@@ -44,12 +42,21 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/">
 		<rdfs:label xml:lang="en">Distributed Loans Ontology</rdfs:label>
 		<dct:abstract>This ontology defines contracts which give the holder some formal participation in some loan.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+		Copyright (c) 2024-2025 FIUTUR
+		Copyright (c) 2024-2025 Object Management Group, Inc.
+		
+		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CommercialLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
@@ -58,10 +65,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DistributedLoans.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2024 FIUTUR</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024-2025 FIUTUR</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dln;AdministrativeAgent">

--- a/SEC/Debt/MortgageBackedSecurities.rdf
+++ b/SEC/Debt/MortgageBackedSecurities.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
@@ -37,6 +38,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
@@ -70,7 +72,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/">
 		<rdfs:label xml:lang="en">Mortgage-backed Securities Ontology</rdfs:label>
 		<dct:abstract>Mortgage backed securities are like asset backed securities except that the underlying loan pool is a pool of mortgage loans.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+Copyright (c) 2015-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/"/>
@@ -95,10 +106,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MortgageBackedSecurities/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2015-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-abs;HomeEquityLineOfCreditPool">
@@ -175,7 +187,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">government mortgage agency</rdfs:label>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -328,7 +328,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund administrator</rdfs:label>
@@ -420,7 +420,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund data provider</rdfs:label>
@@ -519,7 +519,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundManagementCompany">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
 		<rdfs:label xml:lang="en">fund management company</rdfs:label>
 		<skos:definition xml:lang="en">The party that sets up the fund, decides the investment strategy, appoints the agents, and is responsible for the promotion and the marketing of the fund. It makes all of the important decisions related to the fund. Also called fund promotor or fund sponsor or fund manager.</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">In the US: operates on a percentage of the Portfolio assets under management.</cmns-av:explanatoryNote>
@@ -542,7 +542,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund order desk</rdfs:label>
@@ -875,7 +875,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">investment advisor</rdfs:label>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -566,12 +566,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;PortfolioManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;assessedAgainst"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;PortfolioBenchmark"/>
 			</owl:Restriction>
@@ -598,6 +592,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;PortfolioManager"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fund portfolio</rdfs:label>
@@ -818,7 +818,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Account"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundOrderDesk"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1038,7 +1038,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundPortfolio"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -8,6 +8,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
@@ -34,7 +35,6 @@
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-plc-rp "https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -61,6 +61,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
@@ -87,7 +88,6 @@
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-plc-rp="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -139,7 +139,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -160,6 +159,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
@@ -1035,7 +1035,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;PortfolioManager">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;OrganizationMember"/>
+		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>

--- a/SEC/Funds/Funds.rdf
+++ b/SEC/Funds/Funds.rdf
@@ -3,9 +3,9 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-tr-tr "https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -29,9 +29,9 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-tr-tr="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -56,9 +56,17 @@
 		<dct:abstract>This ontology defines fundamental concepts about funds and collective investment vehicles (CIVs).</dct:abstract>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
 		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2018-2025 EDM Council, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
@@ -74,16 +82,18 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Funds/Funds/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Funds/Funds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Funds/Funds.rdf version of this ontology was modified to replace the original fibo-sec-fnd-fnd prefix with fibo-sec-fund-fund for the sake of clarity and to change the restriction on LegalFundStructure from an equivalence to a subclass relationship to address a reasoning error as well as adding a missing restriction on jurisdiction.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Funds/Funds.rdf version of this ontology was modified to move the definition of SpecialPurposeVehicle to the Pools ontology to make it available for use more generally.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Funds/Funds.rdf version of this ontology was modified to eliminate a deprecated element for SpecialPurposeVehicle, which was moved to Pools last quarter.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220501/Funds/Funds.rdf version of this ontology was modified to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Funds/Funds.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Funds/Funds.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Funds/Funds.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;ClosedEndInvestment">
@@ -172,7 +182,7 @@
 		<rdfs:subClassOf>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-be-le-lp;LegalEntity">
+					<rdf:Description rdf:about="&cmns-org;LegalEntity">
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-sec-fund-fund;FundContract">
 					</rdf:Description>

--- a/SEC/Securities/Pools.rdf
+++ b/SEC/Securities/Pools.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -10,7 +11,6 @@
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-pls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -22,6 +22,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -30,7 +31,6 @@
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-pls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -41,20 +41,29 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Pools/">
 		<rdfs:label>Securities Pools Ontology</rdfs:label>
-		<dct:abstract>This ontology defines concepts related to high-level securities pools.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:abstract>This ontology defines concepts related to high-level debt and securities pools.</dct:abstract>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20240101/Securities/Pools/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Securities/Pools/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20211201/Securities/Pools.rdf version of this ontology was modified to move the definition of SpecialPurposeVehicle to this ontology to make it available for use more generally and augment the definition of an instrument pool with ownership.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/Pools/ version of this ontology was modified to correct a logical inconsistency with respect to the representation of baskets.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/Pools/ version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
@@ -64,9 +73,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220501/Securities/Pools.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/Pools.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/Pools.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240101/Securities/Pools.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-pls;DebtPool">
@@ -85,7 +95,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -145,7 +155,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;PooledFund"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Securities/SecuritiesIdentification.rdf
+++ b/SEC/Securities/SecuritiesIdentification.rdf
@@ -8,6 +8,7 @@
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
@@ -36,6 +37,7 @@
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
@@ -59,9 +61,9 @@
 		<rdfs:label>Securities Identification Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts required to identify securities, including a number of well-known securities identifiers and related schemes, registries, and registration authorities.</dct:abstract>
 		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
-		Copyright (c) 2018-2025 Object Management Group, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -86,6 +88,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Securities/SecuritiesIdentification/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20180801/Securities/SecuritiesIdentification.rdf version of this ontology was modified to use the hasCoverageArea property rather than hasJurisdiction for coverage of national numbering agencies, and eliminate redundant subclass relationships for two of the schemes defined herein.</skos:changeNote>
@@ -201,14 +204,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;manages"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-id;NationalSecuritiesIdentifyingNumberRegistry"/>
+				<owl:onProperty rdf:resource="&cmns-loc;hasCoverageArea"/>
+				<owl:someValuesFrom rdf:resource="&cmns-loc;GeopoliticalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-loc;hasCoverageArea"/>
-				<owl:someValuesFrom rdf:resource="&cmns-loc;GeopoliticalEntity"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-id;NationalSecuritiesIdentifyingNumberRegistry"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>national numbering agency</rdfs:label>
@@ -252,7 +255,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-id;NationalNumberingAgency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -365,7 +368,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-ra;RegistrationAuthority"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
+++ b/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
@@ -36,6 +37,7 @@
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
@@ -64,7 +66,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/">
 		<rdfs:label>Securities Identification Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts and primarily individuals required to identify securities, including the individuals that represent a number of well-known securities identifiers and related schemes, registries, and registration authorities.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/"/>
@@ -86,8 +97,9 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/Securities/SecuritiesIdentificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Securities/SecuritiesIdentificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was updated to represent identifiers as classes rather than individuals and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
@@ -105,9 +117,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20231201/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was modified to revise the representation of a RIC code to reflect that it is now published by the London Stock Exchange and is branded using their Refinitiv brand (SEC-196).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240401/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was modified to address a punning issue (GitHub-2040).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240901/Securities/SecuritiesIdentificationIndividuals.rdf version of this ontology was modified to eliminate elements that have been deprecated for over six months (FND-386).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/Securities/SecuritiesIdentificationIndividuals.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-eufseind;Clearstream">
@@ -137,7 +150,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;BloombergLP">
 		<rdf:type rdf:resource="&fibo-be-fct-pub;Publisher"/>
-		<fibo-fnd-rel-rel:manages rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry"/>
+		<cmns-org:manages rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usfsind;ThomsonReuters">
@@ -150,7 +163,7 @@
 		<rdfs:label>CGS CUSIP Access Repository</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.cusip.com/cusip/index.htm"/>
 		<skos:definition>CGS (CUSIP Global Services) CUSIP Access services and repository, a proprietary repository of security identifiers, issued by CUSIP Global Services, that is the National Securities Identifying Number (NSIN) for securities issued in North America, which is also part of the ISIN for the security it identifies</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-sec-sec-idind;CUSIPGlobalServices"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-sec-sec-idind;CUSIPGlobalServices"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-sec-idind;CUSIPGlobalServices">
@@ -293,8 +306,8 @@
 		<rdfs:label>common code repository</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.isin.net/common-code-isin/"/>
 		<skos:definition>distributed international repository of security identifiers, issued by Euroclear or Clearstream (CEDEL), that are used to identify securities in Europe for the purposes of facilitating clearing and settlement of trades</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-eufseind;Clearstream"/>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.isin.net/common-code-isin/</cmns-av:adaptedFrom>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-eufseind;Clearstream"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;EuroclearClearstreamCommonCode">
@@ -417,9 +430,9 @@
 		<rdfs:label>Financial Instrument Global Identifier (FIGI) Registry</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.openfigi.com/"/>
 		<skos:definition>open, OMG standards-based registry used by the FIGI registration authority to manage the financial instrument identifiers and related information that it registers according to the Financial Instrument Global Identifier (FIGI) standard</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 		<cmns-av:abbreviation>FIGI Registry</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/FIGI</cmns-av:adaptedFrom>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistryEntry">
@@ -522,7 +535,7 @@ An equity RIC has several components: the Equity RIC root is in upper case, brok
 		<rdfs:label>SEDOL Master File</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.isin.net/sedol/"/>
 		<skos:definition>repository of security identifiers, issued by the London Stock Exchange, that is the National Securities Identifying Number (NSIN) for securities issued in the United Kingdom, which is also part of the ISIN for the security it identifies</skos:definition>
-		<fibo-fnd-rel-rel:isManagedBy rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchange"/>
+		<cmns-org:isManagedBy rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchange"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-idind;StockExchangeDailyOfficialListCode">

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -13,7 +13,6 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/">
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
@@ -37,7 +36,6 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
@@ -69,7 +67,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-breg "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/">
 	<!ENTITY fibo-fbc-fct-mkt "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
@@ -13,7 +14,6 @@
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/">
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
@@ -26,6 +26,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-breg="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"
 	xmlns:fibo-fbc-fct-mkt="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/"
@@ -37,7 +38,6 @@
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
@@ -50,7 +50,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
 		<rdfs:label>Securities Listings Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for listing securities, such as registered, listed, and exchange-traded security, the notion of a securities exchange, and related services.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/"/>
@@ -62,12 +71,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230601/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Securities/SecuritiesListings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesListings.rdf version of this ontology was revised to reuse the composite date value datatype and add disjointness between registered security and exempt security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate an extraneous subclass axiom.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesListings.rdf version of this ontology was revised to rename isIssuedIn to isIssuedOn, which is more natural to most securities SMEs, generalized certain references to securities exchanges, and eliminate deprecated elements.</skos:changeNote>
@@ -80,15 +89,16 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210601/Securities/SecuritiesListings.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecuritiesListings.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/SecuritiesListings.rdf version of this ontology was modified to normalize the representation of security forms (all individuals rather than a mixed representation).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230601/Securities/SecuritiesListings.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;Exchange">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;ListingService"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -194,14 +204,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:onProperty rdf:resource="&cmns-org;isProvidedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:onProperty rdf:resource="&cmns-org;provides"/>
 				<owl:onClass rdf:resource="&fibo-sec-sec-lst;Listing"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -253,7 +263,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;hasHomeExchange">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isProvidedBy"/>
 		<rdfs:label>has home exchange</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 		<skos:definition>indicates the exchange that is considered the primary market for a security; typically, but not always, in the country in which the security was originally issued</skos:definition>
@@ -308,7 +318,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;isTradedOn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-org;isProvidedBy"/>
 		<rdfs:label>is traded on</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
 		<rdfs:range rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>

--- a/SEC/Securities/SecuritiesRestrictions.rdf
+++ b/SEC/Securities/SecuritiesRestrictions.rdf
@@ -5,6 +5,7 @@
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
@@ -29,6 +30,7 @@
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
@@ -50,7 +52,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/">
 		<rdfs:label>Securities Restrictions Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the concepts related to restrictions on finanicial instruments, securities and listings.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -65,8 +76,9 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/Securities/SecuritiesRestrictions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Securities/SecuritiesRestrictions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to simplify the hierarchy with respect to regulatory requirements and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180901/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to reflect the change in representation of a listing.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
@@ -79,9 +91,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20231101/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240101/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to add a definition for institutional investor and move jurisdiction-specific definitions to new ontologies for those jurisdictions (SEC-113).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240601/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to eliminate elements that have been deprecated over 6 months (FND-386).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/Securities/SecuritiesRestrictions.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
@@ -134,7 +147,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-le-lp;LegalEntity"/>
+				<owl:allValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>institutional investor</rdfs:label>

--- a/SEC/Securities/SecurityAssets.rdf
+++ b/SEC/Securities/SecurityAssets.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -21,6 +22,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -40,7 +42,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/">
 		<rdfs:label>Security Assets Ontology</rdfs:label>
 		<dct:abstract>This ontology defines basic concepts such as portfolio, security holding and holder, and extends the notion of a financial asset to include an acquisition price.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+Copyright (c) 2016-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -52,16 +63,18 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/SecurityAssets/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Securities/SecurityAssets/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecurityAssets.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecurityAssets.rdf version of this ontology was revised to simplify the contract party hierarchy and eliminate complexity introduced by &apos;security holding&apos;.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201101/Securities/SecurityAssets.rdf version of this ontology was revised to fix spelling errors.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20211201/Securities/SecurityAssets.rdf version of this ontology was revised to address text formatting hygiene issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/SecurityAssets.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecurityAssets.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/SecurityAssets.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2016-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-acc-aeq;FinancialAsset">
@@ -92,7 +105,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -103,12 +122,6 @@
 						</owl:unionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>portfolio</rdfs:label>

--- a/etc/testing/data/fnd/Organizations/TestFormalOrganizations.rdf
+++ b/etc/testing/data/fnd/Organizations/TestFormalOrganizations.rdf
@@ -3,8 +3,8 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-tst-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/TestFormalOrganizations/">
@@ -18,8 +18,8 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-tst-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/TestFormalOrganizations/"
@@ -44,12 +44,12 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Organizations/TestFormalOrganizations/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210401/Organizations/TestFormalOrganizations.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230201/Organizations/TestFormalOrganizations.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
@@ -70,7 +70,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;AtlasBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Atlas Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;AtlasBankIdentifier"/>
 	</owl:NamedIndividual>
@@ -81,7 +81,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;BigBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Big Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;BigBankIdentifier"/>
 	</owl:NamedIndividual>
@@ -92,7 +92,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;CaliforniaBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>California Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;CaliforniaBankIdentifier"/>
 	</owl:NamedIndividual>
@@ -103,7 +103,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;FrankfurtBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Frankfurt Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;FrankfurtBankIdentifier"/>
 	</owl:NamedIndividual>
@@ -114,7 +114,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;GlobalBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Global Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;GlobalbankIdentifier"/>
 	</owl:NamedIndividual>
@@ -125,7 +125,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;GoodBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Good Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;GoodBankIdentifier"/>
 	</owl:NamedIndividual>
@@ -136,7 +136,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;LondonBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>London Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;LondonBankIdentifier"/>
 	</owl:NamedIndividual>
@@ -147,7 +147,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;NewConceptInc">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>New Concept Inc.</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;NewConceptIncIdentifier"/>
 	</owl:NamedIndividual>
@@ -158,7 +158,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;NewYorkBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>New York Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;NewYorkBankIdentifier"/>
 	</owl:NamedIndividual>
@@ -169,7 +169,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;ParisBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Paris Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;ParisBankIdentifier"/>
 	</owl:NamedIndividual>
@@ -180,7 +180,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;SecuritiesInc">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Securities Inc</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;SecuritiesIncIdentifier"/>
 	</owl:NamedIndividual>
@@ -191,7 +191,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;TraderInc">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Trader Inc.</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;TraderIncIdentifier"/>
 	</owl:NamedIndividual>
@@ -202,7 +202,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;TrustedBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Trusted Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;TrustedBankIdentifier"/>
 	</owl:NamedIndividual>
@@ -213,7 +213,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;WallStreetBank">
-		<rdf:type rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdf:type rdf:resource="&cmns-org;FormalOrganization"/>
 		<cmns-dsg:hasTextualName>Wall Street Bank</cmns-dsg:hasTextualName>
 		<cmns-id:isIdentifiedBy rdf:resource="&fibo-tst-fnd-org-fm;WallStreetBankIdentifier"/>
 	</owl:NamedIndividual>


### PR DESCRIPTION
## Description

1. Integrated changes from Commons with respect to the FND Organizations ontology, deprecating all elements in that ontology and equivalencing them to the Commons Organizations ontology
2. Replaced some elements of the FND Formal Organizations ontology with the equivalents from the Commons Organizations ontology
3. Replaced FIBO/BE legal person and legal entity classes with their equivalent in the Commons Organizations ontology
4. Replaced a number of widely-used properties: manages, isManagedBy, provides, isProvidedBy, designates, and isDesignatedBy with their equivalents in the Commons Organizations ontology
5. Replaced FIBO/FND/Places properties hasURL and hasWebsite in virtual places with their equivalents in Commons Organizations

Fixes: #2113 / FND-389


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


