### PR TITLE
Correct module name in FIBO metadata

### DIFF
--- a/MetadataFIBO.rdf
+++ b/MetadataFIBO.rdf
@@ -90,7 +90,7 @@ The FIBO ontologies are available for download as OWL 2 DL compliant ontologies 
 		<dct:hasPart rdf:resource="&fibo-bp-mod;BPDomain"/>
 		<dct:hasPart rdf:resource="&fibo-cae-mod;CAEDomain"/>
 		<dct:hasPart rdf:resource="&fibo-der-mod;DERDomain"/>
-		<dct:hasPart rdf:resource="&fibo-exmp-mod;ExmmplesModule"/>
+		<dct:hasPart rdf:resource="&fibo-exmp-mod;ExamplesModule"/>
 		<dct:hasPart rdf:resource="&fibo-fbc-mod;FBCDomain"/>
 		<dct:hasPart rdf:resource="&fibo-fnd-mod;FNDDomain"/>
 		<dct:hasPart rdf:resource="&fibo-ind-mod;INDDomain"/>


### PR DESCRIPTION
## Description

addressed an additional typo related to examples in metadata

Fixes: #2221 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


