### PR TITLE
SEC-200a - Continue to clean up the CIV ontology in SEC/Funds in order to leverage it for use in describing various kinds of more complex instruments, such as CDOs

### DIFF
--- a/BE/OwnershipAndControl/CorporateOwnership.rdf
+++ b/BE/OwnershipAndControl/CorporateOwnership.rdf
@@ -8,6 +8,7 @@
 	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
+	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
@@ -28,6 +29,7 @@
 	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
+	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
@@ -57,6 +59,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -66,7 +69,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250701/OwnershipAndControl/CorporateOwnership/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250801/OwnershipAndControl/CorporateOwnership/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified per the FIBO 2.0 RFC to reference shareholders&apos; equity in the definition of a shareholder.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to generalize the definition of beneficial owner rather than limiting it to shareholding and eliminate a duplicate restriction on shareholder.</skos:changeNote>
@@ -78,6 +81,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20210401/OwnershipAndControl/CorporateOwnership.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/OwnershipAndControl/CorporateOwnership.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/CorporateOwnership.rdf version of the ontology was modified to align the concept of beneficial ownership with the broader ownership pattern (SEC-202).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20250701/OwnershipAndControl/CorporateOwnership.rdf version of the ontology was modified to clarify the differences between a shareholding, purchase lot, and tax lot (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -143,10 +147,25 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote>Beneficial ownership may be shared among a group of individuals. If a beneficial owner acquires a position of more than 5 percent in the United States, it must file Schedule 13D or 13G under Section 12 of the Securities Exchange Act of 1934.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-be-oac-cown;PurchaseLot">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-oac-cown;consistsOfNumberOfUnits"/>
+				<owl:onDataRange rdf:resource="&xsd;decimal"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>purchase lot</rdfs:label>
+		<skos:definition>financial asset that is a block of securities or other financial assets bought in one transaction on a given date at a specific price</skos:definition>
+		<skos:example>Buying 100 shares of Apple on Jan 10 at $150/share is one purchase lot; buying 50 more shares on Mar 15 at $160/share is another purchase lot.</skos:example>
+		<cmns-av:explanatoryNote>Purchase lot is typically used as a trading term by brokers and portfolio managers to describe how holdings are grouped.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-be-oac-cown;Shareholder">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;ConstitutionalOwner"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
-		<rdfs:label xml:lang="en">shareholder</rdfs:label>
+		<rdfs:label>shareholder</rdfs:label>
 		<skos:definition>party that owns shares in and has rights and responsibilities with respect to some asset, provided in exchange for investment</skos:definition>
 		<cmns-av:explanatoryNote>The shares represent an ownership interest in a corporation, mutual fund, or partnership, or a unit of ownership in a structured product, such as a real estate investment trust.</cmns-av:explanatoryNote>
 		<cmns-av:synonym xml:lang="en-US">stockholder</cmns-av:synonym>
@@ -156,14 +175,41 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-oac-cown;Shareholder"/>
+				<owl:onProperty rdf:resource="&fibo-be-oac-cown;consistsOfNumberOfUnits"/>
+				<owl:onDataRange rdf:resource="&xsd;decimal"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>shareholding</rdfs:label>
-		<skos:definition>financial asset that takes the form of shares considered as a unit</skos:definition>
-		<cmns-av:explanatoryNote>The legal power of a shareholder varies in proportion to their shareholding. Typically, ten percent and below stockholding provides no protection. Fifteen percent stockholding may give the power to petition courts against changing the shares class rights. Up to 49.9 percent stockholding normally gives power to demand calling of an extraordinary general meeting. Fifty percent and over stockholding gives power to fire a director and force out minority stockholders by acquiring their shares as per the rules of the firm. Holder of 75 percent of the stock has the power to change the articles and memorandum of association and the firms name, reduce the share capital, allow the firm to buy its own shares from other stockholders, and to shut down the business. One hundred percent stockholding of course gives total power under the corporate legislation.</cmns-av:explanatoryNote>
+		<skos:definition>ownership interest in the equity of a company, represented by shares that confer financial rights and governance privileges</skos:definition>
+		<cmns-av:explanatoryNote>Shareholding refers to the total ownership a party has in some organization, and determines voting power, dividend entitlement, and exposure to risk.</cmns-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-oac-cown;TaxLot">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-oac-cown;consistsOfNumberOfUnits"/>
+				<owl:onDataRange rdf:resource="&xsd;decimal"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>tax lot</rdfs:label>
+		<skos:definition>financial asset that is a block of securities or other financial assets with a distinct cost basis for tax reporting purposes</skos:definition>
+		<cmns-av:explanatoryNote>Tax lots reflect how shares or other assets are tracked for capital gains and may be adjusted by events including:
+- reinvested dividends (creates very small, new tax lots);
+- stock splits or mergers (adjusts basis, may create fractional lots);
+- Wash sale rules (can change which lots are recognized).
+When an investor sells, they select which tax lot to sell (specific ID, FIFO, etc.), which determines realized gain or loss.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:DatatypeProperty rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/fibo-be-oac-cown;consistsOfNumberOfUnits">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
+		<rdfs:label xml:lang="en">consists of number of units</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;decimal"/>
+		<skos:definition xml:lang="en">indicates the number of units of</skos:definition>
+		<cmns-av:explanatoryNote>This property indicates the number of units (e.g., shares, fund units) of the asset held in a shareholding or position, for example.</cmns-av:explanatoryNote>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cown;hasBeneficialOwner">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-own;isAssetOf"/>

--- a/BE/OwnershipAndControl/CorporateOwnership.rdf
+++ b/BE/OwnershipAndControl/CorporateOwnership.rdf
@@ -203,7 +203,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 When an investor sells, they select which tax lot to sell (specific ID, FIFO, etc.), which determines realized gain or loss.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:DatatypeProperty rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/fibo-be-oac-cown;consistsOfNumberOfUnits">
+	<owl:DatatypeProperty rdf:about="&fibo-be-oac-cown;consistsOfNumberOfUnits">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
 		<rdfs:label xml:lang="en">consists of number of units</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;decimal"/>

--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -91,7 +91,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250701/FinancialInstruments/FinancialInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250901/FinancialInstruments/FinancialInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified for the FIBO 2.0 RFC, including minor bug fixes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified as a part of organizational hierarchy simplification, to add maturity-related properties, and to add exempt security.</skos:changeNote>
@@ -119,7 +119,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20241201/FinancialInstruments/FinancialInstruments.rdf version of this ontology was modified to unify and simplify the notion of an underlier across FIBO (DER-112).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250201/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to add calculation agent, which may appear at a higher level than derivatives (DER-55).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250501/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to replace hasConstituent with hasMember for better semantic consistency (FND-396).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250501/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to replace hasConstituent with hasMember for better semantic consistency (FND-396) and to reclassify entitlement under financial instrument, since not all entitlements are securities.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -244,11 +244,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;Entitlement">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
 		<rdfs:label>entitlement</rdfs:label>
-		<skos:definition>financial instrument that provides the holder the privilege to subscribe to or to receive specific assets on terms specified</skos:definition>
+		<skos:definition>financial instrument that provides the holder an interest in, or the privilege to subscribe to, or to receive specific assets under terms specified</skos:definition>
 		<cmns-av:adaptedFrom>ISO 10962, Securities and related financial instruments - Classification of Financial Instruments (CFI code), Fourth edition, 2019-10.</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Note that certain fund units, including but not limited to units in pension funds and other non-public investment structures may be considered entitlements but not securities. They may or may not be identified using traditional financial instrument identifiers. Some entitlements, such as warrants, whose value changes based on the value of some underlier, are considered derivative instruments.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>right</cmns-av:synonym>
 	</owl:Class>
 	

--- a/FBC/FunctionalEntities/FinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/FinancialServicesEntities.rdf
@@ -123,7 +123,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250501/FunctionalEntities/FinancialServicesEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250801/FunctionalEntities/FinancialServicesEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified per the FIBO 2.0 RFC, including, but not limited to, the addition of trade settlement concepts and generalizing the concept of a credit union.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified to refine the concept of a credit union and generalize the definition of an underwriter.</skos:changeNote>
@@ -144,6 +144,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to correct a labelling issue.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250201/FunctionalEntities/FinancialServicesEntities.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/FinancialServicesEntities.rdf version of the ontology was modified to eliminate certain constructs that are redundant and will never be materialized to reduce the number of nodes required for various contract-related constructs (FND-391).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250501/FunctionalEntities/FinancialServicesEntities.rdf version of the ontology was modified to add an acronym to unit investment trust (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -894,6 +895,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 		<rdfs:label>unit investment trust</rdfs:label>
 		<skos:definition>investment company which (a) is organized under a trust indenture, contract of custodianship or agency, or similar instrument, (b) does not have a board of directors, and (c) issues only redeemable securities, each of which represents an undivided interest in a unit of specified securities; but does not include a voting trust</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin>Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
+		<cmns-av:abbreviation>UIT</cmns-av:abbreviation>
 		<cmns-av:synonym>unit investment company</cmns-av:synonym>
 	</owl:Class>
 	

--- a/FND/Law/LegalCapacity.rdf
+++ b/FND/Law/LegalCapacity.rdf
@@ -179,8 +179,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-law-lcap;hasFractionalInterest"/>
-				<owl:onClass rdf:resource="&xsd;decimal"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;decimal"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>contractual interest</rdfs:label>

--- a/FND/Law/LegalCapacity.rdf
+++ b/FND/Law/LegalCapacity.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
+	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -29,6 +30,7 @@
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
+	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -70,9 +72,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250601/Law/LegalCapacity/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250901/Law/LegalCapacity/"/>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Law/LegalCapacity.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
 	(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -96,6 +99,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Law/LegalCapacity.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Law/LegalCapacity.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Law/LegalCapacity.rdf version of the ontology was modified to add contractual obligations needed for certain agreements, including some master agreements, and to link a condition precedent to the clause of a contract on which it depends (DER-55).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250601/Law/LegalCapacity.rdf version of the ontology was modified to clarify the definition of right and add contractual interest, including a property to represent fractional interest (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -170,6 +174,21 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:editorialNote>This is the capacity which defines Contractually Capable Entity (sometimes labeled as &apos;Legal Entity&apos;) as distinct from &apos;Legal Person&apos;. In the latter case the liabilities incurred in the contract accrue also to the Legal Person. In the case of contractual capability, the entity has the authority to enter into contracts, whether or not the liabilities accrue to that same entity (which they do if it is also a Legal Person). For Legal Entities which are not Legal Persons, the liability unwinds to some legal person within the structure of the entity, for example a General Partner or a Trustee.</skos:editorialNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fnd-law-lcap;ContractualInterest">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualRight"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-law-lcap;hasFractionalInterest"/>
+				<owl:onClass rdf:resource="&xsd;decimal"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>contractual interest</rdfs:label>
+		<skos:definition>legally enforceable benefit or entitlement arising from a contract, agreement, or instrument, in which an entity holds specified rights or obligations related to the performance, use, or benefit of something, without necessarily holding ownership</skos:definition>
+		<cmns-av:explanatoryNote>Contractual interest may include rights to income, access, use, or participation, and is governed by the terms and conditions of the underlying contract. It may be transferable or limited, and can coexist with or be independent of ownership rights.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Contractual interests differ from ownership interests in terms of (1) the source of rights, which are specified in an agreement or contract in the case of contractual interests, and in terms of title or equity with respect to ownership, (2) control, which is typically limited at best in the case of contractual interest, and (3) transferability, which depends on the terms of the contract. Examples of contractual interest include fund units, leaseholds, annuities, and rights to certain services, whereas shares, real estate, and assets of a trust reflect ownership interest.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fnd-law-lcap;ContractualObligation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LegalObligation"/>
 		<rdfs:subClassOf>
@@ -210,7 +229,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>contractual right</rdfs:label>
-		<skos:definition>power, privilege, demand, or claim possessed by some party that is conferred by contract</skos:definition>
+		<skos:definition>legally enforceable benefit or entitlement granted to a party within a binding agreement</skos:definition>
+		<cmns-av:explanatoryNote>Contractual rights are established by the terms of a contract, which can be explicit (written) or implied by law, industry standards, or consistent practices.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-lcap;DelegatedLegalAuthority">
@@ -340,8 +360,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>legal right</rdfs:label>
-		<skos:definition>power, privilege, demand, or claim possessed by some party by virtue of law</skos:definition>
-		<cmns-av:explanatoryNote>Every legal right that an individual possesses relates to a corresponding legal duty imposed on another and is recognized and delimited by law for the purpose of securing it. A legal right, if challenged, may be supported in court as recognizable and enforceable in law, statutes, regulations, or other legislative actions.</cmns-av:explanatoryNote>
+		<skos:definition>personal right, privilege, or benefit that a government, contract, or law provides or protects, making an individual or entity eligible to receive something</skos:definition>
+		<cmns-av:explanatoryNote>A legal right, if challenged, may be supported in court as recognizable and enforceable in law, statutes, regulations, or other legislative actions.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This entitlement creates a corresponding obligation for the provider to deliver that benefit.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-lcap;LiabilityCapacity">
@@ -518,7 +539,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LegalConstruct"/>
 		<rdfs:label>right</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://plato.stanford.edu/entries/rights/"/>
-		<skos:definition>entitlement (not) to perform certain actions, or (not) to be in certain states; or entitlement that others (not) perform certain actions or (not) be in certain states</skos:definition>
+		<skos:definition>entitlement to perform certain actions (or not), or to be in certain states (or not); or entitlement that requires others to perform certain actions or be in certain states (or not)</skos:definition>
 		<skos:example>Examples include contractual rights, legal rights, human rights, political rights, and so forth.</skos:example>
 		<cmns-av:explanatoryNote>Rights dominate modern understandings of what actions are permissible and which institutions are just. Rights structure the form of governments, the content of laws, and the shape of morality as many now see it. To accept a set of rights is to approve a distribution of freedom and authority, and so to endorse a certain view of what may, must, and must not be done. According to the Hohfeldian incidents (Wesley Hohfeld (1879-1918)), rights are complex and consist of four major components: privilege, claim, power, and immunity.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -536,6 +557,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:inverseOf rdf:resource="&fibo-fnd-law-lcap;isCapacityOf"/>
 		<skos:definition>identifies an individual or organization that has some ability and availability to carry out certain actions, or has certain rights or obligations</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-law-lcap;hasFractionalInterest">
+		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasNumericValue"/>
+		<rdfs:label>has fractional interest</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;decimal"/>
+		<skos:definition>has proportionate, non-exclusive entitlement to</skos:definition>
+		<cmns-av:explanatoryNote>Fractional interest may be expressed as a percentage, ratio, or unit count, and typically arises in contexts where multiple parties share contractual claims to income, usage, ownership, or participation. It does not imply full control or sole ownership, and may be subject to limitations specified in the underlying legal framework.</cmns-av:explanatoryNote>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-law-lcap;implements">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;involves"/>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -122,7 +122,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250801/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250901/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
@@ -143,7 +143,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20231201/Equities/EquityInstruments.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to clean up details related to regular schedules (FBC-317).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240301/Equities/EquityInstruments.rdf version of the ontology was modified to add a link to the formula used to calculate an adjustable rate dividend and loosen some constraints to make the ontology more useful in cases where one could have information about a preferred share, such as having an adjustable rate dividend, but not necessarily having the details (SEC-138).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240401/Equities/EquityInstruments.rdf version of the ontology was modified to add a property for the number of available shares, required for MiFID reporting (SEC-97).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240701/Equities/EquityInstruments.rdf version of the ontology was modified to reconcile shareholding with equity position (BE-254), (SEC-200).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240701/Equities/EquityInstruments.rdf version of the ontology was modified to reconcile shareholding with equity position (BE-254), and make other small changes such as renaming has floating shares to has floating stock (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -902,7 +902,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasFloatingShares"/>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasFloatingStock"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
 			</owl:Restriction>
@@ -1190,8 +1190,13 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasFloatingShares">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&fibo-sec-eq-eq;hasFloatingStock"/>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasFloatingStock">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
-		<rdfs:label xml:lang="en">has floating shares</rdfs:label>
+		<rdfs:label xml:lang="en">has floating stock</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
 		<skos:definition xml:lang="en">indicates the number of shares that are available for trading, i.e., the number of shares outstanding less closely held shares (those held by insiders) and restricted shares</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">A relatively small float results in higher volatility, as a large purchase or sell order will have significant influence on the value of the stock.</cmns-av:explanatoryNote>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -122,7 +122,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250801/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
@@ -143,7 +143,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20231201/Equities/EquityInstruments.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380) and to clean up details related to regular schedules (FBC-317).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240301/Equities/EquityInstruments.rdf version of the ontology was modified to add a link to the formula used to calculate an adjustable rate dividend and loosen some constraints to make the ontology more useful in cases where one could have information about a preferred share, such as having an adjustable rate dividend, but not necessarily having the details (SEC-138).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240401/Equities/EquityInstruments.rdf version of the ontology was modified to add a property for the number of available shares, required for MiFID reporting (SEC-97).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240701/Equities/EquityInstruments.rdf version of the ontology was modified to reconcile shareholding with equity position (BE-254).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240701/Equities/EquityInstruments.rdf version of the ontology was modified to reconcile shareholding with equity position (BE-254), (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -152,14 +152,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	<owl:Class rdf:about="&fibo-be-oac-cown;Shareholding">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;indicatesNumberOfShares"/>
-				<owl:onDataRange rdf:resource="&xsd;decimal"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1278,10 +1271,8 @@ See https://opensource.org/licenses/MIT.</dct:license>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;indicatesNumberOfShares">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasAmount"/>
-		<rdfs:label xml:lang="en">indicates number of shares</rdfs:label>
-		<rdfs:range rdf:resource="&xsd;decimal"/>
-		<skos:definition xml:lang="en">indicates the number of shares associated with the shareholding or position</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&fibo-be-oac-cown;consistsOfNumberOfUnits"/>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;isRedeemableAtIssuerOption">

--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -504,12 +504,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;hasLiquidity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;Liquidity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-fund-civ;implementsFundPolicy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;FundPortfolioInvestmentPolicy"/>
 			</owl:Restriction>
@@ -803,18 +797,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote>Key investor information shall include appropriate information about the essential characteristics of the UCITS concerned, which is to be provided to investors so that they are reasonably able to understand the nature and the risks of the investment product that is being offered to them and, consequently, to take investment decisions on an informed basis.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-fund-civ;Liquidity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">liquidity</rdfs:label>
-		<skos:definition xml:lang="en">Precise definition needed for liquidity, and check that it is modeled accordingly.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;NetAssetValueCalculationMethod">
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
@@ -828,11 +810,37 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:editorialNote xml:lang="en">These terms were in the ISO FIBIM model but correspond to some details in the EFAMA DD.</skos:editorialNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-fund-civ;NoteFund">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-pls;ManagedInvestment"/>
+		<rdfs:label>note fund</rdfs:label>
+		<skos:definition>pooled investment vehicle that issues debt instruments (notes) to investors rather than (or in addition to) traditional equity interests</skos:definition>
+		<cmns-av:explanatoryNote>The notes issued by a note fund are typically privately rated by agencies like KBRA, DBRS, or Moody&apos;s, tranched into senior and junior classes, and linked to underlying assets such as private loans, credit instruments, or structured products. Note funds are designed to optimize regulatory capital treatment, especially for insurance companies, by offering rated debt instead of equity.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-fund-civ;NoteFundShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;NoteFund"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>note fund share</rdfs:label>
+		<skos:definition>investment interest in a fund that issues notes rather than traditional equity, in cases where the fund is structured as a company</skos:definition>
+		<cmns-av:explanatoryNote>A note fund share refers to an equity or debt-linked interest in a corporate fund vehicle that issues notes.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;NoteFundUnit">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
-		<rdfs:label xml:lang="en">note fund unit</rdfs:label>
-		<skos:definition xml:lang="en">Need a legal definition - to follow. This is one of the mechanisms by which an investor may hold an interest in a fund, but is not a Bond or a Share.</skos:definition>
-		<skos:editorialNote xml:lang="en">It is not possible to determine at this time whether some of the policy facts that apply to bund and share class units apply to all fund units including this one. Once this is defined, all Fund Distribution Policy terms and relationships should be rechecked.</skos:editorialNote>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-fund-civ;NoteFund"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>note fund unit</rdfs:label>
+		<skos:definition>investment interest in a fund that issues notes rather than traditional equity, in cases where the fund is structured as a trust, partnership, or unitized fund</skos:definition>
+		<cmns-av:explanatoryNote>A note fund unit refers to a non-equity interest in a fund that issues rated notes and is organized as a unit trust or limited partnership.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;OrganizationStrategy">
@@ -1290,12 +1298,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:domain rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
 		<rdfs:range rdf:resource="&cmns-dt;Date"/>
 		<skos:definition xml:lang="en">Date of first NAV calculation and start of performance calculations (same as launch date)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasLiquidity">
-		<rdfs:label xml:lang="en">has liquidity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-fund-civ;FundPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-sec-fund-civ;Liquidity"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-civ;hasManagementCompany">

--- a/SEC/Funds/Funds.rdf
+++ b/SEC/Funds/Funds.rdf
@@ -155,12 +155,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-pls;PooledFund"/>
 			</owl:Restriction>

--- a/SEC/Funds/Funds.rdf
+++ b/SEC/Funds/Funds.rdf
@@ -146,13 +146,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;FundUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualRight"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-le-lei;hasOwnershipPercentage"/>
-				<owl:someValuesFrom rdf:resource="&xsd;decimal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualInterest"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>

--- a/SEC/Funds/Funds.rdf
+++ b/SEC/Funds/Funds.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
+	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/">
 	<!ENTITY fibo-be-tr-tr "https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -32,6 +33,7 @@
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
+	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/"
 	xmlns:fibo-be-tr-tr="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/Trusts/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -52,6 +54,8 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/Funds/">
 		<rdfs:label xml:lang="en">Funds Ontology</rdfs:label>
 		<dct:abstract>This ontology defines fundamental concepts about funds and collective investment vehicles (CIVs).</dct:abstract>
+		<dct:contributor>Federated Knowledge, LLC</dct:contributor>
+		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
 		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
 		<dct:license>Copyright (c) 2018-2025 EDM Council, Inc.
@@ -80,7 +84,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Funds/Funds/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20250901/Funds/Funds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Funds/Funds.rdf version of this ontology was modified to replace the original fibo-sec-fnd-fnd prefix with fibo-sec-fund-fund for the sake of clarity and to change the restriction on LegalFundStructure from an equivalence to a subclass relationship to address a reasoning error as well as adding a missing restriction on jurisdiction.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210501/Funds/Funds.rdf version of this ontology was modified to move the definition of SpecialPurposeVehicle to the Pools ontology to make it available for use more generally.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220101/Funds/Funds.rdf version of this ontology was modified to eliminate a deprecated element for SpecialPurposeVehicle, which was moved to Pools last quarter.</skos:changeNote>
@@ -88,6 +92,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Funds/Funds.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Funds/Funds.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Funds/Funds.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389), and to add the notion of a private credit fund and adjust inconsistencies in private equity fund (SEC-203).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Funds/Funds.rdf version of this ontology was modified to refine the definition of fund unit (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2018-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -141,7 +146,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;FundUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-le-lei;hasOwnershipPercentage"/>
+				<owl:someValuesFrom rdf:resource="&xsd;decimal"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
@@ -154,8 +165,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-pls;PooledFund"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund unit</rdfs:label>
-		<skos:definition xml:lang="en">security representing a unit in a fund</skos:definition>
+		<rdfs:label>fund unit</rdfs:label>
+		<skos:definition>quantified share of beneficial interest in a pooled fund, representing a proportional claim on the fund&apos;s assets, income, or entitlements</skos:definition>
+		<cmns-av:explanatoryNote>A fund unit may be tradable or non-tradable depending on the legal form, regulatory status, and operational framework of the fund.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Fund units are allocated to a participant, investor, or beneficiary according to the fund&apos;s governing structure.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;HedgeFund">
@@ -193,6 +206,15 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition xml:lang="en">open-end professionally managed investment fund established for the purpose of investing in securities such as stocks, bonds, money market instruments and similar assets</skos:definition>
 		<cmns-av:adaptedFrom xml:lang="en">ISO 10962:2019 Securities and related financial instruments - Classification of financial instruments (CFI) code, Fourth edition, October 2019</cmns-av:adaptedFrom>
 		<cmns-av:synonym xml:lang="en">standard (vanilla) investment fund</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-fund-fund;NonTradableFundUnit">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;NonNegotiableSecurity"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
+		<rdfs:label xml:lang="en">non-tradable fund unit</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-sec-fund-fund;TradableFundUnit"/>
+		<skos:definition xml:lang="en">security representing an interest in a fund that cannot be traded ontside of the fund itself</skos:definition>
+		<cmns-av:explanatoryNote>Non-tradable fund units are commonly found in pension funds, insurance pools, or internal benefit plans, where units serve as accounting or entitlement mechanisms without market transferability.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;OpenEndInvestment">
@@ -260,6 +282,15 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote xml:lang="en">Sovereign wealth funds include the International Monetary Fund, whose corresponding legal entity is a polity.</cmns-av:explanatoryNote>
 		<cmns-av:synonym xml:lang="en">social wealth fund</cmns-av:synonym>
 		<cmns-av:synonym xml:lang="en">sovereign investment fund</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-fund-fund;TradableFundUnit">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;EquityInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;NegotiableSecurity"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-fund;FundUnit"/>
+		<rdfs:label xml:lang="en">tradable fund unit</rdfs:label>
+		<skos:definition xml:lang="en">security representing a tradable interest in a fund</skos:definition>
+		<cmns-av:explanatoryNote>Tradable fund units typically occur in collective investment schemes such as mutual funds or exchange-traded funds (ETFs), where units are bought and sold on regulated markets.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-fund-fund;hasLegalStructure">

--- a/SEC/Funds/Funds.rdf
+++ b/SEC/Funds/Funds.rdf
@@ -92,7 +92,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Funds/Funds.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Funds/Funds.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Funds/Funds.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389), and to add the notion of a private credit fund and adjust inconsistencies in private equity fund (SEC-203).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Funds/Funds.rdf version of this ontology was modified to refine the definition of fund unit (SEC-200).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Funds/Funds.rdf version of this ontology was modified to broaden the definition of fund unit (SEC-200).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2018-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -146,7 +146,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-fund;FundUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Entitlement"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualRight"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-le-lei;hasOwnershipPercentage"/>

--- a/SEC/Securities/SecurityAssets.rdf
+++ b/SEC/Securities/SecurityAssets.rdf
@@ -103,7 +103,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;isPartOf"/>
+				<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
 				<owl:onClass rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>


### PR DESCRIPTION
## Description

1. Added the concept of a purchase lot and tax lot, clarified the difference between these terms and shareholding
2. Clarified the definitions related to entitlements, given that not all entitlements are securities
3. Clarified definitions related to rights, added contractual interest, added a property 'has fractional interest', and broadened the definition of fund unit to cover cases currently under consideration

Fixes: #2162 / SEC-200


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


