### PR TITLE
SEC-200 - Clean-up the CIV ontology in SEC/Funds in order to leverage it for use in describing various kinds of more complex instruments, such as CDOs

### DIFF
--- a/BE/LegalEntities/LegalPersons.rdf
+++ b/BE/LegalEntities/LegalPersons.rdf
@@ -12,6 +12,7 @@
 	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/">
 	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -35,6 +36,7 @@
 	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"
 	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -61,6 +63,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -72,7 +75,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250301/LegalEntities/LegalPersons/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250801/LegalEntities/LegalPersons/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/LegalEntities/LegalPersons.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/LegalEntities/LegalPersons.rdf version of this ontology was modified per the FIBO 2.0 RFC to normalize restrictions on business license.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/LegalEntities/LegalPersons.rdf version of this ontology was modified to rationalize natural person and legally capable person in a new concept, namely legally competent natural person, simplify / merge the legal person and formal organization class hierarchies, and correct certain definitions, including power of attorney.</skos:changeNote>
@@ -92,6 +95,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/LegalEntities/LegalPersons.rdf version of the ontology was modified to add a French label to special purpose vehicle.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230401/LegalEntities/LegalPersons.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/LegalEntities/LegalPersons.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20250301/LegalEntities/LegalPersons.rdf version of the ontology was modified to add a property for intended liquidation date, which may apply to a temporary entity such as an SPV (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -217,6 +221,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-be-le-lp;SpecialPurposeVehicle">
 		<rdfs:subClassOf rdf:resource="&cmns-org;LegalEntity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-le-lp;hasIntendedLiquidationDate"/>
+				<owl:onClass rdf:resource="&cmns-dt;Date"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="fr-FR">fonds commun de placement</rdfs:label>
 		<rdfs:label xml:lang="en-US">special purpose vehicle</rdfs:label>
 		<skos:definition xml:lang="en">legal entity created to fulfill narrow, specific, and frequently temporary objectives</skos:definition>
@@ -240,6 +251,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote xml:lang="en">Variable interest entity (VIE) is a term used by the Financial Accounting Standards Board (FASB) to refer to a legal entity with certain characteristics such that a public company with a financial interest in the entity is subject to certain financial reporting requirements. Examples include certain Chinese companies, such as Alibaba, that leverage VIEs to gain access to foreign capital that would otherwise not be available due to Chinese government regulations.</cmns-av:explanatoryNote>
 		<cmns-av:synonym xml:lang="en">shell company</cmns-av:synonym>
 	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-le-lp;hasIntendedLiquidationDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-arr-doc;hasTerminationDate"/>
+		<rdfs:label xml:lang="en">has intended liquidation date</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;Date"/>
+		<skos:definition xml:lang="en">links an agreement, contract, or legal entity to a date on which it is scheduled to be sold</skos:definition>
+	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-le-lp;isOrganizedIn">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>

--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -105,7 +105,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20250701/CreditDerivatives/CreditDefaultSwaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20250801/CreditDerivatives/CreditDefaultSwaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20221201/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/CreditDerivatives/CreditDefaultSwaps.rdf version of this ontology was modified to move the property, &apos;is conferred on&apos; to the Legal Capacity ontology and to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230301/CreditDerivatives/CreditDefaultSwaps.rdf version of this ontology was modified to add the concept of a credit default swap index.</skos:changeNote>
@@ -113,7 +113,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231101/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to eliminate a subproperty relationship between the contract price and notional amount, which may not be appropriate (DER-127), and to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to replace additional concepts from FIBO FND with their counterparts in the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20240101/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20250301/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to replace hasConstituent with hasMember for better semantic consistency (FND-396).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20250301/CreditDerivatives/CreditDefaultSwaps.rdf version of the ontology was modified to replace hasConstituent with hasMember for better semantic consistency (FND-396) and to correct a label on has scheduled termination date (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -418,7 +418,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasScheduledTerminationDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-arr-doc;hasTerminationDate"/>
-		<rdfs:label xml:lang="en">scheduled termination date</rdfs:label>
+		<rdfs:label xml:lang="en">has scheduled termination date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionTerms"/>
 		<rdfs:range rdf:resource="&cmns-dt;ExplicitDate"/>
 		<skos:definition xml:lang="en">date on which credit protection is due to expire as agreed by both parties</skos:definition>

--- a/FND/Arrangements/Documents.rdf
+++ b/FND/Arrangements/Documents.rdf
@@ -30,13 +30,22 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 		<rdfs:label>Documents Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation documents for use in other FIBO ontology elements.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2014-2025 EDM Council, Inc.
+Copyright (c) 2014-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241101/Arrangements/Documents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250801/Arrangements/Documents/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20230101/Arrangements/Documents.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Arrangements/Documents.rdf version of this ontology was introduced as a part of the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/ in advance of the Long Beach meeting in December 2014.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Arrangements/Documents.rdf version of this ontology was revised as a part of the issue resolutions identified in the FIBO FND 1.1 RTF report to add a parent of hasDate to date properties.</skos:changeNote>
@@ -51,10 +60,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20211201/Arrangements/Documents.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Arrangements/Documents.rdf version of the ontology was modified to replace many of the concepts with those in the Documents ontology added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Arrangements/Documents.rdf version of the ontology was modified to replace an additional property with its equivalent in the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Arrangements/Documents.rdf version of the ontology was modified to liminate elements that have been deprecated for several quarters (FND-386).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Arrangements/Documents.rdf version of the ontology was modified to eliminate elements that have been deprecated for several quarters (FND-386) and revise the definition of termination date to allow for future termination (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2014-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2014-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-doc;FinancialRecord">
@@ -90,7 +99,7 @@
 		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasEndDate"/>
 		<rdfs:label>has termination date</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-dt;Date"/>
-		<skos:definition>links something, typically an agreement, contract, document, or process, with a date on which it was terminated</skos:definition>
+		<skos:definition>links something, typically an agreement, contract, document, or process, with a date on which it is scheduled to be or was terminated</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/FND/GoalsAndObjectives/Objectives.rdf
+++ b/FND/GoalsAndObjectives/Objectives.rdf
@@ -40,7 +40,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 		<rdfs:label>Objectives Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts including goal, objective, program, and strategy. Objectives are defined as being distinct from goals, in that they constitute time limited and measurable targets which some entity may seek to attain in pursuit of its goals.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -51,7 +60,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241101/GoalsAndObjectives/Objectives/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250801/GoalsAndObjectives/Objectives/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/GoalsAndObjectives/Objectives.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
 	(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -68,9 +77,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20221001/GoalsAndObjectives/Objectives.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary and eliminate unnecessary references to LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to add the concept of a project and related attributes (LOAN-169).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241101/GoalsAndObjectives/Objectives.rdf version of this ontology was modified to add the concept of a method (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-gao-obj;BusinessObjective">
@@ -118,6 +128,18 @@
 		<skos:definition>financial objective used by an investor to determine whether or not a given potential investment is appropriate for themselves or on behalf of another party</skos:definition>
 		<skos:example>An investor whose objective is capital growth might choose to invest in more aggressive, growth-oriented mutual funds and/or stocks, over income-generating mutual funds and/or bonds.</skos:example>
 		<cmns-av:explanatoryNote>The combination of investment objectives and risk tolerance are typically used to identify appropriate investment options.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-gao-obj;Method">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasObjective"/>
+				<owl:onClass rdf:resource="&fibo-fnd-gao-obj;Objective"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>method</rdfs:label>
+		<skos:definition>systematic procedure or approach for doing or calculating something, consisting of defined steps or rules to achieve a result</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-gao-obj;Objective">
@@ -313,26 +335,34 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>strategy</rdfs:label>
-		<skos:definition>plan or method for achieving a specific goal, objective, solution or outcome</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">A strategy may involve activities that are needed in order to achieve specific goals or objectives. It may take into account one or more policies or any number of restrictions and constraints.</cmns-av:explanatoryNote>
+		<skos:definition>high-level plan or approach for achieving a specific goal, objective, solution or outcome</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">A strategy is a high-level plan or approach designed to achieve a long-term goal or outcome, often by choosing among different possible methods or courses of action. A strategy may involve activities that are needed in order to achieve specific goals or objectives. It may take into account one or more policies or any number of restrictions and constraints.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-gao-obj;hasGoal">
 		<rdfs:label>has goal</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-gao-obj;Goal"/>
-		<skos:definition>relates something to a long-term, desired outcome</skos:definition>
+		<skos:definition>has long-term, desired outcome</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-gao-obj;hasObjective">
 		<rdfs:label>has objective</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-gao-obj;Objective"/>
-		<skos:definition>relates something to a specific objective (result) that it aims to achieve within a time frame and with available resources</skos:definition>
+		<skos:definition>aims to achieve within a time frame and with available resources</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-gao-obj;hasStrategy">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;uses"/>
 		<rdfs:label>has strategy</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
-		<skos:definition>relates something to a plan or method for achieving a specific goal, objective, solution or outcome</skos:definition>
+		<skos:definition>applies strategy</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-gao-obj;usesMethod">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;uses"/>
+		<rdfs:label>uses method</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-gao-obj;Method"/>
+		<skos:definition>employs method</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/MD/CIVTemporal/FundsTemporal.rdf
+++ b/MD/CIVTemporal/FundsTemporal.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-fbc-fi-ip "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/">
+	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-md-civx-fun "https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/">
 	<!ENTITY fibo-sec-fund-civ "https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/">
@@ -24,6 +25,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-fbc-fi-ip="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"
+	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-md-civx-fun="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/"
 	xmlns:fibo-sec-fund-civ="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/"
@@ -50,6 +52,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/InstrumentPricing/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/"/>
@@ -72,6 +75,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-md-civx-fun;AccruedTaxes">
 		<rdfs:label xml:lang="en">accrued taxes</rdfs:label>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-md-civx-fun;AnnualizedPerformanceDeterminationMethod">
+		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;PerformanceDeterminationMethod"/>
+		<rdfs:label xml:lang="en">annualized performance determination method</rdfs:label>
+		<skos:definition xml:lang="en">Annualized performance determination.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-md-civx-fun;FeePayable">
@@ -97,6 +106,24 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">funds tax</rdfs:label>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-md-civx-fun;GrossOfFeePerformanceDeterminationMethod">
+		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;PerformanceDeterminationMethod"/>
+		<rdfs:label xml:lang="en">gross of fee performance determination method</rdfs:label>
+		<skos:definition xml:lang="en">Performance determined gross of fee. Review: Is this mutually exclusive with the other listed method? It sounds like it is not.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-md-civx-fun;MoneyWeightedRateOfReturnPerformanceDeterminationMethod">
+		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;PerformanceDeterminationMethod"/>
+		<rdfs:label xml:lang="en">money weighted rate of return performance determination method</rdfs:label>
+		<skos:definition xml:lang="en">Money weighted rate of return.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-md-civx-fun;PerformanceDeterminationMethod">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Method"/>
+		<rdfs:label xml:lang="en">performance determination method</rdfs:label>
+		<skos:definition xml:lang="en">A method for performance determination (e.g. Time weighted and money weighted, annualized, gross of fee) along with the time frame in which this is determined. PLUS Performances NamePeriod</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-md-civx-fun;SigmaValueOfHoldings">
 		<rdfs:label xml:lang="en">sigma value of holdings</rdfs:label>
 	</owl:Class>
@@ -108,6 +135,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:Class rdf:about="&fibo-md-civx-fun;SwingPrice">
 		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
 		<rdfs:label xml:lang="en">swing price</rdfs:label>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-md-civx-fun;TimeWeightedRateOfReturnPerformanceDeterminationMethod">
+		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;PerformanceDeterminationMethod"/>
+		<rdfs:label xml:lang="en">time weighted rate of return performance determination method</rdfs:label>
+		<skos:definition xml:lang="en">Time weighted rate of return.</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationDate.1">
@@ -133,6 +166,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">has performance</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
 		<rdfs:range rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;hasPerformanceDeterminationMethod">
+		<rdfs:label xml:lang="en">has performance determination method</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
+		<rdfs:range rdf:resource="&fibo-md-civx-fun;PerformanceDeterminationMethod"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incurs">
@@ -176,5 +215,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;performanceDeterminationTimeframe">
+		<rdfs:label xml:lang="en">performance determination timeframe</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-md-civx-fun;PerformanceDeterminationMethod"/>
+		<rdfs:range rdf:resource="&cmns-dt;DatePeriod"/>
+		<skos:definition xml:lang="en">The timeframe on which the performance is reported (e.g. 1month, 1 year, YTD).</skos:definition>
+	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/SEC/Debt/CollateralizedDebtObligations.rdf
+++ b/SEC/Debt/CollateralizedDebtObligations.rdf
@@ -563,7 +563,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-cdo;MBSInstrumentSlice">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -170,28 +170,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-be-le-lp;SpecialPurposeVehicle">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;isSetUpFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundsCreation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;isSetUpFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;SPVPurpose"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<cmns-av:explanatoryNote xml:lang="en">A Special Purpose Vehicle (SPV) set up specifically to issue a security or securities. It is set up by a company or a group of companies for some purpose such as to create instruments that are off the company&apos;s balance sheet or to issue Participation Notes for investors in another jurisdiction. The SPV is formed for a specific reason and exists for a specific period of time and is then disbanded. Further notes: Special Purpose Vehicles are also referred to as bankruptcy remote entities, as they isolate financial risk. For Participation Notes: slightly different purpose but the same kind of vehicle. The only investment made by the SPV is that they buy in the stock. These are the same kind of entity in all of the contexts in which they exist.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;AccumulatingShareClass">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundShareClassUnit"/>
 		<rdfs:label xml:lang="en">accumulating share class</rdfs:label>
@@ -802,12 +780,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">Accrued income is distributed periodically to the investor.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;FundsCreation">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;SPVPurpose"/>
-		<rdfs:label xml:lang="en">funds creation</rdfs:label>
-		<skos:definition xml:lang="en">SPV set up for fund management Conesnsus:Review</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundsProcessing">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStage"/>
 		<rdfs:label xml:lang="en">funds processing</rdfs:label>
@@ -1103,13 +1075,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
 		<rdfs:label xml:lang="en">s i c a v</rdfs:label>
 		<skos:definition xml:lang="en">Societe Collective a Capital Variable</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;SPVPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;BusinessObjective"/>
-		<rdfs:label xml:lang="en">s p v purpose</rdfs:label>
-		<skos:definition xml:lang="en">The reason for the creation of a Special Purpose Vehicle.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is used to identify different kinds of SPV which may have different detailed facts about them; however in general all SPVs are much the same.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;SectorStrategy">
@@ -1620,13 +1585,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">Whether registered investors are able to transfer some or all of their holdings to third parties.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;holds">
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;SpecialPurposeVehicle"/>
-		<rdfs:range rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-		<skos:definition xml:lang="en">The Funds Special Purpose Vehicle holds this Fund.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;identifiedAs.5">
 		<rdfs:label xml:lang="en">identified as</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;StakeInFund"/>
@@ -1693,13 +1651,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">Physical application form for the initial subscription by the investor.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;intendedLiquidationDate">
-		<rdfs:label xml:lang="en">intended liquidation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;SpecialPurposeVehicle"/>
-		<rdfs:range rdf:resource="&cmns-dt;Date"/>
-		<skos:definition xml:lang="en">The date on which the SPV is scheduled to be disbanded and wound up.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;investmentFocus">
 		<rdfs:label xml:lang="en">investment focus</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;PortfolioInvestmentStrategy"/>
@@ -1711,12 +1662,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">is calculated in</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;NetAssetValueCalculationMethod"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;isSetUpFor">
-		<rdfs:label xml:lang="en">is set up for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;SpecialPurposeVehicle"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;SPVPurpose"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;isUnitHolder">

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -1094,13 +1094,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">Description of frequency at which the subscriptions and redemptions are done.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;decimalPlaceRounding">
-		<rdfs:label xml:lang="en">decimal place rounding</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundProcessingTerms"/>
-		<rdfs:range rdf:resource="&xsd;integer"/>
-		<skos:definition xml:lang="en">Number of decimal places to which quantities of units/shares are rounded.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;declarationChannel">
 		<rdfs:label xml:lang="en">declaration channel</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;NetAssetValueCalculationMethod"/>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -38,6 +38,7 @@
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-plc-rp "https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
@@ -93,6 +94,7 @@
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-plc-rp="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
@@ -146,6 +148,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCore/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/RealProperty/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
@@ -771,7 +774,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundPortfolioInvestmentLimitations"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;identifies.1"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
 				<owl:someValuesFrom rdf:resource="&cmns-rga;Jurisdiction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -873,7 +876,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;InvestmentStrategy"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;includes"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundPortfolioInvestmentLimitations"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -974,7 +977,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;identifiedAs.5"/>
+				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -986,7 +989,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundsProcessingParty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;issues"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;issues"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1346,13 +1349,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundTransferAgent"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasUnitIssuer">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-fund-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">has unit issuer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;UnitIssuer"/>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;historicPricingIndicator">
 		<rdfs:label xml:lang="en">historic pricing indicator</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;NetAssetValueCalculationMethod"/>
@@ -1373,19 +1369,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether registered investors are able to transfer some or all of their holdings to third parties.</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;identifiedAs.5">
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;StakeInFund"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;identifies.1">
-		<rdfs:label xml:lang="en">identifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;JurisdictionStrategy"/>
-		<rdfs:range rdf:resource="&cmns-rga;Jurisdiction"/>
-		<skos:definition xml:lang="en">Jurisdiction (country, county, state, province, city) of the investment.</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;identifiesAssetTypesBy">
 		<rdfs:label xml:lang="en">identifies asset types by</rdfs:label>
@@ -1419,12 +1402,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether or not the strategy includes firms which are related in some way to the referenced organization.</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;includes">
-		<rdfs:label xml:lang="en">includes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;PortfolioInvestmentStrategy"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundPortfolioInvestmentLimitations"/>
-	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;inclusion">
 		<rdfs:label xml:lang="en">inclusion</rdfs:label>
@@ -1465,24 +1442,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">The price at which the Fund Unit was first issued.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;issues">
-		<rdfs:label xml:lang="en">issues</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;UnitIssuer"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;launchDate">
 		<rdfs:label xml:lang="en">launch date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
 		<skos:definition xml:lang="en">Date of first NAV calculation and start of performance calculations</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;legallyRecordedIn">
-		<rdfs:label xml:lang="en">fund legally recorded in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-		<rdfs:range rdf:resource="&cmns-rga;Jurisdiction"/>
-		<skos:definition xml:lang="en">Relationship note: This relationship has no obvious parent; it is similar to Security legally recorded in Jurisdiction, but that inherits from Contract jurisdiction whereas a Fund is a Pool not a Contract. So the meaning is not the same. Assign parent relationship in future if a more general one exists; at present there is none.</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;limitedSharesAreIssued">
 		<rdfs:label xml:lang="en">limited shares are issued</rdfs:label>
@@ -1949,14 +1913,26 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:Class rdf:about="&fibo-sec-sec-pls;CollectiveInvestmentVehicle">
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;isLegallyRecordedIn"/>
+				<owl:someValuesFrom rdf:resource="&cmns-rga;Jurisdiction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundUnitDistributionMethod"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;UnitIssuer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -2035,18 +2011,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasTransferAgent"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundTransferAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasUnitIssuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;UnitIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;legallyRecordedIn"/>
-				<owl:someValuesFrom rdf:resource="&cmns-rga;Jurisdiction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -14,10 +14,12 @@
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-be-ge-euj "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
+	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -67,10 +69,12 @@
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-be-ge-euj="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
+	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -118,10 +122,12 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
@@ -178,12 +184,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote xml:lang="en">This fact would be determined by the fund unit having a specific Fund Distribution Policy of Accumulating.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;AnnualReportingPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;ReportingFrequencyPolicy"/>
-		<rdfs:label xml:lang="en">annual reporting policy</rdfs:label>
-		<skos:definition xml:lang="en">Reports are presented once a year</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;AnnualizedPerformanceDeterminationMethod">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;PerformanceDeterminationMethod"/>
 		<rdfs:label xml:lang="en">annualized performance determination method</rdfs:label>
@@ -201,18 +201,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">asset class strategy</rdfs:label>
 		<skos:definition xml:lang="en">Strategy which is asset class based.</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">EFAMA: The type of securities or other holdings that may be invested in. FIBIM: Strategy which is asset class based. Can implement this in terms of a classification of those things. Wording implies this is a policy.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;BricksAndMortarHolding">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;takesFormOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-rp;RealEstate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bricks and mortar holding</rdfs:label>
-		<skos:definition xml:lang="en">A holding of built property.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;CommonShareInFund">
@@ -241,18 +229,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">distributing share class</rdfs:label>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;EquityAsset">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity asset</rdfs:label>
-		<skos:definition xml:lang="en">The holding of equity securities in a portfolio.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;EquityFund">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
 		<rdfs:subClassOf>
@@ -267,6 +243,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;EquityPortfolio">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundPortfolio"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-oac-cown;Shareholding"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">equity portfolio</rdfs:label>
 		<skos:definition xml:lang="en">A portfolio which has at least 85% exposure to shares.</skos:definition>
 	</owl:Class>
@@ -322,12 +304,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundBondClassUnit">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundDebt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
@@ -391,25 +367,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundCashDistributionPolicy"/>
 		<rdfs:label xml:lang="en">fund coupon policy</rdfs:label>
 		<skos:definition xml:lang="en">Terms for the expected distribution of bond unit coupons.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;FundDataProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundsProcessingParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund data provider</rdfs:label>
-		<skos:definition xml:lang="en">A party which supplies market data to a fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;FundDebt">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Debt"/>
-		<rdfs:label xml:lang="en">fund debt</rdfs:label>
-		<skos:definition xml:lang="en">Debt issued by a Fund.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">This would normally be held by participants in that pool. in this case the pool is a fund which is formed by each of the participants extending credit to that pool and holding bond units in the pool representing that debt.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundDepositary">
@@ -528,12 +485,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:editorialNote xml:lang="en">This party would presumably be identified as the Fund Management Company in terms of what legal entity fulcils this role? to be determined at further review.</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;FundOrderDeskPhysicalFormDocument">
-		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
-		<rdfs:label xml:lang="en">fund order desk physical form document</rdfs:label>
-		<skos:definition xml:lang="en">A phsyical form obtained through the main fund order desk.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundPortfolio">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
 		<rdfs:subClassOf>
@@ -568,8 +519,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -606,20 +557,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">fund portfolio investment policy</rdfs:label>
 		<skos:definition xml:lang="en">policy with respect to allocation of the portfolio that is designed to meet the stated investment strategy and goals</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">ISO FIBIM: Rough allocation of the portfolio.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;FundProcessingForm">
-		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;mayBe.1"/>
-				<owl:onClass rdf:resource="&fibo-sec-fund-civ;FundOrderDeskPhysicalFormDocument"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund processing form</rdfs:label>
-		<skos:definition xml:lang="en">The form of documentation or control mechanism required for some funds processing activity.</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">Equates to the &quot;Physical Form&quot; in SIO FIBIM for certain activities in funds processing. May or may not be a written physical document. ISO FIBIM Definition: Specifies whether a physical form is required.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundProcessingGeneralTerms">
@@ -695,18 +632,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">Terms for the expected reinvestment of profits on fund units.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;FundReportingTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasAccountingReportingFrequency"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;ReportingFrequencyPolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund reporting terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms describing the accounting methods and reporting arrangements used by the fund.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundShareClassUnit">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
 		<rdfs:subClassOf>
@@ -763,7 +688,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;FundUnitHolding">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
@@ -916,7 +841,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;denominatedIn"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1035,7 +960,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;PrivateEquityHolding">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
@@ -1046,18 +971,23 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">A holding of private equity.</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-fund-civ;RealEstateHolding">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-rp;RealEstate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en">real estate holding</rdfs:label>
+		<skos:definition xml:lang="en">tangible asset consisting of real estate that is owned or controlled by an individual, organization, or entity for investment, operational, or strategic purposes</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;ReferToFundOrderDesk">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundRedemptionRestriction"/>
 		<rdfs:label xml:lang="en">refer to fund order desk</rdfs:label>
 		<skos:definition xml:lang="en">Restriction requiring an investor to refer to the fund order desk prior to redeeming a fund.</skos:definition>
 		<skos:editorialNote xml:lang="en">While it&apos;s unclear from original data models, it&apos;s likely that this restriction is actually to learn from the fund order desk of any other individual kinds of restriction that will apply. This is itself treated as a kind of restriction here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;ReportingFrequencyPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ReportingPolicy"/>
-		<rdfs:label xml:lang="en">reporting frequency policy</rdfs:label>
-		<skos:definition xml:lang="en">Frequency with which financial reports will be presented.</skos:definition>
-		<skos:editorialNote xml:lang="en">This could theoretically be defined in terms of a Frequency (reciprocal of time), but since this kind of reporting in accounting is always either annual or semi-annual these are defined as policies for the provision of such reports</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;RiskLevel">
@@ -1081,12 +1011,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundPortfolioInvestmentLimitations"/>
 		<rdfs:label xml:lang="en">sector strategy</rdfs:label>
 		<skos:definition xml:lang="en">Strategy which is sector based.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;SemiAnnualReportingPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;ReportingFrequencyPolicy"/>
-		<rdfs:label xml:lang="en">semi annual reporting policy</rdfs:label>
-		<skos:definition xml:lang="en">Reports are presented twice a year.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;StakeInFund">
@@ -1133,7 +1057,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;accountingYearEndDate">
 		<rdfs:label xml:lang="en">accounting year end date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundReportingTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-bd;DayOfMonth"/>
 		<skos:definition xml:lang="en">Last day of the accounting year for the fund.</skos:definition>
 	</owl:ObjectProperty>
@@ -1265,45 +1188,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundsProcessingAccount"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;denominatedIn">
-		<rdfs:label xml:lang="en">denominated in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;Liquidity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;denomination">
-		<rdfs:label xml:lang="en">denomination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">Denomination Currency of the fund - Currency in which the fund unit is issued or redenominated and the currency of the NAV calculation.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;denominationCurrency">
-		<rdfs:label xml:lang="en">denomination currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;describedIn">
-		<rdfs:label xml:lang="en">described in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;description">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundPortfolioInvestmentPolicy"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">The manner in which the manager tries to reach the funds objectives</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;description.1">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;PortfolioBenchmark"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">Description of the benchmark used to determine the performance of a portfolio.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;distributedBy">
 		<rdfs:subPropertyOf rdf:resource="&fibo-sec-fund-civ;fundHasRelatedParty"/>
 		<rdfs:label xml:lang="en">distributed by</rdfs:label>
@@ -1328,7 +1212,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;endOfFiscalYear">
 		<rdfs:label xml:lang="en">end of fiscal year</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundReportingTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-bd;DayOfMonth"/>
 		<skos:definition xml:lang="en">Day and month on any given year at which the books are closed and profit and loss is determined.</skos:definition>
 	</owl:ObjectProperty>
@@ -1342,7 +1225,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;firstAccountingYearEndDate">
 		<rdfs:label xml:lang="en">first accounting year end date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundReportingTerms"/>
 		<skos:definition xml:lang="en">Last day of the first accounting year for the fund.</skos:definition>
 	</owl:DatatypeProperty>
 	
@@ -1378,25 +1260,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:range rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasAccountant">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-fund-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">has accountant</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundAccountant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasAccountingInformation">
-		<rdfs:label xml:lang="en">has accounting information</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundReportingTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasAccountingReportingFrequency">
-		<rdfs:label xml:lang="en">has accounting reporting frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundReportingTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;ReportingFrequencyPolicy"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasAdditionalInformation">
 		<rdfs:label xml:lang="en">has additional information</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
@@ -1425,7 +1288,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subPropertyOf rdf:resource="&fibo-sec-fund-civ;fundHasRelatedParty"/>
 		<rdfs:label xml:lang="en">has data provider</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundDataProvider"/>
+		<rdfs:range rdf:resource="&fibo-be-fct-pub;MarketDataProvider"/>
 		<skos:definition xml:lang="en">has an organization which is the data provider and is legally responsible for the information provided</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -1647,7 +1510,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;initialApplicationForm">
 		<rdfs:label xml:lang="en">initial application form</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundProcessingForm"/>
 		<skos:definition xml:lang="en">Physical application form for the initial subscription by the investor.</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -1771,12 +1633,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundAdministrator"/>
 		<rdfs:range rdf:resource="&fibo-sec-fund-civ;UnitIssuer"/>
 		<skos:definition xml:lang="en">The unit issuer would be the fund administrator (except when it is a Bond).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;mayBe.1">
-		<rdfs:label xml:lang="en">may be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundProcessingForm"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundOrderDeskPhysicalFormDocument"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;mayBeDefinedIn">
@@ -1906,7 +1762,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;physicalDocumentRequired">
 		<rdfs:label xml:lang="en">physical document required</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundProcessingForm"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether a phsyical form is required through the main fund order desk. Yes: A phsyical form is required through the main fund order desk. No: A phsyical form is not required through the main fund order desk.</skos:definition>
 	</owl:DatatypeProperty>
@@ -1976,7 +1831,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;redemptionForm">
 		<rdfs:label xml:lang="en">redemption form</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundProcessingForm"/>
 		<skos:definition xml:lang="en">Physical written instruction/renunciation form for redemption of units/shares by the investor.</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -2009,7 +1863,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-fund-civ;signatureRequired">
 		<rdfs:label xml:lang="en">signature required</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundProcessingForm"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether a phsyical form with the investor&apos;s written signature is required through the main fund order desk. Yes:A phsyical form with the investor&apos;s written signature is required through the main fund order desk.</skos:definition>
 	</owl:DatatypeProperty>
@@ -2084,7 +1937,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;subsequentApplicationForm">
 		<rdfs:label xml:lang="en">subsequent application form</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundProcessingForm"/>
 		<skos:definition xml:lang="en">Physical application form for subsequent investments by the same investor.</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -2106,13 +1958,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundSubscriptionTerms"/>
 		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;Fee"/>
 		<skos:definition xml:lang="en">Actual percentage or fixed amount of money due when switching to another fund. Definition origin:EFAMA DD</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;takesFormOf">
-		<rdfs:subPropertyOf rdf:resource="&cmns-col;comprises"/>
-		<rdfs:label xml:lang="en">takes form of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;BricksAndMortarHolding"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-rp;RealEstate"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;trackingError">
@@ -2163,6 +2008,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:Class rdf:about="&fibo-sec-fund-fund;FundUnit">
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasDetails"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;NetAssetValueCalculationMethod"/>
 			</owl:Restriction>
@@ -2185,6 +2036,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	<owl:Class rdf:about="&fibo-sec-sec-pls;CollectiveInvestmentVehicle">
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasStrategy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundUnitDistributionMethod"/>
 			</owl:Restriction>
@@ -2203,12 +2060,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;describedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;distributedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundDistributor"/>
 			</owl:Restriction>
@@ -2217,18 +2068,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;fundHasRelatedParty"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundsProcessingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasAccountant"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundAccountant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasAccountingInformation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundReportingTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -2246,7 +2085,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasDataProvider"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundDataProvider"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-fct-pub;MarketDataProvider"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -2313,6 +2152,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;supervisedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundSupervisoryAuthority"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;isDescribedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundProspectus"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<cmns-av:explanatoryNote xml:lang="en">From EFAMA DD: The word fund can refer to either an investment pool, umbrella or share class, and is commonly refered to as a collective investment vehicle (can have ISIN or not). The meaning here is for the investment pool (of which an Umbrella fund is also one such) and not to the share class.</cmns-av:explanatoryNote>

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -184,12 +184,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote xml:lang="en">This fact would be determined by the fund unit having a specific Fund Distribution Policy of Accumulating.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;AnnualizedPerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;PerformanceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">annualized performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">Annualized performance determination.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;AssetClassStrategy">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundPortfolioInvestmentLimitations"/>
 		<rdfs:subClassOf>
@@ -730,37 +724,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">party involved in the processing of funds</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;FundsProcessingPassport">
-		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundProcessingTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasInformationAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;mayBeDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">funds processing passport</rdfs:label>
-		<skos:definition xml:lang="en">The Funds Processing Passport. This is defined as a document. This has terms drawn from elsewhere in the model which are defined as part of the FPP for reasons defined in the FPP descriptions.</skos:definition>
-		<skos:editorialNote xml:lang="en">Please see FPP Data Descriptions for more information (when available - not included in this model). See EFAMA website for this. Also see XLS for terms of this. These terms are often but net necessarily part of the Prospectus. See also the Thing Formerly Referred To As Investment. The definitions in the FPP descriptions may not be accurate. This is defining what kind of information is requested. Further Action: Now that we have defined sets of formal contractual terems for subvscriptions, redemptions and general terms, and since these terms don&apos;t have a direct relationship to any one Contract at present (as contractual terms should do), there may be a relationship between those terms and the FPP. To be handled in next review.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;GrossOfFeePerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;PerformanceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">gross of fee performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">Performance determined gross of fee. Review: Is this mutually exclusive with the other listed method? It sounds like it is not.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;IncomeAccumulation">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundUnitDistributionMethod"/>
 		<rdfs:label xml:lang="en">income accumulation</rdfs:label>
@@ -849,12 +812,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">Precise definition needed for liquidity, and check that it is modeled accordingly.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;MoneyWeightedRateOfReturnPerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;PerformanceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">money weighted rate of return performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">Money weighted rate of return.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;NetAssetValueCalculationMethod">
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
@@ -892,12 +849,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">other investment fund information</rdfs:label>
 		<skos:definition xml:lang="en">Things which are not part of the prospectus but are important if you want to understand the fund.</skos:definition>
 		<skos:editorialNote xml:lang="en">See terms in EFAMA spreadsheet. These are properties of the fund but are not legally binding. Author follow-up note: I have managed to find a &quot;home&quot; for disposition for most of the entries that are in the spreadsheet. It is not clear which of the spreadsheet terms are indended to come under the general heading in this class. The first place I would look is in the terms I have defined as &quot;Fund Processing Terms&quot;, which are defined as formal, legal contractual terms. If any of those are not legally binding on some party, then this is where they belong instead.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;PerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Strategy"/>
-		<rdfs:label xml:lang="en">performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">A method for performance determination (e.g. Time weighted and money weighted, annualized, gross of fee) along with the time frame in which this is determined. PLUS Performances NamePeriod</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;PortfolioBenchmark">
@@ -1029,12 +980,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">stake in fund</rdfs:label>
 		<skos:definition xml:lang="en">The holding of some portion in a fund, by some party. This stake will generally tak ethe form of some sort of unit in that fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;TimeWeightedRateOfReturnPerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;PerformanceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">time weighted rate of return performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">Time weighted rate of return.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;UnitIssuer">
@@ -1332,12 +1277,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundProcessingTerms"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasInformationAbout">
-		<rdfs:label xml:lang="en">has information about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundsProcessingPassport"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasIntendedRiskLevel">
 		<rdfs:label xml:lang="en">has intended risk level</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundInvestmentObjective"/>
@@ -1368,12 +1307,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">has management company</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
 		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundManager"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasPerformanceDeterminationMethod">
-		<rdfs:label xml:lang="en">has performance determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-pls;CollectiveInvestmentVehicle"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;PerformanceDeterminationMethod"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasPolicyTerms">
@@ -1635,12 +1568,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">The unit issuer would be the fund administrator (except when it is a Bond).</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;mayBeDefinedIn">
-		<rdfs:label xml:lang="en">may be defined in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundsProcessingPassport"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;FundProspectus"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;minimumDeviation">
 		<rdfs:label xml:lang="en">minimum deviation</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;PortfolioBenchmark"/>
@@ -1744,13 +1671,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;InvestmentRestriction"/>
 		<rdfs:range rdf:resource="&cmns-qtu;Percentage"/>
 		<skos:definition xml:lang="en">The percentage of funds that is to be invested at any given time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;performanceDeterminationTimeframe">
-		<rdfs:label xml:lang="en">performance determination timeframe</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;PerformanceDeterminationMethod"/>
-		<rdfs:range rdf:resource="&cmns-dt;DatePeriod"/>
-		<skos:definition xml:lang="en">The timeframe on which the performance is reported (e.g. 1month, 1 year, YTD).</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;performanceFee">
@@ -2104,12 +2024,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasManagementCompany"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasPerformanceDeterminationMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;PerformanceDeterminationMethod"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/SEC/Securities/SecurityAssets.rdf
+++ b/SEC/Securities/SecurityAssets.rdf
@@ -5,11 +5,10 @@
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-ast "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/">
@@ -25,11 +24,10 @@
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-ast="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"
@@ -53,18 +51,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Securities/SecurityAssets/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250801/Securities/SecurityAssets/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecurityAssets.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecurityAssets.rdf version of this ontology was revised to simplify the contract party hierarchy and eliminate complexity introduced by &apos;security holding&apos;.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201101/Securities/SecurityAssets.rdf version of this ontology was revised to fix spelling errors.</skos:changeNote>
@@ -72,6 +68,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Securities/SecurityAssets.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecurityAssets.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/SecurityAssets.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Securities/SecurityAssets.rdf version of the ontology was modified to normalize portfolio and portfolio holding (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -87,6 +84,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-ast;Portfolio">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
 		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -105,8 +103,15 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
+				<owl:onClass rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;PortfolioHolding"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -125,39 +130,17 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>portfolio</rdfs:label>
-		<skos:definition>a collection of investments (financial assets) such as stocks, bonds and cash equivalents, as well as mutual funds</skos:definition>
-		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/portfolio.asp</cmns-av:adaptedFrom>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-sec-ast;PortfolioHolding">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
-				<owl:allValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-oac-opty;Investor">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:allValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>portfolio holding</rdfs:label>
-		<skos:definition>the contents of holding of one or more portfolios of investments held by an individual investor or entity</skos:definition>
+		<skos:definition>collection of investments (financial assets) such as stocks, bonds and cash equivalents, as well as mutual funds, real estate, and so forth</skos:definition>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/h/holdings.asp</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/p/portfolio.asp</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Portfolio holdings may cover a variety of investment products, including stocks, bonds and mutual funds to options, futures and exchange-traded funds, and relatively esoteric instruments such as private equity and hedge funds. 
 
 The number and nature of holdings contribute to the degree of diversification of a portfolio. A mix of stocks across different sectors, bonds of different maturities, and other investments would suggest a well-diversified portfolio, while concentrated holdings in a handful of stocks within a single sector indicates a portfolio with limited diversification.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-sec-ast;PortfolioHolding">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-ast;hasAcquisitionPrice">


### PR DESCRIPTION
## Description

1. Cleaned up redundant definitions related to special purpose vehicles, corrected a typo in a label in the CDS ontology, revised the definition of hasTerminationDate to allow for scheduled terminations, added a property for intended liquidation date to legal persons and a restriction using that property on SPV.
2. Augmented the Goals and Objectives ontology with the concept of a method and clarified some of the property definitions in that ontology
3. Moved performance related terminology to FundsTemporal in MD
4. Eliminated redundancies between the concept of a portfolio and the concept of a portfolio holding and merged the terms based on their restrictions and usage across FIBO

Fixes: #2160 / SEC-200


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


