### PR TITLE
FBC-338 - Not all FIBO ontologies were updated to use the new Commons definition of hasJurisdiction, which should be corrected

### DIFF
--- a/BE/GovernmentEntities/GovernmentEntities.rdf
+++ b/BE/GovernmentEntities/GovernmentEntities.rdf
@@ -72,7 +72,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20250701/GovernmentEntities/GovernmentEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20251001/GovernmentEntities/GovernmentEntities/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was added to Business Entities, per the issue resolutions identified in the FIBO BE 1.1 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.2 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20170201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
@@ -87,7 +87,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to augment the definition of instrumentality with additional notes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230901/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 and loosened restrictions causing reasoning and representational challenges (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/GovernmentEntities/GovernmentEntities.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20250301/GovernmentEntities/GovernmentEntities.rdf version of the ontology was modified to replace hasConstituent with hasMember for better semantic consistency (FND-396).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20250301/GovernmentEntities/GovernmentEntities.rdf version of the ontology was modified to replace hasConstituent with hasMember for better semantic consistency (FND-396) and to further reflect changes made in Commons v1.2 (FBC-338).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -520,10 +520,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-ge-ge;hasJurisdiction">
-		<rdfs:subPropertyOf rdf:resource="&cmns-rga;governs"/>
-		<rdfs:label>has jurisdiction</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-rga;Jurisdiction"/>
-		<skos:definition>relates a polity or government entity to one or more jurisdictions, over which it has some level of legal authority</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-rga;hasJurisdiction"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-ge-ge;hasSharedSovereigntyOver">
@@ -554,10 +552,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-ge-ge;isJurisdictionOf">
-		<rdfs:label>is jurisdiction of</rdfs:label>
-		<rdfs:domain rdf:resource="&cmns-rga;Jurisdiction"/>
-		<owl:inverseOf rdf:resource="&fibo-be-ge-ge;hasJurisdiction"/>
-		<skos:definition>relates a jurisdiction to a polity or other government entity or court that has some level of legal authority over it</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-rga;isJurisdictionOf"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-ge-ge;isRepresentedBy">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -113,7 +113,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20251001/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgenciess.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgenciess.rdf version of this ontology was revised to update the GLEIF LEI registration information for the Bank of Canada, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
@@ -126,6 +126,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of the ontology was modified to further reflect changes made in Commons v1.2 (FBC-338).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -145,7 +146,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="fr">Banque du Canada</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>central bank of Canada</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-cajrga;BankOfCanadaHeadOfficeAddress"/>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="en">Bank of Canada</fibo-fnd-rel-rel:hasLegalName>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="fr">Banque du Canada</fibo-fnd-rel-rel:hasLegalName>
@@ -155,6 +155,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
  The Bank provides liquidity to the financial system, gives policy advice to the federal government on the design and development of the system, oversees major clearing and settlement systems, and provides banking services to these systems and their participants.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.bankofcanada.ca/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;BankOfCanadaHeadOfficeAddress">
@@ -237,7 +238,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">Canada Revenue Agency</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:definition>taxation authority of the Government of Canada</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 		<fibo-be-le-fbo:hasHeadquartersAddress rdf:resource="&fibo-fbc-fct-cajrga;CanadaRevenueAgencyHeadOfficeAddress"/>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="fr">Agence du revenu du Canada</fibo-fnd-rel-rel:hasLegalName>
 		<fibo-fnd-rel-rel:hasLegalName xml:lang="en">Canada Revenue Agency</fibo-fnd-rel-rel:hasLegalName>
@@ -245,6 +245,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote>This agency administers tax laws for the Canadian government and for several of the provinces and territories of Canada.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-caj;GovernmentOfCanada"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.canada.ca/en/revenue-agency.html</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-caj;CanadianJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-cajrga;CanadaRevenueAgencyHeadOfficeAddress">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -123,7 +123,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20251001/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20230301/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old, primarily related to name changes to better map to the legislation that defines the concepts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
@@ -139,6 +139,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), to eliminate redundancies in FIBO, and to augment the number and nature of financial institution entity types to cover more of the National Information Center (NIC) repository managed by the FFIEC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231101/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of the ontology was modified to further reflect changes made in Commons v1.2 (FBC-338).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -410,10 +411,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>California Department of Business Oversight</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>State of California&apos;s Department of Business Oversight</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
 		<cmns-av:explanatoryNote>The Department of Business Oversight (DBO) protects consumers and oversees financial service providers and products. The DBO supervises the operations of state-licensed financial institutions, including banks, credit unions and money transmitters. Additionally, the DBO licenses and regulates a variety of financial service providers, including securities brokers and dealers, investment advisers, payday lenders and other consumer finance lenders.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaGovernment"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://dbo.ca.gov/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CaliforniaRegistrationAuthorityCode">
@@ -442,10 +443,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Commodity Futures Trading Commission</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Commodity Futures Trading Commission (CFTC), an independent Federal agency whose mission is to foster open, transparent, competitive, and financially sound markets, to avoid systemic risk, and to protect the market users and their funds, consumers, and the public from fraud, manipulation, and abusive practices related to derivatives and other products that are subject to the Commodity Exchange Act</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>CFTC</cmns-av:abbreviation>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.cftc.gov/index.htm</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;ConsumerFinanceRegulator">
@@ -463,10 +464,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Consumer Financial Protection Bureau</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Consumer Financial Protection Bureau (CFPB), an independent Federal agency that helps consumer finance markets work by making rules more effective, by consistently and fairly enforcing those rules, and by empowering consumers to take more control over their economic lives</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>CFPB</cmns-av:abbreviation>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.consumerfinance.gov/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;CorporationServiceCompany">
@@ -732,11 +733,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Farm Credit Administration</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Farm Credit Administration (FCA), an independent Federal agency that regulates and examines the banks, associations, and related entities of the Farm Credit System (FCS), including the Federal Agricultural Mortgage Corporation (Farmer Mac)</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>FCA</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The FCS is the largest agricultural lender in the United States. It is a nationwide network of lending institutions that are owned by their borrowers. It serves all 50 States and Puerto Rico.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://fca.gov/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FarmCreditRegulator">
@@ -781,7 +782,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Financial Institutions Examination Council</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>FFIEC, a formal interagency body empowered to prescribe uniform principles, standards, and report forms for the federal examination of financial institutions by the Board of Governors of the Federal Reserve System (FRB), the Federal Deposit Insurance Corporation (FDIC), the National Credit Union Administration (NCUA), the Office of the Comptroller of the Currency (OCC), and the Consumer Financial Protection Bureau (CFPB), and to make recommendations to promote uniformity in the supervision of financial institutions</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>FFIEC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The Federal Financial Institutions Examination Council (FFIEC) was established on March 10, 1979, pursuant to title X of the Financial Institutions Regulatory and Interest Rate Control Act of 1978 (FIRA), Public Law 95-630. In 1989, title XI of the Financial Institutions Reform, Recovery and Enforcement Act of 1989 (FIRREA) established The Appraisal Subcommittee (ASC) within the Examination Council.</cmns-av:explanatoryNote>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;ConsumerFinancialProtectionBureau"/>
@@ -791,6 +791,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalFinancialInstitutionsExaminationRegulator">
@@ -822,7 +823,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-ge-ge;hasJurisdiction"/>
+				<owl:onProperty rdf:resource="&cmns-rga;hasJurisdiction"/>
 				<owl:hasValue rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -836,11 +837,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Housing Finance Agency</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Housing Finance Agency (FHFA), responsible for strengthening and securing the United States secondary mortgage markets by providing effective supervision, sound research, reliable data, and relevant policies</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>FHFA</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The FHFA is an independent regulatory agency responsible for the oversight of vital components of the secondary mortgage markets - the housing government sponsored enterprises of Fannie Mae, Freddie Mac and the Federal Home Loan Bank System. Combined these entities provide more than $5.5 trillion in funding for the U.S. mortgage markets and financial institutions. Additionally, FHFA is the conservator of Fannie Mae and Freddie Mac.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.fhfa.gov/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalHousingFinanceRegulator">
@@ -858,8 +859,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of Atlanta</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Atlanta, whose jurisdiction is the Sixth District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSixthDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.frbatlanta.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSixthDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfBoston">
@@ -867,8 +868,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of Boston</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Boston, whose jurisdiction is the First District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFirstDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.bostonfed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFirstDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfChicago">
@@ -876,8 +877,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of Chicago</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Chicago, whose jurisdiction is the Seventh District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSeventhDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.chicagofed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSeventhDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfCleveland">
@@ -885,8 +886,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of Cleveland</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Cleveland, whose jurisdiction is the Fourth District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFourthDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.clevelandfed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFourthDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfDallas">
@@ -894,8 +895,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of Dallas</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Dallas, whose jurisdiction is the Eleventh District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEleventhDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.dallasfed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEleventhDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfKansasCity">
@@ -903,8 +904,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of Kansas City</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Kansas City, whose jurisdiction is the Tenth District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTenthDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.kansascityfed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTenthDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfMinneapolis">
@@ -912,8 +913,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of Minneapolis</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Minneapolis, whose jurisdiction is the Ninth District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveNinthDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.minneapolisfed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveNinthDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfNewYork">
@@ -921,8 +922,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of New York</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of New York, whose jurisdiction is the Second District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSecondDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.newyorkfed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSecondDistrict"/>
 		<cmns-rlcmp:isPlayedBy rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveBankOfNewYork-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -953,8 +954,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of Philadelphia</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Philadelphia, whose jurisdiction is the Third District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveThirdDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.philadelphiafed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveThirdDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfRichmond">
@@ -962,8 +963,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of Richmond</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of Richmond, whose jurisdiction is the Fifth District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFifthDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.richmondfed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFifthDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfSanFrancisco">
@@ -971,8 +972,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of San Francisco</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of San Francisco, whose jurisdiction is the Twelfth District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTwelfthDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.frbsf.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTwelfthDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBankOfStLouis">
@@ -980,8 +981,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Federal Reserve Bank of St. Louis</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Federal Reserve Bank of St. Louis, whose jurisdiction is the Eighth District of the Federal Reserve</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEighthDistrict"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.stlouisfed.org/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEighthDistrict"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveBoard">
@@ -1023,7 +1024,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-ge-ge;hasJurisdiction"/>
+				<owl:onProperty rdf:resource="&cmns-rga;hasJurisdiction"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveDistrict"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -1272,13 +1273,13 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve System</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>central banking system of the U.S., comprised of the Federal Reserve Board, the 12 Federal Reserve Banks, the Federal Open Market Committee, and the national and state member banks</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>FRS</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The Federal Reserve, the central bank of the United States, provides the nation with a safe, flexible, and stable monetary and financial system.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>Fed</cmns-av:synonym>
 		<cmns-av:synonym>Federal Reserve</cmns-av:synonym>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.federalreserve.gov/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;FederalReserveSystemAsMemberBearingOrganization">
@@ -1463,7 +1464,6 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Financial Stability Oversight Council</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Financial Stability Oversight Council (FSOC), which provides comprehensive monitoring of the stability of our nation&apos;s financial system, as established under the Dodd-Frank Wall Street Reform and Consumer Protection Act</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>FSOC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The Council is charged with identifying risks to the financial stability of the United States; promoting market discipline; and responding to emerging risks to the stability of the United States&apos; financial system. The Council consists of 10 voting members and 5 nonvoting members and brings together the expertise of federal financial regulators, state regulators, and an independent insurance expert appointed by the President.</cmns-av:explanatoryNote>
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;CommodityFuturesTradingCommission"/>
@@ -1476,6 +1476,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<cmns-col:hasMember rdf:resource="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeCommission"/>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">https://www.treasury.gov/initiatives/fsoc/Pages/home.aspx</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-usjrga;IssuerIdentificationNumber">
@@ -1618,11 +1619,11 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>National Credit Union Administration</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>National Credit Union Administration (NCUA), the independent federal agency that regulates, charters and supervises federal credit unions</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>NCUA</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>An independent agency of the federal government, the NCUA operates and manages the National Credit Union Share Insurance Fund (NCUSIF), insuring the deposits of more than 98 million account holders in all federal credit unions and the overwhelming majority of state-chartered credit unions.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.ncua.gov/Pages/default.aspx</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;NationalCreditUnionInsurerAndRegulator">
@@ -1728,11 +1729,11 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Office of the Comptroller of the Currency</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>OCC, which charters, regulates, and supervises all national banks and federal savings associations as well as federal branches and agencies of foreign banks. The OCC is an independent bureau of the U.S. Department of the Treasury.</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>OCC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The mission of the OCC is to ensure that national banks and federal savings associations operate in a safe and sound manner, provide fair access to financial services, treat customers fairly, and comply with applicable laws and regulations.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;USDepartmentOfTheTreasury"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OfficeOfThriftSupervision">
@@ -1741,10 +1742,10 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Office of Thrift Supervision</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>OTS, which is a part of the OCC, responsible for chartering, regulating, and supervising all federal savings associations</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>OTS</cmns-av:abbreviation>
 		<cmns-col:isPartOf rdf:resource="&fibo-fbc-fct-usjrga;OfficeOfTheComptrollerOfTheCurrency"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.occ.gov/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal">
@@ -1908,7 +1909,6 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:label>Securities and Exchange Commission</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>independent commission established by the Securities Act of 1933 and Securities Exchange Act of 1934 whose mission is to protect investors, maintain fair, orderly, and efficient markets, and facilitate capital formation</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>SEC</cmns-av:abbreviation>
 		<cmns-av:explanatoryNote>The SEC oversees the key participants in the securities world, including securities exchanges, securities brokers and dealers, investment advisors, and mutual funds. Here the SEC is concerned primarily with promoting the disclosure of important market-related information, maintaining fair dealing, and protecting against fraud.
  Crucial to the SEC&apos;s effectiveness in each of these areas is its enforcement authority. Each year the SEC brings hundreds of civil enforcement actions against individuals and companies for violation of the securities laws. Typical infractions include insider trading, accounting fraud, and providing false or misleading information about securities and the companies that issue them.
@@ -1916,6 +1916,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
  Though it is the primary overseer and regulator of the U.S. securities markets, the SEC works closely with many other institutions, including Congress, other federal departments and agencies, the self-regulatory organizations (e.g. the stock exchanges), state securities regulators, and various private sector organizations. In particular, the Chairman of the SEC, together with the Chairman of the Federal Reserve, the Secretary of the Treasury, and the Chairman of the Commodity Futures Trading Commission, serves as a member of the President&apos;s Working Group on Financial Markets.</cmns-av:explanatoryNote>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.sec.gov/</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;SecuritiesAndExchangeRegulator">
@@ -2006,7 +2007,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-ge-ge;hasJurisdiction"/>
+				<owl:onProperty rdf:resource="&cmns-rga;hasJurisdiction"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-rga;hasReach"/>
@@ -2095,11 +2096,11 @@ A TIN must be on a withholding certificate if the beneficial owner is claiming a
 		<rdfs:label>U.S. Department of the Treasury</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>U.S. Department of the Treasury, the executive agency responsible for promoting economic prosperity and ensuring the financial security of the United States</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:explanatoryNote>The Department is responsible for a wide range of activities such as advising the President on economic and financial issues, encouraging sustainable economic growth, and fostering improved governance in financial institutions. The Department of the Treasury operates and maintains systems that are critical to the nation&apos;s financial infrastructure, such as the production of coin and currency, the disbursement of payments to the American public, revenue collection, and the borrowing of funds necessary to run the federal government. The Department works with other federal agencies, foreign governments, and international financial institutions to encourage global economic growth, raise standards of living, and to the extent possible, predict and prevent economic and financial crises. The Treasury Department also performs a critical and far-reaching role in enhancing national security by implementing economic sanctions against foreign threats to the U.S., identifying and targeting the financial support networks of national security threats, and improving the safeguards of our financial systems.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>Treasury Department</cmns-av:synonym>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<cmns-org:hasWebsite rdf:datatype="&xsd;anyURI">http://www.treasury.gov/Pages/default.aspx</cmns-org:hasWebsite>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usjrga;UniformBankPerformanceReportRepository">

--- a/FBC/FunctionalEntities/RegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/RegulatoryAgencies.rdf
@@ -81,7 +81,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/RegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20251001/FunctionalEntities/RegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified per the FIBO 2.0 RFC, including deprecation of the hasJurisdiction property that was duplicated in BE via the BE 1.1 RTF.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified as a part of organizational hierarchy simplification.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to eliminate deprecated elements and duplication of concepts with LCC, and remove a redundant superclass declaration on GovernmentIssuedLicense.</skos:changeNote>
@@ -92,7 +92,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/RegulatoryAgencies.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/RegulatoryAgencies.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301FunctionalEntities/RegulatoryAgencies.rdf version of the ontology was modified to correct a reasoning issue uncovered during testing (DER-90).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/RegulatoryAgencies.rdf version of the ontology was modified to correct a reasoning issue uncovered during testing (DER-90) and to further reflect changes made in Commons v1.2 (FBC-338).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -208,14 +208,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-ge-ge;hasJurisdiction"/>
-				<owl:someValuesFrom rdf:resource="&cmns-rga;Jurisdiction"/>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;TaxIdentificationScheme"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-org;manages"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;TaxIdentificationScheme"/>
+				<owl:onProperty rdf:resource="&cmns-rga;hasJurisdiction"/>
+				<owl:someValuesFrom rdf:resource="&cmns-rga;Jurisdiction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>tax authority</rdfs:label>

--- a/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf
+++ b/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
+	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
@@ -32,6 +33,7 @@
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
+	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
@@ -73,12 +75,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20250301/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20251001/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was added to the IND specification per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was revised per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20180801/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was revised to reflect the new hasCoverageArea property and migration of statistical measures in FND.</skos:changeNote>
@@ -90,6 +93,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20230301/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20231201/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of this ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20240101/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20250301/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf version of the ontology was modified to further reflect changes made in Commons v1.2 (FBC-338).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
@@ -215,11 +219,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>United States Department of Labor</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.dol.gov/"/>
 		<skos:definition>individual representing the U.S. Department of Labor, a government department whose mission is to foster, promote, and develop the welfare of the wage earners, job seekers, and retirees of the United States; improve working conditions; advance opportunities for profitable employment; and assure work-related benefits and rights</skos:definition>
-		<fibo-be-ge-ge:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 		<cmns-av:abbreviation>DOL</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.dol.gov/general/aboutdol</cmns-av:adaptedFrom>
 		<cmns-col:isPartOf rdf:resource="&fibo-be-ge-usj;UnitedStatesGovernment"/>
 		<cmns-loc:hasCoverageArea rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-rga:hasJurisdiction rdf:resource="&fibo-be-ge-usj;UnitedStatesJurisdiction"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-usei;UrbanConsumerPriceIndex">


### PR DESCRIPTION
## Description

Several ontologies, primarily in FBC, were updated to use the Commons version of hasJurisdiction, and deprecate the older property in FIBO

Fixes: #2171 / FBC-338


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


