### PR TITLE
FND-404 - Add an explicit annotation property for naming FIBO modules

### DIFF
--- a/ACTUS/MetadataACTUS.rdf
+++ b/ACTUS/MetadataACTUS.rdf
@@ -26,8 +26,8 @@
 		<dct:abstract>This ontology provides metadata about the FIBO Algorithmic Contract Types Unified Standards (ACTUS) Domain, which includes the ACTUS controlled vocabulary and maps it to FIBO, providing the corresponding semantics and enabling integration of knowledge graphs based on FIBO with the ACTUS system.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2024-12-27T18:00:00</dct:issued>
 		<dct:license>Copyright (c) 2024-2026 ACTUS Financial Research Foundation
-Copyright (c) 2024-2026 EDM Council, Inc.
-Copyright (c) 2024-2026 Object Management Group, Inc.
+Copyright (c) EDM Association dba EDM Council, Inc.
+Copyright (c) 2024-2026 Object Management Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -36,35 +36,35 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2026-03-13T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/ACTUS/ACTUSContractTerms/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/ACTUS/ACTUSTaxonomy/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/ACTUS/ACTUSTermApplicabilityMapping/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/ACTUS/20260301/MetadataACTUS/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/ACTUS/20260401/MetadataACTUS/"/>
 		<cmns-av:copyright>Copyright (c) 2024-2026 ACTUS Financial Research Foundation</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2024-2026 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2024-2026 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-actus-mod;ACTUSDomain">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>ACTUS domain</rdfs:label>
-		<dct:abstract>The FIBO Algorithmic Contract Types Unified Standards (ACTUS) Domain includes the ACTUS controlled vocabulary and maps it to FIBO, providing the corresponding semantics and enabling integration of knowledge graphs based on FIBO with the ACTUS system.</dct:abstract>
-		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:abstract>The FIBO Algorithmic Contract Types Unified Standards (ACTUS) Domain includes several ACTUS controlled vocabularies and maps them to FIBO, providing the corresponding semantics and enabling integration of knowledge graphs based on FIBO with the ACTUS system.</dct:abstract>
+		<dct:contributor>Federated Knowledge, LLC</dct:contributor>
+		<dct:contributor>Intuitive Technology Partners, Inc.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>Pinnacle Bank (Morgan Hill, California)</dct:contributor>
 		<dct:contributor>ProBanker Simulations, LLC</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
-		<dct:contributor>Thematix Partners LLC</dct:contributor>
-		<dct:contributor>intuitive.ai</dct:contributor>
+		<dct:contributor>Thematix Partners, LLC</dct:contributor>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/ACTUS/ACTUSContractTerms/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/ACTUS/ACTUSTaxonomy/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/ACTUS/ACTUSTermApplicabilityMapping/"/>
 		<dct:license>Copyright (c) 2024-2026 ACTUS Financial Research Foundation
-Copyright (c) 2024-2026 EDM Council, Inc.
-Copyright (c) 2024-2026 Object Management Group, Inc.
+Copyright (c) EDM Association dba EDM Council, Inc.
+Copyright (c) 2024-2026 Object Management Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -75,10 +75,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 See https://opensource.org/licenses/MIT.</dct:license>
 		<dct:title>FIBO ACTUS Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Algorithmic Contract Types Unified Standards (ACTUS) Domain</dct:title>
+		<rdfs:altLabel>Algorithmic Contract Types Unified Standards (ACTUS)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		<cmns-av:copyright>Copyright (c) 2024-2026 ACTUS Financial Research Foundation</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2024-2026 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2024-2026 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2024-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/BE/MetadataBE.rdf
+++ b/BE/MetadataBE.rdf
@@ -38,8 +38,8 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/">
-		<rdfs:label>Metadata about the EDMC-FIBO Business Entities (BE) Domain</rdfs:label>
-		<dct:abstract>This ontology provides metadata about the FIBO Business Entities (BE) Domain, which covers defines business concepts that are used for data governance, interoperability, and in regulatory reporting about business entities.
+		<rdfs:label>Metadata about the FIBO Business Entities (BE) Domain</rdfs:label>
+		<dct:abstract>This ontology provides metadata about the FIBO Business Entities (BE) Domain, which defines business concepts for data governance, interoperability, and in regulatory reporting about business entities.
 
 The scope of the BE domain includes business and legal entity concepts that are considered by financial industry firms, regulators and other industry participants relevant to financial services and more broadly, including:
  - Legal entities generally

--- a/BE/MetadataBE.rdf
+++ b/BE/MetadataBE.rdf
@@ -41,14 +41,14 @@
 		<rdfs:label>Metadata about the EDMC-FIBO Business Entities (BE) Domain</rdfs:label>
 		<dct:abstract>This ontology provides metadata about the FIBO Business Entities (BE) Domain, which covers defines business concepts that are used for data governance, interoperability, and in regulatory reporting about business entities.
 
-The business scope of the BE ontologies covers a range of business and legal entities that are considered by financial industry firms, regulators and other industry participants to be of relevance in the financial services domain, including:
+The scope of the BE domain includes business and legal entity concepts that are considered by financial industry firms, regulators and other industry participants relevant to financial services and more broadly, including:
  - Legal entities generally
  - Corporate structure, ownership and control, including primary executive roles for businesses,
- - Functional entities such as governments and government entities, non-governmental organizations, international organizations, not-for-profit organization, etc.
+ - Functional entities such as governments and government entities, non-governmental organizations, international organizations, not-for-profit organizations, etc.
  - Concepts specific to corporations, partnerships, private limited companies, sole proprietorships, and trusts.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2018-2025 EDM Council, Inc.
-Copyright (c) 2018-2025 Object Management Group, Inc.
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -56,8 +56,8 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
-		See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2025-10-15T18:00:00</dct:modified>
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/MetadataBEFunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/MetadataBEGovernmentEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/MetadataBELegalEntities/"/>
@@ -68,12 +68,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Trusts/MetadataBETrusts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20251001/MetadataBE/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20260401/MetadataBE/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/BE/MetadataBE.rdf version of this ontology was modified to eliminate informative Functional Entities ontologies, merging their content into others as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190401/MetadataBE.rdf version of the ontology and subordinate module-specific BE metadata ontologies were modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230301/MetadataBE.rdf version of the ontology was modified to merge details from the old corporations ontology into corporate bodies for consistency and useability (BE-259).</skos:changeNote>
-		<cmns-av:copyright>Copyright (c) 2018-2025 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20251001/MetadataBE.rdf version of the ontology was modified to update metadata including providing an expanded domain name for usability in business glossaries (FND-404).</skos:changeNote>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-be-mod;BEDomain">
@@ -81,7 +82,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>business entities (BE) domain</rdfs:label>
 		<dct:abstract>The FIBO Business Entities (BE) Domain covers defines business concepts that are used for data governance, interoperability, and in regulatory reporting about business entities.
 
-The business scope of the BE ontologies covers a range of business and legal entities that are considered by financial industry firms, regulators and other industry participants to be of relevance in the financial services domain, including:
+The scope of the BE domain includes business and legal entity concepts that are considered by financial industry firms, regulators and other industry participants relevant to financial services and more broadly, including:
  - Legal entities generally
  - Corporate structure, ownership and control, including primary executive roles for businesses,
  - Functional entities such as governments and government entities, non-governmental organizations, international organizations, not-for-profit organization, etc.
@@ -94,6 +95,7 @@ The business scope of the BE ontologies covers a range of business and legal ent
 		<dct:contributor>Exprentis</dct:contributor>
 		<dct:contributor>Federated Knowledge, LLC</dct:contributor>
 		<dct:contributor>Hypercube Ltd.</dct:contributor>
+		<dct:contributor>Intuitive Technology Partners, Inc.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
@@ -101,7 +103,7 @@ The business scope of the BE ontologies covers a range of business and legal ent
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
-		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Thematix Partners, LLC</dct:contributor>
 		<dct:contributor>Wells Fargo</dct:contributor>
 		<dct:contributor>Working Ontologist</dct:contributor>
 		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
@@ -114,12 +116,24 @@ The business scope of the BE ontologies covers a range of business and legal ent
 		<dct:hasPart rdf:resource="&fibo-be-plc-mod;PrivateLimitedCompaniesModule"/>
 		<dct:hasPart rdf:resource="&fibo-be-sps-mod;SoleProprietorshipsModule"/>
 		<dct:hasPart rdf:resource="&fibo-be-tr-mod;TrustsModule"/>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Business Entities (BE) Domain</dct:title>
 		<dct:title>FIBO BE Domain</dct:title>
+		<rdfs:altLabel>Business Entities (BE)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
-		<cmns-av:copyright>Copyright (c) 2018-2025 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/BP/MetadataBP.rdf
+++ b/BP/MetadataBP.rdf
@@ -27,29 +27,54 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/">
 		<rdfs:label>Metadata for the EDMC-FIBO Business Process (BP) Domain</rdfs:label>
-		<dct:abstract>The Business Process (BP) domain includes ontologies that define financial process flows such as securities issuance and transaction workflows. In the case of securities issuance process models, these are provided in order to be able to represent reference data concepts that are dependent on the process by which a security was issued. Transaction process semantics provide the basis for the temporal dimension of securities and derivatives transactions.  These are process models represented using basic semantic primitive concepts of events, activities and control flows.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-01T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-03-31T18:00:00</dct:modified>
+		<dct:abstract>The Business Process (BP) domain includes ontologies that define financial process flows such as securities issuance and transaction workflows. In the case of securities issuance process models, these are provided in order to be able to represent reference data concepts that are dependent on the process by which a security was issued. Transaction process semantics provide the basis for the temporal dimension of securities and derivatives transactions.  These are process models represented using basic semantic primitive concepts of events, activities and control flows.
+		
+		Note that the ontologies included in the BP domain are considered provisional and have not undergone serious review or integration with other parts of FIBO as of Q1 2026.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/Process/MetadataBPProcess/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MetadataBPSecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/20230301/MetadataBP/"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/20260401/MetadataBP/"/>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-bp-mod;BPDomain">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>business process domain</rdfs:label>
-		<dct:abstract>The Business Process (BP) domain includes ontologies that define financial process flows such as securities issuance and transaction workflows. In the case of securities issuance process models, these are provided in order to be able to represent reference data concepts that are dependent on the process by which a security was issued. Transaction process semantics provide the basis for the temporal dimension of securities and derivatives transactions.  These are process models represented using basic semantic primitive concepts of events, activities and control flows.</dct:abstract>
+		<dct:abstract>The Business Process (BP) domain includes ontologies that define financial process flows such as securities issuance and transaction workflows. In the case of securities issuance process models, these are provided in order to be able to represent reference data concepts that are dependent on the process by which a security was issued. Transaction process semantics provide the basis for the temporal dimension of securities and derivatives transactions.  These are process models represented using basic semantic primitive concepts of events, activities and control flows.
+		
+		Note that the ontologies included in the BP domain are considered provisional and have not undergone serious review or integration with other parts of FIBO as of Q1 2026.</dct:abstract>
 		<dct:hasPart rdf:resource="&fibo-bp-prc-mod;ProcessModule"/>
 		<dct:hasPart rdf:resource="&fibo-bp-iss-mod;SecuritiesIssuanceModule"/>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>FIBO BP Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Business Process (BP) Domain</dct:title>
+		<rdfs:altLabel>Business Process (BP)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/BP/MetadataBP.rdf
+++ b/BP/MetadataBP.rdf
@@ -31,8 +31,7 @@
 		
 		Note that the ontologies included in the BP domain are considered provisional and have not undergone serious review or integration with other parts of FIBO as of Q1 2026.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
-Copyright (c) 2018-2026 Object Management Group
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/BP/MetadataBP.rdf
+++ b/BP/MetadataBP.rdf
@@ -26,7 +26,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/">
-		<rdfs:label>Metadata for the EDMC-FIBO Business Process (BP) Domain</rdfs:label>
+		<rdfs:label>Metadata for the FIBO Business Process (BP) Domain</rdfs:label>
 		<dct:abstract>The Business Process (BP) domain includes ontologies that define financial process flows such as securities issuance and transaction workflows. In the case of securities issuance process models, these are provided in order to be able to represent reference data concepts that are dependent on the process by which a security was issued. Transaction process semantics provide the basis for the temporal dimension of securities and derivatives transactions.  These are process models represented using basic semantic primitive concepts of events, activities and control flows.
 		
 		Note that the ontologies included in the BP domain are considered provisional and have not undergone serious review or integration with other parts of FIBO as of Q1 2026.</dct:abstract>

--- a/CAE/MetadataCAE.rdf
+++ b/CAE/MetadataCAE.rdf
@@ -24,7 +24,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/">
-		<rdfs:label>Metadata about the EDMC-FIBO Corporate Actions and Events (CAE) Domain</rdfs:label>
+		<rdfs:label>Metadata about the FIBO Corporate Actions and Events (CAE) Domain</rdfs:label>
 		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, as well as more general business events that are relevant to investors and regulators alike.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
 		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.

--- a/CAE/MetadataCAE.rdf
+++ b/CAE/MetadataCAE.rdf
@@ -26,22 +26,31 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/">
 		<rdfs:label>Metadata about the EDMC-FIBO Corporate Actions and Events (CAE) Domain</rdfs:label>
 		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, as well as more general business events that are relevant to investors and regulators alike.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-03-31T18:00:00</dct:modified>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20230301/MetadataCAE/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20260401/MetadataCAE/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-mod;CAEDomain">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>corporate actions and events domain</rdfs:label>
 		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, as well as more general business events that are relevant to investors and regulators alike.</dct:abstract>
-		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Adaptive Analytics, Inc.</dct:contributor>
 		<dct:contributor>Bank of New York Mellon</dct:contributor>
 		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
@@ -52,6 +61,7 @@
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
 		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>Intuitive Technology Partners, Inc.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>John F. Tierney</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
@@ -60,16 +70,28 @@
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
-		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Thematix Partners, LLC</dct:contributor>
 		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
 		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="&fibo-cae-ce-mod;CorporateEventsModule"/>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>FIBO CAE Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Corporate Actions and Events (CAE) Domain</dct:title>
+		<rdfs:altLabel>Corporate Actions and Events (CAE)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/DER/MetadataDER.rdf
+++ b/DER/MetadataDER.rdf
@@ -32,32 +32,42 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/">
 		<rdfs:label>Metadata about the EDMC-FIBO Derivatives (DER) Domain</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/MetadataDERCreditDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/MetadataDERDerivativesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/MetadataDERRateDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/MetadataDERSecurityBasedDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20230201/MetadataDER/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20260401/MetadataDER/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-der-mod;DERDomain">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>derivatives domain</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives.</dct:abstract>
-		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Adaptive Analytics, Inc.</dct:contributor>
 		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Citigroup</dct:contributor>
 		<dct:contributor>Commodities Futures Trading Commission (CFTC)</dct:contributor>
 		<dct:contributor>Credit Suisse</dct:contributor>
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Exprentis</dct:contributor>
-		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Federated Knowledge, LLC</dct:contributor>
+		<dct:contributor>Intuitive Technology Partners, Inc.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>John F. Tierney</dct:contributor>
 		<dct:contributor>Mizuho Financial Group, Inc.</dct:contributor>
@@ -66,7 +76,7 @@
 		<dct:contributor>Quarule</dct:contributor>
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
-		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Thematix Partners, LLC</dct:contributor>
 		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
 		<dct:contributor>Working Ontologist</dct:contributor>
 		<dct:contributor>agnos.ai</dct:contributor>
@@ -75,14 +85,24 @@
 		<dct:hasPart rdf:resource="&fibo-der-drc-mod;DerivativesContractsModule"/>
 		<dct:hasPart rdf:resource="&fibo-der-rat-mod;RateDerivativesModule"/>
 		<dct:hasPart rdf:resource="&fibo-der-sbd-mod;SecurityBasedDerivativesModule"/>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>FIBO DER Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain</dct:title>
+		<rdfs:altLabel>Derivatives (DER)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/DER/MetadataDER.rdf
+++ b/DER/MetadataDER.rdf
@@ -30,7 +30,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/">
-		<rdfs:label>Metadata about the EDMC-FIBO Derivatives (DER) Domain</rdfs:label>
+		<rdfs:label>Metadata about the FIBO Derivatives (DER) Domain</rdfs:label>
 		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
 		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.

--- a/FBC/MetadataFBC.rdf
+++ b/FBC/MetadataFBC.rdf
@@ -30,27 +30,36 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/">
-		<rdfs:label>Metadata about the EDMC-FIBO Financial Business and Commerce (FBC) Domain</rdfs:label>
+		<rdfs:label>Metadata about the FIBO Financial Business and Commerce (FBC) Domain</rdfs:label>
 		<dct:abstract>This ontology provides metadata about the FIBO Financial Business and Commerce (FBC) Domain, which covers business concepts that are common to common to a number of finance domain areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-01-30T18:00:00</dct:modified>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/MetadataFBCDebtAndEquities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/MetadataFBCFinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MetadataFBCFunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/MetadataFBC/"/>
-		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260401/MetadataFBC/"/>
+		<cmns-av:copyright>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-mod;FBCDomain">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>financial business and commerce domain</rdfs:label>
 		<dct:abstract>The financial business and commerce domain covers business concepts that are common to common to a number of finance areas, such as loans, securities, and corporate actions, including products and services, financial intermediaries, registrars and regulators, and financial instruments and products.</dct:abstract>
-		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Adaptive Analytics, Inc.</dct:contributor>
 		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Capacity Post, Inc.</dct:contributor>
 		<dct:contributor>Citigroup</dct:contributor>
@@ -58,7 +67,8 @@
 		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Exprentis</dct:contributor>
-		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Federated Knowledge, LLC</dct:contributor>
+		<dct:contributor>Intuitive Technology Partners, Inc.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
@@ -67,7 +77,7 @@
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
-		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Thematix Partners, LLC</dct:contributor>
 		<dct:contributor>Wells Fargo</dct:contributor>
 		<dct:contributor>agnos.ai UK Ltd.</dct:contributor>
 		<dct:creator rdf:datatype="&xsd;anyURI">https://wiki.edmcouncil.org/pages/viewpage.action?pageId=786677</dct:creator>
@@ -75,12 +85,24 @@
 		<dct:hasPart rdf:resource="&fibo-fbc-fi-mod;FinancialInstrumentsModule"/>
 		<dct:hasPart rdf:resource="&fibo-fbc-fct-mod;FunctionalEntitiesModule"/>
 		<dct:hasPart rdf:resource="&fibo-fbc-pas-mod;FBCProductsAndServicesModule"/>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:issued rdf:datatype="&xsd;dateTime">2015-08-13T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Financial Business and Commerce (FBC) Domain</dct:title>
 		<dct:title>FIBO FBC Domain</dct:title>
+		<rdfs:altLabel>Financial Business and Commerce (FBC)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/FND/MetadataFND.rdf
+++ b/FND/MetadataFND.rdf
@@ -52,20 +52,20 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/">
-		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Domain</rdfs:label>
-		<dct:abstract>The &apos;metadata for FND&apos; describes the FND domain.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2021-03-29T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+		<rdfs:label>Metadata for the FIBO Foundations (FND) Domain</rdfs:label>
+		<dct:abstract>This ontology provides metadata about the FIBO Foundations (FND) domain area, which defines general purpose concepts supporting other domain areas of FIBO. The primary focus of Foundations is on agreements and contracts, their legal underpinnings, and related constructs.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2013-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
-		See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2025-12-12T18:00:00</dct:modified>
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/MetadataFNDAccounting/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/MetadataFNDAgentsAndPeople/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/MetadataFNDAgreements/"/>
@@ -84,16 +84,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/MetadataFNDUtilities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20241101/MetadataFND/"/>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-mod;FNDDomain">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>foundations domain</rdfs:label>
-		<dct:abstract>The Foundations (FND) domain includes ontologies that define general purpose concepts required to support other FIBO domains. These include concepts and relationships about people, organizations, places, and most importantly, contracts that are essential to domains such as Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC). 
+		<dct:abstract>The Foundations (FND) domain includes ontologies that define general purpose concepts required to support other FIBO domains. These include concepts and relationships about people, organizations, places, and most importantly, contracts that are essential to many aspects of financial services.
 
-The scope of the definitions provided in FND is limited to coverage of exactly those concepts needed by other FIBO domain areas.  They may be useful for other domains, such as insurance, but are intentionally underspecified to avoid unintended consequences and thus do not provide exhaustive coverage for any concept contained herein. However, Foundations is designed for growth over time. The expectation is that as additional foundational knowledge is needed to define concepts in other FIBO domain areas, additional ontologies and/or concepts will be integrated into Foundations as required.</dct:abstract>
+The scope of the definitions provided in FND is limited to coverage of exactly those concepts needed by other FIBO domain areas. They may be useful for other domains, such as insurance, but are intentionally underspecified to avoid unintended consequences and thus do not provide exhaustive coverage for any concept contained herein. However, Foundations is designed for growth over time. The expectation is that as additional foundational knowledge is needed to define concepts in other FIBO domain areas, additional ontologies and/or concepts will be integrated into Foundations.</dct:abstract>
 		<dct:creator rdf:datatype="&xsd;anyURI">https://wiki.edmcouncil.org/display/FND/FIBO+-+FCT+-+Foundations+Home</dct:creator>
 		<dct:hasPart rdf:resource="&fibo-fnd-acc-mod;AccountingModule"/>
 		<dct:hasPart rdf:resource="&fibo-fnd-aap-mod;AgentsAndPeopleModule"/>
@@ -110,12 +110,24 @@ The scope of the definitions provided in FND is limited to coverage of exactly t
 		<dct:hasPart rdf:resource="&fibo-fnd-rel-mod;RelationsModule"/>
 		<dct:hasPart rdf:resource="&fibo-fnd-txn-mod;TransactionsExtModule"/>
 		<dct:hasPart rdf:resource="&fibo-fnd-utl-mod;UtilitiesModule"/>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2013-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>FIBO FND Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Foundations (FND) Domain</dct:title>
+		<rdfs:altLabel>Foundations (FND)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/IND/MetadataIND.rdf
+++ b/IND/MetadataIND.rdf
@@ -32,11 +32,20 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/">
-		<rdfs:label>Metadata about the EDMC-FIBO Indices and Indicators (IND) Domain</rdfs:label>
+		<rdfs:label>Metadata about the FIBO Indices and Indicators (IND) Domain</rdfs:label>
 		<dct:abstract>This ontology provides metadata about the FIBO Indices and Indicators (IND) Domain, which covers market indices and reference rates including economic indicators, foreign exchange, interest rates, and other benchmarks.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-03-31T18:00:00</dct:modified>
+		<dct:license>Copyright (c) 2014-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2014-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/MetadataINDEconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/MetadataINDForeignExchange/"/>
@@ -44,9 +53,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MetadataINDInterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/MetadataINDMarketIndices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20230201/MetadataIND/"/>
-		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20260401/MetadataIND/"/>
+		<cmns-av:copyright>Copyright (c) 2014-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-ind-mod;INDDomain">
@@ -54,7 +63,7 @@
 		<rdfs:label>indices and indicators module</rdfs:label>
 		<dct:abstract>The FIBO Indices and Indicators (IND) Domain covers market indices and reference rates including economic indicators, foreign exchange, interest rates, and other benchmarks. The ontologies cover quoted interest rates, economic measures such as employment rates, and quoted indices required to support baskets of securities, including specific kinds of securities in share indices or bond indices, as well as credit indices.</dct:abstract>
 		<dct:contributor>88 Solutions</dct:contributor>
-		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Adaptive Analytics, Inc.</dct:contributor>
 		<dct:contributor>Bank of New York Mellon</dct:contributor>
 		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Bureau of Economic Analysis (BEA, US Department of Commerce)</dct:contributor>
@@ -64,7 +73,9 @@
 		<dct:contributor>Dassault Systemes/No Magic</dct:contributor>
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Federal Reserve Bank of Kansas City</dct:contributor>
+		<dct:contributor>Federated Knowledge, LLC</dct:contributor>
 		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>Intuitive Technology Partners, Inc.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>John F. Tierney</dct:contributor>
 		<dct:contributor>Nordea Bank AB</dct:contributor>
@@ -73,7 +84,7 @@
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
-		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Thematix Partners, LLC</dct:contributor>
 		<dct:contributor>Wells Fargo Bank, N. A.</dct:contributor>
 		<dct:contributor>agnos.ai UK Ltd</dct:contributor>
 		<dct:creator rdf:datatype="&xsd;anyURI">https://wiki.edmcouncil.org/display/IND/FIBO+-+FCT+-+Indices+and+Indicators+Home</dct:creator>
@@ -82,12 +93,24 @@
 		<dct:hasPart rdf:resource="&fibo-ind-ind-mod;IndicatorsModule"/>
 		<dct:hasPart rdf:resource="&fibo-ind-ir-mod;InterestRatesModule"/>
 		<dct:hasPart rdf:resource="&fibo-ind-mkt-mod;MarketIndicesModule"/>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2014-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2014-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>FIBO IND Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Indices and Indicators (IND) Domain</dct:title>
+		<rdfs:altLabel>Indices and Indicators (IND)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/MetadataLOAN.rdf
+++ b/LOAN/MetadataLOAN.rdf
@@ -28,44 +28,66 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/">
-		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) Domain</rdfs:label>
+		<rdfs:label>Metadata for the FIBO Loans (LOAN) Domain</rdfs:label>
 		<dct:abstract>The FIBO Loan domain defines concepts that are common to loans in various market categories including but not limited to commercial, small business, automobile, education and mortgage. High-level concepts relevant to loan contracts include the obligations of parties playing different roles, credit and risk, security agreements as well as additional detail for HMDA-specific loans. Details defining debt instruments in general are covered in a separate debt module in the Securities domain.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-03T18:00:00</dct:modified>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansGeneral/MetadataLOANLoansGeneral/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/MetadataLOANLoansSpecific/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MetadataLOANRealEstateLoans/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20230201/MetadataLOAN/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20260401/MetadataLOAN/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-mod;LOANDomain">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>loan domain</rdfs:label>
 		<dct:abstract>The FIBO Loan domain defines concepts that are common to loans in various market categories including but not limited to commercial, small business, automobile, education and mortgage. High-level concepts relevant to loan contracts include the obligations of parties playing different roles, credit and risk, security agreements as well as additional detail for HMDA-specific loans. Details defining debt instruments in general are covered in a separate debt module in the Securities domain.</dct:abstract>
-		<dct:contributor>Adaptive, Inc.</dct:contributor>
-		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Adaptive Analytics, Inc.</dct:contributor>
+		<dct:contributor>Federated Knowledge, LLC</dct:contributor>
 		<dct:contributor>Hypercube Ltd.</dct:contributor>
+		<dct:contributor>Intuitive Technology Partners, Inc.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>Office of Financial Research (US Dept of the Treasury)</dct:contributor>
 		<dct:contributor>Semantic Arts, Inc.</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
-		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Thematix Partners, LLC</dct:contributor>
 		<dct:contributor>Wells Fargo</dct:contributor>
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:hasPart rdf:resource="&fibo-loan-ln-mod;LoansGeneralModule"/>
 		<dct:hasPart rdf:resource="&fibo-loan-spc-mod;LoansSpecificModule"/>
 		<dct:hasPart rdf:resource="&fibo-loan-reln-mod;RealEstateLoansModule"/>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Loans (LOAN) Domain</dct:title>
 		<dct:title>FIBO LOAN Domain</dct:title>
+		<rdfs:altLabel>Loans (LOAN)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/MetadataMD.rdf
+++ b/MD/MetadataMD.rdf
@@ -30,35 +30,56 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/">
-		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) Domain</rdfs:label>
-		<dct:abstract>The Market Data (MD) domain contains ontologies that represent temporally variant concepts for financial instruments, loans and funds. As such this domain covers the concepts represented in market data, such as prices, yields and analytics for debt and for pools of assets.</dct:abstract>
+		<rdfs:label>Metadata for the FIBO Market Data (MD) Domain</rdfs:label>
+		<dct:abstract>The Market Data (MD) domain contains ontologies that represent temporally variant concepts for financial instruments, loans and funds. As such this domain covers the concepts represented in market data, such as prices, yields and analytics for debt and for pools of assets.
+		
+		Note that the ontologies included in the MD domain are considered provisional and have not undergone serious review or integration with other parts of FIBO as of Q1 2026.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-03-31T18:00:00</dct:modified>
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20230301/MetadataMD/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20260401/MetadataMD/"/>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-mod;MDDomain">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>market data domain</rdfs:label>
-		<dct:abstract>The Market Data (MD) domain contains ontologies that represent temporally variant concepts for financial instruments, loans and funds. As such this domain covers the concepts represented in market data, such as prices, yields and analytics for debt and for pools of assets.</dct:abstract>
+		<dct:abstract>The Market Data (MD) domain contains ontologies that represent temporally variant concepts for financial instruments, loans and funds. As such this domain covers the concepts represented in market data, such as prices, yields and analytics for debt and for pools of assets.
+		
+		Note that the ontologies included in the MD domain are considered provisional and have not undergone serious review or integration with other parts of FIBO as of Q1 2026.</dct:abstract>
 		<dct:hasPart rdf:resource="&fibo-md-civx-mod;CIVTemporalModule"/>
 		<dct:hasPart rdf:resource="&fibo-md-dbtx-mod;DebtTemporalModule"/>
 		<dct:hasPart rdf:resource="&fibo-md-derx-mod;DerivativesTemporalModule"/>
 		<dct:hasPart rdf:resource="&fibo-md-temx-mod;TemporalCoreModule"/>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-03-31T18:00:00</dct:modified>
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>Financial Industry Business Ontology (FIBO) Market Data (MD) Domain</dct:title>
+		<rdfs:altLabel>Market Data (MD)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MetadataFIBO.rdf
+++ b/MetadataFIBO.rdf
@@ -47,8 +47,8 @@
 		<rdfs:label>Metadata for FIBO</rdfs:label>
 		<dct:abstract>This is the top-level metadata vocabulary used to describe the Financial Industry Business Ontology (FIBO).</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-Copyright (c) 2013-2025 Object Management Group, Inc.
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2013-2026 Object Management Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -57,7 +57,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2025-01-03T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/ACTUS/MetadataACTUS/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/"/>
@@ -71,9 +71,9 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20250101/MetadataFIBO/"/>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260401/MetadataFIBO/"/>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-spec;FIBOSpecification">
@@ -94,8 +94,8 @@ The FIBO ontologies are available for download as OWL 2 DL compliant ontologies 
 		<dct:hasPart rdf:resource="&fibo-md-mod;MDDomain"/>
 		<dct:hasPart rdf:resource="&fibo-sec-mod;SECDomain"/>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-Copyright (c) 2013-2025 Object Management Group, Inc.
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2013-2026 Object Management Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -104,11 +104,12 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2025-01-03T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>Financial Industry Business Ontology (FIBO)</dct:title>
+		<rdfs:altLabel>Financial Industry Business Ontology (FIBO)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/MetadataSEC.rdf
+++ b/SEC/MetadataSEC.rdf
@@ -30,27 +30,36 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/">
-		<rdfs:label>Metadata about the EDMC-FIBO Securities (SEC) Domain</rdfs:label>
+		<rdfs:label>Metadata about the FIBO Securities (SEC) Domain</rdfs:label>
 		<dct:abstract>The Securities (SEC) Domain covers many of the concepts that are common to a wide variety of securities as well as those specific to equities and various debt instruments, including but not limited to bonds and a wide range of asset-backed securities. This ontology provides metadata about the Securities Domain and its contents.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2024-11-15T18:00:00</dct:modified>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/MetadataSECEquities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/MetadataSECFunds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/MetadataSECSecurities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20241101/MetadataSEC/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20260401/MetadataSEC/"/>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-mod;SECDomain">
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;Module"/>
 		<rdfs:label>securities domain</rdfs:label>
 		<dct:abstract>The FIBO Securities (SEC) domain provides a model of concepts that are common to financial instruments that are also securities, including but not limited to exchange-traded securities and funds. High-level concepts relevant to securities classification, identification, issuance, and registration of securities generally are covered, as well as additional detail for equities, debt instruments, and funds. More details defining derivatives in particular are covered in a separate derivatives domain area.</dct:abstract>
-		<dct:contributor>Adaptive, Inc.</dct:contributor>
+		<dct:contributor>Adaptive Analytics, Inc.</dct:contributor>
 		<dct:contributor>BIAN</dct:contributor>
 		<dct:contributor>Bloomberg LP</dct:contributor>
 		<dct:contributor>Citigroup</dct:contributor>
@@ -58,9 +67,10 @@
 		<dct:contributor>Dassault Systemes / No Magic</dct:contributor>
 		<dct:contributor>Deutsche Bank</dct:contributor>
 		<dct:contributor>Exprentis</dct:contributor>
-		<dct:contributor>Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Federated Knowledge, LLC</dct:contributor>
 		<dct:contributor>Goldman Sachs</dct:contributor>
 		<dct:contributor>HP Enterprise / Mphasis</dct:contributor>
+		<dct:contributor>Intuitive Technology Partners, Inc.</dct:contributor>
 		<dct:contributor>John F. Gemski</dct:contributor>
 		<dct:contributor>John F. Tierney</dct:contributor>
 		<dct:contributor>Mizuho</dct:contributor>
@@ -71,7 +81,7 @@
 		<dct:contributor>State Street Bank and Trust</dct:contributor>
 		<dct:contributor>Statistics Canada</dct:contributor>
 		<dct:contributor>Tahoe Blue Ltd</dct:contributor>
-		<dct:contributor>Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Thematix Partners, LLC</dct:contributor>
 		<dct:contributor>Wells Fargo Bank, N.A.</dct:contributor>
 		<dct:contributor>agnos.ai U.K. Ltd</dct:contributor>
 		<dct:creator rdf:datatype="&xsd;anyURI">https://wiki.edmcouncil.org/pages/viewpage.action?pageId=786661</dct:creator>
@@ -79,12 +89,24 @@
 		<dct:hasPart rdf:resource="&fibo-sec-eq-mod;EquitiesModule"/>
 		<dct:hasPart rdf:resource="&fibo-sec-fnd-mod;FundsModule"/>
 		<dct:hasPart rdf:resource="&fibo-sec-sec-mod;SecuritiesModule"/>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2026 Object Management Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-04-15T18:00:00</dct:modified>
 		<dct:title>FIBO SEC Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Securities (SEC) Domain</dct:title>
+		<rdfs:altLabel>Securities (SEC)</rdfs:altLabel>
 		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
-		<cmns-av:copyright>Copyright (c) 2018-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2026 Object Management Group</cmns-av:copyright>
 	</owl:NamedIndividual>
 
 </rdf:RDF>


### PR DESCRIPTION
## Description

This resolution revises all of the module level metadata for FIBO, bringing copyrights and other metadata, including abstracts in some cases, up to date and adds rdfs:altLabels to all module metadata to support business glossary and other FIBO user's use cases

Fixes: #2203 / FND-404


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


