### PR TITLE
SEC: expand private_credit_fund definition to include nonprofit funds, Issue #2164 (WIP)

### DIFF
--- a/SEC/Funds/CollectiveInvestmentVehicles.rdf
+++ b/SEC/Funds/CollectiveInvestmentVehicles.rdf
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY IdentifiersAndIndices "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
-	<!ENTITY SpecificationMetadata "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
@@ -58,8 +56,6 @@
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/"
-	xmlns:IdentifiersAndIndices="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
-	xmlns:SpecificationMetadata="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
@@ -182,9 +178,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-acc-cur;hasCurrency">
-	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-fund-civ;AccumulatingShareClass">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-fund-civ;FundShareClassUnit"/>


### PR DESCRIPTION
## Description

This is one small change to start working out the process for hopefully contributing nonprofit and community investment fund info, per Issue #2164 

As I will update in the issue, the `dev_toolkit` serializer is clobbering almost all of the changes that I make locally, but not this one-- so I'm just PR'ing this as a way to say Hi and hopefully get set up better to contribute, which I am enthusiastic about doing if I can.  Thanks for any help or pointers!

Very partially resolves Issue #2164 

## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
  - _See Issue #2164; I got serializer pre-hook for git commit to work, but not Local testing tools_
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [ ] Hygiene tests have been applied by a PR with "(WIP)" in title.
  - _could not get Local testing tools to work_
- [x] The issue has been tested locally using a reasoner (for ontology changes).


