### PR TITLE
DER-152 - Missing the concept of a structured warrant

### DIFF
--- a/DER/DerivativesContracts/RightsAndWarrants.rdf
+++ b/DER/DerivativesContracts/RightsAndWarrants.rdf
@@ -93,13 +93,13 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20250701/DerivativesContracts/RightsAndWarrants/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20250801/DerivativesContracts/RightsAndWarrants/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20211101/DerivativesContracts/RightsAndWarrants.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary, to move the definition of an underlier and the related property, has underlier, to financial instruments so that these concepts are also available for use in relation to pool-backed securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/DerivativesContracts/RightsAndWarrants.rdf version of this ontology was modified to add concepts including mini-future certificate and constant leverage certificate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230801/DerivativesContracts/RightsAndWarrants.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/DerivativesContracts/RightsAndWarrants.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20240101/DerivativesContracts/RightsAndWarrants.rdf version of this ontology was modified to simplify and refine definitions related to underliers (DER-112).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20250301/DerivativesContracts/RightsAndWarrants.rdf version of the ontology was modified to align the definition of &apos;bond with warrant&apos; with the CFI definition (SEC-207) and to adjust the class hierarchy and add definitions related to certain specific kinds of warrants (DER-150).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20250301/DerivativesContracts/RightsAndWarrants.rdf version of the ontology was modified to align the definition of &apos;bond with warrant&apos; with the CFI definition (SEC-207) and to adjust the class hierarchy and add definitions related to certain specific kinds of warrants (DER-150 and DER-152).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -558,6 +558,15 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<rdfs:label xml:lang="en">short mini-future certificate</rdfs:label>
 		<skos:definition xml:lang="en">mini-future certificate that entitles the holder to acquire cash in exchange for specific underlying assets</skos:definition>
 		<cmns-av:adaptedFrom xml:lang="en">ISO 10962, Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth Edition, October 2019</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-der-drc-raw;StructuredWarrant">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-raw;Warrant"/>
+		<rdfs:label xml:lang="en">structured warrant</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.phillipnova.com.sg/wp-content/uploads/2023/08/Structured-Warrants-Product-Info-Sheet.pdf"/>
+		<skos:definition xml:lang="en">warrant that is listed on an exchange, offering investors a way to participate in the price performance of an underlying asset without buying it directly</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">Unlike company-issued warrants, which are tied to corporate fundraising, structured warrants are issued by third-party financial institutions such as investment banks or brokers. They can be based on a variety of underlying assets, including individual company shares, a basket of shares, or an index.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">When structured warrants are exercised, they are typically cash-settled and do not lead to the creation of new shares, thus avoiding dilution of existing shareholders. This is in contrast with company-issued stock options, which can potentially lead to the issuance of new shares, which might dilute the value for existing shareholders.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-raw;SubscriptionRight">


### PR DESCRIPTION

## Description

Added the concept of a structured warrant to the rights and warrants ontology, with the definition provided in DER-152.

Fixes: #2156 / DER-152


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


