### PR TITLE
FND-411 - Clean up and/or eliminate the tiny agents ontology

### DIFF
--- a/ACTUS/catalog-v001.xml
+++ b/ACTUS/catalog-v001.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/ACTUS/ACTUSContractTermMapping/" uri="../ACTUS/ACTUSContractTermMapping.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/ACTUS/ACTUSContractTerms/" uri="../ACTUS/ACTUSContractTerms.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/ACTUS/ACTUSTaxonomy/" uri="../ACTUS/ACTUSTaxonomy.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/ACTUS/MetadataACTUS/" uri="../ACTUS/MetadataACTUS.rdf"/>
@@ -37,8 +38,6 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/" uri="../BE/LegalEntities/LegalPersons.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LEIEntities/" uri="../BE/LegalEntities/LEIEntities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/MetadataBELegalEntities/" uri="../BE/LegalEntities/MetadataBELegalEntities.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/USExampleEntities/" uri="../EXMP/LegalEntities/USExampleEntities.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/NorthAmericanEntities/USExampleExecutives/" uri="../BE/LegalEntities/NorthAmericanEntities/USExampleExecutives.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/MetadataBEOwnershipAndControl/" uri="../BE/OwnershipAndControl/MetadataBEOwnershipAndControl.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/" uri="../BE/OwnershipAndControl/CorporateControl.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/" uri="../BE/OwnershipAndControl/Executives.rdf"/>
@@ -95,14 +94,22 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/SwapsIndividuals/" uri="../DER/DerivativesContracts/SwapsIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/" uri="../DER/RateDerivatives/RateDerivatives.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/" uri="../DER/RateDerivatives/IRSwaps.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/" uri="../DER/RateDerivatives/IRSwapExampleIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/MetadataDERRateDerivatives/" uri="../DER/RateDerivatives/MetadataDERRateDerivatives.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/DowJonesIndustrialAverageCompanies/" uri="../EXMP/LegalEntities/DowJonesIndustrialAverageCompanies.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/DowJonesIndustrialAverageExecutives/" uri="../EXMP/LegalEntities/DowJonesIndustrialAverageExecutives.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/MetadataEXMPLegalEntities/" uri="../EXMP/LegalEntities/MetadataEXMPLegalEntities.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/MetadataEXMP/" uri="../EXMP/MetadataEXMP.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/FinancialInstitutionExamples/" uri="../EXMP/LegalEntities/FinancialInstitutionExamples.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/MarketsAndExchangesExamples/" uri="../EXMP/LegalEntities/MarketsAndExchangesExamples.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/Securities/EquitiesExamples/" uri="../EXMP/Securities/EquitiesExamples.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/Securities/EquityIndexExamples/" uri="../EXMP/Securities/EquityIndexExamples.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/Securities/IRSwapExamples/" uri="../EXMP/Securities/IRSwapExamples.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/EXMP/Securities/MetadataEXMPSecurities/" uri="../EXMP/Securities/MetadataEXMPSecurities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/" uri="../FBC/AllFBC.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-Europe/" uri="../FBC/AllFBC-Europe.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-EuropeAndNorthAmerica/" uri="../FBC/AllFBC-EuropeAndNorthAmerica.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ExampleIndividuals/" uri="../FBC/AllFBC-ExampleIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmerica/" uri="../FBC/AllFBC-NorthAmerica.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-NorthAmericanExamples/" uri="../FBC/AllFBC-NorthAmericanExamples.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceIndividuals/" uri="../FBC/AllFBC-ReferenceIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-ReferenceMarkets/" uri="../FBC/AllFBC-ReferenceMarkets.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/" uri="../FBC/MetadataFBC.rdf"/>
@@ -118,6 +125,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/" uri="../FBC/FunctionalEntities/BusinessCenters.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/" uri="../FBC/FunctionalEntities/BusinessCentersIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessRegistries/" uri="../FBC/FunctionalEntities/BusinessRegistries.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/CommercialRegistrationAuthorities/" uri="../FBC/FunctionalEntities/CommercialRegistrationAuthorities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities/" uri="../FBC/FunctionalEntities/EuropeanEntities/EUFinancialServicesEntities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/" uri="../FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/" uri="../FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf"/>
@@ -128,10 +136,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MetadataFBCFunctionalEntities/" uri="../FBC/FunctionalEntities/MetadataFBCFunctionalEntities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/" uri="../FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/" uri="../FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/" uri="../FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities/" uri="../FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/" uri="../FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/" uri="../FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USNationalInformationCenterControlledVocabularies/" uri="../FBC/FunctionalEntities/NorthAmericanEntities/USNationalInformationCenterControlledVocabularies.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/" uri="../FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/" uri="../FBC/FunctionalEntities/RegulatoryAgencies.rdf"/>
@@ -146,7 +151,6 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/" uri="../FND/Accounting/CurrencyAmount.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/" uri="../FND/Accounting/ISO4217-CurrencyCodes.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/MetadataFNDAccounting/" uri="../FND/Accounting/MetadataFNDAccounting.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/" uri="../FND/AgentsAndPeople/Agents.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/" uri="../FND/AgentsAndPeople/People.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/MetadataFNDAgentsAndPeople/" uri="../FND/AgentsAndPeople/MetadataFNDAgentsAndPeople.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/" uri="../FND/Agreements/Agreements.rdf"/>
@@ -213,7 +217,6 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/" uri="../IND/InterestRates/MarketDataProviders.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MetadataINDInterestRates/" uri="../IND/InterestRates/MetadataINDInterestRates.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/" uri="../IND/MarketIndices/BasketIndices.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/EquityIndexExampleIndividuals/" uri="../IND/MarketIndices/EquityIndexExampleIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/MetadataINDMarketIndices/" uri="../IND/MarketIndices/MetadataINDMarketIndices.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/" uri="../IND/MetadataIND.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/LOAN/AllLOAN/" uri="../LOAN/AllLOAN.rdf"/>
@@ -249,7 +252,6 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/" uri="../MD/TemporalCore/SecurityTradingStatuses.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/" uri="../MetadataFIBO.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/" uri="../SEC/AllSEC.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ExampleIndividuals/" uri="../SEC/AllSEC-ExampleIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-Europe/" uri="../SEC/AllSEC-Europe.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-NorthAmerica/" uri="../SEC/AllSEC-NorthAmerica.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/" uri="../SEC/AllSEC-ReferenceIndividuals.rdf"/>
@@ -266,7 +268,6 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/" uri="../SEC/Debt/TradedShortTermDebt.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/" uri="../SEC/Equities/DepositaryReceipts.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/" uri="../SEC/Equities/EquityCFIClassificationIndividuals.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/" uri="../SEC/Equities/EquitiesExampleIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/" uri="../SEC/Equities/EquityInstruments.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/MetadataSECEquities/" uri="../SEC/Equities/MetadataSECEquities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Funds/CollectiveInvestmentVehicles/" uri="../SEC/Funds/CollectiveInvestmentVehicles.rdf"/>

--- a/AboutFIBODev-TBoxOnly.rdf
+++ b/AboutFIBODev-TBoxOnly.rdf
@@ -32,7 +32,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2026-06-02T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-07-07T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		<cmns-av:usageNote>As of the Q1 2026 release of FIBO, there is one ontology, Bonds, in Securities, that brings in some reference individuals. The intent is to address this in a future release.</cmns-av:usageNote>
@@ -165,7 +165,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CashFlows/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
@@ -311,7 +310,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260601/AboutFIBODev-TBoxOnly/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260701/AboutFIBODev-TBoxOnly/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -25,7 +25,7 @@
   		<rdfs:label>About FIBO Development</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the very latest version of every FIBO ontology (released, provisional, and informative) based on the contents of GitHub, for use in particular while working on revisions. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2013-2026 EDM Association dbe EDM Council, Inc.
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2013-2026 Object Management Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -35,7 +35,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2026-06-05T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-07-07T18:00:00</dct:modified>
 		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2026 Object Management Group</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
@@ -229,7 +229,6 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"/>
 		
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
@@ -384,7 +383,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 	 
-	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260601/AboutFIBODev/"/>
+	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260701/AboutFIBODev/"/>
   </owl:Ontology>
   
 </rdf:RDF>

--- a/AboutFIBOProd-IncludingReferenceData.rdf
+++ b/AboutFIBOProd-IncludingReferenceData.rdf
@@ -25,8 +25,8 @@
 		<rdfs:label>About FIBO Production - including Reference Data</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, including reference data but excluding examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. By reference data we mean ISO currency codes and USPS individuals in FND, juridictions and governments in BE, regulatory agencies and related financial services entities as well as business centers and MIC codes in FBC, FpML interest rates in IND, CFI codes in SEC (incomplete but planned for extension in subsequent releases), and so forth. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-Copyright (c) 2013-2025 Object Management Group, Inc.
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -34,10 +34,10 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
-		See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2025-12-16T18:00:00</dct:modified>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-07-07T18:00:00</dct:modified>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		
 	<!-- 
@@ -253,7 +253,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities/"/>
 
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/MarketsAndExchangesExamples/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		
@@ -272,7 +271,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"/>
 		
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
@@ -391,7 +389,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260601/AboutFIBOProd-IncludingReferenceData/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260701/AboutFIBOProd-IncludingReferenceData/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBOProd-TBoxOnly.rdf
+++ b/AboutFIBOProd-TBoxOnly.rdf
@@ -23,8 +23,8 @@
  		<rdfs:label>About FIBO Production - T-Box Only</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads the latest FIBO production ontologies, excluding reference data and examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-Copyright (c) 2013-2025 Object Management Group, Inc.
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -32,10 +32,10 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
-		See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2025-12-16T18:00:00</dct:modified>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+See https://opensource.org/licenses/MIT.</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-07-07T18:00:00</dct:modified>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		<cmns-av:usageNote>As of the Q2 2025 release of FIBO, there is one ontology, Bonds, in Securities, that brings in some reference individuals. The intent is to address this in a future release.</cmns-av:usageNote>
 		
@@ -146,7 +146,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
@@ -253,7 +252,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20251201/AboutFIBOProd-TBoxOnly/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260701/AboutFIBOProd-TBoxOnly/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -25,8 +25,8 @@
  		<rdfs:label>About FIBO Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users. It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-03-31T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2013-2026 EDM Association dbe EDM Council, Inc.
-Copyright (c) 2013-2026 Object Management Group, Inc.
+		<dct:license>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2018-2025 Object Management Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -35,9 +35,9 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2026-06-05T18:00:00</dct:modified>
-		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2026 Object Management Group</cmns-av:copyright>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-07-07T18:00:00</dct:modified>
+		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group</cmns-av:copyright>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		
 	<!-- 
@@ -193,7 +193,6 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"/>
 		
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
@@ -312,7 +311,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260601/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20260701/AboutFIBOProd/"/>
  </owl:Ontology>
 
 </rdf:RDF>

--- a/BE/OwnershipAndControl/CorporateOwnership.rdf
+++ b/BE/OwnershipAndControl/CorporateOwnership.rdf
@@ -9,7 +9,6 @@
 	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -30,7 +29,6 @@
 	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -44,23 +42,21 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
 		<rdfs:label>Corporate Ownership Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts relating to corporation-specific ownership. Roles are defined in terms of the ownership enjoyed by the party, and are the specific examples of these concepts as they apply to companies incorporated by the issuance of shares.</dct:abstract>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2013-2025 Object Management Group, Inc.
-		
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
-		See https://opensource.org/licenses/MIT.</dct:license>
+See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/OwnershipParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -81,9 +77,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20230101/OwnershipAndControl/CorporateOwnership.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/OwnershipAndControl/CorporateOwnership.rdf version of the ontology was modified to align the concept of beneficial ownership with the broader ownership pattern (SEC-202).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20250701/OwnershipAndControl/CorporateOwnership.rdf version of the ontology was modified to clarify the differences between a shareholding, purchase lot, and tax lot (SEC-200).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20250801/OwnershipAndControl/CorporateOwnership.rdf version of the ontology was modified to eliminate unused references (FND-411).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cown;BeneficialOwner">

--- a/BE/catalog-v001.xml
+++ b/BE/catalog-v001.xml
@@ -53,7 +53,6 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/" uri="../FND/Accounting/CurrencyAmount.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/" uri="../FND/Accounting/ISO4217-CurrencyCodes.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/MetadataFNDAccounting/" uri="../FND/Accounting/MetadataFNDAccounting.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/" uri="../FND/AgentsAndPeople/Agents.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/" uri="../FND/AgentsAndPeople/People.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/MetadataFNDAgentsAndPeople/" uri="../FND/AgentsAndPeople/MetadataFNDAgentsAndPeople.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/" uri="../FND/Agreements/Agreements.rdf"/>

--- a/BP/SecuritiesIssuance/IssuanceProcess.rdf
+++ b/BP/SecuritiesIssuance/IssuanceProcess.rdf
@@ -58,13 +58,21 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/IssuanceProcess/">
 		<rdfs:label xml:lang="en">Issuance Process</rdfs:label>
 		<dct:abstract>General ontology for the process by which securities are issued. Contains the process features common to all or most securities issuance. These are extended in the process ontologies that are specific to particular types of issuance</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/IssuanceDocuments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MuniIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
@@ -81,7 +89,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/IssuanceProcess/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2013-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-bp-iss-prc;AllotmentInformation">

--- a/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
+++ b/BP/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
@@ -70,14 +70,22 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/">
 		<rdfs:label xml:lang="en">PrivateLabelMBSIssuance</rdfs:label>
 		<dct:abstract>Process ontology for the process of issuance (securitization) of mortgage backed securities by commercial institutions rather than by government agencies.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/AgencyMBSIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/IssuanceDocuments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/IssuanceProcess/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MBSIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Reporting/"/>
@@ -100,7 +108,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-bp-iss-pmbs;AllocatePrimaryIdentifier">

--- a/FND/AgentsAndPeople/Agents.rdf
+++ b/FND/AgentsAndPeople/Agents.rdf
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
-	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
-	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -16,12 +12,8 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
-	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
-	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -42,12 +34,9 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/AgentsAndPeople/Agents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/AgentsAndPeople/Agents/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20130801/AgentsAndPeople/Agents.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/AgentsAndPeople/Agents.rdf version of this ontology was modified to support the FIBO 2.0 RFC, primarily with respect to equivalence relationships to LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/AgentsAndPeople/Agents.rdf version of this ontology was modified to loosen the range restriction on hasName to rdfs:Literal, facilitating multi-lingual name representation.</skos:changeNote>
@@ -61,6 +50,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231101/AgentsAndPeople/Agents.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/AgentsAndPeople/Agents.rdf version of the ontology was modified to eliminate elements that have been deprecated for several quarters (FND-386).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241101/AgentsAndPeople/Agents.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/AgentsAndPeople/Agents.rdf version of the ontology was modified to deprecate the concept of automated system, since it is only used in one place and is not well defined, thus allowing elimination of this ontology to simplify FND for better usability (FND-411).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/Foundations/20130601/AgentsAndPeople/Agents.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 		(1) to use slash style URI/IRIs (also called 303 URIs, vs. hash style) as required to support server side processing 
 		(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -73,24 +63,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-aap-agt;AutomatedSystem">
-		<rdfs:subClassOf rdf:resource="&cmns-pts;Agent"/>
-		<rdfs:label>automated system</rdfs:label>
-		<skos:definition>system that reduces or eliminates the need for human involvement in order to complete a task</skos:definition>
-		<cmns-av:adaptedFrom>https://www.reference.com/technology/automated-system-c85583d0f17a632</cmns-av:adaptedFrom>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&cmns-pts;Agent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;hasTextualName"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&cmns-txt;Text"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&cmns-pts;SoftwareAgent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-aap-agt;AutomatedSystem"/>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<skos:note>This class was replaced with a class by the same name in mortgage origination, which is the only place it was used in FIBO, in July 2026. It and the ontology will be elminated by the Q2 2027 release. It is retained until then strictly for backwards compatibility for our users. No equivalent class reference is provided to limit dependencies on this ontology.</skos:note>
 	</owl:Class>
 
 </rdf:RDF>

--- a/FND/AllFND.rdf
+++ b/FND/AllFND.rdf
@@ -2,7 +2,6 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/">
 	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/">
 	<!ENTITY fibo-fnd-acc-4217 "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
@@ -46,7 +45,6 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"
 	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"
 	xmlns:fibo-fnd-acc-4217="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
@@ -92,10 +90,10 @@
 		<dct:abstract>The Foundations (FND) domain includes ontologies that define general purpose concepts required to support other FIBO domains. These include concepts and relationships about people, organizations, places, and most importantly, contracts that are essential to domains such as Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC). 
 
 The scope of the definitions provided in FND is limited to coverage of exactly those concepts needed by other FIBO domain areas. They may be useful for other domains, such as insurance, but are intentionally underspecified to avoid unintended consequences and thus do not provide exhaustive coverage for any concept contained herein. However, Foundations is designed for growth over time. The expectation is that as additional foundational knowledge is needed to define concepts in other FIBO domain areas, additional ontologies and/or concepts will be integrated into Foundations as required.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-12-28T18:00:00</dct:issued>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-Copyright (c) 2013-2025 Object Management Group, Inc.
-
+		<dct:issued rdf:datatype="&xsd;dateTime">2017-12-28T18:00:00</dct:issued>
+		<dct:license>Copyright (c) 2017-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2017-2025 Object Management Group, Inc.
+		
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
@@ -103,14 +101,13 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2025-12-17T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-07-07T18:00:00</dct:modified>
 		<dct:title>FIBO FND Domain</dct:title>
 		<dct:title>Financial Industry Business Ontology (FIBO) Foundations (FND) Domain</dct:title>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -142,7 +139,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20251201/AllFND/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/AllFND/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/AllFND.rdf version of this ontology was modified to incorporate the recently released assessments and ratings ontologies.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190601/AllFND.rdf version of this ontology was modified to eliminate the unused legitimate organizations ontology, thereby simplifying the overal organization hierarchy, eliminate duplication with LCC, and merge countries with locations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/AllFND.rdf version of this ontology was modified to merge goals with objectives.</skos:changeNote>
@@ -150,8 +147,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/AllFND.rdf version of the ontology was modified to add an ontology for real property (LOAN-168).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241001/AllFND.rdf version of the ontology was modified to eliminate the now redundant Roles and Quantities and Units ontologies (FND-386).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/AllFND.rdf version of the ontology was modified to eliminate the now redundant Jurisdictions and Organizations ontologies (FND-399) and to reuse concepts from the Commons 1.3 sites and facilities ontology (FND-401).</skos:changeNote>
-		<cmns-av:copyright>Copyright (c) 2017-2025 EDM Council, Inc.</cmns-av:copyright>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20251201/AllFND.rdf version of the ontology was modified to eliminate the now redundant Agents ontology (FND-411).</skos:changeNote>
 		<cmns-av:copyright>Copyright (c) 2017-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2017-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:explanatoryNote>The &apos;all&apos; FND ontology is provided for convenience for FIBO users. It imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND) domain, and can be loaded directly in tools such as Protege with the expectation that all of the accompanying content will be loaded.</cmns-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/FND/Organizations/FormalOrganizations.rdf
+++ b/FND/Organizations/FormalOrganizations.rdf
@@ -2,10 +2,11 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
-	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
+	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
@@ -20,10 +21,11 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
-	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
+	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
@@ -38,9 +40,9 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
 		<rdfs:label>Formal Organizations Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the Commons concept of a formal organization, which is purposefully underspecified to facilitate mapping to other organization ontologies, such as the W3C organization ontology, or others defined for specific business and financial services standards. It also defines general concepts related to employment by a formal organization.</dct:abstract>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2013-2025 Object Management Group, Inc.
-
+		
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
@@ -53,11 +55,12 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20251201/Organizations/FormalOrganizations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/Organizations/FormalOrganizations/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20130801/Organizations/FormalOrganizations.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://www.omg.org/spec/EDMC-FIBO/FND/1.0/AboutFND-1.0/. It was further revised in the FTF in advance of the Long Beach meeting, resulting in http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Organizations/FormalOrganizations/.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Organizations/FormalOrganizations.rdf version of this ontology was modified per the FIBO 2.0 RFC to integrate concepts from LCC.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Organizations/FormalOrganizations.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
@@ -75,9 +78,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230401/Organizations/FormalOrganizations.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Organizations/FormalOrganizations.rdf version of the ontology was modified to eliminate elements that have been deprecated for more than 3 quarters (FND-399).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Organizations/FormalOrganizations.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20251201/Organizations/FormalOrganizations.rdf version of the ontology was modified to move a restriction on the agent class to this ontology, allowing eliminatation of the agents ontology to simplify imports. (FND-411).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-org-fm;Employee">
@@ -234,6 +238,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;hasGoal"/>
 				<owl:onClass rdf:resource="&fibo-fnd-gao-obj;Goal"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-pts;Agent">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTextualName"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&cmns-txt;Text"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>

--- a/LOAN/RealEstateLoans/MortgageOrigination.rdf
+++ b/LOAN/RealEstateLoans/MortgageOrigination.rdf
@@ -15,7 +15,6 @@
 	<!ENTITY fibo-fbc-dae-gty "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
-	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
@@ -52,7 +51,6 @@
 	xmlns:fibo-fbc-dae-gty="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Guaranty/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
-	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
@@ -76,8 +74,8 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/">
 		<rdfs:label xml:lang="en">Mortgage Origination Ontology</rdfs:label>
 		<dct:abstract>This ontology covers a range of mortgage origination concepts, primarily in the form of controlled vocabularies that can be used to categorize aspects of a given mortgage loan.</dct:abstract>
-		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
-		Copyright (c) 2016-2025 Object Management Group, Inc.
+		<dct:license>Copyright (c) 2016-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2016-2025 Object Management Group, Inc.
 		
 		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -93,7 +91,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
@@ -115,8 +112,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/RealEstateLoans/MortgageOrigination/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2016-2024 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-rp;RealProperty">
@@ -203,8 +200,15 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:adaptedFrom>the 2015 Revised HMDA regulation.</cmns-av:adaptedFrom>
 	</owl:NamedIndividual>
 	
+	<owl:Class rdf:about="&fibo-loan-reln-org;AutomatedSystem">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Arrangement"/>
+		<rdfs:label>automated system</rdfs:label>
+		<skos:definition>system that reduces or eliminates the need for human involvement in order to complete a task</skos:definition>
+		<cmns-av:adaptedFrom>https://www.reference.com/technology/automated-system-c85583d0f17a632</cmns-av:adaptedFrom>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-loan-reln-org;AutomatedUnderwritingSystem">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-aap-agt;AutomatedSystem"/>
+		<rdfs:subClassOf rdf:resource="&fibo-loan-reln-org;AutomatedSystem"/>
 		<rdfs:label>automated underwriting system</rdfs:label>
 		<skos:definition>software system that collects the information necessary to approve a loan application and supports a mortgage lender&apos;s analysis of a new loan application</skos:definition>
 		<cmns-av:explanatoryNote>In the United States, automated underwriting systems review the applicant&apos;s credit history and ability to repay the loan, and determine whether the price the applicant is offering to pay is supported by the property value.</cmns-av:explanatoryNote>


### PR DESCRIPTION
## Description

Moved restrictions on external classes in the FND Agents ontologies to more appropriate ontologies; moved the definition of automated system to the mortgage origination ontology where it is used, and deprecated the remaining automated system class in the agents ontology so that it can be eliminated over time, simplifying imports and maintenance

Fixes: #2223 / FND-411


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


