### PR TITLE
DER-55 - Potential issues with the DerivativesMasterAgreements ontology

### DIFF
--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -8,6 +8,7 @@
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-ma "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
+	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
@@ -31,6 +32,7 @@
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-ma="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
+	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
@@ -60,6 +62,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
@@ -80,25 +83,31 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;CreditEventDefinition">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
+	<owl:Class rdf:about="&fibo-der-drc-ma;CreditSupportAgreement">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isSubordinateTo"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-ma;DerivativeTransactionMasterAgreement"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit event definition</rdfs:label>
-		<skos:definition xml:lang="en">contract definition for a credit event as it pertains to the master agreement</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;CreditSupportAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-ma;hasBeneficiary"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;CreditSupportBeneficiary"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasEstimatedValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -108,6 +117,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit support agreement</rdfs:label>
+		<skos:definition xml:lang="en">addendum to the master agreement that governs the exchange of collateral between parties in derivatives transactions</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">A credit support agreement is designed to mitigate counterparty credit risk by ensuring that collateral is posted to secure obligations under the agreement. Key features include specification of the kinds of collateral that may be used together with the relevant valuation methods, thresholds for the value of the collateral and haircuts applied based on mitigating market risk, margin requirements, dispute resolution with respect to collateral valuation and margin calls, and other operational details related to the transfer, substitution, and return of the collateral if posted.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;CreditSupportBeneficiary">
@@ -170,11 +181,17 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;EarlyTermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TerminationProvision"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-ma;hasEarlyTerminationDate"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;Date"/>
+				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;MasterAgreementEarlyTerminationRight"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -502,7 +519,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;hasEarlyTerminationDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-arr-doc;hasTerminationDate"/>
 		<rdfs:label xml:lang="en">has early termination date</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-dt;Date"/>
+		<rdfs:range rdf:resource="&cmns-dt;ExplicitDate"/>
 		<skos:definition xml:lang="en">indicates a termination date that occurs prior to an explicit expiration date</skos:definition>
 	</owl:ObjectProperty>
 	

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -162,18 +162,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote xml:lang="en">The beneficiary actually holds the collateral and has the right to ask for additional collateral if its value falls below the threshold agreed upon in the credit support agreement.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;CrossDefaultProvisions">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label xml:lang="en">cross default provisions</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;DefaultInterestObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualObligation"/>
-		<rdfs:label xml:lang="en">default interest obligation</rdfs:label>
-		<skos:definition xml:lang="en">Obligation in respect of defaults in the performance of any payment obligation.</skos:definition>
-		<skos:example xml:lang="en">Example text: Default Interest; Other Amounts. Prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party that defaults in the performance of any payment obligation will, to the extent permitted by law and subject to Section 6(c), be required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment, at the Default Rate. Such interest will be calculated on the basis of daily compounding and the actual number of days elapsed. If, prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party defaults in the performance of any obligation required to be settled by delivery, it will compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement. &quot; Note that this last sentence relates to a separate Obligation, labeled as Other Amount Obligation.</skos:example>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ma;DerivativeTransactionMasterAgreement">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MasterAgreement"/>
@@ -187,7 +175,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-ma;hasEarlyTerminationDate"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
+				<owl:onClass rdf:resource="&cmns-dt;ExplicitDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -368,20 +357,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">Whether either party may elect to carry out netting in respect of two or more transactions carried out under this Master Agreement.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;defaultInterestApplicable">
-		<rdfs:label xml:lang="en">default interest applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;DefaultInterestObligation"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether a party that defaults in the performance of any payment obligation will, to the extent permitted by law and this agreement be required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;defaultInterestCompoundingBasis">
-		<rdfs:label xml:lang="en">default interest compounding basis</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;DefaultInterestObligation"/>
-		<rdfs:range rdf:resource="&cmns-dt;DatePeriod"/>
-		<skos:definition xml:lang="en">The basis upon which default interest is to be calculated, as a period of time (e.g. daily).</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;describesTreatmentOf">
 		<rdfs:label xml:lang="en">describes treatment of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;TerminationProvision"/>
@@ -524,13 +499,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">The number of days notice to be given for a change in the given kinds of details.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;specifiedIndebtedness">
-		<rdfs:label xml:lang="en">specified indebtedness</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;CrossDefaultProvisions"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">Any obligation (whether present or future, contingent or otherwise, as principal or surety or otherwise) in respect of borrowed money. May not include obligations in respect of deposits received in the ordinary course of a party’s banking business. FpML: In Schedule: &quot;Specified Indebtedness&quot; will have the meaning specified in Section 14 except that such term shall not include obligations in respect of deposits received in the ordinary course of a party’s banking business. Section 14: &quot;Specified Indebtedness&quot; means, subject to the Schedule, any obligation (whether present or future, contingent or otherwise, as principal or surety or otherwise) in respect of borrowed money. Modeling note: Could extend this to have a yes/no option on the exclusion described in the Schedule to the sample Master Agreement</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;statementCalculationRequirements">
 		<rdfs:label xml:lang="en">statement calculation requirements</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-ma;EarlyTerminationProvision"/>
@@ -544,19 +512,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:domain rdf:resource="&fibo-fnd-pas-psch;PaymentObligation"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether this Obligation is subject to other provisions in the Master Agreement.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;thresholdAmount">
-		<rdfs:label xml:lang="en">threshold amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;CrossDefaultProvisions"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;transactionEarlyTerminationDate">
-		<rdfs:label xml:lang="en">transaction early termination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionPrecedent"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">The condition that some early termination date as been defined in respect to the transaction carried out under this Master Agreement. Further notes: note that this is in respect of a specific transaction transacted under the Master Agreement, so that the condition precedent for the obligation in respect of that specific transaction, is that this early transaction termation has not taken place in respect of this same transaction. Conditions precedent typically include this is not the case, so this is typically or always &quot;no&quot;. Sample text: &quot;the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated.&quot;</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;TerminationProvision">

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -84,7 +84,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
@@ -367,12 +366,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:domain rdf:resource="&fibo-der-drc-ma;NettingTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether either party may elect to carry out netting in respect of two or more transactions carried out under this Master Agreement.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;currencySpecificMethods">
-		<rdfs:label xml:lang="en">currency specific methods</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pas-psch;PaymentObligation"/>
-		<skos:definition xml:lang="en">Payment is to be in the manner customary for the currency in question. Example text: &quot;... in the manner customary for payments in the required currency.&quot; It is not clear what if anything the alternative would be. Included as a &quot;yes/no&quot; term for completeness.</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;defaultInterestApplicable">

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -20,6 +20,7 @@
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
+	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -48,6 +49,7 @@
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
+	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -80,6 +82,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -94,6 +97,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
+	
+	<owl:Class rdf:about="&fibo-der-drc-ma;AccountChangeNotificationObligation">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;NotificationObligation"/>
+		<rdfs:label xml:lang="en">account change notification obligation</rdfs:label>
+		<skos:definition xml:lang="en">obligtation to notify a counterparty of any changes in account details</skos:definition>
+		<skos:example xml:lang="en">Example text: &quot;Either party may change its account for receiving a payment or delivery by giving notice to the other party at least five Local Business Days prior to the scheduled date for the payment or delivery to which such change applies unless such other party gives timely notice of a reasonable objection to such change.&quot; Note that the notice period is given as a fact about the general kind of obligation which is Master Agreement Change notification Obligation.</skos:example>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;CreditSupportAgreement">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;CollateralAgreement"/>
@@ -165,13 +175,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:example xml:lang="en">Example text: Default Interest; Other Amounts. Prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party that defaults in the performance of any payment obligation will, to the extent permitted by law and subject to Section 6(c), be required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment, at the Default Rate. Such interest will be calculated on the basis of daily compounding and the actual number of days elapsed. If, prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party defaults in the performance of any obligation required to be settled by delivery, it will compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement. &quot; Note that this last sentence relates to a separate Obligation, labeled as Other Amount Obligation.</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;DeliveryObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualObligation"/>
-		<rdfs:label xml:lang="en">delivery obligation</rdfs:label>
-		<skos:definition xml:lang="en">Obligation to make deliveries on transactions transacted under the Master Agreement, as specified in any Confirmation made by that party.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">This and the Payment Obligation may be set out in one clause of the Master Agreement. This is the clause which obligates the parties to make the payments or deliveries in accordance with those Confirmations, which are generally messages. May be subject to other provisions in the Master Agreement. Example text: &quot;Each party will make each payment or delivery specified in each Confirmation to be made by it, subject to the other provisions of this Agreement. &quot;</cmns-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ma;DerivativeTransactionMasterAgreement">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MasterAgreement"/>
@@ -205,31 +208,17 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote>Early termination may be automatically triggered by an event of default with respect to any contract obligation, due to corporate action, or for other reasons.  An early termination date may be calculated per the terms of the agreement or specified explicitly at the time the termination event occurs.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementAccountChangeNotificationObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementChangeNotificationObligation"/>
-		<rdfs:label xml:lang="en">master agreement account change notification obligation</rdfs:label>
-		<skos:definition xml:lang="en">The obligtation to notify the counterparty to this agreement, of any changes in account details.</skos:definition>
-		<skos:example xml:lang="en">Example text: &quot;Either party may change its account for receiving a payment or delivery by giving notice to the other party at least five Local Business Days prior to the scheduled date for the payment or delivery to which such change applies unless such other party gives timely notice of a reasonable objection to such change.&quot; Note that the notice period is given as a fact about the general kind of obligation which is Master Agreement Change notification Obligation.</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementChangeNotificationObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualObligation"/>
-		<rdfs:label xml:lang="en">master agreement change notification obligation</rdfs:label>
-		<skos:definition xml:lang="en">The obligation to notify the counterparty to this agreement, of any changes in details.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">General term of which Change of Account is an example.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementConditionPrecedent">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-ma;isPredicatedOn"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isPredicatedOn"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-drc-ma;DeliveryObligation">
+							<rdf:Description rdf:about="&fibo-fnd-law-lcap;DeliveryObligation">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-drc-ma;PaymentObligation">
+							<rdf:Description rdf:about="&fibo-fnd-pas-psch;PaymentObligation">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -246,19 +235,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">master agreement early termination right</rdfs:label>
 		<skos:definition xml:lang="en">contractual right of a party to the master agreement to terminate the agreement early</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">This generally arises from some Default Event on the part of the other party.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementObligationTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-lcap;ContractualObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">master agreement obligations terms</rdfs:label>
-		<skos:definition xml:lang="en">contract terms setting out the obligations on a party to the agreement</skos:definition>
-		<skos:editorialNote xml:lang="en">The obligations are modeled in detail as Obligations. There is little merit in setting out the terms themselves as a model of textual elements - these terms are bext understood in relation to the Obligations which they represent, which are modeled in detail.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementRightToTerminationFollowingDefaultEvent">
@@ -318,20 +294,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">Obligation in regard to other defaults on obligations. Example Contract Text: &quot;If, prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party defaults in the performance of any obligation required to be settled by delivery, it will compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement. &quot;</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;PaymentObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualObligation"/>
-		<rdfs:label xml:lang="en">payment obligation</rdfs:label>
-		<skos:definition xml:lang="en">Obligation to make payments on transactions transacted under the Master Agreement, as specified in any Confirmation made by that party.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">This and the Delivery Obligation may be set out in one clause of the Master Agreement. This is the clause which obligates the parties to make the payments or deliveries in accordance with those Confirmations, which are generally messages. May be subject to other provisions in the Master Agreement. Example text: &quot;Each party will make each payment or delivery specified in each Confirmation to be made by it, subject to the other provisions of this Agreement. &quot; Additional terms in the clause which follows the above, deal with more specific terms about payments.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;PaymentObligationAsDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;PaymentObligation"/>
-		<rdfs:label xml:lang="en">payment obligation as delivery</rdfs:label>
-		<skos:definition xml:lang="en">Obligation for payment in settlement of a transaction when this payment takes the form of delivery of some payment in kind.</skos:definition>
-		<skos:example xml:lang="en">Sample text: &quot;... Where settlement is by delivery (that is, other than by payment), such delivery will be made for receipt on the due date in the manner customary for the relevant obligation unless otherwise specified in the relevant Confirmation or elsewhere in this Agreement. &quot;</skos:example>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ma;PaymentPlaceSpecificationMethod">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
 		<rdfs:label xml:lang="en">payment place specification method</rdfs:label>
@@ -388,7 +350,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;changeOfAccountDetailsAllowed">
 		<rdfs:label xml:lang="en">change of account details allowed</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementAccountChangeNotificationObligation"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ma;AccountChangeNotificationObligation"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether the account details may be varied for individual transactions transacted under this Master Agreement.</skos:definition>
 	</owl:DatatypeProperty>
@@ -409,7 +371,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;currencySpecificMethods">
 		<rdfs:label xml:lang="en">currency specific methods</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;PaymentObligation"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-pas-psch;PaymentObligation"/>
 		<skos:definition xml:lang="en">Payment is to be in the manner customary for the currency in question. Example text: &quot;... in the manner customary for payments in the required currency.&quot; It is not clear what if anything the alternative would be. Included as a &quot;yes/no&quot; term for completeness.</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -456,7 +418,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;freelyTransferableFunds">
 		<rdfs:label xml:lang="en">freely transferable funds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;PaymentObligation"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-pas-psch;PaymentObligation"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 	</owl:DatatypeProperty>
 	
@@ -498,12 +460,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">invoked in event of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementRightToTerminationFollowingDefaultEvent"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;isPredicatedOn">
-		<rdfs:label xml:lang="en">is predicated on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;makeUpForIndemnifiable">
@@ -554,16 +510,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">Provisions for calculation of Payment dates in the event of this Early Termination.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;paymentInKindDeliveryObligation">
-		<rdfs:label xml:lang="en">payment in kind delivery obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;PaymentObligationAsDelivery"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">Precise description of the form in which payment is to be made when payment is in kind.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;paymentPlaceSpecification">
 		<rdfs:label xml:lang="en">payment place specification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;PaymentObligation"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-pas-psch;PaymentObligation"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-ma;PaymentPlaceSpecificationMethod"/>
 		<skos:definition xml:lang="en">The place for payments specified in this Master Agreement.</skos:definition>
 	</owl:ObjectProperty>
@@ -577,7 +526,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;requiredDaysNotice">
 		<rdfs:label xml:lang="en">required days notice</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementChangeNotificationObligation"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-law-lcap;NotificationObligation"/>
 		<rdfs:range rdf:resource="&xsd;integer"/>
 		<skos:definition xml:lang="en">The number of days notice to be given for a change in the given kinds of details.</skos:definition>
 	</owl:DatatypeProperty>
@@ -598,8 +547,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;subjectToOtherProvisions">
 		<rdfs:label xml:lang="en">subject to other provisions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;DeliveryObligation"/>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;PaymentObligation"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-law-lcap;DeliveryObligation"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-pas-psch;PaymentObligation"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether this Obligation is subject to other provisions in the Master Agreement.</skos:definition>
 	</owl:DatatypeProperty>

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -109,7 +109,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isSubordinateTo"/>
-				<owl:onClass rdf:resource="&fibo-der-drc-ma;DerivativeTransactionMasterAgreement"/>
+				<owl:onClass rdf:resource="&fibo-der-drc-ma;DerivativeMasterAgreement"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -162,11 +162,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote xml:lang="en">The beneficiary actually holds the collateral and has the right to ask for additional collateral if its value falls below the threshold agreed upon in the credit support agreement.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;DerivativeTransactionMasterAgreement">
+	<owl:Class rdf:about="&fibo-der-drc-ma;DerivativeMasterAgreement">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MasterAgreement"/>
-		<rdfs:label xml:lang="en">derivative transaction master agreement</rdfs:label>
+		<rdfs:label xml:lang="en">derivative master agreement</rdfs:label>
 		<skos:definition xml:lang="en">master agreement covering derivatives transactions to be carried out between the parties to this contract</skos:definition>
+		<skos:example xml:lang="en">Related to conditions precedent that may apply: &quot;Each obligation of each party under Section 2(a)(i) is subject to (1) the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, (2) the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated and (3) each other applicable condition precedent specified in this Agreement. &quot; In the above, the Obligations defined under Section 2(a)(i) of the Master Agrement is the obligation to make each payment or delivery defined in a Confirmation for a transaction carried out under this Master Agreement.</skos:example>
 		<skos:example xml:lang="en">Sample preamble to one of these: &quot;EXAMPLE BANK, a Michigan banking corporation and SAMPLECOMPANY US, INC. a Delaware corporation have entered and/or anticipate entering into one or more transactions (each a &quot;Transaction&quot;) that are or will be governed by this Master Agreement, which includes the schedule (the &quot;Schedule&quot;), and the documents and other confirming evidence (each a &quot;Confirmation&quot;) exchanged between the parties confirming those Transactions. &quot;</skos:example>
 	</owl:Class>
 	
@@ -194,28 +195,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>early termination provision</rdfs:label>
 		<skos:definition>termination of an agreement for any reason prior to its expiration date</skos:definition>
 		<cmns-av:explanatoryNote>Early termination may be automatically triggered by an event of default with respect to any contract obligation, due to corporate action, or for other reasons.  An early termination date may be calculated per the terms of the agreement or specified explicitly at the time the termination event occurs.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementConditionPrecedent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-law-lcap;isPredicatedOn"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-law-lcap;DeliveryObligation">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-pas-psch;PaymentObligation">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">master agreement condition precedent</rdfs:label>
-		<skos:definition xml:lang="en">condition precedent on payment or delivery on a transaction transacted under this Master Agreement.</skos:definition>
-		<skos:example xml:lang="en">Example text: &quot;Each obligation of each party under Section 2(a)(i) is subject to (1) the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, (2) the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated and (3) each other applicable condition precedent specified in this Agreement. &quot; In the above, the Obligations defined under Section 2(a)(i) of the Master Agrement is the obligation to make each payment or delivery defined in a Confirmation for a transaction carried out under this Master Agreement.</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementEarlyTerminationRight">
@@ -406,7 +385,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;inDefault">
 		<rdfs:label xml:lang="en">in default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionPrecedent"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">The condition that some default has occurred in respect to the other party. Further notes: Conditions precedent typically include that no default has occurred, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
 	</owl:DatatypeProperty>
@@ -452,7 +431,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;ongoingDefault">
 		<rdfs:label xml:lang="en">ongoing default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionPrecedent"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">The condition that some default or potential default is ongoing in respect to the other party. Further notes: Conditions precedent typically include that no default is ongoing, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
 	</owl:DatatypeProperty>
@@ -487,7 +466,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;potentialDefault">
 		<rdfs:label xml:lang="en">potential default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionPrecedent"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">The condition that some potential default has occurred in respect to the other party. Further notes: Conditions precedent typically include that no potential default has occurred, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
 	</owl:DatatypeProperty>

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -4,6 +4,8 @@
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
+	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-ma "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/">
@@ -30,6 +32,8 @@
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
+	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-ma="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/"
@@ -83,6 +87,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
@@ -130,20 +136,26 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:Class rdf:about="&fibo-der-drc-ma;CreditSupportBeneficiary">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;Beneficiary"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&cmns-pts;isAPartyTo"/>
+						<owl:onClass rdf:resource="&fibo-der-drc-ma;CreditSupportAgreement"/>
+						<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+					</owl:Restriction>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit support beneficiary</rdfs:label>
+		<skos:definition xml:lang="en">party that benefits from the collateral posted under the agreement, i.e., that is protected against counterparty credit risk because the collateral serves as security for the obligations owed to them</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">The beneficiary actually holds the collateral and has the right to ask for additional collateral if its value falls below the threshold agreed upon in the credit support agreement.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;CrossDefaultProvisions">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:label xml:lang="en">cross default provisions</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;CurrencySpecificationTerm">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:label xml:lang="en">currency specification term</rdfs:label>
-		<skos:definition xml:lang="en">Term defining the currency or currencies for payments.</skos:definition>
-		<skos:editorialNote xml:lang="en">is found in general terms in example Master Agreement.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;DefaultInterestObligation">
@@ -500,13 +512,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">If a party (&quot;X&quot;) is required to deduct or withhold tax, and if such Tax is an Indemnifiable Tax, whether X is to pay to the other party (&quot;Y&quot;), in addition to the payment to which Y is otherwise entitled under this Agreement, such additional amount as is necessary to ensure that the net amount actually received by Y (free and clear of Indemnifiable Taxes, whether assessed against X or Y) will equal the full amount Y would have received had no such deduction or withholding been required. However, X will not be required to pay any additional amount to Y to the extent that it would not be required to be paid but for:- (A) the failure by Y to comply with or perform any agreement contained in the provisions for furnishing specified information in this agreement; or (B) the failure of a representation made by Y pursuant to the Representation Section of the agreement to be accurate and true unless such failure would not have occurred but for (I) any action taken by a taxing authority, or brought in a court of competent jurisdiction, on or after the date on which a Transaction is entered into (regardless of whether such action is taken or brought with respect to a party to this Agreement) or (II) a Change in Tax Law. Further notes: The above is all definitional of this term.</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;masterAgreementCurrency">
-		<rdfs:label xml:lang="en">master agreement currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;CurrencySpecificationTerm"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency for payments under this Master Agreement. ISDA Master Agreement example text: Payment in the Contractual Currency. Each payment under this Agreement will be made in the relevant currency specified in this Agreement for that payment (the &quot;Contractual Currency&quot;). To the extent permitted by applicable law, any obligation to make payments under this Agreement in the Contractual Currency will not be discharged or satisfied by any tender in any currency other than the Contractual Currency, except to the extent such tender results in the actual receipt by the party to which payment is owed, acting in a reasonable manner and in good faith in converting the currency so tendered into the Contractual Currency, of the full amount in the Contractual Currency of all amounts payable in respect of this Agreement. If for any reason the amount in the Contractual Currency so received falls short of the amount in the Contractual Currency payable in respect of this Agreement, the party required to make the payment will, to the extent permitted by applicable law, immediately pay such additional amount in the Contractual Currency as may be necessary to compensate for the shortfall. If for any reason the amount in the Contractual Currency so received exceeds the amount in the Contractual Currency payable in respect of this Agreement, the party receiving the payment will refund promptly the amount of such excess.</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;mayBeVariedByOne">
 		<rdfs:label xml:lang="en">may be varied by one</rdfs:label>

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -101,7 +101,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:Class rdf:about="&fibo-der-drc-ma;AccountChangeNotificationObligation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;NotificationObligation"/>
 		<rdfs:label xml:lang="en">account change notification obligation</rdfs:label>
-		<skos:definition xml:lang="en">obligtation to notify a counterparty of any changes in account details</skos:definition>
+		<skos:definition xml:lang="en">obligation to notify a counterparty of any changes in account details</skos:definition>
 		<skos:example xml:lang="en">Example text: &quot;Either party may change its account for receiving a payment or delivery by giving notice to the other party at least five Local Business Days prior to the scheduled date for the payment or delivery to which such change applies unless such other party gives timely notice of a reasonable objection to such change.&quot; Note that the notice period is given as a fact about the general kind of obligation which is Master Agreement Change notification Obligation.</skos:example>
 	</owl:Class>
 	
@@ -212,7 +212,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isPredicatedOn"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-law-lcap;isPredicatedOn"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -10,7 +10,9 @@
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
@@ -34,7 +36,9 @@
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
@@ -64,7 +68,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
@@ -100,14 +106,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasEstimatedValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasEstimatedValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -122,6 +128,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;CreditSupportBeneficiary">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;Beneficiary"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
 		<rdfs:label xml:lang="en">credit support beneficiary</rdfs:label>
 	</owl:Class>
@@ -141,13 +148,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;CrossDefaultProvisions">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementContractualCommitment"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:label xml:lang="en">cross default provisions</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;CurrencySpecificationTerm">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementElement"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
 		<rdfs:label xml:lang="en">currency specification term</rdfs:label>
 		<skos:definition xml:lang="en">Term defining the currency or currencies for payments.</skos:definition>
 		<skos:editorialNote xml:lang="en">is found in general terms in example Master Agreement.</skos:editorialNote>
@@ -172,7 +179,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;MasterAgreementElement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">derivative transaction master agreement</rdfs:label>
@@ -180,7 +187,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:example xml:lang="en">Sample preamble to one of these: &quot;EXAMPLE BANK, a Michigan banking corporation and SAMPLECOMPANY US, INC. a Delaware corporation have entered and/or anticipate entering into one or more transactions (each a &quot;Transaction&quot;) that are or will be governed by this Master Agreement, which includes the schedule (the &quot;Schedule&quot;), and the documents and other confirming evidence (each a &quot;Confirmation&quot;) exchanged between the parties confirming those Transactions. &quot;</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;EarlyTermination">
+	<owl:Class rdf:about="&fibo-der-drc-ma;EarlyTerminationProvision">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TerminationProvision"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -200,7 +207,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>early termination</rdfs:label>
+		<rdfs:label>early termination provision</rdfs:label>
 		<skos:definition>termination of an agreement for any reason prior to its expiration date</skos:definition>
 		<cmns-av:explanatoryNote>Early termination may be automatically triggered by an event of default with respect to any contract obligation, due to corporate action, or for other reasons.  An early termination date may be calculated per the terms of the agreement or specified explicitly at the time the termination event occurs.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -219,9 +226,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote xml:lang="en">General term of which Change of Account is an example.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementConditionsPrecedent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementElement"/>
+	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementConditionPrecedent">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-ma;isPredicatedOn"/>
@@ -242,41 +249,15 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:example xml:lang="en">Example text: &quot;Each obligation of each party under Section 2(a)(i) is subject to (1) the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, (2) the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated and (3) each other applicable condition precedent specified in this Agreement. &quot; In the above, the Obligations defined under Section 2(a)(i) of the Master Agrement is the obligation to make each payment or delivery defined in a Confirmation for a transaction carried out under this Master Agreement.</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementContractualCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label xml:lang="en">master agreement contractual commitment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementEarlyTerminationProvisions">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementTerminationProvision"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;MasterAgreementEarlyTerminationRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">master agreement early termination provisions</rdfs:label>
-		<skos:definition xml:lang="en">Terms and Conditions around early termination of the Master Agreement.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">Terms here include: Additional Terminaton Event Affected Parties</cmns-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementEarlyTerminationRight">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualRight"/>
 		<rdfs:label xml:lang="en">master agreement early termination right</rdfs:label>
-		<skos:definition xml:lang="en">a contractual right of a party to the master agreement to terminate the agreement early</skos:definition>
+		<skos:definition xml:lang="en">contractual right of a party to the master agreement to terminate the agreement early</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">This generally arises from some Default Event on the part of the other party.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementElement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:label xml:lang="en">master agreement element</rdfs:label>
-		<skos:definition xml:lang="en">a contract element specific to a master agreement governing derivatives transactions between contract parties</skos:definition>
-		<skos:editorialNote xml:lang="en">This is included so that all OTC Master Agreement Contract Terms Sets may be included under this one set. Terms are also described as specializations of the sorts of terms that they are (e.g. conditions Precedent, Commitments Terms and so on).</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementObligationTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementContractualCommitment"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
@@ -286,14 +267,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">master agreement obligations terms</rdfs:label>
 		<skos:definition xml:lang="en">contract terms setting out the obligations on a party to the agreement</skos:definition>
 		<skos:editorialNote xml:lang="en">The obligations are modeled in detail as Obligations. There is little merit in setting out the terms themselves as a model of textual elements - these terms are bext understood in relation to the Obligations which they represent, which are modeled in detail.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementRepresentation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Representation"/>
-		<rdfs:label xml:lang="en">master agreement representation</rdfs:label>
-		<skos:definition xml:lang="en">a representation made by one of the parties included in the master agreement</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">These typically include: Basic Representations - Status of the organization - Powers of the organization - Absence of conflicts - Existence of the relevant consents - Binding nature of the Agreement. Absence of default and similar events Absence of litigation Accuracy of information Tax representations (withholding; notifications) - Payer - Payee Representations as to the Credit Support Agreement Representations as to regulatory matters</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementRightToTerminationFollowingDefaultEvent">
@@ -328,22 +301,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">&quot;Termination Event&quot; means an Illegality, a Tax Event or a Tax Event Upon Merger or, if specified to be applicable, a Credit Event Upon Merger or an Additional Termination Event.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementTerminationProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TerminationProvision"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-ma;describesTreatmentOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;MasterAgreementTerminationEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">master agreement termination provision</rdfs:label>
-		<skos:definition xml:lang="en">a provision in the master agreement, setting out the conditions, consequences etc. of termination of the agreement</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">Early Termination is a specific set of terms within this, that are specific to this kind of Master Agreement.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ma;NettingTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-ma;MasterAgreementContractualCommitment"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
@@ -478,7 +437,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;describesTreatmentOf">
 		<rdfs:label xml:lang="en">describes treatment of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementTerminationProvision"/>
+		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;TerminationProvision"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-ma;MasterAgreementTerminationEvent"/>
 	</owl:ObjectProperty>
 	
@@ -491,7 +450,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;effectOfDesignation">
 		<rdfs:label xml:lang="en">effect of designation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementEarlyTerminationProvisions"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ma;EarlyTerminationProvision"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition xml:lang="en">Description of the effect of designation of this right.</skos:definition>
 	</owl:DatatypeProperty>
@@ -525,7 +484,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;inDefault">
 		<rdfs:label xml:lang="en">in default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionsPrecedent"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionPrecedent"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">The condition that some default has occurred in respect to the other party. Further notes: Conditions precedent typically include that no default has occurred, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
 	</owl:DatatypeProperty>
@@ -590,7 +549,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;ongoingDefault">
 		<rdfs:label xml:lang="en">ongoing default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionsPrecedent"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionPrecedent"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">The condition that some default or potential default is ongoing in respect to the other party. Further notes: Conditions precedent typically include that no default is ongoing, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
 	</owl:DatatypeProperty>
@@ -611,7 +570,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;paymentDateCalculationRequirement">
 		<rdfs:label xml:lang="en">payment date calculation requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementEarlyTerminationProvisions"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ma;EarlyTerminationProvision"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition xml:lang="en">Provisions for calculation of Payment dates in the event of this Early Termination.</skos:definition>
 	</owl:DatatypeProperty>
@@ -632,7 +591,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;potentialDefault">
 		<rdfs:label xml:lang="en">potential default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionsPrecedent"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionPrecedent"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">The condition that some potential default has occurred in respect to the other party. Further notes: Conditions precedent typically include that no potential default has occurred, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
 	</owl:DatatypeProperty>
@@ -653,7 +612,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;statementCalculationRequirements">
 		<rdfs:label xml:lang="en">statement calculation requirements</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementEarlyTerminationProvisions"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ma;EarlyTerminationProvision"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition xml:lang="en">Provisions for calculation of statements and statement amounts in the event of this Early Termination.</skos:definition>
 	</owl:DatatypeProperty>
@@ -674,9 +633,19 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;transactionEarlyTerminationDate">
 		<rdfs:label xml:lang="en">transaction early termination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionsPrecedent"/>
+		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementConditionPrecedent"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">The condition that some early termination date as been defined in respect to the transaction carried out under this Master Agreement. Further notes: note that this is in respect of a specific transaction transacted under the Master Agreement, so that the condition precedent for the obligation in respect of that specific transaction, is that this early transaction termation has not taken place in respect of this same transaction. Conditions precedent typically include this is not the case, so this is typically or always &quot;no&quot;. Sample text: &quot;the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated.&quot;</skos:definition>
 	</owl:DatatypeProperty>
+	
+	<owl:Class rdf:about="&fibo-fnd-agr-ctr;TerminationProvision">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-ma;describesTreatmentOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;MasterAgreementTerminationEvent"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<cmns-av:explanatoryNote xml:lang="en">Early Termination is a specific set of terms within this, that are specific to this kind of Master Agreement.</cmns-av:explanatoryNote>
+	</owl:Class>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -133,20 +133,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">credit support beneficiary</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;CreditSupportDefaultEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-ma;isFailureInForceOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;CreditSupportAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit support default event</rdfs:label>
-		<skos:definition xml:lang="en">Failure of some Credit Support Agreement.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">Per ISDA Master Agreement exmple, this may take one of the following forms (there may be others not in this example): - Failure to comply with some obligation under the Credit Support Agreement (after a suitable grace period has elapsed) - Expiration or Termination of Credit Support Agreement while it is still needed for the transactions it covers (i.e. not normal termination); - Disavowal or repudiation of the Credit Suport Agreement by one or other party to it. Note that these three all relate to the state of the Credit Support Agreement, and have the effect that the Credit Support Agreement is no longer in effect, during a time when there is some Transaction in play which was intended to be covered by that Agreement. ISDA original terms from Master Agreement example, in full: Credit Support Default. (1) Failure by the party or any Credit Support Provider of such party to comply with or perform any agreement or obligation to be complied with or performed by it in accordance with any Credit Support Document if such failure is continuing after any applicable grace period has elapsed; (2) the expiration or termination of such Credit Support Document or the failing or ceasing of such Credit Support Document to be in full force and effect for the purpose of this Agreement (in either case other than in accordance with its terms) prior to the satisfaction of all obligations of such party under each Transaction to which such Credit Support Document relates without the written consent of the other party; or (3) the party or such Credit Support Provider disaffirms, disclaims, repudiates or rejects, in whole or in part, or challenges the validity of, such Credit Support Document Definition Agreement: SR Draft. Details from ISDA above.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-drc-ma;CrossDefaultProvisions">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:label xml:lang="en">cross default provisions</rdfs:label>
@@ -175,15 +161,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;DerivativeTransactionMasterAgreement">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MasterAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">derivative transaction master agreement</rdfs:label>
-		<skos:definition xml:lang="en">a master agreement covering derivatives transactions to be carried out between the parties to this contract</skos:definition>
+		<skos:definition xml:lang="en">master agreement covering derivatives transactions to be carried out between the parties to this contract</skos:definition>
 		<skos:example xml:lang="en">Sample preamble to one of these: &quot;EXAMPLE BANK, a Michigan banking corporation and SAMPLECOMPANY US, INC. a Delaware corporation have entered and/or anticipate entering into one or more transactions (each a &quot;Transaction&quot;) that are or will be governed by this Master Agreement, which includes the schedule (the &quot;Schedule&quot;), and the documents and other confirming evidence (each a &quot;Confirmation&quot;) exchanged between the parties confirming those Transactions. &quot;</skos:example>
 	</owl:Class>
 	
@@ -222,13 +203,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementChangeNotificationObligation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualObligation"/>
 		<rdfs:label xml:lang="en">master agreement change notification obligation</rdfs:label>
-		<skos:definition xml:lang="en">The obligtaion to notify the counterparty to this agreement, of any changes in details.</skos:definition>
+		<skos:definition xml:lang="en">The obligation to notify the counterparty to this agreement, of any changes in details.</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">General term of which Change of Account is an example.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementConditionPrecedent">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-ma;isPredicatedOn"/>
@@ -244,8 +224,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">master agreement conditions precedent</rdfs:label>
-		<skos:definition xml:lang="en">Conditions precedent on payment or delivery on a transaction transacted under this Master Agreement.</skos:definition>
+		<rdfs:label xml:lang="en">master agreement condition precedent</rdfs:label>
+		<skos:definition xml:lang="en">condition precedent on payment or delivery on a transaction transacted under this Master Agreement.</skos:definition>
 		<skos:example xml:lang="en">Example text: &quot;Each obligation of each party under Section 2(a)(i) is subject to (1) the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, (2) the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated and (3) each other applicable condition precedent specified in this Agreement. &quot; In the above, the Obligations defined under Section 2(a)(i) of the Master Agrement is the obligation to make each payment or delivery defined in a Confirmation for a transaction carried out under this Master Agreement.</skos:example>
 	</owl:Class>
 	
@@ -287,18 +267,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-ma;invokedInEventOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;MasterAgreementTerminationEvent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;TerminationEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">master agreement right to termination following termination event</rdfs:label>
 		<skos:definition xml:lang="en">the right to terminate the agreement following some termination-triggering event</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin xml:lang="en">This specifies an event which is predefined in the Agreement as constituting a Termination Event, with the effect that this right (tro termination) is invoked by the occurrence of that event. That is the assumption modeled here. ISDA Master Agreement example text in full: Right to Terminate Following Termination Event. (i) Notice. If a Termination Event occurs, an Affected Party will, promptly upon becoming aware of it, notify the other party, specifying the nature of that Termination Event and each Affected Transaction and will also give such other information about that Termination Event as the other party may reasonably require. (ii) Transfer to Avoid Termination Event. If either an Illegality under Section 5(b)(i)(1) or a Tax Event occurs and there is only one Affected Party, or if a Tax Event Upon Merger occurs and the Burdened Party is the Affected Party, the Affected Party will, as a condition to its right to designate an Early Termination Date under Section 6(b)(iv), use all reasonable efforts (which will not require such party to incur a loss, excluding immaterial, incidental expenses) to transfer within 20 days after it gives notice under Section 6(b)(i) all its rights and obligations under this Agreement in respect of the Affected Transactions to another of its Offices or Affiliates so that such Termination Event ceases to exist. If the Affected Party is not able to make such a transfer it will give notice to the other party to that effect within such 20 day period, whereupon the other party may effect such a transfer within 30 days after the notice is given under Section 6(b)(i). Any such transfer by a party under this Section 6(b)(ii) will be subject to and conditional upon the prior written consent of the other party, which consent will not be withheld if such other party&amp;rsquo;s policies in effect at such time would permit it to enter into transactions with the transferee on the terms proposed. (iii) Two Affected Parties. If an Illegality under Section 5(b)(i)(1) or a Tax Event occurs and there are two Affected Parties, each party will use all reasonable efforts to reach agreement within 30 days after notice thereof is given under Section 6(b)(i) on action to avoid that Termination Event. (iv) Right to Terminate. If:- (1) a transfer under Section 6(b)(ii) or an agreement under Section 6(b)(iii), as the case may be, has not been effected with respect to all Affected Transactions within 30 days after an Affected Party gives notice under Section 6(b)(i); or (2) an Illegality under Section 5(b)(i)(2), a Credit Event Upon Merger or an Additional Termination Event occurs, or a Tax Event Upon Merger occurs and the Burdened Party is not the Affected Party, either party in the case of an Illegality, the Burdened Party in the case of a Tax Event Upon Merger, any Affected Party in the case of a Tax Event or an Additional Termination Event if there is more than one Affected Party, or the party which is not the Affected Party in the case of a Credit Event Upon Merger or an Additional Termination Event if there is only one Affected Party may, by not more than 20 days notice to the other party and provided that the relevant Termination Event is then continuing, designate a day not earlier than the day such notice is effective as an Early Termination Date in respect of all Affected Transactions.</fibo-fnd-utl-av:definitionOrigin>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementTerminationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
-		<rdfs:label xml:lang="en">master agreement termination event</rdfs:label>
-		<skos:definition xml:lang="en">&quot;Termination Event&quot; means an Illegality, a Tax Event or a Tax Event Upon Merger or, if specified to be applicable, a Credit Event Upon Merger or an Additional Termination Event.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;NettingTerms">
@@ -387,6 +361,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">An obligation with regard to the payment of taxes.</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-der-drc-ma;TerminationEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationSpecificCreditEvent"/>
+		<rdfs:label xml:lang="en">termination event</rdfs:label>
+		<skos:definition xml:lang="en">obligation-specific event that may trigger termination due to an means an illegality, tax event, tax event upon merger or, if specified as applicable, a credit event upon merger or other termination-triggering event</skos:definition>
+	</owl:Class>
+	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;automaticNettingApplicable">
 		<rdfs:label xml:lang="en">automatic netting applicable</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-ma;NettingTerms"/>
@@ -438,7 +418,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;describesTreatmentOf">
 		<rdfs:label xml:lang="en">describes treatment of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;TerminationProvision"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-ma;MasterAgreementTerminationEvent"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-ma;TerminationEvent"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;dischargedByNetting">
@@ -499,19 +479,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;invokedInEventOf">
 		<rdfs:label xml:lang="en">invoked in event of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementRightToTerminationFollowingTerminationEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-ma;MasterAgreementTerminationEvent"/>
+		<rdfs:range rdf:resource="&fibo-der-drc-ma;TerminationEvent"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;invokedInEventOf.1">
 		<rdfs:label xml:lang="en">invoked in event of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementRightToTerminationFollowingDefaultEvent"/>
 		<rdfs:range rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;isFailureInForceOf">
-		<rdfs:label xml:lang="en">is failure in force of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;CreditSupportDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-ma;CreditSupportAgreement"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;isPredicatedOn">
@@ -642,7 +616,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-ma;describesTreatmentOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;MasterAgreementTerminationEvent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;TerminationEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<cmns-av:explanatoryNote xml:lang="en">Early Termination is a specific set of terms within this, that are specific to this kind of Master Agreement.</cmns-av:explanatoryNote>

--- a/FBC/DebtAndEquities/CreditEvents.rdf
+++ b/FBC/DebtAndEquities/CreditEvents.rdf
@@ -10,6 +10,8 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
+	<!ENTITY fibo-fnd-pas-psch "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -29,6 +31,8 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
+	xmlns:fibo-fnd-pas-psch="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -42,9 +46,9 @@
 		<dct:abstract>This ontology defines a range of credit events, that is events in which some payment or payments are not made. These include credit events relating to a specific debt obligation and events relating to the business entity as a whole. 
 		Note: the events defined herein are primarily business rather than consumer oriented, and are specified fairly generally. Many credit events are jurisdiction-specific, such as Chapter 11 restructuring and Chapter 7 bankruptcy in the United States. This ontology is designed to facilitate jurisdiction and instrument-specific extensions as needed.</dct:abstract>
 		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -55,13 +59,15 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/DebtAndEquities/CreditEvents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250401/DebtAndEquities/CreditEvents/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to move a restriction involving breach of covenant from credit event, since not all credit events involve breaches, to default event, and loosen the constraint since a breach depends on the contract.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220401/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to address text formatting issues uncovered by hygiene testing.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/DebtAndEquities/CreditEvents.rdf version of this ontology was revised to augment the definition of obligation-specific event with an optional default threshold to better support credit default swaps.</skos:changeNote>
@@ -69,6 +75,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/DebtAndEquities/CreditEvents.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/DebtAndEquities/CreditEvents.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/DebtAndEquities/CreditEvents.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/DebtAndEquities/CreditEvents.rdf version of this ontology was modified to add the currency pertinent to a credit agreement (DER-55).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2018-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -86,6 +93,26 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
 		<rdfs:label xml:lang="en">credit event</rdfs:label>
 		<skos:definition xml:lang="en">event signifying a sudden change in credit standing, such as bankruptcy or a violation of a bond indenture or loan agreement, that raises doubts about the party&apos;s ability to meet current or future obligations</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;CrossDefaultProvision">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-cre;hasDefaultThresholdAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">cross default provision</rdfs:label>
+		<skos:definition>contract provision that triggers a default under one contract if the borrower defaults on another related obligation</skos:definition>
+		<cmns-av:explanatoryNote>Cross default provisions are commonly found in loans, bond indentures, syndicated loans, and other instruments such as certain master agreements (e.g., derivatives transactions master agreements).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;DefaultEvent">
@@ -172,6 +199,44 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote xml:lang="en">The latter may result in a court action by the issuer or the sale of the securities to recover costs and/or a forfeit of partially paid securities.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;InterestObligationInLightOfDefault">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContingentObligation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualObligation"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-cre;hasDefaultInterestCompoundingBasis"/>
+				<owl:onClass rdf:resource="&cmns-dt;DatePeriod"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-cre;isDefaultInterestApplicable"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isMandatedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-psch;PaymentObligation"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fbc-dae-dbt;CreditAgreement">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fnd-pas-psch;PaymentObligation">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">interest obligation in light of default</rdfs:label>
+		<skos:definition xml:lang="en">obligation in respect of default(s) in the performance of any payment obligation</skos:definition>
+		<skos:example xml:lang="en">Prior to the occurrence or effective designation of an early termination date in respect of the relevant transaction, a party that defaults in the performance of any payment obligation will, to the extent permitted by law (and in the case of an ISDA Master Agreement is subject to Section 6(c)), be required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment, at the default rate. Such interest will be calculated on the basis of daily compounding and the actual number of days elapsed.</skos:example>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-dae-cre;MaturityExtension">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationSpecificCreditEvent"/>
 		<rdfs:label xml:lang="en">maturity extension</rdfs:label>
@@ -244,6 +309,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">obligation-specific credit event whereby the book value of the obligation, such as the outstanding principal amount, is reduced</skos:definition>
 	</owl:Class>
 	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-cre;hasDefaultInterestCompoundingBasis">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDatePeriod"/>
+		<rdfs:label xml:lang="en">has default interest compounding basis</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;InterestObligationInLightOfDefault"/>
+		<rdfs:range rdf:resource="&cmns-dt;DatePeriod"/>
+		<skos:definition xml:lang="en">indicates the basis on which default interest is to be calculated, as a period of time</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-cre;hasDefaultThresholdAmount">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 		<rdfs:label xml:lang="en">has default threshold amount</rdfs:label>
@@ -264,6 +337,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;ObligationRestructuring"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">indicates that the restructuring spans more than one credit event</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-cre;isDefaultInterestApplicable">
+		<rdfs:label xml:lang="en">is default interest applicable</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;InterestObligationInLightOfDefault"/>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition xml:lang="en">indicates whether a party that defaults in the performance of any payment obligation is, to the extent permitted by law and the applicable agreement, required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-cre;isGracePeriodExtendable">

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -120,7 +120,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250401/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away, to support collateral agreements such as deeds of trust, UCC filings and the like, to add the concept of a rate reset time of day, to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations.</skos:changeNote>
@@ -140,6 +140,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240701/DebtAndEquities/Debt.rdf version of this ontology was modified to include a synonym of &apos;has dated date&apos; for &apos;has initial interest accrual date&apos; (FBC-322), to move the definition of promissory note to financial instruments and clarify the definitions of collateral and collateral agreement(LOAN-168), and to add a use of proceeds provision, optionally, to any credit agreement (LOAN-169).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20241101/DebtAndEquities/Debt.rdf version of this ontology was modified to add initial exchange date to any credit agreement.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20241201/DebtAndEquities/Debt.rdf version of this ontology was modified to add several properties needed to define certain credit facilities (FBC-324) and replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/DebtAndEquities/Debt.rdf version of this ontology was modified to add the currency pertinent to a credit agreement (DER-55).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -377,6 +378,13 @@ See https://opensource.org/licenses/MIT.</dct:license>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;isCollateralizedBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;Collateral"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -84,7 +84,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Agreements/Contracts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250401/Agreements/Contracts/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Agreements/Contracts.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 		(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
 		(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -337,7 +337,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;MutualCommitment"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -112,6 +112,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Agreements/Contracts.rdf version of the ontology was modified to better integrate the parties to a contract with the latest patterns (FBC-284).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240501/Agreements/Contracts.rdf version of the ontology was modified to add an optional date of issuance to written contract, which may or may not be the same as the effective date (FBC-322), to add a general notion of collateral agreement (LOAN-168), and to add provisions for disclosures and use of proceeds (LOAN-169).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241101/Agreements/Contracts.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Agreements/Contracts.rdf version of the ontology was modified to link a condition precedent to the contract or clause of a contract on which it depends (DER-55).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -345,8 +346,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>contractual commitment</rdfs:label>
-		<skos:definition>provision specifying something that the contracting parties agree to</skos:definition>
-		<skos:scopeNote>Contractual commitments include general conditions which are common to all types of contracts, such as general and special arrangements, provisions, requirements, rules, rights and obligations, specifications, and standards that form an integral part of an agreement or contract, as well as special conditions which are peculiar to a specific contract (such as, contract change conditions, payment conditions, price variation clauses, penalties).</skos:scopeNote>
+		<skos:definition>provision specifying something that the contracting parties agree to, i.e., a promise or pledge made by one of the parties to perform some action or fulfill some duty</skos:definition>
+		<skos:scopeNote>Contractual commitments include general conditions which are common to all types of contracts, such as general and special arrangements, provisions, requirements, rules, rights and obligations, specifications, and standards that form an integral part of an agreement or contract, as well as special conditions which are peculiar to a specific contract (such as, contract change conditions, payment conditions, price variation clauses, penalties). Such a commitment indicates an intention or willingness to do something, which may not be legally binding, for example, to negotiate in good faith.</skos:scopeNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualDefinition">

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -267,6 +267,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractDocument">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;LegalDocument"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;records"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>contract document</rdfs:label>
 		<skos:definition>legal document that records the formal terms and conditions of some contract</skos:definition>
 		<skos:scopeNote>Written here does not necessarily mean a paper document but includes situations in which the contract is expressed electronically, whether as an electronic representation of a formal document such as in PDF form or as an electronic message, provided in the latter case that the message is expressly given formal contractual standing, for example as indicated in a separate covering agreement between the parties.</skos:scopeNote>

--- a/FND/Law/LegalCapacity.rdf
+++ b/FND/Law/LegalCapacity.rdf
@@ -185,7 +185,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>contractual obligation</rdfs:label>
-		<skos:definition>obligation or duty that is specified in and imposed by a contract</skos:definition>
+		<skos:definition>legally binding obligation that arises from the terms of a contract</skos:definition>
+		<skos:explanatoryNote>Contractual obligations require a party to perform or refrain from performing specific actions, and failure to meet an obligation can result in legal consequences.</skos:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-lcap;ContractualOption">

--- a/FND/Law/LegalCapacity.rdf
+++ b/FND/Law/LegalCapacity.rdf
@@ -585,6 +585,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-law-lcap;isPredicatedOn">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedIn"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;refersTo"/>
 		<rdfs:label xml:lang="en">is predicated on</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
 		<rdfs:range>
@@ -597,6 +599,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				</owl:unionOf>
 			</owl:Class>
 		</rdfs:range>
+		<skos:definition>depends on an assumption or requirement stated in</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-law-lcap;licenses">

--- a/FND/Law/LegalCapacity.rdf
+++ b/FND/Law/LegalCapacity.rdf
@@ -72,7 +72,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Law/LegalCapacity/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250401/Law/LegalCapacity/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Law/LegalCapacity.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
 	(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -94,11 +94,30 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Law/LegalCapacity.rdf version of the ontology was modified to move the property, &apos;is conferred on&apos; from Relations to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Law/LegalCapacity.rdf version of the ontology was modified to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Law/LegalCapacity.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Law/LegalCapacity.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389). Note that this ontology will be removed from FIBO when the deprecated elements herein are eliminated (after a minimum of 6 months).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Law/LegalCapacity.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Law/LegalCapacity.rdf version of the ontology was modified to add contractual obligations needed for certain agreements, including some master agreements, and to link a condition precedent to the clause of a contract on which it depends (DER-55).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
+	
+	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ConditionPrecedent">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-law-lcap;isPredicatedOn"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fnd-law-lcap;ContractualObligation">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-lcap;Claim">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LegalConstruct"/>
@@ -199,6 +218,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>institutionalized and legal power inherent in a particular job, function, or position that is meant to enable its holder to successfully carry out his or her responsibilities, where such power has been delegated through some formal means</skos:definition>
 		<skos:scopeNote>This specifically means the authority to make legally binding commitments.</skos:scopeNote>
 		<cmns-av:explanatoryNote>This is always accompanied by an equal responsibility for one&apos;s actions or a failure to act.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-law-lcap;DeliveryObligation">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContingentObligation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LegalObligation"/>
+		<rdfs:label xml:lang="en">delivery obligation</rdfs:label>
+		<skos:definition xml:lang="en">obligation to deliver something in order to satisfy a claim or debt</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">A delivery obligation is the responsibility of one party to deliver goods, services, instruments, money, or other specified items to another party, typically as outlined in an agreement. Failure to do so may result in breach of contract if the obligation is specified as such, which may have further legal ramifications.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-lcap;Duty">
@@ -423,6 +450,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>the legal capacity to pursue a litigation action in law</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fnd-law-lcap;NotificationObligation">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContingentObligation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LegalObligation"/>
+		<rdfs:label xml:lang="en">notification obligation</rdfs:label>
+		<skos:definition xml:lang="en">requirement for one party to formally inform another party (or parties) about specific events, actions, or changes as outlined in the agreement</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Common triggering events include breaches, changes in circumstances, delays, or other kinds of events that may have a material impact on the agreement.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fnd-law-lcap;Policy">
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -547,6 +582,21 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:range rdf:resource="&cmns-pts;PartyRole"/>
 		<owl:inverseOf rdf:resource="&fibo-fnd-law-lcap;licenses"/>
 		<skos:definition>indicates the party that has issued a particular license to some other party</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-law-lcap;isPredicatedOn">
+		<rdfs:label xml:lang="en">is predicated on</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ConditionPrecedent"/>
+		<rdfs:range>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-law-lcap;ContractualObligation">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:range>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-law-lcap;licenses">

--- a/FND/ProductsAndServices/PaymentsAndSchedules.rdf
+++ b/FND/ProductsAndServices/PaymentsAndSchedules.rdf
@@ -48,7 +48,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/">
 		<rdfs:label>Payments and Schedules Ontology</rdfs:label>
 		<dct:abstract>This ontology defines basic concepts such as payment, payee, payer, and payment schedule, extending the scheduling concepts from the Dates and Times module, among others.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -63,7 +72,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20240101/ProductsAndServices/PaymentsAndSchedules/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250401/ProductsAndServices/PaymentsAndSchedules/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20150801/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report to replace MoneyAmount with MonetaryAmount.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified per the FIBO 2.0 RFC to make hasPaymentAmount a child of hasMonetaryAmount and move hasObligation and isObligationOf to Agreements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20181001/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
@@ -74,9 +83,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220301/ProductsAndServices/PaymentsAndSchedules.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/ProductsAndServices/PaymentsAndSchedules.rdf version of this ontology was modified to normalize properties related to payment obligations (DER-55).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-psch;Payee">
@@ -195,6 +205,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pas-psch;hasPaymentSchedule">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
 		<rdfs:label>has payment schedule</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
 		<skos:definition>specifies the schedule for fulfillment of an obligation</skos:definition>


### PR DESCRIPTION
## Description

Clean-up of the master agreements ontology as follows:
1. Eliminate the concept of a credit event definition, which is now covered in FBC
2. Extended the definition of credit support agreement and better integrated that with other concepts in FIBO
3. Refined and combined concepts related to termination and early termination
4. Eliminated the concepts of a master-agreement specific contractual commitment, element, and representation, which were defined as catch-alls and duplicative of detail in contracts
5. Further integration of content related to credit events, where what was already in FIBO is more comprehensive and should be leveraged (and some may apply to the master agreement rather than the credit support agreement, or both)
6. Refined the definition of a credit support beneficiary, removed redundant details related to currency once that restriction was added to the Debt ontology in FBC to all credit agreements
7. Moved additional contract provisions, obligations to FND as appropriate

Fixes: #2121 / DER-55


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


